### PR TITLE
Changing has_objects to wr_commas and fixing it

### DIFF
--- a/apps/slinky/src/main.c
+++ b/apps/slinky/src/main.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -46,6 +46,7 @@ int init_tasks(void);
 /* Task 1 */
 #define TASK1_PRIO (1)
 #define TASK1_STACK_SIZE    OS_STACK_ALIGN(128)
+#define MAX_CBMEM_BUF 600
 struct os_task task1;
 os_stack_t stack1[TASK1_STACK_SIZE];
 static volatile int g_task1_loops;
@@ -65,7 +66,7 @@ os_stack_t shell_stack[SHELL_TASK_STACK_SIZE];
 #define NEWTMGR_TASK_STACK_SIZE (OS_STACK_ALIGN(512))
 os_stack_t newtmgr_stack[NEWTMGR_TASK_STACK_SIZE];
 
-struct log_handler log_console_handler;
+struct log_handler log_cbmem_handler;
 struct log my_log;
 
 static volatile int g_task2_loops;
@@ -99,6 +100,8 @@ static struct conf_handler test_conf_handler = {
 static uint8_t test8;
 static uint8_t test8_shadow;
 static char test_str[32];
+static uint32_t cbmem_buf[MAX_CBMEM_BUF];
+struct cbmem cbmem;
 
 static char *
 test_conf_get(int argc, char **argv, char *buf, int max_len)
@@ -138,6 +141,7 @@ void
 task1_handler(void *arg)
 {
     struct os_task *t;
+    int prev_pin_state, curr_pin_state;
 
     /* Set the led pin for the E407 devboard */
     g_led_pin = LED_BLINK_PIN;
@@ -153,7 +157,10 @@ task1_handler(void *arg)
         os_time_delay(1000);
 
         /* Toggle the LED */
-        hal_gpio_toggle(g_led_pin);
+        prev_pin_state = hal_gpio_read(g_led_pin);
+        curr_pin_state = hal_gpio_toggle(g_led_pin);
+        LOG_INFO(&my_log, LOG_MODULE_DEFAULT, "GPIO toggle from %u to %u",
+            prev_pin_state, curr_pin_state);
 
         /* Release semaphore to task 2 */
         os_sem_release(&g_test_sem);
@@ -231,21 +238,21 @@ main(int argc, char **argv)
 
 
     log_init();
-
-    log_console_handler_init(&log_console_handler);
-    log_register("log", &my_log, &log_console_handler);
+    cbmem_init(&cbmem, cbmem_buf, MAX_CBMEM_BUF);
+    log_cbmem_handler_init(&log_cbmem_handler, &cbmem);
+    log_register("log", &my_log, &log_cbmem_handler);
 
     LOG_DEBUG(&my_log, LOG_MODULE_DEFAULT, "bla");
     LOG_DEBUG(&my_log, LOG_MODULE_DEFAULT, "bab");
 
     os_init();
 
-    rc = os_mempool_init(&default_mbuf_mpool, DEFAULT_MBUF_MPOOL_NBUFS, 
-            DEFAULT_MBUF_MPOOL_BUF_LEN, default_mbuf_mpool_data, 
+    rc = os_mempool_init(&default_mbuf_mpool, DEFAULT_MBUF_MPOOL_NBUFS,
+            DEFAULT_MBUF_MPOOL_BUF_LEN, default_mbuf_mpool_data,
             "default_mbuf_data");
     assert(rc == 0);
 
-    rc = os_mbuf_pool_init(&default_mbuf_pool, &default_mbuf_mpool, 
+    rc = os_mbuf_pool_init(&default_mbuf_pool, &default_mbuf_mpool,
             DEFAULT_MBUF_MPOOL_BUF_LEN, DEFAULT_MBUF_MPOOL_NBUFS);
     assert(rc == 0);
 
@@ -284,7 +291,7 @@ main(int argc, char **argv)
     stats_module_init();
 
     flash_test_init();
-    
+
     rc = init_tasks();
     os_start();
 

--- a/hw/hal/include/hal/hal_gpio.h
+++ b/hw/hal/include/hal/hal_gpio.h
@@ -44,7 +44,7 @@ enum gpio_pull
 typedef enum gpio_pull gpio_pull_t;
 
 /*
- * IRQ trigger type. 
+ * IRQ trigger type.
  */
 enum gpio_irq_trigger
 {
@@ -61,78 +61,80 @@ typedef enum gpio_irq_trigger gpio_irq_trig_t;
 typedef void (*gpio_irq_handler_t)(void *arg);
 
 /**
- * gpio init in 
- *  
- * Initializes the specified pin as an input 
- * 
+ * gpio init in
+ *
+ * Initializes the specified pin as an input
+ *
  * @param pin   Pin number to set as input
  * @param pull  pull type
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int hal_gpio_init_in(int pin, gpio_pull_t pull);
 
 /**
- * gpio init out 
- *  
- * Initialize the specified pin as an output, setting the pin to the specified 
- * value. 
- * 
+ * gpio init out
+ *
+ * Initialize the specified pin as an output, setting the pin to the specified
+ * value.
+ *
  * @param pin Pin number to set as output
  * @param val Value to set pin
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int hal_gpio_init_out(int pin, int val);
 
 /**
- * gpio set 
- *  
- * Sets specified pin to 1 (high) 
- * 
- * @param pin 
+ * gpio set
+ *
+ * Sets specified pin to 1 (high)
+ *
+ * @param pin
  */
 void hal_gpio_set(int pin);
 
 /**
  * gpio clear
- *  
- * Sets specified pin to 0 (low). 
- * 
- * @param pin 
+ *
+ * Sets specified pin to 0 (low).
+ *
+ * @param pin
  */
 void hal_gpio_clear(int pin);
 
 /**
- * gpio write 
- *  
+ * gpio write
+ *
  * Write a value (either high or low) to the specified pin.
- * 
+ *
  * @param pin Pin to set
  * @param val Value to set pin (0:low 1:high)
  */
 void hal_gpio_write(int pin, int val);
 
 /**
- * gpio read 
- *  
- * Reads the specified pin. 
- *  
- *  
+ * gpio read
+ *
+ * Reads the specified pin.
+ *
+ *
  * @param pin Pin number to read
- * 
+ *
  * @return int 0: low, 1: high
  */
 int hal_gpio_read(int pin);
 
 /**
- * gpio toggle 
- *  
+ * gpio toggle
+ *
  * Toggles the specified pin
- * 
+ *
  * @param pin Pin number to toggle
+ *
+ * @return current gpio state int 0: low, 1: high
  */
-void hal_gpio_toggle(int pin);
+int hal_gpio_toggle(int pin);
 
 int hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
                       gpio_irq_trig_t trig, gpio_pull_t pull);

--- a/hw/mcu/native/src/hal_gpio.c
+++ b/hw/mcu/native/src/hal_gpio.c
@@ -81,7 +81,7 @@ void hal_gpio_write(int pin, int val)
         return;
     }
     hal_gpio[pin].val = (val != 0);
-    printf("hal_gpio set pin %2d to %1d\r", pin, hal_gpio[pin].val); 
+    printf("hal_gpio set pin %2d to %1d\r", pin, hal_gpio[pin].val);
     fflush(stdout);
 }
 
@@ -94,8 +94,10 @@ hal_gpio_read(int pin)
     return hal_gpio[pin].val;
 }
 
-void
+int
 hal_gpio_toggle(int pin)
 {
-    hal_gpio_write(pin, hal_gpio_read(pin) != 1);
+    int pin_state = (hal_gpio_read(pin) != 1);
+    hal_gpio_write(pin, pin_state);
+    return pin_state;
 }

--- a/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -26,28 +26,28 @@
  /* XXX: Notes
  * 1) Right now, we are not disabling the NVIC interrupt source; we only
  * disable the external interrupt from occurring. Dont think either way
- * to do it is an issue... when we release we may want to disable the NVIC 
- *  
+ * to do it is an issue... when we release we may want to disable the NVIC
+ *
  * 2) investigate how thread safe these routines are. HAL_GPIO_Init, for
  * example. Looks like if it gets interrupted while doing config an error
- * may occur. Read/modify write could cause screw-ups. 
- *  
- * 3) Currently, this code does not change the interrupt priority of the 
- * external interrupt vectors in the NVIC. The application developer must 
- * decide on the priority level for each external interrupt and program that 
- * by using the CMSIS NVIC API  (NVIC_SetPriority and NVIC_SetPriorityGrouping) 
- *  
- * 4) The code probably does not handle "re-purposing" gpio very well. 
- * "Re-purposing" means changing a gpio from input to output, or calling 
- * gpio_init_in and expecting previously enabled interrupts to be stopped. 
- *  
- * 5) Possbily add access to HAL_GPIO_DeInit. 
+ * may occur. Read/modify write could cause screw-ups.
+ *
+ * 3) Currently, this code does not change the interrupt priority of the
+ * external interrupt vectors in the NVIC. The application developer must
+ * decide on the priority level for each external interrupt and program that
+ * by using the CMSIS NVIC API  (NVIC_SetPriority and NVIC_SetPriorityGrouping)
+ *
+ * 4) The code probably does not handle "re-purposing" gpio very well.
+ * "Re-purposing" means changing a gpio from input to output, or calling
+ * gpio_init_in and expecting previously enabled interrupts to be stopped.
+ *
+ * 5) Possbily add access to HAL_GPIO_DeInit.
  */
 
-/* 
+/*
  * GPIO pin mapping
- *                  
- */ 
+ *
+ */
 #define GPIO_INDEX(pin)     (pin)
 #define GPIO_MASK(pin)      (1 << GPIO_INDEX(pin))
 
@@ -76,11 +76,11 @@ struct ext_irqs ext_irq_counts;
 
 #if 0
 /**
- * ext irq handler 
- *  
- * Handles the gpio interrupt attached to a gpio pin. 
- * 
- * @param index 
+ * ext irq handler
+ *
+ * Handles the gpio interrupt attached to a gpio pin.
+ *
+ * @param index
  */
 static void
 ext_irq_handler(int index)
@@ -128,9 +128,9 @@ ext_irq3(void)
 
 /**
  * ext irq4
- *  
+ *
  *  External interrupt handler for external interrupt 4.
- * 
+ *
  */
 static void
 ext_irq4(void)
@@ -140,10 +140,10 @@ ext_irq4(void)
 }
 
 /**
- * ext irq9_5 
- *  
- *  External interrupt handler for irqs 9 through 5. 
- * 
+ * ext irq9_5
+ *
+ *  External interrupt handler for irqs 9 through 5.
+ *
  */
 static void
 ext_irq9_5(void)
