### PR TITLE
third approach to mynewt HAL.

### DIFF
--- a/hw/bsp/native/include/bsp/bsp.h
+++ b/hw/bsp/native/include/bsp/bsp.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+#include <mcu/native_bsp.h>
+    
 /* Define special stackos sections */
 #define sec_data_core
 #define sec_bss_core
@@ -41,7 +43,17 @@ extern "C" {
 int bsp_imgr_current_slot(void);
 
 #define NFFS_AREA_MAX    (8)
-
+ 
+/* this is a native build anjd these are just simulated */
+enum BspPinDescriptor {
+    NATIVE_PIN_A0 = MCU_PIN_0,
+    NATIVE_PIN_A1 = MCU_PIN_1,
+    NATIVE_PIN_A2 = MCU_PIN_2,
+    NATIVE_PIN_A3 = MCU_PIN_3,
+    NATIVE_PIN_A4 = MCU_PIN_4,
+    NATIVE_PIN_A5 = MCU_PIN_5,
+    /* TODO */
+};
 
 #ifdef __cplusplus
 }

--- a/hw/hal/include/hal/hal_adc.h
+++ b/hw/hal/include/hal/hal_adc.h
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_ADC_H
+#define HAL_ADC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <bsp/bsp.h>    
+struct hal_adc_device_s; 
+
+/* initialize the ADC corresponding to adc device padc.
+ * Returns 0 on success.  the ADC must be initialized
+ * before calling any other functions in this header file .
+ * If other methods are called with a sysid before init is 
+ * called, the function will return error */
+int hal_adc_init(struct hal_adc_device_s *padc, enum BspPinDescriptor pin);
+
+/*
+ * read the ADC corresponding to sysid in your system.  Returns
+ * the  adc value read or negative on error, See 
+ * hal_adc_get_resolution to check the range of the return value */
+int hal_adc_read(struct hal_adc_device_s *padc);
+
+/* returns the number of bit of resolution in this ADC.  
+ * For example if the system has an 8-bit ADC reporting 
+ * values from 0= to 255 (2^8-1), this function would return
+ * the value 8. returns negative or zero on error */
+int hal_adc_get_resolution(struct hal_adc_device_s *padc);
+
+/* Returns the positive reference voltage for a maximum ADC reading.
+ * This API assumes the negative reference voltage is zero volt.
+ * Returns negative or zero on error.  
+ */
+int hal_adc_get_reference_voltage_mvolts(struct hal_adc_device_s *padc);
+
+/* Converts and ADC value to millivolts. This is a helper function
+ * but does call the ADC to get the reference voltage and 
+ * resolution */
+int hal_adc_val_convert_to_mvolts(struct hal_adc_device_s *padc, int val);
+ 
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_ADC_H */
+

--- a/hw/mcu/native/include/mcu/native_bsp.h
+++ b/hw/mcu/native/include/mcu/native_bsp.h
@@ -19,6 +19,33 @@
 #ifndef H_NATIVE_BSP_
 #define H_NATIVE_BSP_
 
+#include <stdio.h>
+
 extern const struct hal_flash native_flash_dev;
+
+/* this is a native build and these pins are not real.  They are used only
+ * for simulated HAL devices */
+enum McuPinDescriptor {
+    MCU_PIN_0   = 0,
+    MCU_PIN_1   = 1,
+    MCU_PIN_2   = 2,
+    MCU_PIN_3   = 3,
+    MCU_PIN_4   = 4,
+    MCU_PIN_5   = 5,
+};
+
+
+enum adc_channel_type {
+    ADC_RANDOM,
+    ADC_MIN,
+    ADC_MID,
+    ADC_MAX,
+    ADC_FILE
+};
+
+struct hal_adc_device_s {
+    enum adc_channel_type type;
+    FILE *native_fs;
+};
 
 #endif /* H_NATIVE_BSP_ */

