### PR TITLE
Hal pwm final

### DIFF
--- a/hw/bsp/native/include/bsp/bsp.h
+++ b/hw/bsp/native/include/bsp/bsp.h
@@ -42,8 +42,6 @@ int bsp_imgr_current_slot(void);
 
 #define NFFS_AREA_MAX    (8)
 
-#define NUM_SYSTEM_PWM   (4)
-
 #ifdef __cplusplus
 }
 #endif

--- a/hw/bsp/native/include/bsp/bsp_sysid.h
+++ b/hw/bsp/native/include/bsp/bsp_sysid.h
@@ -34,7 +34,16 @@ enum system_device_id {
     NATIVE_A3,
     NATIVE_A4,
     NATIVE_A5,
+    NATIVE_BSP_PWM_0,
+    NATIVE_BSP_PWM_1,
+    NATIVE_BSP_PWM_2,
+    NATIVE_BSP_PWM_3,
+    NATIVE_BSP_PWM_4,
+    NATIVE_BSP_PWM_5,
+    NATIVE_BSP_PWM_6,
+    NATIVE_BSP_PWM_7,    
     /* TODO -- add other hals here */
+    
 };
 
 #ifdef __cplusplus

--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -26,6 +26,9 @@
 #include "hal/hal_adc_int.h"
 #include "bsp/bsp_sysid.h"
 #include "mcu/mcu_hal.h"
+#include <bsp/bsp.h>
+#include <bsp/bsp_sysid.h>
+#include <mcu/hal_pwm.h>
 
 const struct hal_flash *
 bsp_flash_dev(uint8_t id)
@@ -38,7 +41,6 @@ bsp_flash_dev(uint8_t id)
     }
     return &native_flash_dev;
 }
-
 
 /* This is the factory that creates adc devices for the application.
  * Based on the system ID defined, this maps to a creation function for
@@ -60,6 +62,35 @@ bsp_get_hal_adc(enum system_device_id sysid)
         case NATIVE_A5:        
             /* for this BSP we hard code the name of the ADC sample file */
             return native_adc_file_create(MCU_ADC_CHANNEL_5, "foo.txt");
+        default:
+            break;
+    }
+    return NULL;
+}
+
+struct hal_pwm *
+bsp_get_hal_pwm_driver(enum system_device_id sysid) 
+{
+    switch(sysid) 
+    {
+        case NATIVE_BSP_PWM_0:
+            return native_pwm_create (NATIVE_MCU_PWM0);
+        case NATIVE_BSP_PWM_1:
+            return native_pwm_create (NATIVE_MCU_PWM1);
+        case NATIVE_BSP_PWM_2:
+            return native_pwm_create (NATIVE_MCU_PWM2);
+        case NATIVE_BSP_PWM_3:
+            return native_pwm_create (NATIVE_MCU_PWM3);
+        case NATIVE_BSP_PWM_4:
+            return native_pwm_create (NATIVE_MCU_PWM4);
+        case NATIVE_BSP_PWM_5:
+            return native_pwm_create (NATIVE_MCU_PWM5);
+        case NATIVE_BSP_PWM_6:
+            return native_pwm_create (NATIVE_MCU_PWM6);
+        case NATIVE_BSP_PWM_7:
+            return native_pwm_create (NATIVE_MCU_PWM7);
+        default:
+            break;
     }
     return NULL;
 }