@@ -157,10 +157,10 @@ ext_irq9_5(void)
 }
 
 /**
- * ext irq15_10 
- *  
- *  External interrupt handler for irqs 15 through 10. 
- * 
+ * ext irq15_10
+ *
+ *  External interrupt handler for irqs 15 through 10.
+ *
  */
 static void
 ext_irq15_10(void)
@@ -174,13 +174,13 @@ ext_irq15_10(void)
 }
 
 /**
- * hal gpio clk enable 
- *  
- * Enable the port peripheral clock 
- * 
- * @param port_idx 
+ * hal gpio clk enable
+ *
+ * Enable the port peripheral clock
+ *
+ * @param port_idx
  */
-static void 
+static void
 hal_gpio_clk_enable(uint32_t port_idx)
 {
     switch (port_idx) {
@@ -236,14 +236,14 @@ hal_gpio_clk_enable(uint32_t port_idx)
 }
 
 /**
- * hal gpio pin to irq 
- *  
- * Converts the logical pin number to the IRQ number associated with the 
- * external interrupt for that particular GPIO. 
- * 
- * @param pin 
- * 
- * @return IRQn_Type 
+ * hal gpio pin to irq
+ *
+ * Converts the logical pin number to the IRQ number associated with the
+ * external interrupt for that particular GPIO.
+ *
+ * @param pin
+ *
+ * @return IRQn_Type
  */
 static IRQn_Type
 hal_gpio_pin_to_irq(int pin)
@@ -306,14 +306,14 @@ hal_gpio_set_nvic(IRQn_Type irqn)
 }
 
 /**
- * gpio init in 
- *  
- * Initializes the specified pin as an input 
- * 
+ * gpio init in
+ *
+ * Initializes the specified pin as an input
+ *
  * @param pin   Pin number to set as input
  * @param pull  pull type
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int
 hal_gpio_init_in(int pin, gpio_pull_t pull)
@@ -340,15 +340,15 @@ hal_gpio_init_in(int pin, gpio_pull_t pull)
 }
 
 /**
- * gpio init out 
- *  
- * Initialize the specified pin as an output, setting the pin to the specified 
- * value. 
- * 
+ * gpio init out
+ *
+ * Initialize the specified pin as an output, setting the pin to the specified
+ * value.
+ *
  * @param pin Pin number to set as output
  * @param val Value to set pin
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int hal_gpio_init_out(int pin, int val)
 {
@@ -363,11 +363,11 @@ int hal_gpio_init_out(int pin, int val)
 }
 
 /**
- * gpio set 
- *  
- * Sets specified pin to 1 (high) 
- * 
- * @param pin 
+ * gpio set
+ *
+ * Sets specified pin to 1 (high)
+ *
+ * @param pin
  */
 void hal_gpio_set(int pin)
 {
@@ -376,10 +376,10 @@ void hal_gpio_set(int pin)
 
 /**
  * gpio clear
- *  
- * Sets specified pin to 0 (low). 
- * 
- * @param pin 
+ *
+ * Sets specified pin to 0 (low).
+ *
+ * @param pin
  */
 void hal_gpio_clear(int pin)
 {
@@ -387,10 +387,10 @@ void hal_gpio_clear(int pin)
 }
 
 /**
- * gpio write 
- *  
+ * gpio write
+ *
  * Write a value (either high or low) to the specified pin.
- * 
+ *
  * @param pin Pin to set
  * @param val Value to set pin (0:low 1:high)
  */
@@ -404,12 +404,12 @@ void hal_gpio_write(int pin, int val)
 }
 
 /**
- * gpio read 
- *  
- * Reads the specified pin. 
- *  
+ * gpio read
+ *
+ * Reads the specified pin.
+ *
  * @param pin Pin number to read
- * 
+ *
  * @return int 0: low, 1: high
  */
 int hal_gpio_read(int pin)
