### PR TITLE
a hal_dac (Digital To Analog Conversion) API for HAL.

### DIFF
--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -29,6 +29,8 @@
 #include <bsp/bsp.h>
 #include <bsp/bsp_sysid.h>
 #include <mcu/hal_pwm.h>
+#include <mcu/hal_dac.h>
+
 
 const struct hal_flash *
 bsp_flash_dev(uint8_t id)
@@ -93,4 +95,24 @@ bsp_get_hal_pwm_driver(enum system_device_id sysid)
             break;
     }
     return NULL;
+}
+
+
+struct hal_dac *
+bsp_get_hal_dac(enum system_device_id sysid) 
+{
+    switch(sysid) 
+    {
+        case NATIVE_BSP_DAC_0:
+            return native_dac_create(NATIVE_MCU_DAC0);
+        case NATIVE_BSP_DAC_1:
+            return native_dac_create(NATIVE_MCU_DAC1);
+        case NATIVE_BSP_DAC_2:
+            return native_dac_create(NATIVE_MCU_DAC2);
+        case NATIVE_BSP_DAC_3:
+            return native_dac_create(NATIVE_MCU_DAC3);
+        default:
+            break;
+    }
+    return NULL;   
 }

--- a/hw/hal/include/hal/hal_dac.h
+++ b/hw/hal/include/hal/hal_dac.h
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_DAC_H
+#define HAL_DAC_H
+
+/* for the pin descriptor enum */
+#include <bsp/bsp_sysid.h>    
+
+/* This is the device for a Digital to Analog Converter (DAC). 
+ * The application using the DAC device
+ * does not need to know the definition of this device and can operate 
+ * with a pointer to this device.  you can get/build device pointers in the 
+ * BSP 
+ *
+ * NOTE: You can also use PWM devices to simulate analog output.
+ * These are defined in hal_pwm.h */
+struct hal_dac; 
+
+/* initialize the DAC on the corresponding BSP device. Returns a pointer
+ * to the DAC object to use for the methods below. Returns NULL on 
+ * error */
+struct hal_dac *
+hal_dac_init(enum system_device_id sysid);
+
+/*
+ * write the DAC corresponding to sysid in your system.  
+ * Return 0 on success negative on failures. If you 
+ * write a value larger than the DAC size, it will 
+ * get truncated to the maximum DAC value but the write
+ * will succeed.
+ */
+int 
+hal_dac_write(struct hal_dac *pdac, int val);
+
+/* gets the current value that is output on the DAC .
+ * Return the current value on success negative on failures.
+ */
+int 
+hal_dac_get_current(struct hal_dac *pdac);
+
+/* returns the number of bit of resolution in this DAC.  
+ * For example if the system has an 8-bit DAC reporting 
+ * values from 0= to 255 (2^8-1), this function would return
+ * the value 8. returns negative or zero on error */
+int 
+hal_dac_get_bits(struct hal_dac *pdac);
+
+/* Returns the positive reference voltage for a maximum DAC reading.
+ * This API assumes the negative reference voltage is zero volt.
+ * Returns negative or zero on error.  
+ */
+int 
+hal_dac_get_ref_mv(struct hal_dac *pdac);
+
+/* Converts a value in millivolts to a DAC value for this DAC */
+int 
+hal_dac_to_val(struct hal_dac *pdac, int mvolts);
+
+
+#endif /* HAL_DAC_H */  