--- a/hw/hal/include/hal/hal_pwm.h
+++ b/hw/hal/include/hal/hal_pwm.h
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _HAL_HAL_PWM_H
+#define _HAL_HAL_PWM_H
+
+#include <inttypes.h>
+#include <bsp/bsp_sysid.h>
+
+/* This is an abstract hardware API to Pulse Width Modulators.
+ * A Pulse width module produces an output pulse stream with 
+ * a specified period, and duty cycle. */
+struct hal_pwm;
+
+/* Initialize a new PWM device with the given system id.
+ * Returns negative on error, 0 on success*/
+struct hal_pwm*
+hal_pwm_init(enum system_device_id sysid);
+
+/* enables the PWM corresponding to PWM *ppwm.*/
+int
+hal_pwm_on(struct hal_pwm *ppwm);
+
+/* disables the PWM corresponding to PWM *ppwm.*/
+int
+hal_pwm_off(struct hal_pwm *ppwm);
+
+/* There are two APIs for setting the PWM waveform.  You can use one 
+ *  or both in your programs, but only the last one called will apply
+ *
+ * hal_pwm_set_duty_cycle -- sets the PWM waveform for a specific duty cycle
+ *          It uses a 255 clock period and sets the on and off time 
+ *          according to the argument
+ * 
+ * hal_pwm_set_waveform -- sets the PWM waveform for a specific on time
+ *          and period specified in PWM clocks.  its intended for more
+ *          fine-grained control of the PWM waveform.  
+ *
+ */
+
+/* sets the duty cycle of the PWM output. This duty cycle is 
+ * a fractional duty cycle where 0 == off, 255 = on, and 
+ * any value in between is on for fraction clocks and off
+ * for 255-fraction clocks. 
+ * When you are looking for more fine-grained control over
+ * the PWM, use the API set_waveform below.
+ */
+int
+hal_pwm_set_duty_cycle(struct hal_pwm *ppwm, uint8_t fraction);
+
+
+/* Sets the pwm waveform period and on-time in units of the PWM clock 
+  (see below).  Period_clocks and on_clocks cannot exceed the 
+ * 2^N-1 where N is the resolution of the PWM channel  */
+int
+hal_pwm_set_waveform(struct hal_pwm *ppwm, uint32_t period_clocks, uint32_t on_clocks);
+
+
+/* gets the underlying clock driving the PWM output. Return value
+ * is in Hz. Returns negative on error */
+int 
+hal_pwm_get_clock_freq(struct hal_pwm *ppwm);
+
+/* gets the resolution of the PWM in bits.  An N-bit PWM can have 
+ * period and on values between 0 and 2^bits - 1. Returns negative on error  */
+int
+hal_pwm_get_resolution_bits(struct hal_pwm *ppwm);
+
+
+#endif /* _HAL_HAL_PWM_H */
+

--- a/hw/hal/include/hal/hal_pwm_int.h
+++ b/hw/hal/include/hal/hal_pwm_int.h
@@ -16,36 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __NATIVE_BSP_H
-#define __NATIVE_BSP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#ifndef HAL_PWM_INT_H
+#define HAL_PWM_INT_H
 
-/* Define special stackos sections */
-#define sec_data_core
-#define sec_bss_core
-#define sec_bss_nz_core
+#include <hal/hal_pwm.h>
+#include <inttypes.h>
 
-/* More convenient section placement macros. */
-#define bssnz_t
+/* when you are implementing a driver for the hal_pwm. This is the interface
+ * you must provide.  
+ */
 
-/* LED pins */
-#define LED_BLINK_PIN   (0x1)
+struct hal_pwm;
 
-/* Logical UART ports */
-#define UART_CNT	2
-#define CONSOLE_UART	0
+struct hal_pwm_funcs 
+{
+    int (*hpwm_on)        (struct hal_pwm *ppwm);
+    int (*hpwm_off)       (struct hal_pwm *ppwm);
+    int (*hpwm_get_bits)  (struct hal_pwm *ppwm);
+    int (*hpwm_get_clk)   (struct hal_pwm *ppwm);
+    int (*hpwm_set_duty)  (struct hal_pwm *ppwm, uint8_t frac_duty);
+    int (*hpwm_set_wave)  (struct hal_pwm *ppwm, uint32_t period, uint32_t on);
+};
 
-int bsp_imgr_current_slot(void);
+struct hal_pwm 
+{
+    const struct hal_pwm_funcs *driver_api;
+};
 
-#define NFFS_AREA_MAX    (8)
+struct hal_pwm *
+bsp_get_hal_pwm_driver(enum system_device_id sysid);
 
-#define NUM_SYSTEM_PWM   (4)
+#endif /* HAL_PWM_INT_H */
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif  /* __NATIVE_BSP_H */

