### PR TITLE
Change logging format to use 16-bit log index

### DIFF
--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -55,7 +55,6 @@ struct os_mbuf_pool blecent_mbuf_pool;
 struct os_mempool blecent_mbuf_mpool;
 
 /** Log data. */
-static struct log_handler blecent_log_console_handler;
 struct log blecent_log;
 
 /** Priority of the nimble host and controller tasks. */
@@ -557,8 +556,7 @@ main(void)
 
     /* Initialize the logging system. */
     log_init();
-    log_console_handler_init(&blecent_log_console_handler);
-    log_register("blecent", &blecent_log, &blecent_log_console_handler);
+    log_register("blecent", &blecent_log, &log_console_handler, NULL);
 
     /* Initialize the eventq for the application task. */
     os_eventq_init(&blecent_evq);

--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -69,7 +69,6 @@ struct os_mbuf_pool bleprph_mbuf_pool;
 struct os_mempool bleprph_mbuf_mpool;
 
 /** Log data. */
-static struct log_handler bleprph_log_console_handler;
 struct log bleprph_log;
 
 /** Priority of the nimble host and controller tasks. */
@@ -381,8 +380,7 @@ main(void)
 
     /* Initialize the logging system. */
     log_init();
-    log_console_handler_init(&bleprph_log_console_handler);
-    log_register("bleprph", &bleprph_log, &bleprph_log_console_handler);
+    log_register("bleprph", &bleprph_log, &log_console_handler, NULL);
 
     /* Initialize eventq */
     os_eventq_init(&bleprph_evq);

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -1044,9 +1044,10 @@ bletiny_gap_event(struct ble_gap_event *event, void *arg)
 }
 
 static void
-bletiny_on_l2cap_update(int status, void *arg)
+bletiny_on_l2cap_update(uint16_t conn_handle, int status, void *arg)
 {
-    console_printf("l2cap update complete; status=%d\n", status);
+    console_printf("l2cap update complete; conn_handle=%d status=%d\n",
+                   conn_handle, status);
 }
 
 static void

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -112,7 +112,6 @@ struct os_eventq bletiny_evq;
 struct os_task bletiny_task;
 bssnz_t os_stack_t bletiny_stack[BLETINY_STACK_SIZE];
 
-static struct log_handler bletiny_log_console_handler;
 struct log bletiny_log;
 
 bssnz_t struct bletiny_conn bletiny_conns[NIMBLE_OPT(MAX_CONNECTIONS)];
@@ -1685,8 +1684,7 @@ main(void)
 
     /* Initialize the logging system. */
     log_init();
-    log_console_handler_init(&bletiny_log_console_handler);
-    log_register("bletiny", &bletiny_log, &bletiny_log_console_handler);
+    log_register("bletiny", &bletiny_log, &log_console_handler, NULL);
 
     /* Initialize eventq for the application task. */
     os_eventq_init(&bletiny_evq);

--- a/apps/ffs2native/src/main.c
+++ b/apps/ffs2native/src/main.c
@@ -40,7 +40,6 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
-static struct log_handler nffs_log_console_handler;
 struct log nffs_log;
 static const char *copy_in_dir;
 static const char *progname;
@@ -684,8 +683,7 @@ main(int argc, char **argv)
     assert(rc == 0);
 
     log_init();
-    log_console_handler_init(&nffs_log_console_handler);
-    log_register("nffs-log", &nffs_log, &nffs_log_console_handler);
+    log_register("nffs-log", &nffs_log, &log_console_handler, NULL);
 
     file_scratch_idx = MAX_AREAS + 1;
 

--- a/apps/slinky/src/main.c
+++ b/apps/slinky/src/main.c
@@ -79,8 +79,8 @@ static struct os_task task2;
 #define NEWTMGR_TASK_PRIO (4)
 #define NEWTMGR_TASK_STACK_SIZE (OS_STACK_ALIGN(896))
 
-static struct log_handler log_cbmem_handler;
 static struct log my_log;
+extern struct log nffs_log; /* defined in the OS module */
 
 static volatile int g_task2_loops;
 
@@ -147,6 +147,9 @@ static uint8_t test8_shadow;
 static char test_str[32];
 static uint32_t cbmem_buf[MAX_CBMEM_BUF];
 static struct cbmem cbmem;
+
+static uint32_t nffs_cbmem_buf[MAX_CBMEM_BUF];
+static struct cbmem nffs_cbmem;
 
 static char *
 test_conf_get(int argc, char **argv, char *buf, int max_len)
@@ -372,8 +375,9 @@ main(int argc, char **argv)
 
     log_init();
     cbmem_init(&cbmem, cbmem_buf, MAX_CBMEM_BUF);
-    log_cbmem_handler_init(&log_cbmem_handler, &cbmem);
-    log_register("log", &my_log, &log_cbmem_handler);
+    cbmem_init(&nffs_cbmem, nffs_cbmem_buf, MAX_CBMEM_BUF);
+    log_register("log", &my_log, &log_cbmem_handler, &cbmem);
+    log_register("nffs", &nffs_log, &log_cbmem_handler, &nffs_cbmem);
 
     os_init();
 
@@ -422,7 +426,7 @@ main(int argc, char **argv)
 
     flash_test_init();
 
-    reboot_init_handler(LOG_TYPE_STORAGE, 10);
+    reboot_init_handler(LOG_STORE_FCB, 11);
 
 #if defined SPLIT_LOADER || defined SPLIT_APPLICATION
     split_app_init();

--- a/apps/splitty/src/main.c
+++ b/apps/splitty/src/main.c
@@ -78,7 +78,6 @@ static struct os_task task2;
 #define NEWTMGR_TASK_PRIO (4)
 #define NEWTMGR_TASK_STACK_SIZE (OS_STACK_ALIGN(896))
 
-static struct log_handler log_cbmem_handler;
 static struct log my_log;
 
 static volatile int g_task2_loops;
@@ -307,8 +306,7 @@ main(int argc, char **argv)
 
     log_init();
     cbmem_init(&cbmem, cbmem_buf, MAX_CBMEM_BUF);
-    log_cbmem_handler_init(&log_cbmem_handler, &cbmem);
-    log_register("log", &my_log, &log_cbmem_handler);
+    log_register("log", &my_log, &log_cbmem_handler, &cbmem);
 
     os_init();
 

--- a/fs/nffs/src/nffs.c
+++ b/fs/nffs/src/nffs.c
@@ -55,7 +55,6 @@ struct nffs_inode_entry *nffs_lost_found_dir;
 
 static struct os_mutex nffs_mutex;
 
-static struct log_handler nffs_log_console_handler;
 struct log nffs_log;
 
 static int nffs_open(const char *path, uint8_t access_flags,
@@ -725,14 +724,12 @@ nffs_init(void)
         return FS_ENOMEM;
     }
 
