### PR TITLE
an altnerate version for the HAL API for ADC to review with folks.

### DIFF
--- a/hw/bsp/native/include/bsp/bsp.h
+++ b/hw/bsp/native/include/bsp/bsp.h
@@ -43,6 +43,17 @@ int bsp_imgr_current_slot(void);
 #define NFFS_AREA_MAX    (8)
 
 
+
+/* normally you would name these after the stuff you are connecting to */
+struct hal_adc_device_s;
+extern const struct hal_adc_device_s *PADC0;
+extern const struct hal_adc_device_s *PADC1;
+extern const struct hal_adc_device_s *PADC2;
+extern const struct hal_adc_device_s *PADC3;
+extern const struct hal_adc_device_s *PADC4;
+extern const struct hal_adc_device_s *PADC5;
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include "hal/hal_flash_int.h"
+#include "hal/hal_adc_int.h"
 #include "mcu/native_bsp.h"
 
 const struct hal_flash *
@@ -35,3 +36,39 @@ bsp_flash_dev(uint8_t id)
     }
     return &native_flash_dev;
 }
+const struct hal_adc_device_s ADC0 = {
+    &random_adc_funcs,
+    0,
+};
+
+const struct hal_adc_device_s ADC1 = {
+    &random_adc_funcs,
+    1,
+};
+
+const struct hal_adc_device_s ADC2 = {
+    &mmm_adc_funcs,
+    0,
+};
+
+const struct hal_adc_device_s ADC3 = {
+    &mmm_adc_funcs,
+    1,
+};
+
+const struct hal_adc_device_s ADC4 = {
+    &mmm_adc_funcs,
+    2
+};
+
+const struct hal_adc_device_s ADC5 = {
+    &file_adc_funcs,
+    0,
+};
+
+const struct hal_adc_device_s *PADC0 = &ADC0;
+const struct hal_adc_device_s *PADC1 = &ADC1;
+const struct hal_adc_device_s *PADC2 = &ADC2;
+const struct hal_adc_device_s *PADC3 = &ADC3;
+const struct hal_adc_device_s *PADC4 = &ADC4;
+const struct hal_adc_device_s *PADC5 = &ADC5;

--- a/hw/hal/include/hal/hal_adc.h
+++ b/hw/hal/include/hal/hal_adc.h
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_ADC_H
+#define HAL_ADC_H
+
+/* This is the device for an ADC. The application using the ADC device
+  *does not need to know the definition of this device and can operate 
+ * with a pointer to this device.  you can get/build device pointers in the 
+ * BSP */
+struct hal_adc_device_s; 
+
+/* initialize the ADC corresponding to adc device padc.
+ * Returns 0 on success.  the ADC must be initialized
+ * before calling any other functions in this header file .
+ * If other methods are called with a sysid before init is 
+ * called, the function will return error */
+int hal_adc_init(const struct hal_adc_device_s *padc);
+
+/*
+ * read the ADC corresponding to sysid in your system.  Returns
+ * the  adc value read or negative on error, See 
+ * hal_adc_get_resolution to check the range of the return value */
+int hal_adc_read(const struct hal_adc_device_s *padc);
+
+/* returns the number of bit of resolution in this ADC.  
+ * For example if the system has an 8-bit ADC reporting 
+ * values from 0= to 255 (2^8-1), this function would return
+ * the value 8. returns negative or zero on error */
+int hal_adc_get_resolution(const struct hal_adc_device_s *padc);
+
+/* Returns the positive reference voltage for a maximum ADC reading.
+ * This API assumes the negative reference voltage is zero volt.
+ * Returns negative or zero on error.  
+ */
+int hal_adc_get_reference_voltage_mvolts(const struct hal_adc_device_s *padc);
+
+/* Converts and ADC value to millivolts. This is a helper function
+ * but does call the ADC to get the reference voltage and 
+ * resolution */
+int hal_adc_val_convert_to_mvolts(const struct hal_adc_device_s *padc, int val);
+
+#endif /* HAL_ADC_H */

--- a/hw/hal/include/hal/hal_adc_int.h
+++ b/hw/hal/include/hal/hal_adc_int.h
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_ADC_INT_H
+#define HAL_ADC_INT_H
+
+#include <inttypes.h>
+
+
+struct hal_adc_device_s;
+
+/* These functions make up the driver API for ADC devices.  All 
+ * ADC devices with Mynewt support implement this interface */
+struct hal_adc_funcs_s {
+    int (*hadc_read)                     (const struct hal_adc_device_s *padc);
+    int  (*hadc_get_resolution)          (const struct hal_adc_device_s *padc);
+    int (*hadc_get_reference_mvolts)     (const struct hal_adc_device_s *padc);
+    int  (*hadc_init)                    (const struct hal_adc_device_s *padc);
+};
+
+/* This is the internal device representation for a hal_adc device.
+ * 
+ *  driver_api -- the function pointers for the driver associated this device
+ *  device_id -- many drivers support multiple devices. This enumerates them
+ *  _reserved -- pad 64 bits and reserve space 
+ * 
+ */
+struct hal_adc_device_s {
+    const struct hal_adc_funcs_s  *driver_api;
+    uint16_t                       device_id;
+    uint16_t                       _reserved;
+};
+
+#endif /* HAL_ADC_INT_H */