--- a/hw/hal/include/hal/hal_dac_int.h
+++ b/hw/hal/include/hal/hal_dac_int.h
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_DAC_INT_H
+#define HAL_DAC_INT_H
+
+#include <inttypes.h>
+#include <bsp/bsp_sysid.h>
+
+
+struct hal_dac;
+
+/* These functions make up the driver API for DAC devices.  All 
+ * DAC devices with Mynewt support implement this interface */
+struct hal_dac_funcs {
+    int (*hdac_write)            (struct hal_dac *pdac, int val);
+    int (*hdac_current)          (struct hal_dac *pdac);
+    int (*hdac_get_bits)         (struct hal_dac *pdac);
+    int (*hdac_get_ref_mv)       (struct hal_dac *pdac);    
+};
+
+/* This is the internal device representation for a hal_dac device.
+ * 
+ * Its main goal is to wrap the const drivers in a non-const structure.
+ * Thus these can be made on the stack and wrapped with other non-const
+ * structures. 
+ * 
+ * For example, if you are creating a dac driver you can use
+ * 
+ * struct my_dac_driver {
+ *     struct hal_dac   parent;
+ *     int              my_stuff 1;
+ *     char            *mybuff;
+ * };
+ * 
+ * See the native MCU and BSP for examples 
+ */
+struct hal_dac {
+    const struct hal_dac_funcs  *driver_api;
+};
+
+/* The  BSP must implement this factory to get devices for the 
+ * application.  */
+extern struct hal_dac *
+bsp_get_hal_dac(enum system_device_id sysid);
+
+#endif /* HAL_DAC_INT_H */ 

--- a/hw/hal/src/hal_dac.c
+++ b/hw/hal/src/hal_dac.c
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <inttypes.h>
+#include <hal/hal_dac.h>
+#include <hal/hal_dac_int.h>
+
+struct hal_dac *
+hal_dac_init(enum system_device_id pin) 
+{
+    return bsp_get_hal_dac(pin);
+}
+
+int 
+hal_dac_write(struct hal_dac *pdac, int val) 
+{
+    if (pdac && pdac->driver_api && pdac->driver_api->hdac_write) {
+        return pdac->driver_api->hdac_write(pdac, val);
+    }
+    return -1;
+}
+
+int 
+hal_dac_get_bits(struct hal_dac *pdac) 
+{
+    if (pdac && pdac->driver_api && pdac->driver_api->hdac_get_bits) {
+        return pdac->driver_api->hdac_get_bits(pdac);
+    }
+    return -1;
+}
+
+int 
+hal_dac_get_ref_mv(struct hal_dac *pdac) 
+{
+    if (pdac && pdac->driver_api && pdac->driver_api->hdac_get_ref_mv) {
+        return pdac->driver_api->hdac_get_ref_mv(pdac);
+    }
+    return -1;
+}
+
+/* gets the current DAC value */
+int 
+hal_dac_get_current(struct hal_dac *pdac) 
+{
+    if (pdac && pdac->driver_api && pdac->driver_api->hdac_get_ref_mv) {
+        return pdac->driver_api->hdac_current(pdac);
+    }
+    return -1;
+}
+
+/* Converts a millivolt value to the right DAC settings for this DAC.
+ */
+int 
+hal_dac_to_val(struct hal_dac *pdac, int mvolts) 
+{
+    int rc = -1;
+    int bits = hal_dac_get_bits(pdac);
+    int ref = hal_dac_get_ref_mv(pdac);
+            
+    if ((bits > 0) && (ref >= 0)) 
+    {
+        /* assume that 2^N -1 is full scale. This line multiples by 2^N-1 
+         * and then rounds up */
+        rc = (mvolts << bits) - mvolts + (ref >> 1);
+        rc /= ref;
+        
+        /* don't let this exceed the DAC max */
+        if(rc >= (1 << bits)) {
+            rc = (1 << bits) - 1;
+        }
+    }
+    return rc;
+}

--- a/hw/mcu/native/include/mcu/hal_dac.h
+++ b/hw/mcu/native/include/mcu/hal_dac.h
@@ -16,33 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __NATIVE_BSP_SYSID_H
-#define __NATIVE_BSP_SYSID_H
 
-/* This file defines the system device descriptors for this BSP.
- * System device descriptors are any HAL devies */
+#ifndef _NATIVE_HAL_DAC_H
+#define _NATIVE_HAL_DAC_H
 
