### PR TITLE
Bugfix to remove nffs hash entries on error conditions

### DIFF
--- a/fs/nffs/pkg.yml
+++ b/fs/nffs/pkg.yml
@@ -33,3 +33,4 @@ pkg.deps:
     - libs/os
     - libs/testutil
     - sys/log
+    - sys/stats

--- a/fs/nffs/src/nffs_block.c
+++ b/fs/nffs/src/nffs_block.c
@@ -89,6 +89,7 @@ nffs_block_read_disk(uint8_t area_idx, uint32_t area_offset,
 {
     int rc;
 
+    STATS_INC(nffs_stats, nffs_readcnt_block);
     rc = nffs_flash_read(area_idx, area_offset, out_disk_block,
                          sizeof *out_disk_block);
     if (rc != 0) {
@@ -436,6 +437,7 @@ nffs_block_read_data(const struct nffs_block *block, uint16_t offset,
     area_offset += sizeof (struct nffs_disk_block);
     area_offset += offset;
 
+    STATS_INC(nffs_stats, nffs_readcnt_data);
     rc = nffs_flash_read(area_idx, area_offset, dst, length);
     if (rc != 0) {
         return rc;

--- a/fs/nffs/src/nffs_crc.c
+++ b/fs/nffs/src/nffs_crc.c
@@ -37,6 +37,7 @@ nffs_crc_flash(uint16_t initial_crc, uint8_t area_idx, uint32_t area_offset,
             chunk_len = len;
         }
 
+        STATS_INC(nffs_stats, nffs_readcnt_crc);
         rc = nffs_flash_read(area_idx, area_offset, nffs_flash_buf, chunk_len);
         if (rc != 0) {
             return rc;

--- a/fs/nffs/src/nffs_flash.c
+++ b/fs/nffs/src/nffs_flash.c
@@ -54,6 +54,7 @@ nffs_flash_read(uint8_t area_idx, uint32_t area_offset, void *data,
         return FS_EOFFSET;
     }
 
+    STATS_INC(nffs_stats, nffs_iocnt_read);
     rc = hal_flash_read(area->na_flash_id, area->na_offset + area_offset, data,
                         len);
     if (rc != 0) {
@@ -95,6 +96,7 @@ nffs_flash_write(uint8_t area_idx, uint32_t area_offset, const void *data,
         return FS_EOFFSET;
     }
 
+    STATS_INC(nffs_stats, nffs_iocnt_write);
     rc = hal_flash_write(area->na_flash_id, area->na_offset + area_offset,
                          data, len);
     if (rc != 0) {
@@ -133,6 +135,7 @@ nffs_flash_copy(uint8_t area_idx_from, uint32_t area_offset_from,
             chunk_len = len;
         }
 
+        STATS_INC(nffs_stats, nffs_readcnt_copy);
         rc = nffs_flash_read(area_idx_from, area_offset_from, nffs_flash_buf,
                              chunk_len);
         if (rc != 0) {

--- a/fs/nffs/src/nffs_format.c
+++ b/fs/nffs/src/nffs_format.c
@@ -35,6 +35,7 @@ nffs_format_from_scratch_area(uint8_t area_idx, uint8_t area_id)
     int rc;
 
     assert(area_idx < nffs_num_areas);
+    STATS_INC(nffs_stats, nffs_readcnt_format);
     rc = nffs_flash_read(area_idx, 0, &disk_area, sizeof disk_area);
     if (rc != 0) {
         return rc;

--- a/fs/nffs/src/nffs_gc.c
+++ b/fs/nffs/src/nffs_gc.c
@@ -210,6 +210,7 @@ nffs_gc_block_chain_collate(struct nffs_hash_entry *last_entry,
         nffs_flash_loc_expand(block.nb_hash_entry->nhe_flash_loc,
                               &from_area_idx, &from_area_offset);
         from_area_offset += sizeof disk_block;
+        STATS_INC(nffs_stats, nffs_readcnt_gccollate);
         rc = nffs_flash_read(from_area_idx, from_area_offset,
                              data + data_offset, block.nb_data_len);
         if (rc != 0) {
@@ -534,6 +535,7 @@ nffs_gc(uint8_t *out_area_idx)
      * reset its pointers to cached objects.
      */
     nffs_gc_count++;
+    STATS_INC(nffs_stats, nffs_gccnt);
 
     return 0;
 }

--- a/fs/nffs/src/nffs_hash.c
+++ b/fs/nffs/src/nffs_hash.c
@@ -156,7 +156,7 @@ nffs_hash_insert(struct nffs_hash_entry *entry)
     list = nffs_hash + idx;
 
     SLIST_INSERT_HEAD(list, entry, nhe_next);
-    nffs_hashcnt_ins++;
+    STATS_INC(nffs_stats, nffs_hashcnt_ins);
 
     if (nffs_hash_id_is_inode(entry->nhe_id)) {
         nie = nffs_hash_find_inode(entry->nhe_id);
@@ -186,7 +186,7 @@ nffs_hash_remove(struct nffs_hash_entry *entry)
     list = nffs_hash + idx;
 
     SLIST_REMOVE(list, entry, nffs_hash_entry, nhe_next);
-    nffs_hashcnt_rm++;
+    STATS_INC(nffs_stats, nffs_hashcnt_rm);
 
     if (nffs_hash_id_is_inode(entry->nhe_id) && nie) {
         nffs_inode_unsetflags(nie, NFFS_INODE_FLAG_INHASH);

--- a/fs/nffs/src/nffs_misc.c
+++ b/fs/nffs/src/nffs_misc.c
@@ -153,6 +153,7 @@ nffs_misc_gc_if_oom(void *resource, int *out_rc)
     /* Attempt a garbage collection on the next area. */
     *out_rc = nffs_gc(NULL);
     total_gc_cycles++;
+    STATS_INC(nffs_stats, nffs_gccnt);
     if (*out_rc != 0) {
         return 0;
     }

--- a/fs/nffs/src/nffs_priv.h
+++ b/fs/nffs/src/nffs_priv.h
@@ -27,6 +27,7 @@
 #include "nffs/nffs.h"
 #include "fs/fs.h"
 #include "util/crc16.h"
+#include "stats/stats.h"
 
 #define NFFS_HASH_SIZE               256
 
@@ -124,7 +125,8 @@ struct nffs_inode_entry {
     };
     uint8_t nie_refcnt;
     uint8_t nie_flags;
-    uint16_t reserved16;
+    uint8_t nie_blkcnt;
+    uint8_t reserved8;
 };
 
 #define    NFFS_INODE_FLAG_FREE        0x00
@@ -174,6 +176,7 @@ struct nffs_area {
     uint16_t na_id;
     uint8_t na_gc_seq;
     uint8_t na_flash_id;
+    uint32_t na_obsolete;   /* deleted bytecount */
 };
 
 struct nffs_disk_object {
@@ -236,9 +239,28 @@ struct nffs_dir {
     struct nffs_dirent nd_dirent;
 };
 
-extern uint32_t nffs_hashcnt_ins;
-extern uint32_t nffs_hashcnt_rm;
-extern uint32_t nffs_object_count;
+STATS_SECT_START(nffs_stats)
+    STATS_SECT_ENTRY(nffs_hashcnt_ins)
+    STATS_SECT_ENTRY(nffs_hashcnt_rm)
+    STATS_SECT_ENTRY(nffs_object_count)
+    STATS_SECT_ENTRY(nffs_iocnt_read)
+    STATS_SECT_ENTRY(nffs_iocnt_write)
+    STATS_SECT_ENTRY(nffs_gccnt)
+    STATS_SECT_ENTRY(nffs_readcnt_data)
+    STATS_SECT_ENTRY(nffs_readcnt_block)
+    STATS_SECT_ENTRY(nffs_readcnt_crc)
+    STATS_SECT_ENTRY(nffs_readcnt_copy)
+    STATS_SECT_ENTRY(nffs_readcnt_format)
+    STATS_SECT_ENTRY(nffs_readcnt_gccollate)
+    STATS_SECT_ENTRY(nffs_readcnt_inode)
+    STATS_SECT_ENTRY(nffs_readcnt_inodeent)
+    STATS_SECT_ENTRY(nffs_readcnt_rename)
+    STATS_SECT_ENTRY(nffs_readcnt_update)
+    STATS_SECT_ENTRY(nffs_readcnt_filename)
+    STATS_SECT_ENTRY(nffs_readcnt_object)
+    STATS_SECT_ENTRY(nffs_readcnt_detect)
+STATS_SECT_END
+extern STATS_SECT_DECL(nffs_stats) nffs_stats;
 
 extern void *nffs_file_mem;
 extern void *nffs_block_entry_mem;

--- a/sys/stats/src/stats.c
+++ b/sys/stats/src/stats.c
@@ -149,7 +149,7 @@ int
 stats_init(struct stats_hdr *shdr, uint8_t size, uint8_t cnt,
         struct stats_name_map *map, uint8_t map_cnt)
 {
-    memset((uint8_t *) shdr, 0, sizeof(*shdr) + (size * cnt));
+    memset((uint8_t *) shdr+sizeof(*shdr), 0, size * cnt);
 
     shdr->s_size = size;
     shdr->s_cnt = cnt;


### PR DESCRIPTION
This addresses a bug where file hash entries allocated during nffs restore were not removed from the hash table if the entry was freed. Also, statistics are maintained for different types of flash reads.