### PR TITLE
ATT: send a Read By Group Type Response in the case of BLE_HS_EMSGSIZE

### DIFF
--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -2071,7 +2071,7 @@ ble_att_svr_rx_read_group_type(uint16_t conn_handle, struct os_mbuf **rxom)
 
     rc = ble_att_svr_build_read_group_type_rsp(conn_handle, &req, uuid128,
                                                &txom, &att_err, &err_handle);
-    if (rc != 0) {
+    if (rc != 0 && rc != BLE_HS_EMSGSIZE) {
         goto done;
     }
 


### PR DESCRIPTION
Read By Group Type Response messages can raise BLE_HS_EMSGSIZE when the
response is large and the MTU is small. In this case the message built
by ble_att_svr_build_read_group_type_rsp() is valid and complete
(despite the error-looking return value), and should be sent to the
remote party.
