### PR TITLE
first draft of the HAL ADC driver with sim support

### DIFF
--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -40,22 +40,23 @@ bsp_flash_dev(uint8_t id)
 extern int 
 bsp_get_hal_adc_driver(int sysid,  
                        int *devid_out, 
-                       struct hal_adc_s **padc_out) {
+                       struct hal_adc_s **padc_out) 
+{
     switch(sysid) {
         case 0:
         case 1:
             *devid_out = sysid;
-            *padc_out = &native_random_adc;
+            *padc_out = pnative_random_adc;
             return 0;
         case 2:
         case 3:
         case 4:
             *devid_out = (sysid - 2);
-            *padc_out = &native_min_mid_max_adc;
+            *padc_out = pnative_min_mid_max_adc;
             return 0;
         case 5:
             *devid_out = (sysid - 5);
-            *padc_out = &native_file_adc;            
+            *padc_out = pnative_file_adc;            
             return 0;
     }
     return -1;

--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -35,3 +35,28 @@ bsp_flash_dev(uint8_t id)
     }
     return &native_flash_dev;
 }
+
+/* This BSP will use all the ADCs provided by the native MCU implementation */
+extern int 
+bsp_get_hal_adc_driver(int sysid,  
+                       int *devid_out, 
+                       struct hal_adc_s **padc_out) {
+    switch(sysid) {
+        case 0:
+        case 1:
+            *devid_out = sysid;
+            *padc_out = &native_random_adc;
+            return 0;
+        case 2:
+        case 3:
+        case 4:
+            *devid_out = (sysid - 2);
+            *padc_out = &native_min_mid_max_adc;
+            return 0;
+        case 5:
+            *devid_out = (sysid - 5);
+            *padc_out = &native_file_adc;            
+            return 0;
+    }
+    return -1;
+}

--- a/hw/hal/include/hal/hal_adc.h
+++ b/hw/hal/include/hal/hal_adc.h
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_ADC_H
+#define HAL_ADC_H
+
+/* initialize the ADC corresponding to the system id sysid.  
+ * Returns 0 on success.  the ADC must be initialized
+ * before calling any other functions in this header file .
+ * If other methods are called with a sysid before init is 
+ * called, the function will return error */
+int hal_adc_init(int sysid);
+
+/*
+ * read the ADC corresponding to sysid in your system.  Returns
+ * the  adc value read or negative on error, See 
+ * hal_adc_get_resolution to check the range of the return value */
+int hal_adc_read(int sysid);
+
+/* returns the number of bit of resolution in this ADC.  
+ * For example if the system has an 8-bit ADC reporting 
+ * values from 0= to 255 (2^8-1), this function would return
+ * the value 8. returns negative or zero on error */
+int hal_adc_get_resolution(int sysid);
+
+/* Returns the positive reference voltage for a maximum ADC reading.
+ * This API assumes the negative reference voltage is zero volt.
+ * Returns negative or zero on error.  
+ */
+int hal_adc_get_reference_voltage_mvolts(int sysid);
+
+/* Converts and ADC value to millivolts  */
+int hal_adc_val_convert_to_mvolts(int sysid, int val);
+
+
+#endif /* HAL_ADC_H */

--- a/hw/hal/include/hal/hal_adc_int.h
+++ b/hw/hal/include/hal/hal_adc_int.h
@@ -16,39 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __NATIVE_BSP_H
-#define __NATIVE_BSP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#ifndef HAL_ADC_INT_H
+#define HAL_ADC_INT_H
 
-/* Define special stackos sections */
-#define sec_data_core
-#define sec_bss_core
-#define sec_bss_nz_core
+struct hal_adc_funcs_s {
+    int (*hadc_read)(int devid);
+    int  (*hadc_get_resolution)(int devid);
+    int (*hadc_get_reference_mvolts)(int devid);
+    int  (*hadc_init)(int devid);
+};
 
