### PR TITLE
nffs bug fixes and enhancements

### DIFF
--- a/apps/ffs2native/src/main.c
+++ b/apps/ffs2native/src/main.c
@@ -53,6 +53,7 @@ int file_scratch_idx;
 #define MAX_AREAS    16
 static struct nffs_area_desc area_descs[MAX_AREAS];
 int nffs_version;
+int force_version;
 
 /** On-disk representation of a version 0 inode (file or directory). */
 struct nffs_disk_V0inode {
@@ -415,6 +416,7 @@ print_nffs_flash_V0object(struct nffs_area_desc *area, uint32_t off)
     uint32_t magic;
     int rc;
 
+    printf("print_nffs_flash_V0object(area:%d off%d)\n", area->nad_flash_id, off);
     rc = file_flash_read(area->nad_offset + off, &magic, sizeof magic);
     assert(rc == 0);
 
@@ -440,25 +442,35 @@ print_nffs_flash_inode(struct nffs_area_desc *area, uint32_t off)
     char filename[128];
     int len;
     int rc;
+    uint16_t crc16;
+    int badcrc = 0;
 
     rc = file_flash_read(area->nad_offset + off, &ndi, sizeof(ndi));
     assert(rc == 0);
+
+    crc16 = crc16_ccitt(0, (void*)&ndi, NFFS_DISK_INODE_OFFSET_CRC);
 
     memset(filename, 0, sizeof(filename));
     len = min(sizeof(filename) - 1, ndi.ndi_filename_len);
     rc = file_flash_read(area->nad_offset + off + sizeof(ndi), filename, len);
 
-    printf("  off %x %s id %x flen %d seq %d last %x prnt %x flgs %x %s\n",
+    crc16 = crc16_ccitt(crc16, filename, ndi.ndi_filename_len);
+    if (crc16 != ndi.ndi_crc16) {
+        badcrc = 1;
+    }
+
+    printf("  off %x %s id %x flen %d seq %d last %x prnt %x flgs %x %s%s\n",
            off,
            (nffs_hash_id_is_file(ndi.ndi_id) ? "File" :
-            (nffs_hash_id_is_dir(ndi.ndi_id) ? "Dir" : "???")),
+            nffs_hash_id_is_dir(ndi.ndi_id) ? "Dir" : "???"),
            ndi.ndi_id,
            ndi.ndi_filename_len,
            ndi.ndi_seq,
            ndi.ndi_lastblock_id,
            ndi.ndi_parent_id,
            ndi.ndi_flags,
-           filename);
+           filename,
+           badcrc ? " (Bad CRC!)" : "");
     return sizeof(ndi) + ndi.ndi_filename_len;
 }
 