@@ -418,33 +418,33 @@ int hal_gpio_read(int pin)
 }
 
 /**
- * gpio toggle 
- *  
+ * gpio toggle
+ *
  * Toggles the specified pin
- * 
+ *
  * @param pin Pin number to toggle
+ *
+ * @return current pin state int 0: low, 1: high
  */
-void hal_gpio_toggle(int pin)
+int hal_gpio_toggle(int pin)
 {
-    if (hal_gpio_read(pin)) {
-        hal_gpio_clear(pin);
-    } else {
-        hal_gpio_set(pin);
-    }
+    int pin_state = (hal_gpio_read(pin) != 1);
+    hal_gpio_write(pin, pin_state);
+    return pin_state;
 }
 
 /**
  * gpio irq init
- * 
- * Initialize an external interrupt on a gpio pin 
- * 
+ *
+ * Initialize an external interrupt on a gpio pin
+ *
  * @param pin       Pin number to enable gpio.
  * @param handler   Interrupt handler
  * @param arg       Argument to pass to interrupt handler
  * @param trig      Trigger mode of interrupt
  * @param pull      Push/pull mode of input.
- * 
- * @return int 
+ *
+ * @return int
  */
 int
 hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
@@ -516,13 +516,13 @@ hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
 
 /**
  * gpio irq release
- *  
- * No longer interrupt when something occurs on the pin. NOTE: this function 
- * does not change the GPIO push/pull setting nor does it change the 
- * SYSCFG EXTICR registers. It also does not disable the NVIC interrupt enable 
- * setting for the irq. 
- * 
- * @param pin 
+ *
+ * No longer interrupt when something occurs on the pin. NOTE: this function
+ * does not change the GPIO push/pull setting nor does it change the
+ * SYSCFG EXTICR registers. It also does not disable the NVIC interrupt enable
+ * setting for the irq.
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_release(int pin)
@@ -548,11 +548,11 @@ hal_gpio_irq_release(int pin)
 }
 
 /**
- * gpio irq enable 
- *  
- * Enable the irq on the specified pin 
- * 
- * @param pin 
+ * gpio irq enable
+ *
+ * Enable the irq on the specified pin
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_enable(int pin)
@@ -573,9 +573,9 @@ hal_gpio_irq_enable(int pin)
 
 /**
  * gpio irq disable
- * 
- * 
- * @param pin 
+ *
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_disable(int pin)

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -26,28 +26,28 @@
  /* XXX: Notes
  * 1) Right now, we are not disabling the NVIC interrupt source; we only
  * disable the external interrupt from occurring. Dont think either way
- * to do it is an issue... when we release we may want to disable the NVIC 
- *  
+ * to do it is an issue... when we release we may want to disable the NVIC
+ *
  * 2) investigate how thread safe these routines are. HAL_GPIO_Init, for
  * example. Looks like if it gets interrupted while doing config an error
- * may occur. Read/modify write could cause screw-ups. 
- *  
- * 3) Currently, this code does not change the interrupt priority of the 
- * external interrupt vectors in the NVIC. The application developer must 
- * decide on the priority level for each external interrupt and program that 
- * by using the CMSIS NVIC API  (NVIC_SetPriority and NVIC_SetPriorityGrouping) 
- *  
- * 4) The code probably does not handle "re-purposing" gpio very well. 
- * "Re-purposing" means changing a gpio from input to output, or calling 
- * gpio_init_in and expecting previously enabled interrupts to be stopped. 
- *  
- * 5) Possbily add access to HAL_GPIO_DeInit. 
+ * may occur. Read/modify write could cause screw-ups.
+ *
+ * 3) Currently, this code does not change the interrupt priority of the
+ * external interrupt vectors in the NVIC. The application developer must
+ * decide on the priority level for each external interrupt and program that
+ * by using the CMSIS NVIC API  (NVIC_SetPriority and NVIC_SetPriorityGrouping)
+ *
+ * 4) The code probably does not handle "re-purposing" gpio very well.
+ * "Re-purposing" means changing a gpio from input to output, or calling
+ * gpio_init_in and expecting previously enabled interrupts to be stopped.
+ *
+ * 5) Possbily add access to HAL_GPIO_DeInit.
  */
 