-    log_init();
-    log_console_handler_init(&nffs_log_console_handler);
-    log_register("nffs", &nffs_log, &nffs_log_console_handler);
-
     rc = nffs_misc_reset();
     if (rc != 0) {
         return rc;
     }
+
+    NFFS_LOG(DEBUG, "nffs_init");
 
     fs_register(&nffs_ops);
     return 0;

--- a/fs/nffs/src/nffs_priv.h
+++ b/fs/nffs/src/nffs_priv.h
@@ -504,10 +504,10 @@ int nffs_write_to_file(struct nffs_file *file, const void *data, int len);
 
 #define NFFS_FLASH_LOC_NONE  nffs_flash_loc(NFFS_AREA_ID_NONE, 0)
 
-#ifdef NFFS_DEBUG
+#ifdef ARCH_sim
 #include <stdio.h>
 #define NFFS_LOG(lvl, ...) \
-      printf(__VA_ARGS__)
+    printf(__VA_ARGS__)
 #else
 #define NFFS_LOG(lvl, ...) \
     LOG_ ## lvl(&nffs_log, LOG_MODULE_NFFS, __VA_ARGS__)

--- a/hw/bsp/arduino_primo_nrf52/primo_download.sh
+++ b/hw/bsp/arduino_primo_nrf52/primo_download.sh
@@ -72,6 +72,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 if [ $USE_OPENOCD -eq 1 ]; then
     #
     # XXXX note that this is using openocd through STM32, with openocd

--- a/hw/bsp/arduino_primo_nrf52/src/arch/cortex_m4/gcc_startup_nrf52.s
+++ b/hw/bsp/arduino_primo_nrf52/src/arch/cortex_m4/gcc_startup_nrf52.s
@@ -138,6 +138,10 @@ __isr_vector:
 Reset_Handler:
     .fnstart
 
+    /* This is called but current_slot is in the data section so it is
+     * overwritten. its only called here to ensure that the global and this
+     * function are linked into the loader */
+    BL      bsp_slot_init_split_application
 
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
@@ -167,11 +171,6 @@ Reset_Handler:
 
     LDR     R0, =SystemInit
     BLX     R0
-
-    /* This is called but current_slot is in the data section so it is
-     * overwritten. its only called here to ensure that the global and this
-     * function are linked into the loader */
-    BL      bsp_slot_init_split_application
 
     LDR     R0, =_start
     BX      R0

--- a/hw/bsp/bmd300eval/bmd300eval_download.sh
+++ b/hw/bsp/bmd300eval/bmd300eval_download.sh
@@ -67,6 +67,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/bsp/bmd300eval/src/arch/cortex_m4/gcc_startup_nrf52.s
+++ b/hw/bsp/bmd300eval/src/arch/cortex_m4/gcc_startup_nrf52.s
@@ -138,6 +138,11 @@ __isr_vector:
 Reset_Handler:
     .fnstart
 
+    /* This is called but current_slot is in the data section so it is
+     * overwritten. its only called here to ensure that the global and this
+     * function are linked into the loader */
+    BL      bsp_slot_init_split_application
+
 
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
@@ -167,11 +172,6 @@ Reset_Handler:
 
     LDR     R0, =SystemInit
     BLX     R0
-
-    /* This is called but current_slot is in the data section so it is
-     * overwritten. its only called here to ensure that the global and this
-     * function are linked into the loader */
-    BL      bsp_slot_init_split_application
 
     LDR     R0, =_start
     BX      R0

--- a/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_download.sh
+++ b/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_download.sh
@@ -54,6 +54,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/bsp/nrf51-blenano/nrf51dk_download.sh
+++ b/hw/bsp/nrf51-blenano/nrf51dk_download.sh
@@ -67,6 +67,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/bsp/nrf51-blenano/src/arch/cortex_m0/gcc_startup_nrf51.s
+++ b/hw/bsp/nrf51-blenano/src/arch/cortex_m0/gcc_startup_nrf51.s
@@ -149,6 +149,11 @@ Reset_Handler:
     ORRS    R2, R1
     STR     R2, [R0]
 
+    /* This is called but current_slot is in the data section so it is
+     * overwritten. its only called here to ensure that the global and this
+     * function are linked into the loader */
+    BL      bsp_slot_init_split_application
+
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
  *      linker script.
@@ -172,11 +177,6 @@ Reset_Handler:
     LDR     R0, =__HeapBase
     LDR     R1, =__HeapLimit
     BL      _sbrkInit
-
-    /* This is called but current_slot is in the data section so it is
-     * overwritten. its only called here to ensure that the global and this
-     * function are linked into the loader */
-    BL      bsp_slot_init_split_application
 
     LDR     R0, =SystemInit
     BLX     R0

--- a/hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_download.sh
+++ b/hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_download.sh
@@ -67,6 +67,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/bsp/nrf51dk-16kbram/src/arch/cortex_m0/gcc_startup_nrf51.s
+++ b/hw/bsp/nrf51dk-16kbram/src/arch/cortex_m0/gcc_startup_nrf51.s
@@ -149,6 +149,11 @@ Reset_Handler:
     ORRS    R2, R1
     STR     R2, [R0]
 
+    /* This is called but current_slot is in the data section so it is
+     * overwritten. its only called here to ensure that the global and this
+     * function are linked into the loader */
+    BL      bsp_slot_init_split_application
+
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
  *      linker script.
@@ -172,11 +177,6 @@ Reset_Handler:
     LDR     R0, =__HeapBase
     LDR     R1, =__HeapLimit
     BL      _sbrkInit
-
-    /* This is called but current_slot is in the data section so it is
-     * overwritten. its only called here to ensure that the global and this
-     * function are linked into the loader */
-    BL      bsp_slot_init_split_application
 
     LDR     R0, =SystemInit
     BLX     R0

--- a/hw/bsp/nrf51dk/nrf51dk_download.sh
+++ b/hw/bsp/nrf51dk/nrf51dk_download.sh
@@ -67,6 +67,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/bsp/nrf51dk/src/arch/cortex_m0/gcc_startup_nrf51.s
+++ b/hw/bsp/nrf51dk/src/arch/cortex_m0/gcc_startup_nrf51.s
@@ -149,6 +149,11 @@ Reset_Handler:
     ORRS    R2, R1
     STR     R2, [R0]
 
+    /* This is called but current_slot is in the data section so it is
+     * overwritten. its only called here to ensure that the global and this
+     * function are linked into the loader */
+    BL      bsp_slot_init_split_application
+
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
  *      linker script.
@@ -172,11 +177,6 @@ Reset_Handler:
     LDR     R0, =__HeapBase
     LDR     R1, =__HeapLimit
     BL      _sbrkInit
-
-    /* This is called but current_slot is in the data section so it is
-     * overwritten. its only called here to ensure that the global and this
-     * function are linked into the loader */
-    BL      bsp_slot_init_split_application
 
     LDR     R0, =SystemInit
     BLX     R0

