### PR TITLE
att: use offset when preparing Read Blob Response

### DIFF
--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -1589,7 +1589,8 @@ ble_att_svr_rx_read_blob(uint16_t conn_handle, struct os_mbuf **rxom)
         goto done;
     }
 
-    rc = ble_att_svr_build_read_blob_rsp(ctxt.attr_data, ctxt.data_len, mtu,
+    rc = ble_att_svr_build_read_blob_rsp(ctxt.attr_data + ctxt_offset,
+                                         ctxt.data_len - ctxt_offset, mtu,
                                          &txom, &att_err);
     if (rc != 0) {
         err_handle = req.babq_handle;


### PR DESCRIPTION
This remediates a bug wherein the offset of a Read Blob Request (from
the central) is ignored and the response always includes first MTU-1
bytes of the attribute value regardless of offset requested. As a
result, most hosts sit in an infinite loop incrementing the offset but
continually receiving the first MTU-1 bytes.

Note that this code has not been carefully tested for boundary
conditions.
