### PR TITLE
Don't read on-flash structures that extend beyond flash area

### DIFF
--- a/apps/ffs2native/src/main.c
+++ b/apps/ffs2native/src/main.c
@@ -544,6 +544,7 @@ print_nffs_file_flash(char *flash_area, size_t size)
     struct nffs_disk_area *nda;
     int nad_cnt = 0;    /* Nffs Area Descriptor count */
     int off;
+    int objsz;
 
     daptr = flash_area;
     eoda = flash_area + size;
@@ -576,8 +577,13 @@ print_nffs_file_flash(char *flash_area, size_t size)
                    nda->nda_ver != NFFS_AREA_VER ? " (V0)" : "",
                    nad_cnt == file_scratch_idx ? " (Scratch)" : "");
 
+            if (nffs_version == 0) {
+                objsz = sizeof (struct nffs_disk_V0object);
+            } else {
+                objsz = sizeof (struct nffs_disk_object);
+            }
             off = sizeof (struct nffs_disk_area);
-            while (off < area_descs[nad_cnt].nad_length) {
+            while (off + objsz < area_descs[nad_cnt].nad_length) {
                 if (nffs_version == 0) {
                     off += print_nffs_flash_V0object(&area_descs[nad_cnt], off);
                 } else if (nffs_version == NFFS_AREA_VER) {


### PR DESCRIPTION
Data at the end of a flash area could be incorrectly parsed as valid structures.
Code was added to check for runoff past end of area.