--- a/hw/bsp/nrf52dk/nrf52dk_download.sh
+++ b/hw/bsp/nrf52dk/nrf52dk_download.sh
@@ -67,6 +67,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/bsp/nrf52dk/src/arch/cortex_m4/gcc_startup_nrf52.s
+++ b/hw/bsp/nrf52dk/src/arch/cortex_m4/gcc_startup_nrf52.s
@@ -138,6 +138,10 @@ __isr_vector:
 Reset_Handler:
     .fnstart
 
+    /* This is called but current_slot is in the data section so it is
+     * overwritten. its only called here to ensure that the global and this
+     * function are linked into the loader */
+    BL      bsp_slot_init_split_application
 
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
@@ -167,11 +171,6 @@ Reset_Handler:
 
     LDR     R0, =SystemInit
     BLX     R0
-
-    /* This is called but current_slot is in the data section so it is
-     * overwritten. its only called here to ensure that the global and this
-     * function are linked into the loader */
-    BL      bsp_slot_init_split_application
 
     LDR     R0, =_start
     BX      R0

--- a/hw/bsp/nrf52pdk/nrf52pdk_download.sh
+++ b/hw/bsp/nrf52pdk/nrf52pdk_download.sh
@@ -54,6 +54,11 @@ fi
 
 echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
+if [ ! -f $FILE_NAME ]; then
+    echo "File " $FILE_NAME "not found"
+    exit 1
+fi
+
 # XXX for some reason JLinkExe overwrites flash at offset 0 when
 # downloading somewhere in the flash. So need to figure out how to tell it
 # not to do that, or report failure if gdb fails to write this file

--- a/hw/hal/include/hal/hal_watchdog.h
+++ b/hw/hal/include/hal/hal_watchdog.h
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _HAL_WATCHDOG_H_
+#define _HAL_WATCHDOG_H_
+
+/*
+ * Set a recurring watchdog timer to fire no sooner than in 'expire_secs'
+ * seconds. Watchdog should be tickled periodically with a frequency
+ * smaller than 'expire_secs'. Watchdog needs to be then started with
+ * a call to hal_watchdog_enable().
+ *
+ * @param expire_secs		Watchdog timer expiration time
+ *
+ * @return			< 0 on failure; on success return the actual
+ *                              expiration time as positive value
+ */
+int hal_watchdog_init(int expire_secs);
+
+/*
+ * Starts the watchdog.
+ *
+ * @return			0 on success; non-zero on failure.
+ */
+int hal_watchdog_enable(void);
+
+/*
+ * Stops the watchdog.
+ *
+ * @return			0 on success; non-zero on failure.
+ */
+int hal_watchdog_stop(void);
+
+/*
+ * Tickles the watchdog. Needs to be done before 'expire_secs' fires.
+ */
+void hal_watchdog_tickle(void);
+
+#endif /* _HAL_WATCHDOG_H_ */

--- a/libs/console/full/src/prompt.c
+++ b/libs/console/full/src/prompt.c
@@ -36,5 +36,5 @@ console_set_prompt(char p)
 void
 console_print_prompt(void)
 {
-    console_printf(console_prompt);
+    console_printf("%s", console_prompt);
 }

--- a/libs/os/include/os/os_time.h
+++ b/libs/os/include/os/os_time.h
@@ -55,11 +55,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef uint32_t os_time_t;
-
 #ifndef UINT32_MAX
 #define UINT32_MAX  0xFFFFFFFFU
 #endif