--- a/hw/hal/src/hal_adc.c
+++ b/hw/hal/src/hal_adc.c
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <inttypes.h>
+#include <hal/hal_adc.h>
+#include <hal/hal_adc_int.h>
+
+int hal_adc_init(const struct hal_adc_device_s *padc) {
+    if(padc && padc->driver_api && padc->driver_api->hadc_init) {
+        return padc->driver_api->hadc_init(padc);
+    }
+    return -1;
+}
+
+int hal_adc_read(const struct hal_adc_device_s *padc) {
+    if(padc && padc->driver_api && padc->driver_api->hadc_read) {
+        return padc->driver_api->hadc_read(padc);
+    }
+    return -1;
+}
+
+int hal_adc_get_resolution(const struct hal_adc_device_s *padc) {
+    if(padc && padc->driver_api && padc->driver_api->hadc_get_resolution) {
+        return padc->driver_api->hadc_get_resolution(padc);
+    }
+    return -1;
+}
+
+int hal_adc_get_reference_voltage_mvolts(const struct hal_adc_device_s *padc) {
+    if(padc && padc->driver_api && padc->driver_api->hadc_get_reference_mvolts) {
+        return padc->driver_api->hadc_get_reference_mvolts(padc);
+    }
+    return -1;
+}
+
+/* returns the ADC read value converted to mvolts or negative on error */
+int 
+hal_adc_val_convert_to_mvolts(const struct hal_adc_device_s *padc, int val) 
+{
+    int ret_val = -1;
+    
+    if(val >= 0)  {
+        int ref;
+        ref = hal_adc_get_reference_voltage_mvolts(padc);   
+        if(ref > 0) {
+            val *= ref;
+            ref = hal_adc_get_resolution(padc);            
+            /* doubt there will be many 1 bit ADC, but this will
+             * adjust if its two bits or more */
+            if( ref > 1) {
+                /* round */
+                val += (1 << (ref - 2));
+                ret_val = (val >> ref);                
+            } 
+        }
+    }
+    return ret_val;
+}

--- a/hw/mcu/native/include/mcu/native_bsp.h
+++ b/hw/mcu/native/include/mcu/native_bsp.h
@@ -21,4 +21,23 @@
 
 extern const struct hal_flash native_flash_dev;
 
+#define MAX_RANDOM_ADC_DEVICES (2)
+#define MAX_MMM_ADC_DEVICES    (3)
+#define MAX_FILE_ADC_DEVICES   (1)
+
+/* This ADC had two channels (0-1) that return 8-bit 
+ * random numbers */
+extern const struct hal_adc_funcs_s random_adc_funcs;
+
+
+/* This ADC has three 12-bit channels (0-2) that return, min,
+ * mid, max, respectively . */
+extern const struct hal_adc_funcs_s mmm_adc_funcs;
+
+
+/* this ADC has one channel (0) that reads bytes from 
+ * a file and returns 8-bit ADC values .  When the file
+ * ends, the reads will return -1  */
+extern const struct hal_adc_funcs_s file_adc_funcs;
+
 #endif /* H_NATIVE_BSP_ */