--- a/hw/mcu/native/src/hal_adc.c
+++ b/hw/mcu/native/src/hal_adc.c
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <hal/hal_adc.h>
+#include <mcu/native_bsp.h>
+#include <bsp/bsp.h>
+
+/* initialize the ADC corresponding to adc device padc.
+ * Returns 0 on success.  the ADC must be initialized
+ * before calling any other functions in this header file .
+ * If other methods are called with a sysid before init is 
+ * called, the function will return error */
+int hal_adc_init(struct hal_adc_device_s *padc, enum BspPinDescriptor pin) {
+    
+    memset(padc, 0, sizeof(*padc));
+    
+    switch(pin) {
+        case MCU_PIN_0:
+        case MCU_PIN_1:
+            padc->type = ADC_RANDOM;
+            break;
+        case MCU_PIN_2:
+            padc->type = ADC_MIN;
+            break;
+        case MCU_PIN_3:
+            padc->type = ADC_MID;
+            break;
+        case MCU_PIN_4:
+            padc->type = ADC_MAX;
+            break;
+        case MCU_PIN_5:
+            padc->type = ADC_FILE;
+            break;
+        default:
+            return -1;
+    }
+    
+    switch(padc->type) {
+        case ADC_FILE:
+        {
+            char fname[64];
+
+            /* try to open a file with the name native_adc_%d.bin */
+            sprintf(fname, "./native_adc_0.bin");
+            padc->native_fs = fopen(fname, "r");
+
+            if(padc->native_fs <= 0) {
+                return -2;
+            }        
+            break;
+        }
+        default:
+            /* nothing to do */
+            break;
+    }
+
+    return 0;
+}
+
+
+/*
+ * read the ADC corresponding to sysid in your system.  Returns
+ * the  adc value read or negative on error, See 
+ * hal_adc_get_resolution to check the range of the return value */
+int hal_adc_read(struct hal_adc_device_s *padc) {
+    int rc;
+    int val;
+
+    switch(padc->type) {
+        case ADC_RANDOM:
+            return (rand() & 0xff);
+        case ADC_MIN:
+            return 0;            
+        case ADC_MID:
+            return 0xff >> 1;
+        case ADC_MAX:
+            return 0xff;
+        case ADC_FILE:
+            
+            if(padc->native_fs) {
+                rc = fread( &val, 1, 1, padc->native_fs);
+
+                if (rc == 1) {
+                    return (int) (val & 0xff);
+                } else {
+                    fclose(padc->native_fs);
+                    padc->native_fs = 0;
+                }
+                return rc;
+            }
+            return -2;
+    }
+    return -1;
+}
+        
+
+/* returns the number of bit of resolution in this ADC.  
+ * For example if the system has an 8-bit ADC reporting 
+ * values from 0= to 255 (2^8-1), this function would return
+ * the value 8. returns negative or zero on error */
+int hal_adc_get_resolution(struct hal_adc_device_s *padc) {
+    return 8;
+}
+
+/* Returns the positive reference voltage for a maximum ADC reading.
+ * This API assumes the negative reference voltage is zero volt.
+ * Returns negative or zero on error.  
+ */
+int hal_adc_get_reference_voltage_mvolts(struct hal_adc_device_s *padc) {
+    return 5000;
+}
+
+/* Converts and ADC value to millivolts. This is a helper function
+ * but does call the ADC to get the reference voltage and 
+ * resolution */
+int hal_adc_val_convert_to_mvolts(struct hal_adc_device_s *padc, int val)
+{
+    int ret_val = -1;
+    
+    if(val >= 0)  {
+        int ref;
+        ref = hal_adc_get_reference_voltage_mvolts(padc);   
+        if(ref > 0) {
+            val *= ref;
+            ref = hal_adc_get_resolution(padc);            
+            /* doubt there will be many 1 bit ADC, but this will
+             * adjust if its two bits or more */
+            if( ref > 1) {
+                /* round */
+                val += (1 << (ref - 1)) - 1;
+                ret_val = (val >> ref);                
+            }  else {
+                ret_val = val;
+            }
+        }
+    }
+    return ret_val;
+}  


### PR DESCRIPTION
This is what an mbed style hal interface would look like across the ADC.

It would not support multiple ADC devices like the other two version.

Application code was a combination of the two methods.  I could cretae 

hal_adc_device_t my_adcs[6];

The I could initialize as 

    hal_adc_init(&adcs[0], NATIVE_PIN_A0);
    hal_adc_init(&adcs[1], NATIVE_PIN_A1);
    hal_adc_init(&adcs[2], NATIVE_PIN_A2);
    hal_adc_init(&adcs[3], NATIVE_PIN_A3);
    hal_adc_init(&adcs[4], NATIVE_PIN_A4);
    hal_adc_init(&adcs[5], NATIVE_PIN_A5);

but I could loop over them to do stuff like

        for(i = 0; i < 6; i++) {
            int val, mv;
            val = hal_adc_read(&adcs[i]);
            mv = hal_adc_val_convert_to_mvolts(&adcs[i], val);
            console_printf("adc-%d (%d,%d), ",i,val,mv);
        } 
        console_printf("\n");
