### PR TITLE
Don't do anything in signal handlers when process is blocked in 'sigsuspend()'.

### DIFF
--- a/libs/os/src/arch/sim/os_arch_sim.c
+++ b/libs/os/src/arch/sim/os_arch_sim.c
@@ -363,6 +363,7 @@ timer_handler(int sig)
         time_diff.tv_sec = 0;
         time_diff.tv_usec %= OS_USEC_PER_TICK;
         timersub(&time_now, &time_diff, &time_last);
+
         os_time_advance(ticks);
     }
 }


### PR DESCRIPTION
When the OS is idling it may disable the periodic timer and enter the tickless mode. The OS exits the tickless mode on arrival of an interrupt/signal (note that OS time is incorrect when this happens). Thus it is important to call 'timer_handler()' to correct the OS time before executing anything else.
