### PR TITLE
Remove sanity assertion from os_arch_idle().

### DIFF
--- a/libs/os/src/arch/sim/os_arch_sim.c
+++ b/libs/os/src/arch/sim/os_arch_sim.c
@@ -181,8 +181,6 @@ os_arch_in_critical(void)
 void
 os_arch_idle(void)
 {
-    assert(!os_arch_in_critical());
-
     sigsuspend(&nosigs);        /* Wait for a signal to wake us up */
 }
 


### PR DESCRIPTION
The assertion is correct and does not fire when the program is running
normally however it triggers a false positive when a breakpoint is set
in 'os_arch_idle()' by lldb.