### PR TITLE
Arduino M0 pro support not included in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ environments, where power and cost are driving factors.
 
 It currently supports the following hardware platforms: 
     
-* Arduino Zero and Zero Pro
+* Arduino Zero, Zero Pro and M0 Pro
 * Nordic NRF51 and NRF52
 * Rigado BMD-300
 * STM32F3 and STMF32F4 

--- a/repository.yml
+++ b/repository.yml
@@ -21,6 +21,7 @@ repo.name: apache-mynewt-core
 repo.versions:
     "0.0.0": "develop"
     "0.7.9": "mynewt_0_8_0_b2_tag"
-    "0-latest": "0.7.9"
+    "0.8.0": "mynewt_0_8_0_tag"
+    "0-latest": "0.8.0"
     "0-dev": "0.0.0"
-    "0.8-latest": "0.7.9"
+    "0.8-latest": "0.8.0"

--- a/repository.yml
+++ b/repository.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+repo.name: apache-mynewt-core
+repo.versions:
+    "0.0.0": "develop"
+    "0.7.9": "mynewt_0_8_0_b2_tag"
+    "0-latest": "0.7.9"
+    "0-dev": "0.0.0"
+    "0.8-latest": "0.7.9"


### PR DESCRIPTION
Hi,
Mynewt already supports Arduino M0 Pro. But I noticed that it is not mentioned in the README.md