-/* More convenient section placement macros. */
-#define bssnz_t
+struct hal_adc_s {
+    const struct hal_adc_funcs_s  *driver_api;
+};
 
-/* LED pins */
-#define LED_BLINK_PIN   (0x1)
+/* NOTE: When using the hal_adc APIs, your BSP will need to implement
+ * this function.  This function maps the system ID to a device ID
+ * and a driver interface for the underlying code to use. */
+extern int 
+bsp_get_hal_adc_driver(int sysid,  
+                       int *devid_out, 
+                       struct hal_adc_s **padc_out);
 
-/* Logical UART ports */
-#define UART_CNT	2
-#define CONSOLE_UART	0
-
-int bsp_imgr_current_slot(void);
-
-#define NFFS_AREA_MAX    (8)
-
-/* channels 0 and 1 are random 
- * channels 2,3,4 are min/mid/max constant */
-/* channel 5 is file from native_adc_0.bin */
-#define ADC_CHANNEL_MAX  (6)
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif  /* __NATIVE_BSP_H */
+#endif /* HAL_ADC_INT_H */

--- a/hw/hal/include/hal/hal_adc_int.h
+++ b/hw/hal/include/hal/hal_adc_int.h
@@ -20,11 +20,13 @@
 #ifndef HAL_ADC_INT_H
 #define HAL_ADC_INT_H
 