-/* 
+/*
  * GPIO pin mapping
- *                  
- */ 
+ *
+ */
 #define GPIO_INDEX(pin)     (pin)
 #define GPIO_MASK(pin)      (1 << GPIO_INDEX(pin))
 
@@ -76,11 +76,11 @@ struct ext_irqs ext_irq_counts;
 
 #if 0
 /**
- * ext irq handler 
- *  
- * Handles the gpio interrupt attached to a gpio pin. 
- * 
- * @param index 
+ * ext irq handler
+ *
+ * Handles the gpio interrupt attached to a gpio pin.
+ *
+ * @param index
  */
 static void
 ext_irq_handler(int index)
@@ -128,9 +128,9 @@ ext_irq3(void)
 
 /**
  * ext irq4
- *  
+ *
  *  External interrupt handler for external interrupt 4.
- * 
+ *
  */
 static void
 ext_irq4(void)
@@ -140,10 +140,10 @@ ext_irq4(void)
 }
 
 /**
- * ext irq9_5 
- *  
- *  External interrupt handler for irqs 9 through 5. 
- * 
+ * ext irq9_5
+ *
+ *  External interrupt handler for irqs 9 through 5.
+ *
  */
 static void
 ext_irq9_5(void)
@@ -157,10 +157,10 @@ ext_irq9_5(void)
 }
 
 /**
- * ext irq15_10 
- *  
- *  External interrupt handler for irqs 15 through 10. 
- * 
+ * ext irq15_10
+ *
+ *  External interrupt handler for irqs 15 through 10.
+ *
  */
 static void
 ext_irq15_10(void)
@@ -174,13 +174,13 @@ ext_irq15_10(void)
 }
 
 /**
- * hal gpio clk enable 
- *  
- * Enable the port peripheral clock 
- * 
- * @param port_idx 
+ * hal gpio clk enable
+ *
+ * Enable the port peripheral clock
+ *
+ * @param port_idx
  */