--- a/hw/hal/src/hal_pwm.c
+++ b/hw/hal/src/hal_pwm.c
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <bsp/bsp_sysid.h>
+#include <hal/hal_pwm.h>
+#include <hal/hal_pwm_int.h>
+
+struct hal_pwm *
+hal_pwm_init(enum system_device_id sysid) 
+{
+    return bsp_get_hal_pwm_driver(sysid);
+}
+
+int
+hal_pwm_on(struct hal_pwm *ppwm) 
+{
+    if (ppwm && ppwm->driver_api && ppwm->driver_api->hpwm_on ) 
+    {
+        return ppwm->driver_api->hpwm_on(ppwm);
+    }
+    return -1;  
+}
+
+int
+hal_pwm_off(struct hal_pwm *ppwm) 
+{
+    if (ppwm && ppwm->driver_api && ppwm->driver_api->hpwm_off ) 
+    {
+        return ppwm->driver_api->hpwm_off(ppwm);
+    }
+    return -1;      
+}
+
+int
+hal_pwm_set_duty_cycle(struct hal_pwm *ppwm, uint8_t fraction) {
+    if (ppwm && ppwm->driver_api && ppwm->driver_api->hpwm_set_duty ) 
+    {
+        return ppwm->driver_api->hpwm_set_duty(ppwm, fraction);
+    }
+    return -1;      
+}
+
+int
+hal_pwm_set_waveform(struct hal_pwm *ppwm, uint32_t period_clocks, uint32_t on_clocks) {
+    if (ppwm && ppwm->driver_api && ppwm->driver_api->hpwm_set_wave ) 
+    {
+        return ppwm->driver_api->hpwm_set_wave(ppwm, period_clocks, on_clocks);
+    }
+    return -1;       
+}
+
+int 
+hal_pwm_get_clock_freq(struct hal_pwm *ppwm) {
+    if (ppwm && ppwm->driver_api && ppwm->driver_api->hpwm_get_clk ) 
+    {
+        return ppwm->driver_api->hpwm_get_clk(ppwm);
+    }
+    return -1;     
+}
+
+/* gets the resolution of the PWM in bits.  An N-bit PWM can have 
+ * period and on values between 0 and 2^bits - 1 */
+int
+hal_pwm_get_resolution_bits(struct hal_pwm *ppwm) {
+    if (ppwm && ppwm->driver_api && ppwm->driver_api->hpwm_get_bits ) 
+    {
+        return ppwm->driver_api->hpwm_get_bits(ppwm);
+    }
+    return -1;        
+}

--- a/hw/mcu/native/include/mcu/hal_pwm.h
+++ b/hw/mcu/native/include/mcu/hal_pwm.h
@@ -16,36 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __NATIVE_BSP_H
-#define __NATIVE_BSP_H
+
+#ifndef _NATIVE_HAL_PWM_H
+#define _NATIVE_HAL_PWM_H
+
+enum native_pwm_channel 
+{
+    NATIVE_MCU_PWM0 = 0,
+    NATIVE_MCU_PWM1,
+    NATIVE_MCU_PWM2,
+    NATIVE_MCU_PWM3,
+    NATIVE_MCU_PWM4,
+    NATIVE_MCU_PWM5,
+    NATIVE_MCU_PWM6,
+    NATIVE_MCU_PWM7,
+    NATIVE_MCU_PWM_MAX
+};
+ 
+/* to create a pwm driver */
+struct hal_pwm *
+native_pwm_create (enum native_pwm_channel);
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Define special stackos sections */
-#define sec_data_core
-#define sec_bss_core
-#define sec_bss_nz_core
 
-/* More convenient section placement macros. */
-#define bssnz_t
 
-/* LED pins */
-#define LED_BLINK_PIN   (0x1)
-
-/* Logical UART ports */
-#define UART_CNT	2
-#define CONSOLE_UART	0
-
-int bsp_imgr_current_slot(void);
-
-#define NFFS_AREA_MAX    (8)
-
-#define NUM_SYSTEM_PWM   (4)
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __NATIVE_BSP_H */
+#endif /* _NATIVE_HAL_PWM_H */
+

--- a/hw/mcu/native/pkg.yml
+++ b/hw/mcu/native/pkg.yml
@@ -28,3 +28,6 @@ pkg.keywords:
 pkg.deps:
     - hw/hal
     - compiler/sim
+    
+pkg.req_apis:
+    - console