@@ -467,34 +479,56 @@ print_nffs_flash_block(struct nffs_area_desc *area, uint32_t off)
 {
     struct nffs_disk_block ndb;
     int rc;
+    uint16_t crc16;
+    int badcrc = 0;
+    int dataover = 0;
 
     rc = file_flash_read(area->nad_offset + off, &ndb, sizeof(ndb));
     assert(rc == 0);
 
-    printf("  off %x Block id %x len %d seq %d prev %x own ino %x\n",
+    if (off + ndb.ndb_data_len > area->nad_length) {
+        dataover++;
+    } else {
+        crc16 = crc16_ccitt(0, (void*)&ndb, NFFS_DISK_BLOCK_OFFSET_CRC);
+        crc16 = crc16_ccitt(crc16,
+            (void*)(file_flash_area + area->nad_offset + off + sizeof(ndb)),
+            ndb.ndb_data_len);
+        if (crc16 != ndb.ndb_crc16) {
+            badcrc++;
+        }
+    }
+
+    printf("  off %x Block id %x len %d seq %d prev %x own ino %x%s%s\n",
            off,
            ndb.ndb_id,
            ndb.ndb_data_len,
            ndb.ndb_seq,
            ndb.ndb_prev_id,
-           ndb.ndb_inode_id);
+           ndb.ndb_inode_id,
+           dataover ? " (Bad data length)" : "",
+           badcrc ? " (Bad CRC!)" : "");
+    if (dataover) {
+        return 1;
+    }
     return sizeof(ndb) + ndb.ndb_data_len;
 }
 
 static int
 print_nffs_flash_object(struct nffs_area_desc *area, uint32_t off)
 {
-    struct nffs_disk_object ndo;
+    struct nffs_disk_inode *ndi;
+    struct nffs_disk_block *ndb;
 
-    file_flash_read(area->nad_offset + off, &ndo, sizeof(ndo));
+    ndi = (struct nffs_disk_inode*)(file_flash_area + area->nad_offset + off);
+    ndb = (struct nffs_disk_block*)ndi;
 
-    if (nffs_hash_id_is_inode(ndo.ndo_disk_inode.ndi_id)) {
+    if (nffs_hash_id_is_inode(ndi->ndi_id)) {
         return print_nffs_flash_inode(area, off);
 
-    } else if (nffs_hash_id_is_block(ndo.ndo_disk_block.ndb_id)) {
+    } else if (nffs_hash_id_is_block(ndb->ndb_id)) {
         return print_nffs_flash_block(area, off);
 
-    } else if (ndo.ndo_disk_block.ndb_id == 0xffffffff) {
+    } else if (ndb->ndb_id == 0xffffffff) {
         return area->nad_length;
 
     } else {
@@ -520,7 +554,11 @@ print_nffs_file_flash(char *flash_area, size_t size)
             area_descs[nad_cnt].nad_offset = (daptr - flash_area);
             area_descs[nad_cnt].nad_length = nda->nda_length;
             area_descs[nad_cnt].nad_flash_id = nda->nda_id;
-            nffs_version = nda->nda_ver;
+            if (force_version >= 0) {
+                nffs_version = force_version;
+            } else {
+                nffs_version = nda->nda_ver;
+            }
 
             if (nda->nda_id == 0xff)
                 file_scratch_idx = nad_cnt;
@@ -593,8 +631,9 @@ main(int argc, char **argv)
     int standalone = 0;
             
     progname = argv[0];
+    force_version = -1;
 
-    while ((ch = getopt(argc, argv, "c:d:f:sv")) != -1) {
+    while ((ch = getopt(argc, argv, "c:d:f:sv01")) != -1) {
         switch (ch) {
         case 'c':
             fp = fopen(optarg, "rb");
@@ -613,6 +652,12 @@ main(int argc, char **argv)
             break;
         case 'v':
             print_verbose++;
+            break;
+        case '0':
+            force_version = 0;
+            break;
+        case '1':
+            force_version = 1;
             break;
         case '?':
         default:

--- a/fs/fs/src/fsutil.c
+++ b/fs/fs/src/fsutil.c
@@ -49,7 +49,7 @@ fsutil_write_file(const char *path, const void *data, uint32_t len)
     struct fs_file *file;
     int rc;
 
-    rc = fs_open(path, FS_ACCESS_WRITE | FS_ACCESS_TRUNCATE, &file);
+    rc = fs_open(path, FS_ACCESS_WRITE, &file);
     if (rc != 0) {
         goto done;
     }

--- a/fs/nffs/src/nffs.c
+++ b/fs/nffs/src/nffs.c
@@ -118,6 +118,14 @@ nffs_unlock(void)
     assert(rc == 0 || rc == OS_NOT_STARTED);
 }
 
+static void
+nffs_stats_init(void)
+{
+    nffs_hashcnt_ins = 0;
+    nffs_hashcnt_rm = 0;
+    nffs_object_count = 0;
+}
+
 /**
  * Opens a file at the specified path.  The result of opening a nonexistent
  * file depends on the access flags specified.  All intermediate directories
@@ -623,6 +631,8 @@ nffs_init(void)
     nffs_config_init();
 
     nffs_cache_clear();
+
+    nffs_stats_init();
 
     rc = os_mutex_init(&nffs_mutex);
     if (rc != 0) {

--- a/fs/nffs/src/nffs_block.c
+++ b/fs/nffs/src/nffs_block.c
@@ -255,6 +255,9 @@ nffs_block_delete_from_ram(struct nffs_hash_entry *block_entry)
     if (rc == 0 || rc == FS_ECORRUPT) {
         /* If file system corruption was detected, the resulting block is still
          * valid and can be removed from RAM.
+         * Note that FS_CORRUPT can occur because the owning inode was not
+         * found in the hash table - this can occur during the sweep where
+         * the inodes were deleted ahead of the blocks.
          */
         inode_entry = block.nb_inode_entry;
         if (inode_entry != NULL &&

--- a/fs/nffs/src/nffs_cache.c
+++ b/fs/nffs/src/nffs_cache.c
@@ -313,10 +313,10 @@ nffs_cache_log_block(struct nffs_cache_inode *cache_inode,
 {
     NFFS_LOG(DEBUG, "id=%u inode=%u flash_off=0x%08x "
                     "file_off=%u len=%d (entry=%p)\n",
-             cache_block->ncb_block.nb_hash_entry->nhe_id,
-             cache_inode->nci_inode.ni_inode_entry->nie_hash_entry.nhe_id,
-             cache_block->ncb_block.nb_hash_entry->nhe_flash_loc,
-             cache_block->ncb_file_offset,
+             (unsigned int)cache_block->ncb_block.nb_hash_entry->nhe_id,
+             (unsigned int)cache_inode->nci_inode.ni_inode_entry->nie_hash_entry.nhe_id,
+             (unsigned int)cache_block->ncb_block.nb_hash_entry->nhe_flash_loc,
+             (unsigned int)cache_block->ncb_file_offset,
              cache_block->ncb_block.nb_data_len,
              cache_block->ncb_block.nb_hash_entry);
 }

--- a/fs/nffs/src/nffs_hash.c
+++ b/fs/nffs/src/nffs_hash.c
@@ -156,6 +156,7 @@ nffs_hash_insert(struct nffs_hash_entry *entry)
     list = nffs_hash + idx;
 
     SLIST_INSERT_HEAD(list, entry, nhe_next);
+    nffs_hashcnt_ins++;
 
     if (nffs_hash_id_is_inode(entry->nhe_id)) {
         nie = nffs_hash_find_inode(entry->nhe_id);
@@ -185,6 +186,7 @@ nffs_hash_remove(struct nffs_hash_entry *entry)
     list = nffs_hash + idx;
 
     SLIST_REMOVE(list, entry, nffs_hash_entry, nhe_next);
+    nffs_hashcnt_rm++;
 
     if (nffs_hash_id_is_inode(entry->nhe_id) && nie) {
         nffs_inode_unsetflags(nie, NFFS_INODE_FLAG_INHASH);

--- a/fs/nffs/src/nffs_inode.c
+++ b/fs/nffs/src/nffs_inode.c
@@ -114,6 +114,9 @@ nffs_inode_write_disk(const struct nffs_disk_inode *disk_inode,
 {
     int rc;
 
+    /* Only the DELETED flag is ever written out to flash */
+    assert((disk_inode->ndi_flags & ~NFFS_INODE_FLAG_DELETED) == 0);
+
     rc = nffs_flash_write(area_idx, area_offset, disk_inode,
                           sizeof *disk_inode);
     if (rc != 0) {
@@ -611,6 +614,7 @@ nffs_inode_rename(struct nffs_inode_entry *inode_entry,
     disk_inode.ndi_id = inode_entry->nie_hash_entry.nhe_id;
     disk_inode.ndi_seq = inode.ni_seq + 1;
     disk_inode.ndi_parent_id = nffs_inode_parent_id(&inode);
+    disk_inode.ndi_flags = 0;
     disk_inode.ndi_filename_len = filename_len;
     if (inode_entry->nie_last_block_entry &&
         inode_entry->nie_last_block_entry->nhe_id != NFFS_ID_NONE)

--- a/fs/nffs/src/nffs_priv.h
+++ b/fs/nffs/src/nffs_priv.h
@@ -236,6 +236,10 @@ struct nffs_dir {
     struct nffs_dirent nd_dirent;
 };
 
+uint32_t nffs_hashcnt_ins;
+uint32_t nffs_hashcnt_rm;
+uint32_t nffs_object_count;
+
 extern void *nffs_file_mem;
 extern void *nffs_block_entry_mem;
 extern void *nffs_inode_mem;


### PR DESCRIPTION
These changes were made to address jira issue mynewt-343. A couple of bugs were
fixed include the removal of an incorrect assert in nffs_restore_inode(), and
resetting the sweep when a block is removed in nffs_restore_sweep(). Also:
* bug fix in how V1 filesystems are parsed in ffs2native app. CRC check added for each record.
* fsutil_write_file() was update to not automatically cause files to truncate to zero bytes on write
* nffs_stats() routine was added to track how many objects were parsed and are in the hash table. 