-static void 
+static void
 hal_gpio_clk_enable(uint32_t port_idx)
 {
     switch (port_idx) {
@@ -236,14 +236,14 @@ hal_gpio_clk_enable(uint32_t port_idx)
 }
 
 /**
- * hal gpio pin to irq 
- *  
- * Converts the logical pin number to the IRQ number associated with the 
- * external interrupt for that particular GPIO. 
- * 
- * @param pin 
- * 
- * @return IRQn_Type 
+ * hal gpio pin to irq
+ *
+ * Converts the logical pin number to the IRQ number associated with the
+ * external interrupt for that particular GPIO.
+ *
+ * @param pin
+ *
+ * @return IRQn_Type
  */
 static IRQn_Type
 hal_gpio_pin_to_irq(int pin)
@@ -306,14 +306,14 @@ hal_gpio_set_nvic(IRQn_Type irqn)
 }
 
 /**
- * gpio init in 
- *  
- * Initializes the specified pin as an input 
- * 
+ * gpio init in
+ *
+ * Initializes the specified pin as an input
+ *
  * @param pin   Pin number to set as input
  * @param pull  pull type
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int
 hal_gpio_init_in(int pin, gpio_pull_t pull)
@@ -340,15 +340,15 @@ hal_gpio_init_in(int pin, gpio_pull_t pull)
 }
 
 /**
- * gpio init out 
- *  
- * Initialize the specified pin as an output, setting the pin to the specified 
- * value. 
- * 
+ * gpio init out
+ *
+ * Initialize the specified pin as an output, setting the pin to the specified
+ * value.
+ *
  * @param pin Pin number to set as output
  * @param val Value to set pin
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int hal_gpio_init_out(int pin, int val)
 {
@@ -363,11 +363,11 @@ int hal_gpio_init_out(int pin, int val)
 }
 
 /**
- * gpio set 
- *  
- * Sets specified pin to 1 (high) 
- * 
- * @param pin 
+ * gpio set
+ *
+ * Sets specified pin to 1 (high)
+ *
+ * @param pin
  */
 void hal_gpio_set(int pin)
 {
@@ -376,10 +376,10 @@ void hal_gpio_set(int pin)
 
 /**
  * gpio clear
- *  
- * Sets specified pin to 0 (low). 
- * 
- * @param pin 
+ *
+ * Sets specified pin to 0 (low).
+ *
+ * @param pin
  */
 void hal_gpio_clear(int pin)
 {
@@ -387,10 +387,10 @@ void hal_gpio_clear(int pin)
 }
 
 /**
- * gpio write 
- *  
+ * gpio write
+ *
  * Write a value (either high or low) to the specified pin.
- * 
+ *
  * @param pin Pin to set
  * @param val Value to set pin (0:low 1:high)
  */
@@ -404,12 +404,12 @@ void hal_gpio_write(int pin, int val)
 }
 
 /**
- * gpio read 
- *  
- * Reads the specified pin. 
- *  
+ * gpio read
+ *
+ * Reads the specified pin.
+ *
  * @param pin Pin number to read
- * 
+ *
  * @return int 0: low, 1: high
  */
 int hal_gpio_read(int pin)
@@ -418,33 +418,33 @@ int hal_gpio_read(int pin)
 }
 
 /**
- * gpio toggle 
- *  
+ * gpio toggle
+ *
  * Toggles the specified pin
- * 
+ *
  * @param pin Pin number to toggle
+ *
+ * @return current pin state int 0: low, 1: high
  */
-void hal_gpio_toggle(int pin)
+int hal_gpio_toggle(int pin)
 {
-    if (hal_gpio_read(pin)) {
-        hal_gpio_clear(pin);
-    } else {
-        hal_gpio_set(pin);
-    }
+    int pin_state = (hal_gpio_read(pin) != 1);
+    hal_gpio_write(pin, pin_state);
+    return pin_state;
 }
 
 /**
  * gpio irq init
- * 
- * Initialize an external interrupt on a gpio pin 
- * 
+ *
+ * Initialize an external interrupt on a gpio pin
+ *
  * @param pin       Pin number to enable gpio.
  * @param handler   Interrupt handler
  * @param arg       Argument to pass to interrupt handler
  * @param trig      Trigger mode of interrupt
  * @param pull      Push/pull mode of input.
- * 
- * @return int 
+ *
+ * @return int
  */
 int
 hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
