### PR TITLE
Console shell

### DIFF
--- a/libs/console/full/include/console/console.h
+++ b/libs/console/full/include/console/console.h
@@ -20,7 +20,6 @@
 #define __CONSOLE_H__
 
 #include <stdarg.h>
-//#include "console/prompt.h"
 
 typedef void (*console_rx_cb)(void);
 

--- a/libs/console/full/include/console/prompt.h
+++ b/libs/console/full/include/console/prompt.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -16,24 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #ifndef __CONSOLE_H__
 #define __CONSOLE_H__
 
 #include <stdarg.h>
-//#include "console/prompt.h"
 
-typedef void (*console_rx_cb)(void);
 
-int console_init(console_rx_cb rx_cb);
-int console_is_init(void);
-void console_write(const char *str, int cnt);
-int console_read(char *str, int cnt, int *newline);
-void console_blocking_mode(void);
-void console_echo(int on);
+/* print console prompt */
+void console_print_prompt();
+/* set the console prompt character */
+void console_set_prompt(char);
 
-void console_printf(const char *fmt, ...)
-    __attribute__ ((format (printf, 1, 2)));;
 
-extern int console_is_midline;
+extern char console_prompt[2];
+
 
 #endif /* __CONSOLE_H__ */

--- a/libs/console/full/src/cons_tty.c
+++ b/libs/console/full/src/cons_tty.c
@@ -21,7 +21,9 @@
 #include "os/os.h"
 #include "hal/hal_uart.h"
 #include "bsp/bsp.h"
+
 #include "console/console.h"
+#include "console/prompt.h"
 
 int g_console_is_init;
 
@@ -43,6 +45,7 @@ int console_is_midline;
 #define CONSOLE_TAIL_INC(cr)	(((cr)->cr_tail + 1) & ((cr)->cr_size - 1))
 
 typedef void (*console_write_char)(char);
+void console_print_prompt(void);
 
 struct console_ring {
     uint8_t cr_head;
@@ -392,6 +395,7 @@ console_init(console_rx_cb rx_cb)
     }
 
     g_console_is_init = 1;
-
+    console_print_prompt();
+    
     return 0;
 }

--- a/libs/console/full/src/prompt.c
+++ b/libs/console/full/src/prompt.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -16,24 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __CONSOLE_H__
-#define __CONSOLE_H__
 
-#include <stdarg.h>
-//#include "console/prompt.h"
 
-typedef void (*console_rx_cb)(void);
+#include "console/console.h"
+#include "console/prompt.h"
 
-int console_init(console_rx_cb rx_cb);
-int console_is_init(void);
-void console_write(const char *str, int cnt);
-int console_read(char *str, int cnt, int *newline);
-void console_blocking_mode(void);
-void console_echo(int on);
+/* console prompt, always followed by a space */
+char console_prompt[3] = {' ', '>', ' '};
 
-void console_printf(const char *fmt, ...)
-    __attribute__ ((format (printf, 1, 2)));;
 
-extern int console_is_midline;
+/* set the prompt character, leave the space */
+void 
+console_set_prompt(char p)
+{
+    console_prompt[1] = p;
+}
 
-#endif /* __CONSOLE_H__ */
+/* print the prompt to the console */
+void
+console_print_prompt(void)
+{
+    console_printf(console_prompt);
+}

--- a/libs/console/stub/include/console/console_prompt.h
+++ b/libs/console/stub/include/console/console_prompt.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -16,24 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #ifndef __CONSOLE_H__
 #define __CONSOLE_H__
 
 #include <stdarg.h>
-//#include "console/prompt.h"
 
-typedef void (*console_rx_cb)(void);
 
-int console_init(console_rx_cb rx_cb);
-int console_is_init(void);
-void console_write(const char *str, int cnt);
-int console_read(char *str, int cnt, int *newline);
-void console_blocking_mode(void);
-void console_echo(int on);
+/* print console prompt */
+void console_print_prompt(void);
+/* set the console prompt character */
+void console_set_prompt(char);
 
-void console_printf(const char *fmt, ...)
-    __attribute__ ((format (printf, 1, 2)));;
 
-extern int console_is_midline;
+extern char console_prompt[2];
+
 
 #endif /* __CONSOLE_H__ */

--- a/libs/shell/include/shell/shell.h
+++ b/libs/shell/include/shell/shell.h
@@ -43,4 +43,7 @@ void shell_console_rx_cb(void);
 int shell_task_init(uint8_t prio, os_stack_t *stack, uint16_t stack_size,
                     int max_input_length);
 
+int shell_cmd_list_lock(void);
+int shell_cmd_list_unlock(void);
+
 #endif /* __SHELL_H__ */

--- a/libs/shell/include/shell/shell_prompt.h
+++ b/libs/shell/include/shell/shell_prompt.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -16,24 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __CONSOLE_H__
-#define __CONSOLE_H__
 
-#include <stdarg.h>
-//#include "console/prompt.h"
 
-typedef void (*console_rx_cb)(void);
 
-int console_init(console_rx_cb rx_cb);
-int console_is_init(void);
-void console_write(const char *str, int cnt);
-int console_read(char *str, int cnt, int *newline);
-void console_blocking_mode(void);
-void console_echo(int on);
+int shell_prompt_cmd(int argc, char **argv);
 
-void console_printf(const char *fmt, ...)
-    __attribute__ ((format (printf, 1, 2)));;
-
-extern int console_is_midline;
-
-#endif /* __CONSOLE_H__ */

--- a/libs/shell/src/shell_prompt.c
+++ b/libs/shell/src/shell_prompt.c
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include "shell/shell.h"
+#include <console/console.h>
+
+static char shell_prompt = '>';
+
+void console_set_prompt(char p);
+
+/**
+ * Handles the 'prompt' command
+ * with set argument, sets the prompt to the provided char
+ * with the show argument, echos the current prompt
+ * otherwise echos the prompt and the usage message
+ */
+int
+shell_prompt_cmd(int argc, char **argv)
+{
+    int rc;
+
+    rc = shell_cmd_list_lock();
+    if (rc != 0) {
+        return -1;
+    }
+    if(argc > 1){
+        if(!strcmp(argv[1], "show")){
+            console_printf("Prompt character: %c\n", shell_prompt);
+        }   
+        else if (!strcmp(argv[1],"set")){
+            shell_prompt = argv[2][0];
+            console_printf("Prompt set to: %c\n", argv[2][0]);
+            console_set_prompt(argv[2][0]);
+        }
+        else {
+            goto usage;
+        }
+        
+    } 
+    else {
+        goto usage;
+        
+    }
+usage:
+    console_printf("Usage: prompt [set|show] [prompt_char]\n");
+    
+    shell_cmd_list_unlock();
+    
+    return (0);
+  
+}
+ 


### PR DESCRIPTION
I moved all the prompt-printing stuff to their own files. Timestamps are printed before each prompt, and timestamps before output is working as expected. 

newtmgr tests run on nrf52dk board and they work as expected. 