-/* this is a native build and these are just simulated */
-enum system_device_id {
-    NATIVE_A0,
-    NATIVE_A1,
-    NATIVE_A2,
-    NATIVE_A3,
-    NATIVE_A4,
-    NATIVE_A5,
-    NATIVE_BSP_PWM_0,
-    NATIVE_BSP_PWM_1,
-    NATIVE_BSP_PWM_2,
-    NATIVE_BSP_PWM_3,
-    NATIVE_BSP_PWM_4,
-    NATIVE_BSP_PWM_5,
-    NATIVE_BSP_PWM_6,
-    NATIVE_BSP_PWM_7, 
-    NATIVE_BSP_DAC_0,
-    NATIVE_BSP_DAC_1,
-    NATIVE_BSP_DAC_2,
-    NATIVE_BSP_DAC_3,
-    /* TODO -- add other hals here */    
+enum native_dac_channel 
+{
+    NATIVE_MCU_DAC0 = 0,
+    NATIVE_MCU_DAC1,
+    NATIVE_MCU_DAC2,
+    NATIVE_MCU_DAC3,
 };
+ 
+/* to create a native dac driver */
+struct hal_dac *
+native_dac_create (enum native_dac_channel);
 
-#endif  /* __NATIVE_BSP_SYSID_H */
+#endif /* _NATIVE_HAL_PWM_H */
+

--- a/hw/mcu/native/src/hal_dac.c
+++ b/hw/mcu/native/src/hal_dac.c
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <hal/hal_dac.h>
+#include <hal/hal_dac_int.h>
+#include <mcu/hal_dac.h>
+
+/* forwards for the const structure below */
+static int native_dac_write(struct hal_dac *pdac, int val);
+static int native_dac_bits(struct hal_dac *pdac);
+static int native_dac_current(struct hal_dac *pdac);
+static int native_dac_refmv(struct hal_dac *pdac);
+
+/* This DAC had four channels that print out the value  
+ * random numbers */
+const struct hal_dac_funcs native_dac_funcs = {
+    .hdac_current = &native_dac_current,
+    .hdac_get_ref_mv = &native_dac_refmv,
+    .hdac_get_bits = &native_dac_bits,
+    .hdac_write = &native_dac_write,
+};
+
+struct native_hal_dac {
+    struct hal_dac parent;
+    uint8_t        channel;
+    uint8_t        last_written_val;
+};
+
+struct hal_dac * 
+native_dac_create(enum native_dac_channel chan) 
+{
+    struct native_hal_dac *pdac = NULL;
+    
+    switch(chan) {
+        case NATIVE_MCU_DAC0:
+        case NATIVE_MCU_DAC1:
+        case NATIVE_MCU_DAC2:
+        case NATIVE_MCU_DAC3:
+            pdac = malloc(sizeof(struct native_hal_dac));
+            if (pdac) {
+                pdac->parent.driver_api = &native_dac_funcs;
+                pdac->channel = chan;
+                pdac->last_written_val = 0;
+            }
+    }    
+    return &pdac->parent;
+}
+
+int 
+native_dac_bits(struct hal_dac *pdac) 
+{
+    struct native_hal_dac *pn = (struct native_hal_dac *) pdac;
+    if (pn && pn->parent.driver_api == &native_dac_funcs) {
+         return 8;        
+    }
+    return -1;
+}
+
+int 
+native_dac_refmv(struct hal_dac *pdac) 
+{
+    struct native_hal_dac *pn = (struct native_hal_dac *) pdac;
+    if (pn && pn->parent.driver_api == &native_dac_funcs) {
+         return 5000;        
+    }
+    return -1;
+}
+
+
+int 
+native_dac_current(struct hal_dac *pdac) 
+{
+    struct native_hal_dac *pn = (struct native_hal_dac *) pdac;
+    if (pn && pn->parent.driver_api == &native_dac_funcs) {
+         return (int) pn->last_written_val;        
+    }
+    return -1;
+}
+
+int 
+native_dac_write(struct hal_dac *pdac, int val) 
+{
+    struct native_hal_dac *pn = (struct native_hal_dac *) pdac;
+    
+    if (val > 255) {
+        val = 255;
+    }
+        
+    if (pn && pn->parent.driver_api == &native_dac_funcs) {
+        pn->last_written_val = val;
+        return 0;
+    }
+    return -1;    
+}


### PR DESCRIPTION
This looks similar to the hal ADC API except allows you to write a value
(intead of read).  It also allows you to read the current value from the DAC