### PR TITLE
I2C interface supporting blocking read and write

### DIFF
--- a/hw/hal/include/hal/hal_i2c.h
+++ b/hw/hal/include/hal/hal_i2c.h
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HAL_I2C_H
+#define HAL_I2C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+#include <bsp/bsp_sysid.h>
+
+/* This is the API for an i2c bus.  I tried to make this a simple API */
+
+struct hal_i2c;
+
+/* when sending a packet, use this structure to pass the arguments */
+struct hal_i2c_master_data {
+    uint8_t  address;   /* destination address */
+            /* NOTE: Write addresses are even and read addresses are odd
+             * but in this API, you must enter a single address that is the
+             * write address divide by 2.  For example, for address 
+             * 80, you would enter a 40 */
+    uint8_t *buffer;    /* buffer space to hold the transmit or receive */
+    uint16_t len;       /* length of buffer to transmit or receive */
+};
+
+/* Initialize a new i2c device with the given system id.
+ * Returns negative on error, 0 on success. */
+struct hal_i2c*
+hal_i2c_init(enum system_device_id sysid);
+
+/* Sends <len> bytes of data on the i2c.  This API assumes that you 
+ * issued a successful start condition.  It will fail if you
+ * have not. This API does NOT issue a stop condition.  You must stop the 
+ * bus after successful or unsuccessful write attempts.  Returns 0 on 
+ * success, negative on failure */
+int
+hal_i2c_master_write(struct hal_i2c*, struct hal_i2c_master_data *pdata);
+
+/* Reads <len> bytes of data on the i2c.  This API assumes that you 
+ * issued a successful start condition.  It will fail if you
+ * have not. This API does NOT issue a stop condition.  You must stop the 
+ * bus after successful or unsuccessful write attempts.  Returns 0 on 
+ * success, negative on failure */
+int
+hal_i2c_master_read(struct hal_i2c*, struct hal_i2c_master_data *pdata);
+
+/* issues a start condition and address on the SPI bus. Returns 0 
+ * on success, negative on error.
+ */
+int 
+hal_i2c_master_start(struct hal_i2c*);
+
+/* issues a stop condition on the bus.  You must issue a stop condition for
+ * every successful start condition on the bus */
+int 
+hal_i2c_master_stop(struct hal_i2c*);
+
+
+/* Probes the i2c bus for a device with this address.  THIS API 
+ * issues a start condition, probes the address and issues a stop
+ * condition.  
+ */
+int 
+hal_i2c_master_probe(struct hal_i2c*, uint8_t address);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_I2C_H */

--- a/hw/hal/include/hal/hal_i2c_int.h
+++ b/hw/hal/include/hal/hal_i2c_int.h
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef HAL_I2C_INT_H
+#define HAL_I2C_INT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <hal/hal_i2c.h>
+#include <inttypes.h>
+
+struct hal_i2c;
+
+struct hal_i2c_funcs {
+    int (*hi2cm_write_data) (struct hal_i2c *pi2c, struct hal_i2c_master_data *ppkt);
+    int (*hi2cm_read_data)  (struct hal_i2c *pi2c, struct hal_i2c_master_data *ppkt);
+    int (*hi2cm_probe)      (struct hal_i2c *pi2c, uint8_t address);
+    int (*hi2cm_start)      (struct hal_i2c *pi2c);
+    int (*hi2cm_stop)       (struct hal_i2c *pi2c);
+};
+
+struct hal_i2c
+{
+    const struct hal_i2c_funcs *driver_api;
+};
+
+struct hal_i2c *
+bsp_get_hal_i2c_driver(enum system_device_id sysid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_I2C_INT_H */
+

--- a/hw/hal/src/hal_i2c.c
+++ b/hw/hal/src/hal_i2c.c
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <bsp/bsp_sysid.h>
+#include <hal/hal_i2c.h>
+#include <hal/hal_i2c_int.h>
+
+struct hal_i2c *
+hal_i2c_init(enum system_device_id sysid)
+{
+    return bsp_get_hal_i2c_driver(sysid);
+}
+
+int
+hal_i2c_master_write(struct hal_i2c *pi2c, struct hal_i2c_master_data *ppkt)
+{
+    if (pi2c && pi2c->driver_api && pi2c->driver_api->hi2cm_write_data )
+    {
+        return pi2c->driver_api->hi2cm_write_data(pi2c, ppkt);
+    }
+    return -1;
+}
+
+int
+hal_i2c_master_read(struct hal_i2c *pi2c, struct hal_i2c_master_data *ppkt)
+{
+    if (pi2c && pi2c->driver_api && pi2c->driver_api->hi2cm_read_data )
+    {
+        return pi2c->driver_api->hi2cm_read_data(pi2c, ppkt);
+    }
+    return -1;
+}
+
+int
+hal_i2c_master_probe(struct hal_i2c *pi2c, uint8_t address)
+{
+    if (pi2c && pi2c->driver_api && pi2c->driver_api->hi2cm_probe )
+    {
+        return pi2c->driver_api->hi2cm_probe(pi2c, address);
+    }
+    return -1;
+}
+
+int
+hal_i2c_master_start(struct hal_i2c *pi2c)
+{
+    if (pi2c && pi2c->driver_api && pi2c->driver_api->hi2cm_start )
+    {
+        return pi2c->driver_api->hi2cm_start(pi2c);
+    }
+    return -1;
+}
+
+
+int
+hal_i2c_master_stop(struct hal_i2c *pi2c)
+{
+    if (pi2c && pi2c->driver_api && pi2c->driver_api->hi2cm_stop )
+    {
+        return pi2c->driver_api->hi2cm_stop(pi2c);
+    }
+    return -1;
+}


### PR DESCRIPTION
An interface to support blocking I2c read and write.  This allows for read transactions, write transactions, and combined read/write (Like random access eeprom)