--- a/hw/mcu/native/src/hal_pwm.c
+++ b/hw/mcu/native/src/hal_pwm.c
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <hal/hal_pwm.h>
+#include <hal/hal_pwm_int.h>
+#include <mcu/hal_pwm.h>
+#include <console/console.h>
+
+/* if you change this, you have to change sizes below */
+#define NATIVE_PWM_BITS (16)
+#define NATIVE_PWM_CLK_FREQ_HZ  (1000000)
+
+struct native_pwm_drv {
+    struct hal_pwm   driver;    
+    uint8_t          channel;
+    uint8_t          status;
+    uint16_t         on_ticks;
+    uint16_t         period_ticks;
+};
+
+static int native_pwm_off(struct hal_pwm *ppwm);
+static int native_pwm_on(struct hal_pwm *ppwm);
+static int native_pwm_set_wave(struct hal_pwm *ppwm, uint32_t period, uint32_t on);
+static int native_pwm_set_duty(struct hal_pwm *ppwm, uint8_t frac_duty);
+static int native_pwm_get_bits(struct hal_pwm *ppwm);
+static int native_pwm_get_clock(struct hal_pwm *ppwm);
+
+/* the function API for the driver  */
+static const struct hal_pwm_funcs  native_pwm_funcs = 
+{
+    .hpwm_get_bits = &native_pwm_get_bits,
+    .hpwm_get_clk = &native_pwm_get_clock,
+    .hpwm_off = &native_pwm_off,
+    .hpwm_on = &native_pwm_on,
+    .hpwm_set_duty = &native_pwm_set_duty,
+    .hpwm_set_wave = &native_pwm_set_wave,
+};
+
+struct hal_pwm *
+native_pwm_create (enum native_pwm_channel chan)
+{
+    struct native_pwm_drv *ppwm;
+    
+    if(chan >= NATIVE_MCU_PWM_MAX) 
+    {
+        return NULL;
+    }
+    
+    ppwm = malloc(sizeof(struct native_pwm_drv));
+    
+    if(ppwm) 
+    {
+        ppwm->driver.driver_api =  &native_pwm_funcs;
+        ppwm->period_ticks = 0xffff;        
+        /* 50% duty cycle */
+        ppwm->on_ticks = ppwm->period_ticks >> 1;
+        ppwm->status = 0;
+        ppwm->channel = chan;
+    }
+    return &ppwm->driver;
+}
+
+int 
+native_pwm_on(struct hal_pwm *ppwm) 
+{
+    struct native_pwm_drv *pn = (struct native_pwm_drv *) ppwm;
+    if(pn) 
+    {
+        console_printf("Device %p %d started with period=%u on=%u\n", 
+                pn, pn->channel, pn->period_ticks, pn->on_ticks);
+        return 0;
+    }
+    return -1;
+}
+
+int 
+native_pwm_off(struct hal_pwm *ppwm)
+{
+    struct native_pwm_drv *pn = (struct native_pwm_drv *) ppwm;
+ 
+    if(pn) 
+    {
+        console_printf("Device %p %d stopped with period=%u on=%u\n", 
+                pn, pn->channel, pn->period_ticks, pn->on_ticks);    
+        return 0;
+    }
+
+    return -1;
+}
+
+static int native_pwm_get_bits(struct hal_pwm *ppwm) {
+    if(ppwm) {
+        return NATIVE_PWM_BITS;
+    }
+    return -1;
+}
+
+static int native_pwm_get_clock(struct hal_pwm *ppwm) {
+    if(ppwm) {
+        return NATIVE_PWM_CLK_FREQ_HZ;
+    }
+    return -1;
+    
+}
+
+int 
+native_pwm_set_duty(struct hal_pwm *ppwm, uint8_t fraction)
+{
+    struct native_pwm_drv *pn = (struct native_pwm_drv *) ppwm;
+ 
+    if(pn) 
+    {    
+        pn->period_ticks = 255;
+        pn->on_ticks = fraction;
+        return 0;
+    }
+    return -2;
+}
+
+int 
+native_pwm_set_wave(struct hal_pwm *ppwm, uint32_t period, uint32_t on)
+{
+    struct native_pwm_drv *pn = (struct native_pwm_drv *) ppwm;
+ 
+    if(pn) 
+    {    
+        if(period > ((1 << NATIVE_PWM_BITS) - 1)) {
+            return -2;
+        }
+        if(on > ((1 << NATIVE_PWM_BITS) - 1)) {
+            return -3;
+        }
+        pn->period_ticks = period;
+        pn->on_ticks = on;
+        return 0;
+    }
+    return -4;
+}
+


### PR DESCRIPTION
A second version of the PWM API (First pull request was closed).

    This is a second version of the hal_pwm API.
    
    Its based on a discussion from the devlist.
    
    It contains two different ways to "set" the PWM waveform, a
    simple way with duty cycle and a more advanced way with clock ticks.
    
    It also adds methods to query the resolution(bits) and clock
    frequency of the underlying device when use the more advanced
    waveform control.