### PR TITLE
Arduino M0 support not included in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ environments, where power and cost are driving factors.
 
 It currently supports the following hardware platforms: 
     
-* Arduino Zero and Zero Pro
+* Arduino Zero, Zero Pro and M0 Pro
 * Nordic NRF51 and NRF52
 * Rigado BMD-300
 * STM32F3 and STMF32F4 


### PR DESCRIPTION
Hi, I noticed only Arduino Zero and Arduino Zero-Pro boards are present as supported Arduino boards. 
Arduino M0-Pro should be there too.