+struct hal_adc_s;
+
 struct hal_adc_funcs_s {
-    int (*hadc_read)(int devid);
-    int  (*hadc_get_resolution)(int devid);
-    int (*hadc_get_reference_mvolts)(int devid);
-    int  (*hadc_init)(int devid);
+    int (*hadc_read)                     (struct hal_adc_s *padc, int devid);
+    int  (*hadc_get_resolution)          (struct hal_adc_s *padc, int devid);
+    int (*hadc_get_reference_mvolts)     (struct hal_adc_s *padc, int devid);
+    int  (*hadc_init)                    (struct hal_adc_s *padc, int devid);
 };
 
 struct hal_adc_s {

--- a/hw/hal/src/hal_adc.c
+++ b/hw/hal/src/hal_adc.c
@@ -21,13 +21,15 @@
 #include <hal/hal_adc.h>
 #include <hal/hal_adc_int.h>
 
-int hal_adc_init(int sysid) {
+int 
+hal_adc_init(int sysid) 
+{
     int devid;
     struct hal_adc_s *padc;
     int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
     
     if(0 == rc) {
-        return padc->driver_api->hadc_init(devid);
+        return padc->driver_api->hadc_init(padc, devid);
     }
     return rc;
 }
@@ -36,13 +38,15 @@ int hal_adc_init(int sysid) {
  * read the ADC corresponding to sysid in your system.  Returns
  * the  adc value read or negative on error, See 
  * hal_adc_get_resolution to check the range of the return value */
-int hal_adc_read(int sysid) {
+int 
+hal_adc_read(int sysid) 
+{
     int devid;
     struct hal_adc_s *padc;
     int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
     
     if(0 == rc) {
-        return padc->driver_api->hadc_read(devid);
+        return padc->driver_api->hadc_read(padc, devid);
     }
     return rc;
 }
@@ -51,13 +55,15 @@ int hal_adc_read(int sysid) {
  * For example if the system has an 8-bit ADC reporting 
  * values from 0= to 255 (2^8-1), this function would return
  * the value 8. */
-int hal_adc_get_resolution(int sysid)  {
+int 
+hal_adc_get_resolution(int sysid)  
+{
     int devid;
     struct hal_adc_s *padc;
     int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
     
     if(0 == rc) {
-        return padc->driver_api->hadc_get_resolution(devid);
+        return padc->driver_api->hadc_get_resolution(padc, devid);
     }
     return rc;
 }
@@ -66,19 +72,23 @@ int hal_adc_get_resolution(int sysid)  {
  * This API assumes the negative reference voltage is zero volt.
  * Returns negative on error.  
  */
-int hal_adc_get_reference_voltage_mvolts(int sysid)  {
+int 
+hal_adc_get_reference_voltage_mvolts(int sysid)  
+{
     int devid;
     struct hal_adc_s *padc;
     int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
     
     if(0 == rc) {
-        return padc->driver_api->hadc_get_reference_mvolts(devid);
+        return padc->driver_api->hadc_get_reference_mvolts(padc, devid);
     }
     return rc;
 }
 
 /* returns the ADC read value converted to mvolts or negative on error */
-int hal_adc_val_convert_to_mvolts(int sysid, int val) {
+int 
+hal_adc_val_convert_to_mvolts(int sysid, int val) 
+{
     int ret_val = -1;
     
     if(val >= 0)  {

--- a/hw/hal/src/hal_adc.c
+++ b/hw/hal/src/hal_adc.c
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <inttypes.h>
+#include <assert.h>
+#include <hal/hal_adc.h>
+#include <hal/hal_adc_int.h>
+
+int hal_adc_init(int sysid) {
+    int devid;
+    struct hal_adc_s *padc;
+    int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
+    
+    if(0 == rc) {
+        return padc->driver_api->hadc_init(devid);
+    }
+    return rc;
+}
+
+/*
+ * read the ADC corresponding to sysid in your system.  Returns
+ * the  adc value read or negative on error, See 
+ * hal_adc_get_resolution to check the range of the return value */
+int hal_adc_read(int sysid) {
+    int devid;
+    struct hal_adc_s *padc;
+    int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
+    
+    if(0 == rc) {
+        return padc->driver_api->hadc_read(devid);
+    }
+    return rc;
+}
+
+/* returns the number of bit of resolution in this ADC.  
+ * For example if the system has an 8-bit ADC reporting 
+ * values from 0= to 255 (2^8-1), this function would return
+ * the value 8. */
+int hal_adc_get_resolution(int sysid)  {
+    int devid;
+    struct hal_adc_s *padc;
+    int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
+    
+    if(0 == rc) {
+        return padc->driver_api->hadc_get_resolution(devid);
+    }
+    return rc;
+}
+
+/* Returns the positive reference voltage for a maximum ADC reading.
+ * This API assumes the negative reference voltage is zero volt.
+ * Returns negative on error.  
+ */
+int hal_adc_get_reference_voltage_mvolts(int sysid)  {
+    int devid;
+    struct hal_adc_s *padc;
+    int rc = bsp_get_hal_adc_driver(sysid, &devid, &padc);
+    
+    if(0 == rc) {
+        return padc->driver_api->hadc_get_reference_mvolts(devid);
+    }
+    return rc;
+}
+
+/* returns the ADC read value converted to mvolts or negative on error */
+int hal_adc_val_convert_to_mvolts(int sysid, int val) {
+    int ret_val = -1;
+    
+    if(val >= 0)  {
+        int ref;
+        ref = hal_adc_get_reference_voltage_mvolts(sysid);   
+        if(ref > 0) {
+            val *= ref;
+            ref = hal_adc_get_resolution(sysid);            
+            /* doubt there will be many 1 bit ADC, but this will
+             * adjust if its two bits or more */
+            if( ref > 1) {
+                /* round */
+                val += (1 << (ref - 2));
+                ret_val = (val >> ref);                
+            } 
+        }
+    }
+    return ret_val;
+}

--- a/hw/mcu/native/include/mcu/native_bsp.h
+++ b/hw/mcu/native/include/mcu/native_bsp.h
@@ -21,4 +21,22 @@
 
 extern const struct hal_flash native_flash_dev;
 
+
+/* These are defined for testing in native */
+
+/* all ADCS below have a reference voltage of 5 V */
+
+/* This ADC had two channels (0-1) that return 8-bit 
+ * random numbers */
+extern struct hal_adc_s native_random_adc;
+
+/* This ADC has three 12-bit channels (0-2) that return, min,
+ * mid, max, respectively  */
+extern struct hal_adc_s native_min_mid_max_adc;
+
+/* this ADC has one channel (0) that reads bytes from 
+ * a file and returns 8-bit ADC values .  When the file
+ * ends, the reads will return -1  */
+extern struct hal_adc_s native_file_adc;
+
 #endif /* H_NATIVE_BSP_ */

--- a/hw/mcu/native/include/mcu/native_bsp.h
+++ b/hw/mcu/native/include/mcu/native_bsp.h
@@ -28,15 +28,15 @@ extern const struct hal_flash native_flash_dev;
 
 /* This ADC had two channels (0-1) that return 8-bit 
  * random numbers */
-extern struct hal_adc_s native_random_adc;
+extern struct hal_adc_s *pnative_random_adc;
 
 /* This ADC has three 12-bit channels (0-2) that return, min,
  * mid, max, respectively  */
-extern struct hal_adc_s native_min_mid_max_adc;
+extern struct hal_adc_s *pnative_min_mid_max_adc;
 
 /* this ADC has one channel (0) that reads bytes from 
  * a file and returns 8-bit ADC values .  When the file
  * ends, the reads will return -1  */
-extern struct hal_adc_s native_file_adc;
+extern struct hal_adc_s *pnative_file_adc;
 
 #endif /* H_NATIVE_BSP_ */

--- a/hw/mcu/native/src/hal_adc.c
+++ b/hw/mcu/native/src/hal_adc.c
@@ -29,23 +29,31 @@
                             }                                           \
                         } while(0);           
     
-int native_adc_random_init(int devid) {
+int 
+native_adc_random_init(struct hal_adc_s *padc, int devid) 
+{
     DEVID_CHECK(2);
     /* nothing to do since this is simulated */
     return 0;
 }
 
-int native_adc_random_get_resolution(int devid) {
+int 
+native_adc_random_get_resolution(struct hal_adc_s *padc, int devid) 
+{
      DEVID_CHECK(2);
      return 8;
 }
 
-int native_adc_random_get_reference_mvolts(int devid) {
+int 
+native_adc_random_get_reference_mvolts(struct hal_adc_s *padc, int devid) 
+{
      DEVID_CHECK(2);
      return 5000;    
 }
 
-int native_adc_random_read(int devid) {
+int 
+native_adc_random_read(struct hal_adc_s *padc, int devid) 
+{
      DEVID_CHECK(2);
     return rand() & 0xff;
 }
@@ -59,27 +67,37 @@ static const struct hal_adc_funcs_s random_adc_funcs = {
     .hadc_read = &native_adc_random_read,
 };
 
-const struct hal_adc_s native_random_adc = {
+static const struct hal_adc_s native_random_adc = {
     .driver_api = &random_adc_funcs,
 };
 
-int native_adc_mmm_init(int devid) {
+const struct hal_adc_s *pnative_random_adc = &native_random_adc;
+
+int 
+native_adc_mmm_init(struct hal_adc_s *padc, int devid) 
+{
     DEVID_CHECK(3);
     /* nothing to do since this is simulated */
     return 0;
 }
 
-int native_adc_mmm_get_resolution(int devid) {
+int 
+native_adc_mmm_get_resolution(struct hal_adc_s *padc, int devid) 
+{
      DEVID_CHECK(3);
      return 12;
 }
 
-int native_adc_mmm_get_reference_mvolts(int devid) {
+int 
+native_adc_mmm_get_reference_mvolts(struct hal_adc_s *padc, int devid) 
+{
      DEVID_CHECK(3);
      return 5000;    
 }
 
-int native_adc_mmm_read(int devid) {
+int 
+native_adc_mmm_read(struct hal_adc_s *padc, int devid) 
+{
      switch(devid) {
          case 0:
              return 0;
@@ -99,49 +117,73 @@ static const struct hal_adc_funcs_s mmm_adc_funcs = {
     .hadc_read = &native_adc_mmm_read,
 };
 
-const struct hal_adc_s native_min_mid_max_adc = {
+static const struct hal_adc_s native_min_mid_max_adc = {
     .driver_api = &mmm_adc_funcs,
 };
 
+const struct hal_adc_s *pnative_min_mid_max_adc = &native_min_mid_max_adc;
 
-FILE *native_fs;
 
-int native_adc_file_init(int devid) {
-    DEVID_CHECK(1);
+
+/* This driver reads ADC values from a file . It stores some internal 
+ * state for itself. It does this by  wrapping the driver structure 
+ * with its own state and then casting back to its own driver pointer
+ * inside the methods */
+struct adc_fldrv_state_s {
+    struct hal_adc_s driver;  // must be first 
+    FILE *native_fs;    
+};
+
+int 
+native_adc_file_init(struct hal_adc_s *padc, int devid) 
+{
+    struct adc_fldrv_state_s *pdrv = (struct adc_fldrv_state_s *) padc;    
     char fname[64];
+    DEVID_CHECK(1);
     
     /* try to open a file with the name native_adc_%d.bin */
     sprintf(fname, "./native_adc_%d.bin", devid);
-    native_fs = fopen(fname, "r");
+    pdrv->native_fs = fopen(fname, "r");
     
-    if(native_fs <= 0) {
+    if(pdrv->native_fs <= 0) {
         return -1;
     }
     
     return 0;
 }
 
-int native_adc_file_get_resolution(int devid) {
-     DEVID_CHECK(1);
-     return 8;
+int 
+native_adc_file_get_resolution(struct hal_adc_s *padc, int devid) 
+{
+    DEVID_CHECK(1);
+    return 8;
 }
 
-int native_adc_file_get_reference_mvolts(int devid) {
-     DEVID_CHECK(1);
-     return 5000;    
+int 
+native_adc_file_get_reference_mvolts(struct hal_adc_s *padc, int devid) 
+{
+    DEVID_CHECK(1);
+    return 5000;    
 }
 
-int native_adc_file_read(int devid) {
+int 
+native_adc_file_read(struct hal_adc_s *padc, int devid) 
+{
+    struct adc_fldrv_state_s *pdrv = (struct adc_fldrv_state_s *) padc;
     int rc;
     uint8_t val; 
     DEVID_CHECK(1);
+    
+    if(pdrv->native_fs <= 0) {
+        return -2;
+    }
      
-    rc = fread( &val, 1, 1, native_fs);
+    rc = fread( &val, 1, 1, pdrv->native_fs);
     
     if (rc == 1) {
         return (int) val;
     } else {
-        fclose(native_fs);
+        fclose(pdrv->native_fs);
     }
     
     return -1;
@@ -154,9 +196,9 @@ static const struct hal_adc_funcs_s file_adc_funcs = {
     .hadc_read = &native_adc_file_read,
 };
 
-/* this ADC has one channel that reads bytes from 
- * a file and returns 8-bit ADC values .  When
- it reaches the end of the file, it repeats */
-const struct hal_adc_s native_file_adc = {
-    .driver_api = &file_adc_funcs,
+static struct adc_fldrv_state_s internal_state = {
+    .driver.driver_api = &file_adc_funcs,
 };
+
+/* external pointer to the driver interface */
+const struct hal_adc_s *pnative_file_adc = &internal_state.driver;

--- a/hw/mcu/native/src/hal_adc.c
+++ b/hw/mcu/native/src/hal_adc.c
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <hal/hal_adc.h>
+#include <hal/hal_adc_int.h>
+
+#define DEVID_CHECK(max) do {                                           \
+                            if((devid < 0) || (devid > max)) {          \
+                               return -1;                               \
+                            }                                           \
+                        } while(0);           
+    
+int native_adc_random_init(int devid) {
+    DEVID_CHECK(2);
+    /* nothing to do since this is simulated */
+    return 0;
+}
+
+int native_adc_random_get_resolution(int devid) {
+     DEVID_CHECK(2);
+     return 8;
+}
+
+int native_adc_random_get_reference_mvolts(int devid) {
+     DEVID_CHECK(2);
+     return 5000;    
+}
+
+int native_adc_random_read(int devid) {
+     DEVID_CHECK(2);
+    return rand() & 0xff;
+}
+
+/* This ADC had two channels that return 8-bit 
+ * random numbers */
+static const struct hal_adc_funcs_s random_adc_funcs = {
+    .hadc_get_reference_mvolts = &native_adc_random_get_reference_mvolts,
+    .hadc_get_resolution = &native_adc_random_get_resolution,
+    .hadc_init = &native_adc_random_init,
+    .hadc_read = &native_adc_random_read,
+};
+
+const struct hal_adc_s native_random_adc = {
+    .driver_api = &random_adc_funcs,
+};
+
+int native_adc_mmm_init(int devid) {
+    DEVID_CHECK(3);
+    /* nothing to do since this is simulated */
+    return 0;
+}
+
+int native_adc_mmm_get_resolution(int devid) {
+     DEVID_CHECK(3);
+     return 12;
+}
+
+int native_adc_mmm_get_reference_mvolts(int devid) {
+     DEVID_CHECK(3);
+     return 5000;    
+}
+
+int native_adc_mmm_read(int devid) {
+     switch(devid) {
+         case 0:
+             return 0;
+         case 1:
+             return 2047;
+         case 2:
+             return 4095;
+         default:
+             return -1;
+     }
+}
+
+static const struct hal_adc_funcs_s mmm_adc_funcs = {
+    .hadc_get_reference_mvolts = &native_adc_mmm_get_reference_mvolts,
+    .hadc_get_resolution = &native_adc_mmm_get_resolution,
+    .hadc_init = &native_adc_mmm_init,
+    .hadc_read = &native_adc_mmm_read,
+};
+
+const struct hal_adc_s native_min_mid_max_adc = {
+    .driver_api = &mmm_adc_funcs,
+};
+
+
+FILE *native_fs;
+
+int native_adc_file_init(int devid) {
+    DEVID_CHECK(1);
+    char fname[64];
+    
+    /* try to open a file with the name native_adc_%d.bin */
+    sprintf(fname, "./native_adc_%d.bin", devid);
+    native_fs = fopen(fname, "r");
+    
+    if(native_fs <= 0) {
+        return -1;
+    }
+    
+    return 0;
+}
+
+int native_adc_file_get_resolution(int devid) {
+     DEVID_CHECK(1);
+     return 8;
+}
+
+int native_adc_file_get_reference_mvolts(int devid) {
+     DEVID_CHECK(1);
+     return 5000;    
+}
+
+int native_adc_file_read(int devid) {
+    int rc;
+    uint8_t val; 
+    DEVID_CHECK(1);
+     
+    rc = fread( &val, 1, 1, native_fs);
+    
+    if (rc == 1) {
+        return (int) val;
+    } else {
+        fclose(native_fs);
+    }
+    
+    return -1;
+}
+
+static const struct hal_adc_funcs_s file_adc_funcs = {
+    .hadc_get_reference_mvolts = &native_adc_file_get_reference_mvolts,
+    .hadc_get_resolution = &native_adc_file_get_resolution,
+    .hadc_init = &native_adc_file_init,
+    .hadc_read = &native_adc_file_read,
+};
+
+/* this ADC has one channel that reads bytes from 
+ * a file and returns 8-bit ADC values .  When
+ it reaches the end of the file, it repeats */
+const struct hal_adc_s native_file_adc = {
+    .driver_api = &file_adc_funcs,
+};


### PR DESCRIPTION
This contains the following

1) The api in hal/hal_adc.h
2) The shim which brokers between the BSP and MCU
3) An implementation of 3 fake ADC devices for the native platform