@@ -516,13 +516,13 @@ hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
 
 /**
  * gpio irq release
- *  
- * No longer interrupt when something occurs on the pin. NOTE: this function 
- * does not change the GPIO push/pull setting nor does it change the 
- * SYSCFG EXTICR registers. It also does not disable the NVIC interrupt enable 
- * setting for the irq. 
- * 
- * @param pin 
+ *
+ * No longer interrupt when something occurs on the pin. NOTE: this function
+ * does not change the GPIO push/pull setting nor does it change the
+ * SYSCFG EXTICR registers. It also does not disable the NVIC interrupt enable
+ * setting for the irq.
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_release(int pin)
@@ -548,11 +548,11 @@ hal_gpio_irq_release(int pin)
 }
 
 /**
- * gpio irq enable 
- *  
- * Enable the irq on the specified pin 
- * 
- * @param pin 
+ * gpio irq enable
+ *
+ * Enable the irq on the specified pin
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_enable(int pin)
@@ -573,9 +573,9 @@ hal_gpio_irq_enable(int pin)
 
 /**
  * gpio irq disable
- * 
- * 
- * @param pin 
+ *
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_disable(int pin)

--- a/hw/mcu/stm/stm32f4xx/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32f4xx/src/hal_gpio.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -27,25 +27,25 @@
  /* XXX: Notes
  * 1) Right now, we are not disabling the NVIC interrupt source; we only
  * disable the external interrupt from occurring. Dont think either way
- * to do it is an issue... when we release we may want to disable the NVIC 
- *  
+ * to do it is an issue... when we release we may want to disable the NVIC
+ *
  * 2) investigate how thread safe these routines are. HAL_GPIO_Init, for
  * example. Looks like if it gets interrupted while doing config an error
- * may occur. Read/modify write could cause screw-ups. 
- *  
- * 3) Currently, this code does not change the interrupt priority of the 
- * external interrupt vectors in the NVIC. The application developer must 
- * decide on the priority level for each external interrupt and program that 
- * by using the CMSIS NVIC API  (NVIC_SetPriority and NVIC_SetPriorityGrouping) 
- *  
- * 4) The code probably does not handle "re-purposing" gpio very well. 
- * "Re-purposing" means changing a gpio from input to output, or calling 
- * gpio_init_in and expecting previously enabled interrupts to be stopped. 
- *  
- * 5) Possbily add access to HAL_GPIO_DeInit. 
+ * may occur. Read/modify write could cause screw-ups.
+ *
+ * 3) Currently, this code does not change the interrupt priority of the
+ * external interrupt vectors in the NVIC. The application developer must
+ * decide on the priority level for each external interrupt and program that
+ * by using the CMSIS NVIC API  (NVIC_SetPriority and NVIC_SetPriorityGrouping)
+ *
+ * 4) The code probably does not handle "re-purposing" gpio very well.
+ * "Re-purposing" means changing a gpio from input to output, or calling
+ * gpio_init_in and expecting previously enabled interrupts to be stopped.
+ *
+ * 5) Possbily add access to HAL_GPIO_DeInit.
  */
 
-/* 
+/*
  * GPIO pin mapping
  *
  * The stm32F4xx processors have 16 gpio pins per port. We map the logical pin
@@ -53,15 +53,15 @@
  *      Port A: PA0-PA15 map to pins 0 - 15.
  *      Port B: PB0-PB15 map to pins 16 - 31.
  *      Port C: PC0-PC15 map to pins 32 - 47.
- * 
+ *
  *      To convert a gpio to pin number, do the following:
  *          - Convert port label to its numeric value (A=0, B=1, C=2, etc).
  *          - Multiply by 16.
  *          - Add port pin number.
- * 
+ *
  *      Ex: PD11 = (4 * 16) + 11 = 75.
  *          PA0 = (0 * 16) + 0 = 0
- */ 
+ */
 #define GPIO_INDEX(pin)     ((pin) & 0x0F)
 #define GPIO_PORT(pin)      (((pin) >> 4) & 0x0F)
 #define GPIO_MASK(pin)      (1 << GPIO_INDEX(pin))
@@ -133,11 +133,11 @@ struct ext_irqs
 struct ext_irqs ext_irq_counts;
 
 /**
- * ext irq handler 
- *  
- * Handles the gpio interrupt attached to a gpio pin. 
- * 
- * @param index 
+ * ext irq handler
+ *
+ * Handles the gpio interrupt attached to a gpio pin.
+ *
+ * @param index
  */
 static void
 ext_irq_handler(int index)
@@ -185,9 +185,9 @@ ext_irq3(void)
 
 /**
  * ext irq4
- *  
+ *
  *  External interrupt handler for external interrupt 4.
- * 
+ *
  */
 static void
 ext_irq4(void)
@@ -197,10 +197,10 @@ ext_irq4(void)
 }
 
 /**
- * ext irq9_5 
- *  
- *  External interrupt handler for irqs 9 through 5. 
- * 
+ * ext irq9_5
+ *
+ *  External interrupt handler for irqs 9 through 5.
+ *
  */
 static void
 ext_irq9_5(void)
@@ -214,10 +214,10 @@ ext_irq9_5(void)
 }
 
 /**
- * ext irq15_10 
- *  
- *  External interrupt handler for irqs 15 through 10. 
- * 
+ * ext irq15_10
+ *
+ *  External interrupt handler for irqs 15 through 10.
+ *
  */
 static void
 ext_irq15_10(void)
@@ -231,13 +231,13 @@ ext_irq15_10(void)
 }
 
 /**
- * hal gpio clk enable 
- *  
- * Enable the port peripheral clock 
- * 
- * @param port_idx 
+ * hal gpio clk enable
+ *
+ * Enable the port peripheral clock
+ *
+ * @param port_idx
  */
