### PR TITLE
Fixed bug where ID was always wrong in response

### DIFF
--- a/libs/newtmgr/src/newtmgr.c
+++ b/libs/newtmgr/src/newtmgr.c
@@ -472,7 +472,6 @@ nmgr_handle_req(struct nmgr_transport *nt, struct os_mbuf *req)
 
         rsp_hdr->nh_len = htons(rsp_hdr->nh_len);
         rsp_hdr->nh_group = htons(rsp_hdr->nh_group);
-        rsp_hdr->nh_id = htons(rsp_hdr->nh_id);
 
         off += sizeof(hdr) + OS_ALIGN(hdr.nh_len, 4);
     }


### PR DESCRIPTION
Fixes The newtmgr response notification's ID field always being 0. The ID field is only 1 byte so there is no reason to reverse the endianness.