--- a/hw/mcu/native/src/hal_adc.c
+++ b/hw/mcu/native/src/hal_adc.c
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <hal/hal_adc.h>
+#include <hal/hal_adc_int.h>
+#include <mcu/native_bsp.h>
+
+#define DEVID_CHECK(max) do {                                           \
+                            if(padc->device_id > max) {                 \
+                               return -1;                               \
+                            }                                           \
+                        } while(0);           
+    
+int 
+native_adc_random_init(const struct hal_adc_device_s *padc) 
+{
+    DEVID_CHECK(MAX_RANDOM_ADC_DEVICES);
+    /* nothing to do since this is simulated */
+    return 0;
+}
+
+int 
+native_adc_random_get_resolution(const struct hal_adc_device_s *padc) 
+{
+     DEVID_CHECK(MAX_RANDOM_ADC_DEVICES);
+     return 8;
+}
+
+int 
+native_adc_random_get_reference_mvolts(const struct hal_adc_device_s *padc) 
+{
+     DEVID_CHECK(MAX_RANDOM_ADC_DEVICES);
+     return 5000;    
+}
+
+int 
+native_adc_random_read(const struct hal_adc_device_s *padc) 
+{
+     DEVID_CHECK(MAX_RANDOM_ADC_DEVICES);
+    return rand() & 0xff;
+}
+
+/* This ADC had two channels that return 8-bit 
+ * random numbers */
+const struct hal_adc_funcs_s random_adc_funcs = {
+    .hadc_get_reference_mvolts = &native_adc_random_get_reference_mvolts,
+    .hadc_get_resolution = &native_adc_random_get_resolution,
+    .hadc_init = &native_adc_random_init,
+    .hadc_read = &native_adc_random_read,
+};
+
+int 
+native_adc_mmm_init(const struct hal_adc_device_s *padc) 
+{
+    DEVID_CHECK(MAX_MMM_ADC_DEVICES);
+    /* nothing to do since this is simulated */
+    return 0;
+}
+
+int 
+native_adc_mmm_get_resolution(const struct hal_adc_device_s *padc) 
+{
+     DEVID_CHECK(MAX_MMM_ADC_DEVICES);
+     return 12;
+}
+
+int 
+native_adc_mmm_get_reference_mvolts(const struct hal_adc_device_s *padc) 
+{
+     DEVID_CHECK(MAX_MMM_ADC_DEVICES);
+     return 5000;    
+}
+
+int 
+native_adc_mmm_read(const struct hal_adc_device_s *padc) 
+{
+     switch(padc->device_id) {
+         case 0:
+             return 0;
+         case 1:
+             return 2047;
+         case 2:
+             return 4095;
+         default:
+             return -1;
+     }
+}
+
+const struct hal_adc_funcs_s mmm_adc_funcs = {
+    .hadc_get_reference_mvolts = &native_adc_mmm_get_reference_mvolts,
+    .hadc_get_resolution = &native_adc_mmm_get_resolution,
+    .hadc_init = &native_adc_mmm_init,
+    .hadc_read = &native_adc_mmm_read,
+};
+
+/* This driver reads ADC values from a file . It stores some internal 
+ * state for itself. It does this by  wrapping the driver structure 
+ * with its own state and then casting back to its own driver pointer
+ * inside the methods */
+struct adc_fldrv_state_s {
+    FILE *native_fs;
+};
+
+/* here I decided to allocate a maximum number of these.  To be
+ * memory conscious, I could malloc these and link them together */
+struct adc_fldrv_state_s g_state[MAX_FILE_ADC_DEVICES];    
+
+int 
+native_adc_file_init(const struct hal_adc_device_s *padc) 
+{
+    struct adc_fldrv_state_s *pstate = &g_state[padc->device_id];
+    char fname[64];
+    DEVID_CHECK(MAX_FILE_ADC_DEVICES);
+    
+    /* try to open a file with the name native_adc_%d.bin */
+    sprintf(fname, "./native_adc_%d.bin", padc->device_id);
+    pstate->native_fs = fopen(fname, "r");
+    
+    if(pstate->native_fs <= 0) {
+        return -1;
+    }
+    
+    return 0;
+}
+
+int 
+native_adc_file_get_resolution(const struct hal_adc_device_s *padc) 
+{
+    DEVID_CHECK(MAX_FILE_ADC_DEVICES);
+    return 8;
+}
+
+int 
+native_adc_file_get_reference_mvolts(const struct hal_adc_device_s *padc) 
+{
+    DEVID_CHECK(MAX_FILE_ADC_DEVICES);
+    return 5000;    
+}
+
+int 
+native_adc_file_read(const struct hal_adc_device_s *padc) 
+{
+    struct adc_fldrv_state_s *pstate = &g_state[padc->device_id];
+    int rc;
+    uint8_t val; 
+    DEVID_CHECK(MAX_FILE_ADC_DEVICES);
+    
+    if(pstate->native_fs <= 0) {
+        return -2;
+    }
+     
+    rc = fread( &val, 1, 1, pstate->native_fs);
+    
+    if (rc == 1) {
+        return (int) val;
+    } else {
+        fclose(pstate->native_fs);
+    }
+    
+    return -1;
+}
+
+const struct hal_adc_funcs_s file_adc_funcs = {
+    .hadc_get_reference_mvolts = &native_adc_file_get_reference_mvolts,
+    .hadc_get_resolution = &native_adc_file_get_resolution,
+    .hadc_init = &native_adc_file_init,
+    .hadc_read = &native_adc_file_read,
+};


### PR DESCRIPTION
All, Here is an alternate version of hal_ADC using a structure pointer instead of a sysid.

This shows the good and bad tradeoffs of that except for the test app.  So I'll highlight it here.

My app was doing something non-useful, it went

for(i = 0; i < ADC_MAX; i++) {
    int val;
    hal_init(i);
    val = hal_adc_read(i);
    printf("adc %d val %d\n", i, val);
}

This was really just for testing, but when I converted to this new API I had to do:

hal_init(PADC0);
val = hal_adc_read(PADC0);
printf("adc0 %d\n", val);
hal_init(PADC1);
val = hal_adc_read(PADC1);
printf("adc1 %d\n", val);
hal_init(PADC2);
val = hal_adc_read(PADC2);
printf("adc2 %d\n", val);
hal_init(PADC3);
val = hal_adc_read(PADC3);
printf("adc3 %d\n", val);
hal_init(PADC4);
val = hal_adc_read(PADC4);
printf("adc4 %d\n", val);
hal_init(PADC5);
val = hal_adc_read(PADC5);
printf("adc5 %d\n", val);

Not sure whether this is good or bad, but highlights the differences. It seems unlikely that folks would add loops around all of the ADC, but this would certain be much harder in this new API.

The benefits are that there are no longer sysid space to define and translate.