-static void 
+static void
 hal_gpio_clk_enable(uint32_t port_idx)
 {
     switch (port_idx) {
@@ -293,14 +293,14 @@ hal_gpio_clk_enable(uint32_t port_idx)
 }
 
 /**
- * hal gpio pin to irq 
- *  
- * Converts the logical pin number to the IRQ number associated with the 
- * external interrupt for that particular GPIO. 
- * 
- * @param pin 
- * 
- * @return IRQn_Type 
+ * hal gpio pin to irq
+ *
+ * Converts the logical pin number to the IRQ number associated with the
+ * external interrupt for that particular GPIO.
+ *
+ * @param pin
+ *
+ * @return IRQn_Type
  */
 static IRQn_Type
 hal_gpio_pin_to_irq(int pin)
@@ -361,13 +361,13 @@ hal_gpio_set_nvic(IRQn_Type irqn)
 
 /**
  * hal gpio init
- *  
- * Called to initialize a gpio. 
- * 
- * @param pin 
- * @param cfg 
- * 
- * @return int 
+ *
+ * Called to initialize a gpio.
+ *
+ * @param pin
+ * @param cfg
+ *
+ * @return int
  */
 static int
 hal_gpio_init(int pin, GPIO_InitTypeDef *cfg)
@@ -394,14 +394,14 @@ hal_gpio_init(int pin, GPIO_InitTypeDef *cfg)
 }
 
 /**
- * gpio init in 
- *  
- * Initializes the specified pin as an input 
- * 
+ * gpio init in
+ *
+ * Initializes the specified pin as an input
+ *
  * @param pin   Pin number to set as input
  * @param pull  pull type
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int
 hal_gpio_init_in(int pin, gpio_pull_t pull)
@@ -417,15 +417,15 @@ hal_gpio_init_in(int pin, gpio_pull_t pull)
 }
 
 /**
- * gpio init out 
- *  
- * Initialize the specified pin as an output, setting the pin to the specified 
- * value. 
- * 
+ * gpio init out
+ *
+ * Initialize the specified pin as an output, setting the pin to the specified
+ * value.
+ *
  * @param pin Pin number to set as output
  * @param val Value to set pin
- * 
- * @return int  0: no error; -1 otherwise. 
+ *
+ * @return int  0: no error; -1 otherwise.
  */
 int hal_gpio_init_out(int pin, int val)
 {
@@ -460,11 +460,11 @@ hal_gpio_init_af(int pin, uint8_t af_type, enum gpio_pull pull)
 }
 
 /**
- * gpio set 
- *  
- * Sets specified pin to 1 (high) 
- * 
- * @param pin 
+ * gpio set
+ *
+ * Sets specified pin to 1 (high)
+ *
+ * @param pin
  */
 void hal_gpio_set(int pin)
 {
@@ -478,10 +478,10 @@ void hal_gpio_set(int pin)
 
 /**
  * gpio clear
- *  
- * Sets specified pin to 0 (low). 
- * 
- * @param pin 
+ *
+ * Sets specified pin to 0 (low).
+ *
+ * @param pin
  */
 void hal_gpio_clear(int pin)
 {
@@ -494,10 +494,10 @@ void hal_gpio_clear(int pin)
 }
 
 /**
- * gpio write 
- *  
+ * gpio write
+ *
  * Write a value (either high or low) to the specified pin.
- * 
+ *
  * @param pin Pin to set
  * @param val Value to set pin (0:low 1:high)
  */
@@ -511,12 +511,12 @@ void hal_gpio_write(int pin, int val)
 }
 
 /**
- * gpio read 
- *  
- * Reads the specified pin. 
- *  
+ * gpio read
+ *
+ * Reads the specified pin.
+ *
  * @param pin Pin number to read
- * 
+ *
  * @return int 0: low, 1: high
  */
 int hal_gpio_read(int pin)
@@ -530,33 +530,33 @@ int hal_gpio_read(int pin)
 }
 
 /**
- * gpio toggle 
- *  
+ * gpio toggle
+ *
  * Toggles the specified pin
- * 
+ *
  * @param pin Pin number to toggle
+ *
+ * @return current pin state int 0: low 1 : high
  */
-void hal_gpio_toggle(int pin)
+int hal_gpio_toggle(int pin)
 {
-    if (hal_gpio_read(pin)) {
-        hal_gpio_clear(pin);
-    } else {
-        hal_gpio_set(pin);
-    }
+    int pin_state = (hal_gpio_read(pin) != 1);
+    hal_gpio_write(pin, pin_state);
+    return pin_state;
 }
 
 /**
  * gpio irq init
- * 
- * Initialize an external interrupt on a gpio pin 
- * 
+ *
+ * Initialize an external interrupt on a gpio pin
+ *
  * @param pin       Pin number to enable gpio.
  * @param handler   Interrupt handler
  * @param arg       Argument to pass to interrupt handler
  * @param trig      Trigger mode of interrupt
  * @param pull      Push/pull mode of input.
- * 
- * @return int 
+ *
+ * @return int
  */
 int
 hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