+
+typedef uint32_t os_time_t;
+#define OS_TIME_MAX UINT32_MAX
  
 /* Used to wait forever for events and mutexs */
 #define OS_TIMEOUT_NEVER    (UINT32_MAX)

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -1663,6 +1663,8 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
         /* Set flag so we send connection update event */
         upd = &connsm->conn_update_req;
         if ((connsm->conn_role == BLE_LL_CONN_ROLE_MASTER)  ||
+            ((connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) &&
+             IS_PENDING_CTRL_PROC(connsm, BLE_LL_CTRL_PROC_CONN_PARAM_REQ)) ||
             (connsm->conn_itvl != upd->interval)            ||
             (connsm->slave_latency != upd->latency)         ||
             (connsm->supervision_tmo != upd->timeout)) {

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -555,6 +555,7 @@ int ble_gap_wl_set(const struct ble_gap_white_entry *white_list,
                    uint8_t white_list_count);
 int ble_gap_update_params(uint16_t conn_handle,
                           const struct ble_gap_upd_params *params);
+int ble_gap_dbg_update_active(uint16_t conn_handle);
 int ble_gap_security_initiate(uint16_t conn_handle);
 int ble_gap_pair_initiate(uint16_t conn_handle);
 int ble_gap_encryption_initiate(uint16_t conn_handle, const uint8_t *ltk,

--- a/net/nimble/host/include/host/ble_l2cap.h
+++ b/net/nimble/host/include/host/ble_l2cap.h
@@ -52,7 +52,8 @@ struct ble_hs_conn;
 #define BLE_L2CAP_SIG_ERR_MTU_EXCEEDED          0x0001
 #define BLE_L2CAP_SIG_ERR_INVALID_CID           0x0002
 
-typedef void ble_l2cap_sig_update_fn(int status, void *arg);
+typedef void ble_l2cap_sig_update_fn(uint16_t conn_handle, int status,
+                                     void *arg);
 
 struct ble_l2cap_sig_update_params {
     uint16_t itvl_min;

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -32,8 +32,6 @@
  */
 #define BLE_HS_MAX_EVS_IN_A_ROW 2
 
-static struct log_handler ble_hs_log_console_handler;
-
 struct os_mempool ble_hs_hci_ev_pool;
 static void *ble_hs_hci_os_event_buf;
 
@@ -561,8 +559,7 @@ ble_hs_init(struct os_eventq *app_evq, struct ble_hs_cfg *cfg)
     ble_hs_cfg_init(cfg);
 
     log_init();
-    log_console_handler_init(&ble_hs_log_console_handler);
-    log_register("ble_hs", &ble_hs_log, &ble_hs_log_console_handler);
+    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL);
 
     ble_hs_hci_os_event_buf = malloc(
         OS_MEMPOOL_BYTES(ble_hs_cfg.max_hci_bufs, sizeof (struct os_event)));

--- a/net/nimble/host/src/ble_hs_conn_priv.h
+++ b/net/nimble/host/src/ble_hs_conn_priv.h
@@ -31,7 +31,6 @@ struct ble_l2cap_chan;
 typedef uint8_t ble_hs_conn_flags_t;
 
 #define BLE_HS_CONN_F_MASTER        0x01
-#define BLE_HS_CONN_F_UPDATE        0x02
 
 struct ble_hs_conn {
     SLIST_ENTRY(ble_hs_conn) bhc_next;

--- a/net/nimble/host/src/ble_l2cap_sig_priv.h
+++ b/net/nimble/host/src/ble_l2cap_sig_priv.h
@@ -80,6 +80,7 @@ int ble_l2cap_sig_reject_invalid_cid_tx(struct ble_hs_conn *conn,
                                         uint8_t id,
                                         uint16_t src_cid, uint16_t dst_cid);
 
+void ble_l2cap_sig_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_l2cap_sig_heartbeat(void);
 struct ble_l2cap_chan *ble_l2cap_sig_create_chan(void);
 int ble_l2cap_sig_init(void);

--- a/net/nimble/host/src/test/ble_hs_test_util.h
+++ b/net/nimble/host/src/test/ble_hs_test_util.h
@@ -50,6 +50,13 @@ struct ble_hs_test_util_mbuf_params {
     unsigned prep_list:1;
 };
 
+#define BLE_HS_TEST_UTIL_L2CAP_HCI_HDR(handle, pb, len) \
+    ((struct hci_data_hdr) {                            \
+        .hdh_handle_pb_bc = ((handle)  << 0) |          \
+                            ((pb)      << 12),          \
+        .hdh_len = (len)                                \
+    })
+
 void ble_hs_test_util_prev_tx_enqueue(struct os_mbuf *om);
 struct os_mbuf *ble_hs_test_util_prev_tx_dequeue(void);
 struct os_mbuf *ble_hs_test_util_prev_tx_dequeue_pullup(void);
@@ -87,6 +94,7 @@ int ble_hs_test_util_connect(uint8_t own_addr_type,
                                    uint8_t ack_status);
 int ble_hs_test_util_conn_cancel(uint8_t ack_status);
 void ble_hs_test_util_conn_cancel_full(void);
+void ble_hs_test_util_set_ack_disconnect(uint8_t hci_status);
 int ble_hs_test_util_conn_terminate(uint16_t conn_handle, uint8_t hci_status);
 void ble_hs_test_util_conn_disconnect(uint16_t conn_handle);
 int ble_hs_test_util_exp_hci_status(int cmd_idx, int fail_idx,
@@ -148,6 +156,12 @@ void ble_hs_test_util_verify_tx_write_rsp(void);
 void ble_hs_test_util_verify_tx_mtu_cmd(int is_req, uint16_t mtu);
 void ble_hs_test_util_verify_tx_err_rsp(uint8_t req_op, uint16_t handle,
                                         uint8_t error_code);
+uint8_t ble_hs_test_util_verify_tx_l2cap_update_req(
+    struct ble_l2cap_sig_update_params *params);
+int ble_hs_test_util_rx_l2cap_update_rsp(uint16_t conn_handle,
+                                         uint8_t id, uint16_t result);
+void ble_hs_test_util_verify_tx_l2cap_update_rsp(uint8_t exp_id,
+                                                 uint16_t exp_result);
 void ble_hs_test_util_set_static_rnd_addr(void);
 struct os_mbuf *ble_hs_test_util_om_from_flat(const void *buf, uint16_t len);
 int ble_hs_test_util_flat_attr_cmp(const struct ble_hs_test_util_flat_attr *a,

--- a/net/nimble/host/src/test/ble_l2cap_test.c
+++ b/net/nimble/host/src/test/ble_l2cap_test.c
@@ -26,6 +26,7 @@
 
 #define BLE_L2CAP_TEST_CID  99
 
+static uint16_t ble_l2cap_test_update_conn_handle;
 static int ble_l2cap_test_update_status;
 static void *ble_l2cap_test_update_arg;
 
@@ -33,17 +34,11 @@ static void *ble_l2cap_test_update_arg;
  * $util                                                                     *
  *****************************************************************************/
 
-#define BLE_L2CAP_TEST_UTIL_HCI_HDR(handle, pb, len)    \
-    ((struct hci_data_hdr) {                            \
-        .hdh_handle_pb_bc = ((handle)  << 0) |          \
-                            ((pb)      << 12),          \
-        .hdh_len = (len)                                \
-    })
-
 static void
 ble_l2cap_test_util_init(void)
 {
     ble_hs_test_util_init();
+    ble_l2cap_test_update_conn_handle = BLE_HS_CONN_HANDLE_NONE;
     ble_l2cap_test_update_status = -1;
     ble_l2cap_test_update_arg = (void *)(uintptr_t)-1;
 }
@@ -58,7 +53,7 @@ ble_l2cap_test_util_rx_update_req(uint16_t conn_handle, uint8_t id,
     void *v;
     int rc;
 
-    hci_hdr = BLE_L2CAP_TEST_UTIL_HCI_HDR(
+    hci_hdr = BLE_HS_TEST_UTIL_L2CAP_HCI_HDR(
         2, BLE_HCI_PB_FIRST_FLUSH,
         BLE_L2CAP_HDR_SZ + BLE_L2CAP_SIG_HDR_SZ + BLE_L2CAP_SIG_UPDATE_REQ_SZ);
 
@@ -78,102 +73,6 @@ ble_l2cap_test_util_rx_update_req(uint16_t conn_handle, uint8_t id,
     rc = ble_hs_test_util_l2cap_rx_first_frag(conn_handle, BLE_L2CAP_CID_SIG,
                                               &hci_hdr, om);
     TEST_ASSERT_FATAL(rc == 0);
-}
-
-static int
-ble_l2cap_test_util_rx_update_rsp(uint16_t conn_handle,
-                                  uint8_t id, uint16_t result)
-{
-    struct ble_l2cap_sig_update_rsp rsp;
-    struct hci_data_hdr hci_hdr;
-    struct os_mbuf *om;
-    void *v;
-    int rc;
-
-    hci_hdr = BLE_L2CAP_TEST_UTIL_HCI_HDR(
-        2, BLE_HCI_PB_FIRST_FLUSH,
-        BLE_L2CAP_HDR_SZ + BLE_L2CAP_SIG_HDR_SZ + BLE_L2CAP_SIG_UPDATE_RSP_SZ);
-
-    rc = ble_l2cap_sig_init_cmd(BLE_L2CAP_SIG_OP_UPDATE_RSP, id,
-                                BLE_L2CAP_SIG_UPDATE_RSP_SZ, &om, &v);
-    TEST_ASSERT_FATAL(rc == 0);
-
-    rsp.result = result;
-    ble_l2cap_sig_update_rsp_write(v, BLE_L2CAP_SIG_UPDATE_RSP_SZ, &rsp);
-
-    rc = ble_hs_test_util_l2cap_rx_first_frag(conn_handle, BLE_L2CAP_CID_SIG,
-                                              &hci_hdr, om);
-    return rc;
-}
-
-
-static struct os_mbuf *
-ble_l2cap_test_util_verify_tx_sig_hdr(uint8_t op, uint8_t id,
-                                      uint16_t payload_len,
-                                      struct ble_l2cap_sig_hdr *out_hdr)
-{
-    struct ble_l2cap_sig_hdr hdr;
-    struct os_mbuf *om;
-
-    om = ble_hs_test_util_prev_tx_dequeue();
-    TEST_ASSERT_FATAL(om != NULL);
-
-    TEST_ASSERT(OS_MBUF_PKTLEN(om) == BLE_L2CAP_SIG_HDR_SZ + payload_len);
-    ble_l2cap_sig_hdr_parse(om->om_data, om->om_len, &hdr);
-    TEST_ASSERT(hdr.op == op);
-    if (id != 0) {
-        TEST_ASSERT(hdr.identifier == id);
-    }
-    TEST_ASSERT(hdr.length == payload_len);
-
-    om->om_data += BLE_L2CAP_SIG_HDR_SZ;
-    om->om_len -= BLE_L2CAP_SIG_HDR_SZ;
-
-    if (out_hdr != NULL) {
-        *out_hdr = hdr;
-    }
-
-    return om;
-}
-
-/**
- * @return                      The L2CAP sig identifier in the request.
- */
-static uint8_t
-ble_l2cap_test_util_verify_tx_update_req(
-    struct ble_l2cap_sig_update_params *params)
-{
-    struct ble_l2cap_sig_update_req req;
-    struct ble_l2cap_sig_hdr hdr;
-    struct os_mbuf *om;
-
-    om = ble_l2cap_test_util_verify_tx_sig_hdr(BLE_L2CAP_SIG_OP_UPDATE_REQ, 0,
-                                               BLE_L2CAP_SIG_UPDATE_REQ_SZ,
-                                               &hdr);
-
-    /* Verify payload. */
-    ble_l2cap_sig_update_req_parse(om->om_data, om->om_len, &req);
-    TEST_ASSERT(req.itvl_min == params->itvl_min);
-    TEST_ASSERT(req.itvl_max == params->itvl_max);
-    TEST_ASSERT(req.slave_latency == params->slave_latency);
-    TEST_ASSERT(req.timeout_multiplier == params->timeout_multiplier);
-
-    return hdr.identifier;
-}
-
-static void
-ble_l2cap_test_util_verify_tx_update_rsp(uint8_t exp_id, uint16_t exp_result)
-{
-    struct ble_l2cap_sig_update_rsp rsp;
-    struct os_mbuf *om;
-
-    om = ble_l2cap_test_util_verify_tx_sig_hdr(BLE_L2CAP_SIG_OP_UPDATE_RSP,
-                                               exp_id,
-                                               BLE_L2CAP_SIG_UPDATE_RSP_SZ,
-                                               NULL);
-
-    ble_l2cap_sig_update_rsp_parse(om->om_data, om->om_len, &rsp);
-    TEST_ASSERT(rsp.result == exp_result);
 }
 
 static void
@@ -252,7 +151,7 @@ ble_l2cap_test_util_rx_first_frag(uint16_t conn_handle,
     TEST_ASSERT_FATAL(om != NULL);
 
     hci_len = sizeof hci_hdr + l2cap_frag_len;
-    hci_hdr = BLE_L2CAP_TEST_UTIL_HCI_HDR(conn_handle,
+    hci_hdr = BLE_HS_TEST_UTIL_L2CAP_HCI_HDR(conn_handle,
                                           BLE_HCI_PB_FIRST_FLUSH, hci_len);
     rc = ble_hs_test_util_l2cap_rx(conn_handle, &hci_hdr, om);
     return rc;
@@ -272,7 +171,7 @@ ble_l2cap_test_util_rx_next_frag(uint16_t conn_handle, uint16_t hci_len)
     v = os_mbuf_extend(om, hci_len);
     TEST_ASSERT_FATAL(v != NULL);
 
-    hci_hdr = BLE_L2CAP_TEST_UTIL_HCI_HDR(conn_handle,
+    hci_hdr = BLE_HS_TEST_UTIL_L2CAP_HCI_HDR(conn_handle,
                                           BLE_HCI_PB_MIDDLE, hci_len);
     rc = ble_hs_test_util_l2cap_rx(conn_handle, &hci_hdr, om);
     return rc;
@@ -372,7 +271,7 @@ TEST_CASE(ble_l2cap_test_case_frag_single)
                                     NULL, NULL);
 
     /*** HCI header specifies middle fragment without start. */
-    hci_hdr = BLE_L2CAP_TEST_UTIL_HCI_HDR(2, BLE_HCI_PB_MIDDLE, 10);
+    hci_hdr = BLE_HS_TEST_UTIL_L2CAP_HCI_HDR(2, BLE_HCI_PB_MIDDLE, 10);
 
     om = ble_hs_mbuf_l2cap_pkt();
     TEST_ASSERT_FATAL(om != NULL);
@@ -467,7 +366,7 @@ TEST_CASE(ble_l2cap_test_case_sig_unsol_rsp)
                                     NULL, NULL);
 
     /* Receive an unsolicited response. */
-    rc = ble_l2cap_test_util_rx_update_rsp(2, 100, 0);
+    rc = ble_hs_test_util_rx_l2cap_update_rsp(2, 100, 0);
     TEST_ASSERT(rc == BLE_HS_ENOENT);
 
     /* Ensure we did not send anything in return. */
@@ -499,8 +398,6 @@ ble_l2cap_test_util_peer_updates(int accept)
 {
     struct ble_l2cap_sig_update_params l2cap_params;
     struct ble_gap_upd_params params;
-    ble_hs_conn_flags_t conn_flags;
-    int rc;
 
     ble_l2cap_test_util_init();
 
@@ -516,7 +413,7 @@ ble_l2cap_test_util_peer_updates(int accept)
 
     /* Ensure an update response command got sent. */
     ble_hs_process_tx_data_queue();
-    ble_l2cap_test_util_verify_tx_update_rsp(1, !accept);
+    ble_hs_test_util_verify_tx_l2cap_update_rsp(1, !accept);
 
     if (accept) {
         params.itvl_min = 0x200;
@@ -528,14 +425,14 @@ ble_l2cap_test_util_peer_updates(int accept)
         ble_l2cap_test_util_verify_tx_update_conn(&params);
     } else {
         /* Ensure no update got scheduled. */
-        rc = ble_hs_atomic_conn_flags(2, &conn_flags);
-        TEST_ASSERT(rc == 0 && !(conn_flags & BLE_HS_CONN_F_UPDATE));
+        TEST_ASSERT(!ble_gap_dbg_update_active(2));
     }
 }
 
 static void
-ble_l2cap_test_util_update_cb(int status, void *arg)
+ble_l2cap_test_util_update_cb(uint16_t conn_handle, int status, void *arg)
 {
+    ble_l2cap_test_update_conn_handle = conn_handle;
     ble_l2cap_test_update_status = status;
     ble_l2cap_test_update_arg = arg;
 }
@@ -565,10 +462,10 @@ ble_l2cap_test_util_we_update(int peer_accepts)
     ble_hs_test_util_tx_all();
 
     /* Ensure an update request got sent. */
-    id = ble_l2cap_test_util_verify_tx_update_req(&params);
+    id = ble_hs_test_util_verify_tx_l2cap_update_req(&params);
 
     /* Receive response from peer. */
-    rc = ble_l2cap_test_util_rx_update_rsp(2, id, !peer_accepts);
+    rc = ble_hs_test_util_rx_l2cap_update_rsp(2, id, !peer_accepts);
     TEST_ASSERT(rc == 0);
 
     /* Ensure callback got called. */
@@ -646,17 +543,17 @@ TEST_CASE(ble_l2cap_test_case_sig_update_init_fail_bad_id)
     ble_hs_test_util_tx_all();
 
     /* Ensure an update request got sent. */
-    id = ble_l2cap_test_util_verify_tx_update_req(&params);
+    id = ble_hs_test_util_verify_tx_l2cap_update_req(&params);
 
     /* Receive response from peer with incorrect ID. */
-    rc = ble_l2cap_test_util_rx_update_rsp(2, id + 1, 0);
+    rc = ble_hs_test_util_rx_l2cap_update_rsp(2, id + 1, 0);
     TEST_ASSERT(rc == BLE_HS_ENOENT);
 
     /* Ensure callback did not get called. */
     TEST_ASSERT(ble_l2cap_test_update_status == -1);
 
     /* Receive response from peer with correct ID. */
-    rc = ble_l2cap_test_util_rx_update_rsp(2, id, 0);
+    rc = ble_hs_test_util_rx_l2cap_update_rsp(2, id, 0);
     TEST_ASSERT(rc == 0);
 
     /* Ensure callback got called. */

--- a/sys/fcb/include/fcb/fcb.h
+++ b/sys/fcb/include/fcb/fcb.h
@@ -73,6 +73,16 @@ struct fcb {
 int fcb_init(struct fcb *fcb);
 
 /*
+ * fcb_log is needed as the number of entries in a log
+ */
+struct fcb_log {
+    struct fcb fl_fcb;
+    uint8_t fl_entries;
+} fcb_log;
+
+int log_fcb_init(struct fcb_log *fcblog, struct fcb *fcb, uint16_t entries);
+
+/*
  * fcb_append() appends an entry to circular buffer. When writing the
  * contents for the entry, use loc->fl_area and loc->fl_data_off with
  * flash_area_write(). When you're finished, call fcb_append_finish() with

--- a/sys/log/include/log/log.h
+++ b/sys/log/include/log/log.h
@@ -28,7 +28,10 @@
 struct log_info {
     int64_t li_timestamp;
     uint8_t li_index;
+    uint8_t li_version;
 };
+#define LOG_VERSION_V2  2
+#define LOG_VERSION_V1  1
 
 extern struct log_info g_log_info;
 
@@ -65,8 +68,8 @@ struct log_handler {
 
 struct log_entry_hdr {
     int64_t ue_ts;
-    uint16_t ue_module;
-    uint8_t ue_index;
+    uint16_t ue_index;
+    uint8_t ue_module;
     uint8_t ue_level;
 }__attribute__((__packed__));
 #define LOG_ENTRY_HDR_SIZE (sizeof(struct log_entry_hdr))

--- a/sys/log/include/log/log.h
+++ b/sys/log/include/log/log.h
@@ -63,7 +63,6 @@ struct log_handler {
     lh_walk_func_t log_walk;
     lh_flush_func_t log_flush;
     lh_rtr_erase_func_t log_rtr_erase;
-    void *log_arg;
 };
 
 struct log_entry_hdr {
@@ -110,6 +109,13 @@ struct log_entry_hdr {
     (LOG_MODULE_NFFS        == module ? "NFFS"        :\
     (LOG_MODULE_REBOOT      == module ? "REBOOT"      :\
      "UNKNOWN")))))))
+
+/*
+ * Logging Implementations
+ */
+#define LOG_STORE_CONSOLE    1
+#define LOG_STORE_CBMEM      2
+#define LOG_STORE_FCB        3
 
 /* UTC Timestamnp for Jan 2016 00:00:00 */
 #define UTC01_01_2016    1451606400
@@ -159,6 +165,7 @@ struct log_entry_hdr {
 struct log {
     char *l_name;
     struct log_handler *l_log;
+    void *l_arg;
     STAILQ_ENTRY(log) l_next;
 };
 
@@ -175,7 +182,8 @@ int log_init(void);
 struct log *log_list_get_next(struct log *);
 
 /* Log functions, manipulate a single log */
-int log_register(char *name, struct log *log, struct log_handler *);
+int log_register(char *name, struct log *log, const struct log_handler *,
+                 void *arg);
 int log_append(struct log *, uint16_t, uint16_t, void *, uint16_t);
 
 #define LOG_PRINTF_MAX_ENTRY_LEN (128)
@@ -187,14 +195,10 @@ int log_walk(struct log *log, log_walk_func_t walk_func,
 int log_flush(struct log *log);
 int log_rtr_erase(struct log *log, void *arg);
 
-
-
 /* Handler exports */
-int log_cbmem_handler_init(struct log_handler *, struct cbmem *);
-int log_console_handler_init(struct log_handler *);
-struct fcb;
-int log_fcb_handler_init(struct log_handler *, struct fcb *,
-                         uint8_t entries);
+extern const struct log_handler log_console_handler;
+extern const struct log_handler log_cbmem_handler;
+extern const struct log_handler log_fcb_handler;
 
 /* Private */
 #ifdef NEWTMGR_PRESENT

--- a/sys/log/src/log.c
+++ b/sys/log/src/log.c
@@ -58,6 +58,10 @@ log_init(void)
     }
     log_inited = 1;
 
+    g_log_info.li_version = LOG_VERSION_V2;
+    g_log_info.li_index = 0;
+    g_log_info.li_timestamp = 0;
+
 #ifdef SHELL_PRESENT
     shell_cmd_register(&g_shell_log_cmd);
 #endif

--- a/sys/log/src/log.c
+++ b/sys/log/src/log.c
@@ -113,6 +113,7 @@ log_append(struct log *log, uint16_t module, uint16_t level, void *data,
 
     ue = (struct log_entry_hdr *) data;
 
+    /* Could check for li_index wraparound here */
     g_log_info.li_index++;
 
     /* Try to get UTC Time */
@@ -132,11 +133,6 @@ log_append(struct log *log, uint16_t module, uint16_t level, void *data,
     rc = log->l_log->log_append(log, data, len + LOG_ENTRY_HDR_SIZE);
     if (rc != 0) {
         goto err;
-    }
-
-    /* Resetting index every millisecond */
-    if (g_log_info.li_timestamp > 1000 + prev_ts) {
-        g_log_info.li_index = 0;
     }
 
     return (0);

--- a/sys/log/src/log_cbmem.c
+++ b/sys/log/src/log_cbmem.c
@@ -16,13 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 #include <os/os.h>
-
 #include <util/cbmem.h>
-
 #include "log/log.h"
-
 
 static int
 log_cbmem_append(struct log *log, void *buf, int len)
@@ -30,7 +26,7 @@ log_cbmem_append(struct log *log, void *buf, int len)
     struct cbmem *cbmem;
     int rc;
 
-    cbmem = (struct cbmem *) log->l_log->log_arg;
+    cbmem = (struct cbmem *) log->l_arg;
 
     rc = cbmem_append(cbmem, buf, len);
     if (rc != 0) {
@@ -50,7 +46,7 @@ log_cbmem_read(struct log *log, void *dptr, void *buf, uint16_t offset,
     struct cbmem_entry_hdr *hdr;
     int rc;
 
-    cbmem = (struct cbmem *) log->l_log->log_arg;
+    cbmem = (struct cbmem *) log->l_arg;
     hdr = (struct cbmem_entry_hdr *) dptr;
 
     rc = cbmem_read(cbmem, hdr, buf, offset, len);
@@ -66,7 +62,7 @@ log_cbmem_walk(struct log *log, log_walk_func_t walk_func, void *arg)
     struct cbmem_iter iter;
     int rc;
 
-    cbmem = (struct cbmem *) log->l_log->log_arg;
+    cbmem = (struct cbmem *) log->l_arg;
 
     rc = cbmem_lock_acquire(cbmem);
     if (rc != 0) {
@@ -102,7 +98,7 @@ log_cbmem_flush(struct log *log)
     struct cbmem *cbmem;
     int rc;
 
-    cbmem = (struct cbmem *) log->l_log->log_arg;
+    cbmem = (struct cbmem *) log->l_arg;
 
     rc = cbmem_flush(cbmem);
     if (rc != 0) {
@@ -114,16 +110,11 @@ err:
     return (rc);
 }
 
-int
-log_cbmem_handler_init(struct log_handler *handler, struct cbmem *cbmem)
-{
-    handler->log_type = LOG_TYPE_MEMORY;
-    handler->log_read = log_cbmem_read;
-    handler->log_append = log_cbmem_append;
-    handler->log_walk = log_cbmem_walk;
-    handler->log_flush = log_cbmem_flush;
-    handler->log_arg = (void *) cbmem;
-    handler->log_rtr_erase = NULL;
-
-    return (0);
-}
+const struct log_handler log_cbmem_handler = {
+    .log_type = LOG_TYPE_MEMORY,
+    .log_read = log_cbmem_read,
+    .log_append = log_cbmem_append,
+    .log_walk = log_cbmem_walk,
+    .log_flush = log_cbmem_flush,
+    .log_rtr_erase = NULL,
+};

--- a/sys/log/src/log_console.c
+++ b/sys/log/src/log_console.c
@@ -18,13 +18,9 @@
  */
 
 #include <os/os.h>
-
 #include <util/cbmem.h>
-
 #include <console/console.h>
-
 #include "log/log.h"
-
 
 static int
 log_console_append(struct log *log, void *buf, int len)
@@ -69,17 +65,11 @@ log_console_flush(struct log *log)
     return (OS_EINVAL);
 }
 
-int
-log_console_handler_init(struct log_handler *handler)
-{
-    handler->log_type = LOG_TYPE_STREAM;
-    handler->log_read = log_console_read;
-    handler->log_append = log_console_append;
-    handler->log_walk = log_console_walk;
-    handler->log_flush = log_console_flush;
-    handler->log_arg = NULL;
-    handler->log_rtr_erase = NULL;
-
-    return (0);
-}
-
+const struct log_handler log_console_handler = {
+    .log_type = LOG_TYPE_STREAM,
+    .log_read = log_console_read,
+    .log_append = log_console_append,
+    .log_walk = log_console_walk,
+    .log_flush = log_console_flush,
+    .log_rtr_erase = NULL,
+};

--- a/sys/log/src/log_fcb.c
+++ b/sys/log/src/log_fcb.c
@@ -27,10 +27,6 @@
 #include "log/log.h"
 
 static struct flash_area sector;
-struct fcb_log {
-    uint8_t fl_entries;
-    struct fcb *fl_fcb;
-} fcb_log;
 
 static int
 log_fcb_append(struct log *log, void *buf, int len)
@@ -40,8 +36,8 @@ log_fcb_append(struct log *log, void *buf, int len)
     struct fcb_log *fcb_log;
     int rc;
 
-    fcb_log = (struct fcb_log *)log->l_log->log_arg;
-    fcb = fcb_log->fl_fcb;
+    fcb_log = (struct fcb_log *)log->l_arg;
+    fcb = &fcb_log->fl_fcb;
 
     while (1) {
         rc = fcb_append(fcb, len, &loc);
@@ -106,7 +102,7 @@ log_fcb_walk(struct log *log, log_walk_func_t walk_func, void *arg)
     int rc;
 
     rc = 0;
-    fcb = ((struct fcb_log *)log->l_log->log_arg)->fl_fcb;
+    fcb = &((struct fcb_log *)log->l_arg)->fl_fcb;
 
     memset(&loc, 0, sizeof(loc));
 
@@ -122,9 +118,7 @@ log_fcb_walk(struct log *log, log_walk_func_t walk_func, void *arg)
 static int
 log_fcb_flush(struct log *log)
 {
-
-    return fcb_clear(((struct fcb_log *)log->l_log->log_arg)->fl_fcb);
-
+    return fcb_clear(&((struct fcb_log *)log->l_arg)->fl_fcb);
 }
 
 /**
@@ -141,7 +135,6 @@ log_fcb_copy_entry(struct log *log, struct fcb_entry *entry,
     int dlen;
     int rc;
     struct fcb *fcb_tmp;
-    uint8_t entries_tmp;
 
     rc = log_fcb_read(log, entry, &ueh, 0, sizeof(ueh));
     if (rc != sizeof(ueh)) {
@@ -157,11 +150,9 @@ log_fcb_copy_entry(struct log *log, struct fcb_entry *entry,
     data[rc] = '\0';
 
     /* Changing the fcb to be logged to be dst fcb */
-    fcb_tmp = ((struct fcb_log *)log->l_log->log_arg)->fl_fcb;
+    fcb_tmp = &((struct fcb_log *)log->l_arg)->fl_fcb;
 
-    entries_tmp = ((struct fcb_log *)log->l_log->log_arg)->fl_entries;
-
-    rc = log_fcb_handler_init(log->l_log, dst_fcb, 0);
+    rc = log_register(log->l_name, log, &log_fcb_handler, dst_fcb);
     if (rc) {
         goto err;
     }
@@ -171,7 +162,7 @@ log_fcb_copy_entry(struct log *log, struct fcb_entry *entry,
         goto err;
     }
 
-    rc = log_fcb_handler_init(log->l_log, fcb_tmp, entries_tmp);
+    rc = log_register(log->l_name, log, &log_fcb_handler, fcb_tmp);
     if (rc) {
         goto err;
     }
@@ -232,7 +223,7 @@ log_fcb_rtr_erase(struct log *log, void *arg)
     }
 
     fcb_log = (struct fcb_log *)arg;
-    fcb = fcb_log->fl_fcb;
+    fcb = (struct fcb *)fcb_log;
 
     memset(&fcb_scratch, 0, sizeof(fcb_scratch));
 
@@ -243,7 +234,7 @@ log_fcb_rtr_erase(struct log *log, void *arg)
     fcb_scratch.f_sectors = &sector;
     fcb_scratch.f_sector_cnt = 1;
     fcb_scratch.f_magic = 0x7EADBADF;
-    fcb_scratch.f_version = 0;
+    fcb_scratch.f_version = g_log_info.li_version;
 
     flash_area_erase(&sector, 0, sector.fa_size);
     rc = fcb_init(&fcb_scratch);
@@ -276,20 +267,13 @@ err:
     return (rc);
 }
 
-int
-log_fcb_handler_init(struct log_handler *handler, struct fcb *fcb, uint8_t entries)
-{
-    handler->log_type = LOG_TYPE_STORAGE;
-    handler->log_read = log_fcb_read;
-    handler->log_append = log_fcb_append;
-    handler->log_walk = log_fcb_walk;
-    handler->log_flush = log_fcb_flush;
-    handler->log_rtr_erase = log_fcb_rtr_erase;
-    fcb_log.fl_entries = entries;
-    fcb_log.fl_fcb = fcb;
-    handler->log_arg = &fcb_log;
-
-    return 0;
-}
+const struct log_handler log_fcb_handler = {
+    .log_type = LOG_TYPE_STORAGE,
+    .log_read = log_fcb_read,
+    .log_append = log_fcb_append,
+    .log_walk = log_fcb_walk,
+    .log_flush = log_fcb_flush,
+    .log_rtr_erase = log_fcb_rtr_erase,
+};
 
 #endif

--- a/sys/log/src/test/log_test.c
+++ b/sys/log/src/test/log_test.c
@@ -33,7 +33,6 @@ static struct flash_area fcb_areas[] = {
         .fa_size = 16 * 1024
     }
 };
-static struct log_handler log_fcb_handler;
 static struct fcb log_fcb;
 static struct log my_log;
 
@@ -61,10 +60,8 @@ TEST_CASE(log_setup_fcb)
     }
     rc = fcb_init(&log_fcb);
     TEST_ASSERT(rc == 0);
-    rc = log_fcb_handler_init(&log_fcb_handler, &log_fcb, 0);
-    TEST_ASSERT(rc == 0);
 
-    log_register("log", &my_log, &log_fcb_handler);
+    log_register("log", &my_log, &log_fcb_handler, &log_fcb);
 }
 
 TEST_CASE(log_append_fcb)

--- a/sys/reboot/include/reboot/log_reboot.h
+++ b/sys/reboot/include/reboot/log_reboot.h
@@ -29,7 +29,7 @@
     (GEN_CORE     == reason ? "GEN_CORE" :\
      "UNKNOWN")))
 
-int reboot_init_handler(int log_type, uint8_t entries);
+int reboot_init_handler(int log_store_type, uint8_t entries);
 int log_reboot(int reason);
 
 #endif /* _LOG_REBOOT_H__ */

--- a/sys/reboot/src/log_reboot.c
+++ b/sys/reboot/src/log_reboot.c
@@ -35,8 +35,7 @@
 #include <shell/shell.h>
 #endif
 
-static struct log_handler reboot_log_handler;
-static struct fcb fcb;
+static struct log_handler *reboot_log_handler;
 static struct log reboot_log;
 static uint16_t reboot_cnt;
 static uint16_t soft_reboot;
@@ -45,6 +44,8 @@ static char soft_reboot_str[12];
 static char *reboot_cnt_get(int argc, char **argv, char *buf, int max_len);
 static int reboot_cnt_set(int argc, char **argv, char *val);
 static struct flash_area sector;
+
+static struct fcb_log reboot_log_fcb;
 
 struct conf_handler reboot_conf_handler = {
     .ch_name = "reboot",
@@ -60,44 +61,46 @@ struct conf_handler reboot_conf_handler = {
  * @return 0 on success; non-zero on failure
  */
 int
-reboot_init_handler(int log_type, uint8_t entries)
+reboot_init_handler(int log_store_type, uint8_t entries)
 {
     int rc;
     const struct flash_area *ptr;
+    struct fcb *fcbp = &reboot_log_fcb.fl_fcb;
 
     rc = conf_register(&reboot_conf_handler);
 
-    switch (log_type) {
-        case LOG_TYPE_STORAGE:
+    switch (log_store_type) {
+        case LOG_STORE_FCB:
             if (flash_area_open(FLASH_AREA_REBOOT_LOG, &ptr)) {
                 goto err;
             }
             sector = *ptr;
-            fcb.f_sectors = &sector;
-            fcb.f_sector_cnt = 1;
-            fcb.f_magic = 0x7EADBADF;
-            fcb.f_version = 0;
+            fcbp->f_sectors = &sector;
+            fcbp->f_sector_cnt = 1;
+            fcbp->f_magic = 0x7EADBADF;
+            fcbp->f_version = g_log_info.li_version;
 
-            rc = fcb_init(&fcb);
+            reboot_log_fcb.fl_entries = entries;
+
+            rc = fcb_init(fcbp);
             if (rc) {
                 goto err;
             }
-            rc = log_fcb_handler_init(&reboot_log_handler, &fcb, entries);
+            reboot_log_handler = (struct log_handler *)&log_fcb_handler;
             if (rc) {
                 goto err;
             }
             break;
-       case LOG_TYPE_STREAM:
-            rc = log_console_handler_init(&reboot_log_handler);
-            if (rc) {
-                goto err;
-            }
+       case LOG_STORE_CONSOLE:
+            reboot_log_handler = (struct log_handler *)&log_console_handler;
             break;
        default:
             assert(0);
     }
 
-    rc = log_register("reboot_log", &reboot_log, &reboot_log_handler);
+    rc = log_register("reboot_log", &reboot_log,
+                      (struct log_handler *)reboot_log_handler,
+                      &reboot_log_fcb);
 err:
     return (rc);
 }


### PR DESCRIPTION
Change log struct (log_entry_hdr) from using an 8-bit to 16-bit index (ue_index) and reducing the log module number (ue_module) from 16-bit to 8-bit preserving the size of the structure. Also removed code which reset the index every 1ms.

Added a version id in the global log_info structure so the log record format can be differentiated OTW or from non-volatile storage. Initialize g_log_info struct with current version.

Partial checkin for MYNEWT-368 - remaining work to store record format in FCB.