@@ -623,13 +623,13 @@ hal_gpio_irq_init(int pin, gpio_irq_handler_t handler, void *arg,
 
 /**
  * gpio irq release
- *  
- * No longer interrupt when something occurs on the pin. NOTE: this function 
- * does not change the GPIO push/pull setting nor does it change the 
- * SYSCFG EXTICR registers. It also does not disable the NVIC interrupt enable 
- * setting for the irq. 
- * 
- * @param pin 
+ *
+ * No longer interrupt when something occurs on the pin. NOTE: this function
+ * does not change the GPIO push/pull setting nor does it change the
+ * SYSCFG EXTICR registers. It also does not disable the NVIC interrupt enable
+ * setting for the irq.
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_release(int pin)
@@ -651,11 +651,11 @@ hal_gpio_irq_release(int pin)
 }
 
 /**
- * gpio irq enable 
- *  
- * Enable the irq on the specified pin 
- * 
- * @param pin 
+ * gpio irq enable
+ *
+ * Enable the irq on the specified pin
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_enable(int pin)
@@ -672,9 +672,9 @@ hal_gpio_irq_enable(int pin)
 
 /**
  * gpio irq disable
- * 
- * 
- * @param pin 
+ *
+ *
+ * @param pin
  */
 void
 hal_gpio_irq_disable(int pin)

--- a/libs/json/include/json/json.h
+++ b/libs/json/include/json/json.h
@@ -94,7 +94,7 @@ typedef int (*json_write_func_t)(void *buf, char *data,
 struct json_encoder {
     json_write_func_t je_write;
     void *je_arg;
-    int je_has_objects:1;
+    int je_wr_commas:1;
     char je_encode_buf[64];
 };
 

--- a/libs/json/src/json_encode.c
+++ b/libs/json/src/json_encode.c
@@ -38,11 +38,12 @@
 int
 json_encode_object_start(struct json_encoder *encoder)
 {
-    if (encoder->je_has_objects) {
+    if (encoder->je_wr_commas) {
         encoder->je_write(encoder->je_arg, ",", sizeof(",")-1);
+        encoder->je_wr_commas = 0;
     }
     JSON_ENCODE_OBJECT_START(encoder);
-    encoder->je_has_objects = 0;
+    encoder->je_wr_commas = 0;
 
     return (0);
 }
@@ -151,8 +152,9 @@ err:
 int
 json_encode_object_key(struct json_encoder *encoder, char *key)
 {
-    if (encoder->je_has_objects) {
+    if (encoder->je_wr_commas) {
         encoder->je_write(encoder->je_arg, ",", sizeof(",")-1);
+        encoder->je_wr_commas = 0;
     }
 
     /* Write the key entry */
@@ -169,8 +171,9 @@ json_encode_object_entry(struct json_encoder *encoder, char *key,
 {
     int rc;
 
-    if (encoder->je_has_objects) {
+    if (encoder->je_wr_commas) {
         encoder->je_write(encoder->je_arg, ",", sizeof(",")-1);
+        encoder->je_wr_commas = 0;
     }
     /* Write the key entry */
     encoder->je_write(encoder->je_arg, "\"", sizeof("\"")-1);
@@ -181,7 +184,7 @@ json_encode_object_entry(struct json_encoder *encoder, char *key,
     if (rc != 0) {
         goto err;
     }
-    encoder->je_has_objects = 1;
+    encoder->je_wr_commas = 1;
 
     return (0);
 err:
@@ -193,7 +196,7 @@ json_encode_object_finish(struct json_encoder *encoder)
 {
     JSON_ENCODE_OBJECT_END(encoder);
     /* Useful in case of nested objects. */
-    encoder->je_has_objects = 1;
+    encoder->je_wr_commas = 1;
 
     return (0);
 }
@@ -208,7 +211,7 @@ int
 json_encode_array_start(struct json_encoder *encoder)
 {
     JSON_ENCODE_ARRAY_START(encoder);
-    encoder->je_has_objects = 0;
+    encoder->je_wr_commas = 0;
 
     return (0);
 }
@@ -218,15 +221,16 @@ json_encode_array_value(struct json_encoder *encoder, struct json_value *jv)
 {
     int rc;
 
-    if (encoder->je_has_objects) {
+    if (encoder->je_wr_commas) {
         encoder->je_write(encoder->je_arg, ",", sizeof(",")-1);
+        encoder->je_wr_commas = 0;
     }
 
     rc = json_encode_value(encoder, jv);
     if (rc != 0) {
         goto err;
     }
-    encoder->je_has_objects = 1;
+    encoder->je_wr_commas = 1;
 
     return (0);
 err:

--- a/libs/newtmgr/src/newtmgr.c
+++ b/libs/newtmgr/src/newtmgr.c
@@ -355,7 +355,7 @@ nmgr_jbuf_setibuf(struct nmgr_jbuf *njb, struct os_mbuf *m,
     njb->njb_off = off;
     njb->njb_end = off + len;
     njb->njb_in_m = m;
-    njb->njb_enc.je_has_objects = 0;
+    njb->njb_enc.je_wr_commas = 0;
 
     return (0);
 }


### PR DESCRIPTION
For json a comma should be present at the end of every object if there
are multiple objects. Also, there shouldn't be trailing commas.

Problem: The je_has_objects flag would track commas as there wasn't a specific
way to do that with the json lib. It wasn't adding commas at the right
places.

Solution: A comma gets added at the right places now. Particularly, at
the end of each object and the flag gets reset each time a comma gets
added.

This should fix the problem we see with nested json encoding.
Also changing the name to be more specific.