### PR TITLE
Add #ifdef __cplusplus   extern "C" {   guards to all headers.

### DIFF
--- a/apps/blecent/src/blecent.h
+++ b/apps/blecent/src/blecent.h
@@ -22,6 +22,10 @@
 
 #include "os/queue.h"
 #include "log/log.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_adv_fields;
 struct ble_gap_conn_desc;
 struct ble_hs_cfg;
@@ -113,5 +117,9 @@ peer_svc_find_uuid(const struct peer *peer, const uint8_t *uuid128);
 int peer_delete(uint16_t conn_handle);
 int peer_add(uint16_t conn_handle);
 int peer_init(int max_peers, int max_svcs, int max_chrs, int max_dscs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/apps/bleprph/src/bleprph.h
+++ b/apps/bleprph/src/bleprph.h
@@ -21,6 +21,10 @@
 #define H_BLEPRPH_
 
 #include "log/log.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_cfg;
 struct ble_gatt_register_ctxt;
 
@@ -47,5 +51,9 @@ int gatt_svr_init(struct ble_hs_cfg *cfg);
 /** Misc. */
 void print_bytes(const uint8_t *bytes, int len);
 void print_addr(const void *addr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/apps/bletest/src/bletest_priv.h
+++ b/apps/bletest/src/bletest_priv.h
@@ -20,6 +20,10 @@
 #ifndef H_BLETEST_PRIV_
 #define H_BLETEST_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void bletest_send_conn_update(uint16_t handle);
 
 #if (BLE_LL_CFG_FEAT_LE_ENCRYPTION == 1)
@@ -62,5 +66,9 @@ int bletest_hci_le_add_resolv_list(uint8_t *local_irk, uint8_t *peer_irk,
                                    uint8_t *peer_ident_addr, uint8_t addr_type);
 int bletest_hci_le_enable_resolv_list(uint8_t enable);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* H_BLETEST_PRIV_*/

--- a/apps/bletiny/src/bletiny.h
+++ b/apps/bletiny/src/bletiny.h
@@ -26,6 +26,10 @@
 #include "os/queue.h"
 
 #include "host/ble_gatt.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_gap_white_entry;
 struct ble_hs_adv_fields;
 struct ble_gap_upd_params;
@@ -203,5 +207,9 @@ uint16_t chr_end_handle(const struct bletiny_svc *svc,
                         const struct bletiny_chr *chr);
 int chr_is_empty(const struct bletiny_svc *svc, const struct bletiny_chr *chr);
 void print_conn_desc(const struct ble_gap_conn_desc *desc);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/drivers/uart_bitbang/include/uart_bitbang/uart_bitbang.h
+++ b/drivers/uart_bitbang/include/uart_bitbang/uart_bitbang.h
@@ -20,6 +20,14 @@
 #ifndef __UART_BITBANG_H__
 #define __UART_BITBANG_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int uart_bitbang_init(int rxpin, int txpin, uint32_t cputimer_freq);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UART_BITBANG_H__ */

--- a/drivers/uart_bitbang/include/uart_bitbang/uart_bitbang_api.h
+++ b/drivers/uart_bitbang/include/uart_bitbang/uart_bitbang_api.h
@@ -20,6 +20,10 @@
 #ifndef __UART_BITBANG_API_H__
 #define __UART_BITBANG_API_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int uart_bitbang_config(int port, int32_t baudrate, uint8_t databits,
   uint8_t stopbits, enum hal_uart_parity parity,
   enum hal_uart_flow_ctl flow_ctl);
@@ -29,5 +33,9 @@ void uart_bitbang_start_rx(int port);
 void uart_bitbang_start_tx(int port);
 void uart_bitbang_blocking_tx(int port, uint8_t data);
 int uart_bitbang_close(int port);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/fs/include/fs/fs.h
+++ b/fs/fs/include/fs/fs.h
@@ -23,6 +23,10 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Common interface to access files.
  */
@@ -74,5 +78,9 @@ int fs_dirent_is_dir(const struct fs_dirent *);
 #define FS_EEXIST       11  /* File or directory already exists */
 #define FS_EACCESS      12  /* Operation prohibited by file open mode */
 #define FS_EUNINIT      13  /* File system not initialized */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/fs/include/fs/fs_if.h
+++ b/fs/fs/include/fs/fs_if.h
@@ -20,6 +20,10 @@
 #ifndef __FS_IF_H__
 #define __FS_IF_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Common interface filesystem(s) provide.
  */
@@ -54,5 +58,9 @@ struct fs_ops {
  * Currently allow only one type of FS, starts at root.
  */
 int fs_register(const struct fs_ops *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/fs/include/fs/fsutil.h
+++ b/fs/fs/include/fs/fsutil.h
@@ -22,8 +22,16 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int fsutil_read_file(const char *path, uint32_t offset, uint32_t len,
                      void *dst, uint32_t *out_len);
 int fsutil_write_file(const char *path, const void *data, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/fs/src/fs_priv.h
+++ b/fs/fs/src/fs_priv.h
@@ -19,11 +19,19 @@
 #ifndef __FS_PRIV_H__
 #define __FS_PRIV_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct fs_ops;
 extern const struct fs_ops *fs_root_ops;
 
 #ifdef SHELL_PRESENT
 void fs_cli_init(void);
 #endif /* SHELL_PRESENT */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/nffs/include/nffs/nffs.h
+++ b/fs/nffs/include/nffs/nffs.h
@@ -23,6 +23,10 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NFFS_FILENAME_MAX_LEN   256  /* Does not require null terminator. */
 #define NFFS_MAX_AREAS          256
 
@@ -57,5 +61,9 @@ struct nffs_area_desc {
 int nffs_init(void);
 int nffs_detect(const struct nffs_area_desc *area_descs);
 int nffs_format(const struct nffs_area_desc *area_descs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/nffs/include/nffs/nffs_test.h
+++ b/fs/nffs/include/nffs/nffs_test.h
@@ -20,6 +20,14 @@
 #ifndef H_NFFS_TEST_
 #define H_NFFS_TEST_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int nffs_test_all(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/fs/nffs/src/nffs_priv.h
+++ b/fs/nffs/src/nffs_priv.h
@@ -28,6 +28,10 @@
 #include "fs/fs.h"
 #include "util/crc16.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NFFS_HASH_SIZE               256
 
 #define NFFS_ID_DIR_MIN              0
@@ -489,6 +493,10 @@ int nffs_write_to_file(struct nffs_file *file, const void *data, int len);
 #else
 #define NFFS_LOG(lvl, ...) \
     LOG_ ## lvl(&nffs_log, LOG_MODULE_NFFS, __VA_ARGS__)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/fs/nffs/src/test/arch/sim/nffs_test_priv.h
+++ b/fs/nffs/src/test/arch/sim/nffs_test_priv.h
@@ -20,6 +20,10 @@
 #ifndef H_NFFS_TEST_PRIV_
 #define H_NFFS_TEST_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct nffs_test_block_desc {
     const char *data;
     int data_len;
@@ -37,6 +41,10 @@ int nffs_test(void);
 
 extern const struct nffs_test_file_desc *nffs_test_system_01;
 extern const struct nffs_test_file_desc *nffs_test_system_01_rm_1014_mk10;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/hw/bsp/native/include/bsp/bsp_sysid.h
+++ b/hw/bsp/native/include/bsp/bsp_sysid.h
@@ -19,6 +19,10 @@
 #ifndef __NATIVE_BSP_SYSID_H
 #define __NATIVE_BSP_SYSID_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* This file defines the system device descriptors for this BSP.
  * System device descriptors are any HAL devies */
 
@@ -44,5 +48,9 @@ enum system_device_id {
     NATIVE_BSP_DAC_3,
     /* TODO -- add other hals here */    
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* __NATIVE_BSP_SYSID_H */

--- a/hw/mcu/native/include/mcu/hal_dac.h
+++ b/hw/mcu/native/include/mcu/hal_dac.h
@@ -20,6 +20,10 @@
 #ifndef _NATIVE_HAL_DAC_H
 #define _NATIVE_HAL_DAC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum native_dac_channel 
 {
     NATIVE_MCU_DAC0 = 0,
@@ -31,6 +35,10 @@ enum native_dac_channel
 /* to create a native dac driver */
 struct hal_dac *
 native_dac_create (enum native_dac_channel);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _NATIVE_HAL_PWM_H */
 

--- a/hw/mcu/native/include/mcu/mcu_sim.h
+++ b/hw/mcu/native/include/mcu/mcu_sim.h
@@ -19,11 +19,19 @@
 #ifndef __MCU_SIM_H__
 #define __MCU_SIM_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define OS_TICKS_PER_SEC    (1000)
 
 extern char *native_flash_file;
 extern char *native_uart_log_file;
 
 void mcu_sim_parse_args(int argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MCU_SIM_H__ */

--- a/hw/mcu/native/include/mcu/native_bsp.h
+++ b/hw/mcu/native/include/mcu/native_bsp.h
@@ -19,6 +19,14 @@
 #ifndef H_NATIVE_BSP_
 #define H_NATIVE_BSP_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const struct hal_flash native_flash_dev;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_NATIVE_BSP_ */

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/compiler_abstraction.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/compiler_abstraction.h
@@ -30,6 +30,10 @@
 #ifndef _COMPILER_ABSTRACTION_H
 #define _COMPILER_ABSTRACTION_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*lint ++flb "Enter library region" */
 
 #if defined ( __CC_ARM )
@@ -122,5 +126,9 @@
 #endif
 
 /*lint --flb "Leave library region" */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/cortex_m0.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/cortex_m0.h
@@ -22,11 +22,19 @@
 
 #include "mcu/nrf51.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * The nRF51 microcontroller uses RTC0 for periodic interrupts and it is
  * clocked at 32768Hz. The tick frequency is chosen such that it divides
  * cleanly into 32768 to avoid a systemic bias in the actual tick frequency.
  */
 #define OS_TICKS_PER_SEC    (128)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MCU_CORTEX_M0_H__ */

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/nrf.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/nrf.h
@@ -31,6 +31,10 @@
 #ifndef NRF_H
 #define NRF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_WIN32)         
     /* Do not include nrf51 specific files when building for PC host */
 #elif defined(__unix)       
@@ -55,6 +59,10 @@
     #include "compiler_abstraction.h"
 
 #endif /* _WIN32 || __unix || __APPLE__ */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF_H */
 

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51422_peripherals.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51422_peripherals.h
@@ -32,6 +32,10 @@
 #define _NRF51422_PERIPHERALS_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Software Interrupts */
 #define SWI_PRESENT
 #define SWI_COUNT 6
@@ -112,5 +116,9 @@
 #define LPCOMP_PRESENT
 #define LPCOMP_COUNT 1
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif      // _NRF51422_PERIPHERALS_H

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51822_peripherals.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51822_peripherals.h
@@ -32,6 +32,10 @@
 #define _NRF51822_PERIPHERALS_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Software Interrupts */
 #define SWI_PRESENT
 #define SWI_COUNT 6
@@ -112,5 +116,9 @@
 #define LPCOMP_PRESENT
 #define LPCOMP_COUNT 1
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif      // _NRF51822_PERIPHERALS_H

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_bitfields.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_bitfields.h
@@ -30,6 +30,10 @@
 #ifndef __NRF51_BITS_H
 #define __NRF51_BITS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*lint ++flb "Enter library region" */
 
 /* Peripheral: AAR */
@@ -6880,4 +6884,8 @@
 
 
 /*lint --flb "Leave library region" */
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_deprecated.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_deprecated.h
@@ -31,6 +31,10 @@
 #ifndef NRF51_DEPRECATED_H
 #define NRF51_DEPRECATED_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*lint ++flb "Enter library region */
 
 /* This file is given to prevent your SW from not compiling with the updates made to nrf51.h and 
@@ -433,6 +437,10 @@
 
 
 /*lint --flb "Leave library region" */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF51_DEPRECATED_H */
 

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/compiler_abstraction.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/compiler_abstraction.h
@@ -30,6 +30,10 @@
 #ifndef _COMPILER_ABSTRACTION_H
 #define _COMPILER_ABSTRACTION_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*lint ++flb "Enter library region" */
 
 #if defined ( __CC_ARM )
@@ -122,5 +126,9 @@
 #endif
 
 /*lint --flb "Leave library region" */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -22,10 +22,18 @@
 
 #include "mcu/nrf52.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(BSP_HAS_32768_XTAL)
 #define OS_TICKS_PER_SEC    (128)
 #else
 #define OS_TICKS_PER_SEC    (1000)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __MCU_CORTEX_M4_H__ */

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf.h
@@ -31,6 +31,10 @@
 #ifndef NRF_H
 #define NRF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_WIN32)         
     /* Do not include nrf51 specific files when building for PC host */
 #elif defined(__unix)       
@@ -55,6 +59,10 @@
     #include "compiler_abstraction.h"
 
 #endif /* _WIN32 || __unix || __APPLE__ */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF_H */
 

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf51_to_nrf52.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf51_to_nrf52.h
@@ -31,6 +31,10 @@
 #ifndef NRF51_TO_NRF52_H
 #define NRF51_TO_NRF52_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*lint ++flb "Enter library region */
 
 /* This file is given to prevent your SW from not compiling with the name changes between nRF51 and nRF52 devices. 
@@ -930,6 +934,10 @@
 
 
 /*lint --flb "Leave library region" */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF51_TO_NRF52_H */
 

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52832_peripherals.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52832_peripherals.h
@@ -32,6 +32,10 @@
 #define _NRF52832_PERIPHERALS_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Software Interrupts */
 #define SWI_PRESENT
 #define SWI_COUNT 6
@@ -173,5 +177,9 @@
 #define MWU_PRESENT
 #define MWU_COUNT 1
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif      // _NRF52832_PERIPHERALS_H

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_bitfields.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_bitfields.h
@@ -30,6 +30,10 @@
 #ifndef __NRF52_BITS_H
 #define __NRF52_BITS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*lint ++flb "Enter library region" */
 
 /* Peripheral: AAR */
@@ -12137,4 +12141,8 @@
 
 
 /*lint --flb "Leave library region" */
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/hw/mcu/stm/stm32f4xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/cortex_m4.h
@@ -22,6 +22,14 @@
 
 #include "mcu/stm32f4xx.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define OS_TICKS_PER_SEC    (1000)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MCU_CORTEX_M4_H__ */

--- a/hw/mcu/stm/stm32f4xx/include/mcu/stm32f4_bsp.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/stm32f4_bsp.h
@@ -20,6 +20,10 @@
 #ifndef __MCU_STM32F4_BSP_H_
 #define __MCU_STM32F4_BSP_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * BSP specific UART settings.
  */
@@ -44,5 +48,9 @@ int hal_gpio_init_af(int pin, uint8_t af_type, enum gpio_pull pull);
 
 struct hal_flash;
 extern struct hal_flash stm32f4_flash_dev;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MCU_STM32F4_BSP_H_ */

--- a/libs/baselibc/include/assert.h
+++ b/libs/baselibc/include/assert.h
@@ -5,6 +5,10 @@
 #ifndef _ASSERT_H
 #define _ASSERT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef NDEBUG
 
 /*
@@ -23,6 +27,10 @@ extern void __assert_func(const char *, int, const char *, const char *)
 
 #define assert(x) ((x) ? (void)0 : __assert_func(__FILE__, __LINE__, NULL, NULL))
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif				/* _ASSERT_H */

--- a/libs/baselibc/include/ctype.h
+++ b/libs/baselibc/include/ctype.h
@@ -10,6 +10,10 @@
 #include <klibc/extern.h>
 #include <klibc/inline.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 __extern_inline int isupper(int __c)
 {
 	return __c >= 'A' && __c <= 'Z';
@@ -82,5 +86,9 @@ __extern_inline int tolower(int __c)
 {
 	return isupper(__c) ? (__c | 32) : __c;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif				/* _CTYPE_H */

--- a/libs/baselibc/include/inttypes.h
+++ b/libs/baselibc/include/inttypes.h
@@ -9,6 +9,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static __inline__ intmax_t imaxabs(intmax_t __n)
 {
 	return (__n < (intmax_t) 0) ? -__n : __n;
@@ -221,6 +225,10 @@ __extern uintmax_t strntoumax(const char *, char **, int, size_t);
 #define SCNxMAX	 __PRI64_RANK "x"
 #define SCNxPTR  __PRIPTR_RANK "x"
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif				/* _INTTYPES_H */

--- a/libs/baselibc/include/klibc/extern.h
+++ b/libs/baselibc/include/klibc/extern.h
@@ -6,11 +6,19 @@
 #define _KLIBC_EXTERN_H
 
 #ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
 #define __extern extern "C"
 #else
 #define __extern extern
 #endif
 
 #define __alias(x) __attribute__((weak, alias(x)))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif				/* _KLIBC_EXTERN_H */

--- a/libs/baselibc/include/klibc/inline.h
+++ b/libs/baselibc/include/klibc/inline.h
@@ -5,8 +5,16 @@
 #ifndef _KLIBC_INLINE_H
 #define _KLIBC_INLINE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef __extern_inline
 #define __extern_inline extern inline __attribute__((gnu_inline))
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif				/* _KLIBC_INLINE_H */

--- a/libs/baselibc/include/stdio.h
+++ b/libs/baselibc/include/stdio.h
@@ -11,6 +11,10 @@
 #include <stddef.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The File structure is designed to be compatible with ChibiOS/RT type
  * BaseSequentialStream.
  */
@@ -120,5 +124,9 @@ struct MemFile
 
 FILE *fmemopen_w(struct MemFile* storage, char *buffer, size_t size);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif				/* _STDIO_H */

--- a/libs/baselibc/include/stdlib.h
+++ b/libs/baselibc/include/stdlib.h
@@ -10,6 +10,10 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 __extern_inline int abs(int __n)
 {
 	return (__n < 0) ? -__n : __n;
@@ -97,5 +101,9 @@ __extern_inline void srandom(unsigned int __s)
 {
 	srand48(__s);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif				/* _STDLIB_H */

--- a/libs/baselibc/include/string.h
+++ b/libs/baselibc/include/string.h
@@ -8,6 +8,10 @@
 #include <klibc/extern.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 __extern void *memccpy(void *, const void *, int, size_t);
 __extern void *memchr(const void *, int, size_t);
 __extern void *memrchr(const void *, int, size_t);
@@ -55,5 +59,9 @@ inline static size_t strxfrm(char *dest, const char *src, size_t n)
 	strncpy(dest, src, n);
 	return strlen(src);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif				/* _STRING_H */

--- a/libs/baselibc/src/malloc.h
+++ b/libs/baselibc/src/malloc.h
@@ -21,6 +21,10 @@ struct arena_header {
 
 #ifdef DEBUG_MALLOC
 #define ARENA_TYPE_USED 0x64e69c70
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ARENA_TYPE_FREE 0x012d610a
 #define ARENA_TYPE_HEAD 0x971676b5
 #define ARENA_TYPE_DEAD 0xeeeeeeee
@@ -28,6 +32,10 @@ struct arena_header {
 #define ARENA_TYPE_USED 0
 #define ARENA_TYPE_FREE 1
 #define ARENA_TYPE_HEAD 2
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 
 #define ARENA_SIZE_MASK (~(sizeof(struct arena_header)-1))

--- a/libs/bleuart/include/bleuart/bleuart.h
+++ b/libs/bleuart/include/bleuart/bleuart.h
@@ -20,6 +20,10 @@
 #ifndef _BLEUART_H_
 #define _BLEUART_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int
 bleuart_init(int max_input);
 int
@@ -30,5 +34,9 @@ void
 bleuart_set_conn_handle(uint16_t conn_handle);
 
 extern const uint8_t gatt_svr_svc_uart[16];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _BLEUART_H */

--- a/libs/boot_serial/include/boot_serial/boot_serial.h
+++ b/libs/boot_serial/include/boot_serial/boot_serial.h
@@ -20,6 +20,10 @@
 #ifndef __BOOT_SERIAL_H__
 #define __BOOT_SERIAL_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Create a task for uploading image0 over serial.
  *
@@ -29,5 +33,9 @@
  */
 int boot_serial_task_init(struct os_task *task, uint8_t prio,
   os_stack_t *stack, uint16_t stack_size, int max_input);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*  __BOOT_SERIAL_H__ */

--- a/libs/boot_serial/src/boot_serial_priv.h
+++ b/libs/boot_serial/src/boot_serial_priv.h
@@ -20,6 +20,10 @@
 #ifndef __BOOTUTIL_SERIAL_PRIV_H__
 #define __BOOTUTIL_SERIAL_PRIV_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * From shell.h
  */
@@ -57,5 +61,9 @@ struct nmgr_hdr {
 
 
 void boot_serial_input(char *buf, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*  __BOOTUTIL_SERIAL_PRIV_H__ */

--- a/libs/bootutil/include/bootutil/bootutil_misc.h
+++ b/libs/bootutil/include/bootutil/bootutil_misc.h
@@ -20,9 +20,17 @@
 #ifndef __BOOTUTIL_MISC_H_
 #define __BOOTUTIL_MISC_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int boot_vect_read_test(int *slot);
 int boot_vect_read_main(int *slot);
 int boot_vect_write_test(int slot);
 int boot_vect_write_main(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*  __BOOTUTIL_MISC_H_ */

--- a/libs/bootutil/include/bootutil/bootutil_test.h
+++ b/libs/bootutil/include/bootutil/bootutil_test.h
@@ -20,6 +20,14 @@
 #ifndef H_BOOTUTIL_TEST_
 #define H_BOOTUTIL_TEST_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int boot_test_all(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/bootutil/include/bootutil/image.h
+++ b/libs/bootutil/include/bootutil/image.h
@@ -22,6 +22,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IMAGE_MAGIC                 0x96f3b83c
 #define IMAGE_MAGIC_NONE            0xffffffff
 
@@ -78,5 +82,9 @@ _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
 
 int bootutil_img_validate(struct image_header *hdr, uint8_t flash_id,
   uint32_t addr, uint8_t *tmp_buf, uint32_t tmp_buf_sz);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/bootutil/include/bootutil/loader.h
+++ b/libs/bootutil/include/bootutil/loader.h
@@ -21,6 +21,10 @@
 #define H_LOADER_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct image_header;
 
 /** A request object instructing the boot loader how to proceed. */
@@ -68,5 +72,9 @@ struct boot_rsp {
 };
 
 int boot_go(const struct boot_req *req, struct boot_rsp *rsp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/bootutil/include/bootutil/sign_key.h
+++ b/libs/bootutil/include/bootutil/sign_key.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct bootutil_key {
     const uint8_t *key;
     const unsigned int *len;
@@ -29,5 +33,9 @@ struct bootutil_key {
 
 extern const struct bootutil_key bootutil_keys[];
 extern const int bootutil_key_cnt;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __BOOTUTIL_SIGN_KEY_H_ */

--- a/libs/bootutil/src/bootutil_priv.h
+++ b/libs/bootutil/src/bootutil_priv.h
@@ -22,6 +22,10 @@
 
 #include "bootutil/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BOOT_EFLASH     1
 #define BOOT_EFILE      2
 #define BOOT_EBADIMAGE  3
@@ -72,6 +76,10 @@ void boot_scratch_magic(struct boot_img_trailer *bit);
 
 struct boot_req;
 void boot_req_set(struct boot_req *req);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/cmsis-core/include/cmsis-core/core_caFunc.h
+++ b/libs/cmsis-core/include/cmsis-core/core_caFunc.h
@@ -39,6 +39,10 @@
 #define __CORE_CAFUNC_H__
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ###########################  Core Function Access  ########################### */
 /** \ingroup  CMSIS_Core_FunctionInterface
     \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
@@ -1157,5 +1161,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __v7_clean_inv_dcache_al
 
 /*@} end of CMSIS_Core_RegAccFunctions */
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CAFUNC_H__ */

--- a/libs/cmsis-core/include/cmsis-core/core_caInstr.h
+++ b/libs/cmsis-core/include/cmsis-core/core_caInstr.h
@@ -37,9 +37,17 @@
 #ifndef __CORE_CAINSTR_H__
 #define __CORE_CAINSTR_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define __CORTEX_M 0x3
 #include "core_cmInstr.h"
 #undef  __CORTEX_M
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/cmsis-core/include/cmsis-core/core_cmFunc.h
+++ b/libs/cmsis-core/include/cmsis-core/core_cmFunc.h
@@ -39,6 +39,10 @@
 #define __CORE_CMFUNC_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ###########################  Core Function Access  ########################### */
 /** \ingroup  CMSIS_Core_FunctionInterface
     \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
@@ -632,5 +636,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FPSCR(uint32_t fps
 
 /*@} end of CMSIS_Core_RegAccFunctions */
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMFUNC_H */

--- a/libs/cmsis-core/include/cmsis-core/core_cmInstr.h
+++ b/libs/cmsis-core/include/cmsis-core/core_cmInstr.h
@@ -39,6 +39,10 @@
 #define __CORE_CMINSTR_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ##########################  Core Instruction Access  ######################### */
 /** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
   Access to dedicated instructions
@@ -684,5 +688,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint8_t __CLZ(uint32_t value)
 #endif
 
 /*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMINSTR_H */

--- a/libs/console/full/include/console/console.h
+++ b/libs/console/full/include/console/console.h
@@ -21,6 +21,10 @@
 
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*console_rx_cb)(void);
 
 int console_init(console_rx_cb rx_cb);
@@ -34,5 +38,9 @@ void console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));;
 
 extern int console_is_midline;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CONSOLE_H__ */

--- a/libs/console/stub/include/console/console.h
+++ b/libs/console/stub/include/console/console.h
@@ -21,6 +21,10 @@
 
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*console_rx_cb)(void);
 
 static int inline
@@ -66,6 +70,10 @@ console_echo(int on)
 }
 
 #define console_is_midline  (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CONSOLE__ */
 

--- a/libs/crash_test/include/crash_test/crash_test.h
+++ b/libs/crash_test/include/crash_test/crash_test.h
@@ -19,9 +19,17 @@
 #ifndef __CRASH_TEST_H__
 #define __CRASH_TEST_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Adds the crash commands to your shell/newtmgr.
  */
 int crash_test_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CRASH_TEST_H__ */

--- a/libs/crash_test/src/crash_test_priv.h
+++ b/libs/crash_test/src/crash_test_priv.h
@@ -19,6 +19,10 @@
 #ifndef __CRASH_TEST_PRIV_H__
 #define __CRASH_TEST_PRIV_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef SHELL_PRESENT
 extern struct shell_cmd crash_cmd_struct;
 #endif
@@ -27,5 +31,9 @@ extern struct nmgr_group crash_test_nmgr_group;
 #endif
 
 int crash_device(char *how);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CRASH_TEST_PRIV_H__ */

--- a/libs/elua/elua_base/include/elua_base/elua.h
+++ b/libs/elua/elua_base/include/elua_base/elua.h
@@ -20,8 +20,16 @@
 #ifndef __ELUA_BASE_H__
 #define __ELUA_BASE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int lua_main( int argc, char **argv );
 
 int lua_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ELUA_BASE_H__ */

--- a/libs/elua/elua_base/src/lapi.h
+++ b/libs/elua/elua_base/src/lapi.h
@@ -11,6 +11,14 @@
 #include "lobject.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 LUAI_FUNC void luaA_pushobject (lua_State *L, const TValue *o);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lauxlib.h
+++ b/libs/elua/elua_base/src/lauxlib.h
@@ -15,6 +15,10 @@
 #include "lua.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(LUA_COMPAT_GETN)
 LUALIB_API int (luaL_getn) (lua_State *L, int t);
 LUALIB_API void (luaL_setn) (lua_State *L, int t, int n);
@@ -173,6 +177,10 @@ LUALIB_API void (luaL_pushresult) (luaL_Buffer *B);
 
 
 #define luaL_reg	luaL_Reg
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/elua/elua_base/src/lcode.h
+++ b/libs/elua/elua_base/src/lcode.h
@@ -13,6 +13,10 @@
 #include "lparser.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 ** Marks the end of a patch list. It is an invalid value both as an absolute
 ** address, and as a list link (would link an element to itself).
@@ -72,5 +76,9 @@ LUAI_FUNC void luaK_infix (FuncState *fs, BinOpr op, expdesc *v);
 LUAI_FUNC void luaK_posfix (FuncState *fs, BinOpr op, expdesc *v1, expdesc *v2);
 LUAI_FUNC void luaK_setlist (FuncState *fs, int base, int nelems, int tostore);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/ldebug.h
+++ b/libs/elua/elua_base/src/ldebug.h
@@ -11,6 +11,10 @@
 #include "lstate.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define pcRel(pc, p)	(cast(int, (pc) - (p)->code) - 1)
 
 #define getline(f,pc)	(((f)->lineinfo) ? (f)->lineinfo[pc] : 0)
@@ -29,5 +33,9 @@ LUAI_FUNC void luaG_runerror (lua_State *L, const char *fmt, ...);
 LUAI_FUNC void luaG_errormsg (lua_State *L);
 LUAI_FUNC int luaG_checkcode (const Proto *pt);
 LUAI_FUNC int luaG_checkopenop (Instruction i);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/ldo.h
+++ b/libs/elua/elua_base/src/ldo.h
@@ -13,6 +13,10 @@
 #include "lzio.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define luaD_checkstack(L,n)	\
   if ((char *)L->stack_last - (char *)L->top <= (n)*(int)sizeof(TValue)) \
     luaD_growstack(L, n); \
@@ -52,6 +56,10 @@ LUAI_FUNC void luaD_throw (lua_State *L, int errcode);
 LUAI_FUNC int luaD_rawrunprotected (lua_State *L, Pfunc f, void *ud);
 
 LUAI_FUNC void luaD_seterrorobj (lua_State *L, int errcode, StkId oldtop);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/elua/elua_base/src/legc.h
+++ b/libs/elua/elua_base/src/legc.h
@@ -5,6 +5,10 @@
 
 #include "lstate.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // EGC operations modes
 #define EGC_NOT_ACTIVE        0   // EGC disabled
 #define EGC_ON_ALLOC_FAILURE  1   // run EGC on allocation failure
@@ -12,6 +16,10 @@
 #define EGC_ALWAYS            4   // always run EGC before an allocation
 
 void legc_set_mode(lua_State *L, int mode, unsigned limit);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/elua/elua_base/src/lfunc.h
+++ b/libs/elua/elua_base/src/lfunc.h
@@ -12,6 +12,10 @@
 
 #include "lgc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define sizeCclosure(n)	(cast(int, sizeof(CClosure)) + \
                          cast(int, sizeof(TValue)*((n)-1)))
 
@@ -33,5 +37,9 @@ LUAI_FUNC void luaF_freeupval (lua_State *L, UpVal *uv);
 LUAI_FUNC const char *luaF_getlocalname (const Proto *func, int local_number,
                                          int pc);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lgc.h
+++ b/libs/elua/elua_base/src/lgc.h
@@ -11,6 +11,10 @@
 #include "lobject.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 ** Possible states of the Garbage Collector
 */
@@ -132,5 +136,9 @@ LUAI_FUNC void luaC_linkupval (lua_State *L, UpVal *uv);
 LUAI_FUNC void luaC_barrierf (lua_State *L, GCObject *o, GCObject *v);
 LUAI_FUNC void luaC_barrierback (lua_State *L, Table *t);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/llex.h
+++ b/libs/elua/elua_base/src/llex.h
@@ -11,6 +11,10 @@
 #include "lzio.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define FIRST_RESERVED	257
 
 /* maximum length of a reserved word */
@@ -77,5 +81,9 @@ LUAI_FUNC void luaX_lexerror (LexState *ls, const char *msg, int token);
 LUAI_FUNC void luaX_syntaxerror (LexState *ls, const char *s);
 LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/llimits.h
+++ b/libs/elua/elua_base/src/llimits.h
@@ -15,6 +15,10 @@
 #include "lua.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef LUAI_UINT32 lu_int32;
 
 typedef LUAI_UMEM lu_mem;
@@ -123,6 +127,10 @@ typedef lu_int32 Instruction;
 #define condhardstacktests(x)	((void)0)
 #else
 #define condhardstacktests(x)	x
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/libs/elua/elua_base/src/lmem.h
+++ b/libs/elua/elua_base/src/lmem.h
@@ -13,6 +13,10 @@
 #include "llimits.h"
 #include "lua.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MEMERRMSG	"not enough memory"
 
 
@@ -44,6 +48,10 @@ LUAI_FUNC void *luaM_toobig (lua_State *L);
 LUAI_FUNC void *luaM_growaux_ (lua_State *L, void *block, int *size,
                                size_t size_elem, int limit,
                                const char *errormsg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/elua/elua_base/src/lobject.h
+++ b/libs/elua/elua_base/src/lobject.h
@@ -16,6 +16,10 @@
 #include "lua.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* tags for values visible from Lua */
 #define LAST_TAG	LUA_TTHREAD
 
@@ -552,6 +556,10 @@ LUAI_FUNC const char *luaO_pushvfstring (lua_State *L, const char *fmt,
 LUAI_FUNC const char *luaO_pushfstring (lua_State *L, const char *fmt, ...);
 LUAI_FUNC void luaO_chunkid (char *out, const char *source, size_t len);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/elua/elua_base/src/lopcodes.h
+++ b/libs/elua/elua_base/src/lopcodes.h
@@ -10,6 +10,10 @@
 #include "llimits.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*===========================================================================
   We assume that instructions are unsigned numbers.
   All instructions have an opcode in the first 6 bits.
@@ -264,5 +268,9 @@ LUAI_DATA const char *const luaP_opnames[NUM_OPCODES+1];  /* opcode names */
 /* number of list items to accumulate before a SETLIST instruction */
 #define LFIELDS_PER_FLUSH	50
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lparser.h
+++ b/libs/elua/elua_base/src/lparser.h
@@ -12,6 +12,10 @@
 #include "lzio.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 ** Expression descriptor
 */
@@ -78,5 +82,9 @@ typedef struct FuncState {
 LUAI_FUNC Proto *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff,
                                             const char *name);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lrodefs.h
+++ b/libs/elua/elua_base/src/lrodefs.h
@@ -12,6 +12,10 @@
 
 #if (MIN_OPT_LEVEL > 0) && (LUA_OPTIMIZE_MEMORY >= MIN_OPT_LEVEL)
 #define LUA_REG_TYPE                luaR_entry 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LSTRKEY                     LRO_STRKEY
 #define LNUMKEY                     LRO_NUMKEY
 #define LNILKEY                     LRO_NILKEY
@@ -30,5 +34,9 @@
 #define LREGISTER(L, name, table)\
   luaL_register(L, name, table);\
   return 1
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 

--- a/libs/elua/elua_base/src/lrotable.h
+++ b/libs/elua/elua_base/src/lrotable.h
@@ -8,6 +8,10 @@
 #include "lobject.h"
 #include "luaconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Macros one can use to define rotable entries */
 #ifndef LUA_PACK_VALUE
 #define LRO_FUNCVAL(v)  {{.p = v}, LUA_TLIGHTFUNCTION}
@@ -72,6 +76,10 @@ void* luaR_getmeta(void *data);
 int luaR_isrotable(void *p);
 #else
 #define luaR_isrotable(p)     (0)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/libs/elua/elua_base/src/lstate.h
+++ b/libs/elua/elua_base/src/lstate.h
@@ -15,6 +15,10 @@
 
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct lua_longjmp;  /* defined in ldo.c */
 
 
@@ -166,6 +170,10 @@ union GCObject {
 
 LUAI_FUNC lua_State *luaE_newthread (lua_State *L);
 LUAI_FUNC void luaE_freethread (lua_State *L, lua_State *L1);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/elua/elua_base/src/lstring.h
+++ b/libs/elua/elua_base/src/lstring.h
@@ -13,6 +13,10 @@
 #include "lstate.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define sizestring(s) (sizeof(union TString)+(luaS_isreadonly(s) ? sizeof(char **) : ((s)->len+1)*sizeof(char)))
 
 #define sizeudata(u)	(sizeof(union Udata)+(u)->len)
@@ -30,5 +34,9 @@ LUAI_FUNC void luaS_resize (lua_State *L, int newsize);
 LUAI_FUNC Udata *luaS_newudata (lua_State *L, size_t s, Table *e);
 LUAI_FUNC TString *luaS_newlstr (lua_State *L, const char *str, size_t l);
 LUAI_FUNC TString *luaS_newrolstr (lua_State *L, const char *str, size_t l);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/ltable.h
+++ b/libs/elua/elua_base/src/ltable.h
@@ -10,6 +10,10 @@
 #include "lobject.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define gnode(t,i)	(&(t)->node[i])
 #define gkey(n)		(&(n)->i_key.tvk)
 #define gval(n)		(&(n)->i_val)
@@ -40,5 +44,9 @@ LUAI_FUNC Node *luaH_mainposition (const Table *t, const TValue *key);
 LUAI_FUNC int luaH_isdummy (Node *n);
 #endif
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/ltm.h
+++ b/libs/elua/elua_base/src/ltm.h
@@ -11,6 +11,10 @@
 #include "lobject.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 * WARNING: if you change the order of this enumeration,
 * grep "ORDER TM"
@@ -50,5 +54,9 @@ LUAI_FUNC const TValue *luaT_gettm (Table *events, TMS event, TString *ename);
 LUAI_FUNC const TValue *luaT_gettmbyobj (lua_State *L, const TValue *o,
                                                        TMS event);
 LUAI_FUNC void luaT_init (lua_State *L);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lua.h
+++ b/libs/elua/elua_base/src/lua.h
@@ -16,6 +16,10 @@
 #include "luaconf.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LUA_VERSION	"Lua 5.1"
 #define LUA_RELEASE	"Lua 5.1.4"
 #define LUA_VERSION_NUM	501
@@ -395,5 +399,9 @@ int lua_main( int argc, char **argv );
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************************************************************/
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/luaconf.h
+++ b/libs/elua/elua_base/src/luaconf.h
@@ -11,6 +11,10 @@
 #include <limits.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 ** ==================================================================
 ** Search for "@@" to find all configurable definitions.
@@ -886,6 +890,10 @@ typedef long int32_t;
 
 #if LUA_OPTIMIZE_MEMORY == 2 && defined(LUA_USE_POPEN)
 #error "Pipes not supported in aggresive optimization mode (LUA_OPTIMIZE_MEMORY=2)"
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/libs/elua/elua_base/src/lualib.h
+++ b/libs/elua/elua_base/src/lualib.h
@@ -11,6 +11,10 @@
 #include "lua.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Key to file-handle type */
 #define LUA_FILEHANDLE		"FILE*"
 
@@ -49,5 +53,9 @@ LUALIB_API void (luaL_openlibs) (lua_State *L);
 #define lua_assert(x)	((void)0)
 #endif
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lundump.h
+++ b/libs/elua/elua_base/src/lundump.h
@@ -12,6 +12,10 @@
 #include "lobject.h"
 #include "lzio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint32_t strsize_t;
 
 /* info about target machine for cross-compilation */
@@ -56,5 +60,9 @@ LUAI_FUNC void luaU_print (const Proto* f, int full);
 
 /* target lua_Number is integral but a constant is non-integer */
 #define LUA_ERR_CC_NOTINTEGER 102
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lvm.h
+++ b/libs/elua/elua_base/src/lvm.h
@@ -13,6 +13,10 @@
 #include "ltm.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define tostring(L,o) ((ttype(o) == LUA_TSTRING) || (luaV_tostring(L, o)))
 
 #define tonumber(o,n)	(ttype(o) == LUA_TNUMBER || \
@@ -32,5 +36,9 @@ LUAI_FUNC void luaV_settable (lua_State *L, const TValue *t, TValue *key,
                                             StkId val);
 LUAI_FUNC void luaV_execute (lua_State *L, int nexeccalls);
 LUAI_FUNC void luaV_concat (lua_State *L, int total, int last);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/elua/elua_base/src/lzio.h
+++ b/libs/elua/elua_base/src/lzio.h
@@ -13,6 +13,10 @@
 #include "lmem.h"
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define EOZ	(-1)			/* end of stream */
 
 typedef struct Zio ZIO;
@@ -68,5 +72,9 @@ struct Zio {
 
 
 LUAI_FUNC int luaZ_fill (ZIO *z);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/flash_test/include/flash_test/flash_test.h
+++ b/libs/flash_test/include/flash_test/flash_test.h
@@ -19,9 +19,17 @@
 #ifndef __FLASH_TEST_H__ 
 #define __FLASH_TEST_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * adds the flash test commands to your shell */
 int
 flash_test_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __FLASH_TEST_H__ */

--- a/libs/imgmgr/include/imgmgr/imgmgr.h
+++ b/libs/imgmgr/include/imgmgr/imgmgr.h
@@ -20,6 +20,10 @@
 #ifndef _IMGMGR_H_
 #define _IMGMGR_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IMGMGR_NMGR_OP_LIST		0
 #define IMGMGR_NMGR_OP_UPLOAD		1
 #define IMGMGR_NMGR_OP_BOOT		2
@@ -58,5 +62,9 @@ int imgr_read_info(int area_id, struct image_version *ver, uint8_t *hash);
  * Returns version number of current image (if available).
  */
 int imgr_my_version(struct image_version *ver);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _IMGMGR_H */

--- a/libs/imgmgr/src/imgmgr_priv.h
+++ b/libs/imgmgr/src/imgmgr_priv.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IMGMGR_MAX_IMGS		2
 
 #define IMGMGR_HASH_STR		48
@@ -107,5 +111,9 @@ int imgr_core_erase(struct nmgr_jbuf *);
 
 int imgr_find_by_ver(struct image_version *find, uint8_t *hash);
 int imgr_find_by_hash(uint8_t *find, struct image_version *ver);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IMGMGR_PRIV_H */

--- a/libs/inet_def_service/include/inet_def_service/inet_def_service.h
+++ b/libs/inet_def_service/include/inet_def_service/inet_def_service.h
@@ -20,6 +20,14 @@
 #ifndef __INET_DEF_SERVICE_H__
 #define __INET_DEF_SERVICE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int inet_def_service_init(uint8_t prio, os_stack_t *stack, uint16_t stack_sz);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __INET_DEF_SERVICE_H__ */

--- a/libs/json/include/json/json.h
+++ b/libs/json/include/json/json.h
@@ -27,6 +27,10 @@
 #include <sys/types.h>
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define JSON_VALUE_TYPE_BOOL   (0)
 #define JSON_VALUE_TYPE_UINT64 (1)
 #define JSON_VALUE_TYPE_INT64  (2)
@@ -241,5 +245,9 @@ int json_read_array(struct json_buffer *, const struct json_array_t *);
         .addr.array.arr.objects.stride = sizeof(a[0]), \
         .addr.array.count = n, \
         .addr.array.maxlen = (int)(sizeof(a)/sizeof(a[0]))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _JSON_H_ */

--- a/libs/json/src/test/test_json.h
+++ b/libs/json/src/test/test_json.h
@@ -20,8 +20,16 @@
 #ifndef TEST_JSON_H
 #define TEST_JSON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 TEST_CASE_DECL(test_json_simple_encode);
 TEST_CASE_DECL(test_json_simple_decode);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TEST_JSON_H */
 

--- a/libs/mbedtls/include/mbedtls/bn_mul.h
+++ b/libs/mbedtls/include/mbedtls/bn_mul.h
@@ -39,6 +39,10 @@
 
 #include "bignum.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(MBEDTLS_HAVE_ASM)
 
 #ifndef asm
@@ -872,5 +876,9 @@
 
 #endif /* C (generic)  */
 #endif /* C (longlong) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* bn_mul.h */

--- a/libs/mbedtls/include/mbedtls/check_config.h
+++ b/libs/mbedtls/include/mbedtls/check_config.h
@@ -29,6 +29,10 @@
 #ifndef MBEDTLS_CHECK_CONFIG_H
 #define MBEDTLS_CHECK_CONFIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * We assume CHAR_BIT is 8 in many places. In practice, this is true on our
  * target platforms, so not an issue, but let's just be extra sure.
@@ -536,5 +540,9 @@
  * #if defined(MBEDTLS_xxx_C) that results in emtpy translation units.
  */
 typedef int mbedtls_iso_c_forbids_empty_translation_units;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MBEDTLS_CHECK_CONFIG_H */

--- a/libs/mbedtls/include/mbedtls/compat-1.3.h
+++ b/libs/mbedtls/include/mbedtls/compat-1.3.h
@@ -33,6 +33,10 @@
 #ifndef MBEDTLS_COMPAT13_H
 #define MBEDTLS_COMPAT13_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * config.h options
  */
@@ -2631,4 +2635,8 @@
 #define xtea_setup mbedtls_xtea_setup
 
 #endif /* compat-1.3.h */
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MBEDTLS_DEPRECATED_REMOVED */

--- a/libs/mbedtls/include/mbedtls/config.h
+++ b/libs/mbedtls/include/mbedtls/config.h
@@ -28,6 +28,10 @@
 #ifndef MBEDTLS_CONFIG_H
 #define MBEDTLS_CONFIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
@@ -2519,5 +2523,9 @@
 #endif
 
 #include "check_config.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MBEDTLS_CONFIG_H */

--- a/libs/mbedtls/include/mbedtls/config_mynewt.h
+++ b/libs/mbedtls/include/mbedtls/config_mynewt.h
@@ -28,6 +28,10 @@
 #ifndef MBEDTLS_CONFIG_MYNEWT_H
 #define MBEDTLS_CONFIG_MYNEWT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #undef MBEDTLS_HAVE_TIME /* we have no time.h */
 #undef MBEDTLS_HAVE_TIME_DATE
 #define MBEDTLS_PLATFORM_PRINTF_ALT	console_print
@@ -135,5 +139,9 @@
 
 /* \} name SECTION: Module configuration options */
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MBEDTLS_CONFIG_MYNEWT_H */

--- a/libs/mbedtls/include/mbedtls/mbedtls_test.h
+++ b/libs/mbedtls/include/mbedtls/mbedtls_test.h
@@ -19,6 +19,14 @@
 #ifndef _MBEDTLS_TEST_H_
 #define _MBEDTLS_TEST_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int mbedtls_test_all();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/mbedtls/include/mbedtls/pk_internal.h
+++ b/libs/mbedtls/include/mbedtls/pk_internal.h
@@ -24,6 +24,10 @@
 #ifndef MBEDTLS_PK_WRAP_H
 #define MBEDTLS_PK_WRAP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "config.h"
 #else
@@ -109,6 +113,10 @@ extern const mbedtls_pk_info_t mbedtls_ecdsa_info;
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 extern const mbedtls_pk_info_t mbedtls_rsa_alt_info;
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* MBEDTLS_PK_WRAP_H */

--- a/libs/newtmgr/include/newtmgr/newtmgr.h
+++ b/libs/newtmgr/include/newtmgr/newtmgr.h
@@ -24,6 +24,10 @@
 #include <inttypes.h>
 #include <os/os.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* MTU for newtmgr responses */
 #define NMGR_MAX_MTU 1024
 
@@ -133,5 +137,9 @@ int nmgr_transport_init(struct nmgr_transport *nt,
 int nmgr_rx_req(struct nmgr_transport *nt, struct os_mbuf *req);
 int nmgr_rsp_extend(struct nmgr_hdr *, struct os_mbuf *, void *data, uint16_t);
 int nmgr_group_register(struct nmgr_group *group);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _NETMGR_H */

--- a/libs/newtmgr/src/newtmgr_priv.h
+++ b/libs/newtmgr/src/newtmgr_priv.h
@@ -19,6 +19,10 @@
 #ifndef __NETMGR_PRIV_H_
 #define __NETMGR_PRIV_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct os_eventq g_nmgr_evq;
 
 int nmgr_def_taskstat_read(struct nmgr_jbuf *);
@@ -27,5 +31,9 @@ int nmgr_def_logs_read(struct nmgr_jbuf *);
 int nmgr_datetime_get(struct nmgr_jbuf *);
 int nmgr_datetime_set(struct nmgr_jbuf *);
 int nmgr_reset(struct nmgr_jbuf *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/newtmgr/transport/ble/include/nmgrble/newtmgr_ble.h
+++ b/libs/newtmgr/transport/ble/include/nmgrble/newtmgr_ble.h
@@ -20,9 +20,17 @@
 #ifndef _NEWTMGR_BLE_H_
 #define _NEWTMGR_BLE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int
 nmgr_ble_proc_mq_evt(struct os_event *ev);
 int
 nmgr_ble_gatt_svr_init(struct os_eventq *evq, struct ble_hs_cfg *cfg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _NETMGR_H */

--- a/libs/os/include/os/arch/cortex_m0/os/os_arch.h
+++ b/libs/os/include/os/arch/cortex_m0/os/os_arch.h
@@ -23,6 +23,10 @@
 #include <stdint.h>
 #include <mcu/cortex_m0.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_task;
 
 /* Run in priviliged or unprivileged Thread mode */
@@ -70,5 +74,9 @@ void os_default_irq_asm(void);
 /* External function prototypes supplied by BSP */
 void os_bsp_systick_init(uint32_t os_ticks_per_sec, int prio);
 void os_bsp_ctx_sw(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_ARCH_ARM_H */

--- a/libs/os/include/os/arch/cortex_m4/os/os_arch.h
+++ b/libs/os/include/os/arch/cortex_m4/os/os_arch.h
@@ -23,6 +23,10 @@
 #include <stdint.h>
 #include "mcu/cortex_m4.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_task;
 
 /* Run in priviliged or unprivileged Thread mode */
@@ -71,5 +75,9 @@ void os_default_irq_asm(void);
 void os_bsp_systick_init(uint32_t os_tick_per_sec, int prio);
 void os_bsp_idle(os_time_t ticks);
 void os_bsp_ctx_sw(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_ARCH_ARM_H */

--- a/libs/os/include/os/arch/sim/os/os_arch.h
+++ b/libs/os/include/os/arch/sim/os/os_arch.h
@@ -22,6 +22,10 @@
 
 #include <mcu/mcu_sim.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_task;
 
 /* CPU status register */
@@ -70,5 +74,9 @@ int os_arch_in_critical(void);
 os_error_t os_arch_os_init(void);
 void os_arch_os_stop(void);
 os_error_t os_arch_os_start(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_ARCH_SIM_H */

--- a/libs/os/include/os/endian.h
+++ b/libs/os/include/os/endian.h
@@ -22,6 +22,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 #ifndef ntohll
@@ -89,4 +93,8 @@
 #endif
 
 #endif
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/libs/os/include/os/os.h
+++ b/libs/os/include/os/os.h
@@ -23,6 +23,10 @@
 #include <stdlib.h>
 //#include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef min
 #define min(a, b) ((a)<(b)?(a):(b))
 #endif
@@ -95,5 +99,9 @@ void os_init_idle_task(void);
 #include "os/os_sem.h"
 #include "os/os_mempool.h"
 #include "os/os_mbuf.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_H */

--- a/libs/os/include/os/os_callout.h
+++ b/libs/os/include/os/os_callout.h
@@ -21,6 +21,10 @@
 #ifndef _OS_CALLOUT_H
 #define _OS_CALLOUT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define OS_CALLOUT_F_QUEUED (0x01)
 
 struct os_callout {
@@ -53,6 +57,10 @@ os_callout_queued(struct os_callout *c)
 {
     return c->c_next.tqe_prev != NULL;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_CALLOUT_H */
 

--- a/libs/os/include/os/os_cfg.h
+++ b/libs/os/include/os/os_cfg.h
@@ -22,4 +22,12 @@
 #define _OS_CFG_H_ 
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _OS_CFG_H_ */

--- a/libs/os/include/os/os_eventq.h
+++ b/libs/os/include/os/os_eventq.h
@@ -23,6 +23,10 @@
 #include <inttypes.h>
 #include <os/os_time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_event {
     uint8_t ev_queued;
     uint8_t ev_type;
@@ -46,6 +50,10 @@ void os_eventq_put(struct os_eventq *, struct os_event *);
 struct os_event *os_eventq_get(struct os_eventq *);
 struct os_event *os_eventq_poll(struct os_eventq **, int, os_time_t);
 void os_eventq_remove(struct os_eventq *, struct os_event *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_EVENTQ_H */
 

--- a/libs/os/include/os/os_heap.h
+++ b/libs/os/include/os/os_heap.h
@@ -22,9 +22,17 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void *os_malloc(size_t size);
 void os_free(void *mem);
 void *os_realloc(void *ptr, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/libs/os/include/os/os_malloc.h
+++ b/libs/os/include/os/os_malloc.h
@@ -22,6 +22,10 @@
 
 #include "os/os_heap.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #undef  malloc
 #define malloc  os_malloc
 
@@ -30,5 +34,9 @@
 
 #undef  realloc
 #define realloc  os_realloc
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/os/include/os/os_mbuf.h
+++ b/libs/os/include/os/os_mbuf.h
@@ -23,6 +23,10 @@
 #include "os/queue.h"
 #include "os/os_eventq.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * A mbuf pool from which to allocate mbufs. This contains a pointer to the os 
  * mempool to allocate mbufs out of, the total number of elements in the pool, 
@@ -290,5 +294,9 @@ int os_mbuf_copyinto(struct os_mbuf *om, int off, const void *src, int len);
 void os_mbuf_concat(struct os_mbuf *first, struct os_mbuf *second);
 void *os_mbuf_extend(struct os_mbuf *om, uint16_t len);
 struct os_mbuf *os_mbuf_pullup(struct os_mbuf *om, uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_MBUF_H */ 

--- a/libs/os/include/os/os_mempool.h
+++ b/libs/os/include/os/os_mempool.h
@@ -23,6 +23,10 @@
 #include "os/os.h"
 #include "os/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* 
  * A memory block structure. This simply contains a pointer to the free list 
  * chain and is only used when the block is on the free list. When the block 
@@ -90,5 +94,9 @@ void *os_memblock_get(struct os_mempool *mp);
 
 /* Put the memory block back into the pool */
 os_error_t os_memblock_put(struct os_mempool *mp, void *block_addr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _OS_MEMPOOL_H_ */

--- a/libs/os/include/os/os_mutex.h
+++ b/libs/os/include/os/os_mutex.h
@@ -23,6 +23,10 @@
 #include "os/os.h"
 #include "os/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mutex
 {
     SLIST_HEAD(, os_task) mu_head;  /* chain of waiting tasks */
@@ -55,5 +59,9 @@ os_error_t os_mutex_release(struct os_mutex *mu);
 
 /* Pend (wait) for a mutex */
 os_error_t os_mutex_pend(struct os_mutex *mu, uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _OS_MUTEX_H_ */

--- a/libs/os/include/os/os_sanity.h
+++ b/libs/os/include/os/os_sanity.h
@@ -25,6 +25,10 @@
 #include "os/os_time.h"
 #include "os/queue.h" 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_sanity_check;
 typedef int (*os_sanity_check_func_t)(struct os_sanity_check *, void *);
 
@@ -50,5 +54,9 @@ int os_sanity_task_checkin(struct os_task *);
 int os_sanity_check_init(struct os_sanity_check *);
 int os_sanity_check_register(struct os_sanity_check *);
 int os_sanity_check_reset(struct os_sanity_check *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_SANITY_H */

--- a/libs/os/include/os/os_sched.h
+++ b/libs/os/include/os/os_sched.h
@@ -22,6 +22,10 @@
 
 #include "os/os_task.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void os_sched_ctx_sw_hook(struct os_task *);
 struct os_task *os_sched_get_current_task(void);
 void os_sched_set_current_task(struct os_task *);
@@ -33,5 +37,9 @@ int os_sched_sleep(struct os_task *, os_time_t nticks);
 int os_sched_wakeup(struct os_task *);
 void os_sched_resort(struct os_task *);
 os_time_t os_sched_wakeup_ticks(os_time_t now);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_SCHED_H */

--- a/libs/os/include/os/os_sem.h
+++ b/libs/os/include/os/os_sem.h
@@ -22,6 +22,10 @@
 
 #include "os/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_sem
 {
     SLIST_HEAD(, os_task) sem_head;     /* chain of waiting tasks */
@@ -48,5 +52,9 @@ os_error_t os_sem_release(struct os_sem *sem);
 
 /* Pend (wait) for a semaphore */
 os_error_t os_sem_pend(struct os_sem *sem, uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _OS_MUTEX_H_ */

--- a/libs/os/include/os/os_task.h
+++ b/libs/os/include/os/os_task.h
@@ -24,6 +24,10 @@
 #include "os/os_sanity.h" 
 #include "os/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The highest and lowest task priorities */
 #define OS_TASK_PRI_HIGHEST (0)
 #define OS_TASK_PRI_LOWEST  (0xff)
@@ -110,5 +114,9 @@ struct os_task_info {
 struct os_task *os_task_info_get_next(const struct os_task *, 
         struct os_task_info *);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_TASK_H */

--- a/libs/os/include/os/os_test.h
+++ b/libs/os/include/os/os_test.h
@@ -20,6 +20,14 @@
 #ifndef H_OS_TEST_
 #define H_OS_TEST_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int os_test_all(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/os/include/os/os_time.h
+++ b/libs/os/include/os/os_time.h
@@ -55,6 +55,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef UINT32_MAX
 #define UINT32_MAX  0xFFFFFFFFU
 #endif
@@ -107,5 +111,9 @@ int os_settimeofday(struct os_timeval *utctime, struct os_timezone *tz);
 int os_gettimeofday(struct os_timeval *utctime, struct os_timezone *tz);
 int64_t os_get_uptime_usec(void);
 int os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OS_TIME_H */

--- a/libs/os/include/os/queue.h
+++ b/libs/os/include/os/queue.h
@@ -33,6 +33,10 @@
 #ifndef _QUEUE_H_
 #define	_QUEUE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This file defines five types of data structures: singly-linked lists,
  * singly-linked tail queues, lists, tail queues, and circular queues.
@@ -510,5 +514,9 @@ struct {								\
 		CIRCLEQ_NEXT(CIRCLEQ_PREV((elm), field), field) =	\
 		    CIRCLEQ_NEXT((elm), field);				\
 } while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_QUEUE_H_ */

--- a/libs/os/src/os_priv.h
+++ b/libs/os/src/os_priv.h
@@ -22,6 +22,10 @@
 
 #include "os/queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 TAILQ_HEAD(os_task_list, os_task);
 TAILQ_HEAD(os_callout_list, os_callout);
 STAILQ_HEAD(os_task_stailq, os_task);
@@ -32,5 +36,9 @@ extern struct os_task_list g_os_sleep_list;
 extern struct os_task_stailq g_os_task_list;
 extern struct os_task *g_current_task;
 extern struct os_callout_list g_callout_list;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/os/src/test/os_test_priv.h
+++ b/libs/os/src/test/os_test_priv.h
@@ -20,6 +20,10 @@
 #ifndef H_OS_TEST_PRIV_
 #define H_OS_TEST_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void os_test_restart(void);
 
 int os_mempool_test_suite(void);
@@ -28,5 +32,9 @@ int os_mutex_test_suite(void);
 int os_sem_test_suite(void);
 int os_eventq_test_suite(void);
 int os_callout_test_suite(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/shell/include/shell/shell.h
+++ b/libs/shell/include/shell/shell.h
@@ -21,6 +21,10 @@
 
 #include <os/os.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int (*shell_cmd_func_t)(int argc, char **argv);
 struct shell_cmd {
     char *sc_cmd;
@@ -42,5 +46,9 @@ int shell_nlip_output(struct os_mbuf *m);
 void shell_console_rx_cb(void);
 int shell_task_init(uint8_t prio, os_stack_t *stack, uint16_t stack_size,
                     int max_input_length);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SHELL_H__ */

--- a/libs/shell/src/shell_priv.h
+++ b/libs/shell/src/shell_priv.h
@@ -20,8 +20,16 @@
 #ifndef __SHELL_PRIV_H_
 #define __SHELL_PRIV_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int shell_os_tasks_display_cmd(int argc, char **argv);
 int shell_os_mpool_display_cmd(int argc, char **argv);
 int shell_os_date_cmd(int argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SHELL_PRIV_H_ */

--- a/libs/testreport/include/testreport/testreport.h
+++ b/libs/testreport/include/testreport/testreport.h
@@ -20,6 +20,10 @@
 #ifndef H_TESTREPORT_
 #define H_TESTREPORT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct nffs_area_desc;
 
 struct tr_config {
@@ -30,5 +34,9 @@ struct tr_config {
 extern struct tr_config tr_config;
 
 int tr_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/testreport/src/testreport_priv.h
+++ b/libs/testreport/src/testreport_priv.h
@@ -23,6 +23,10 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int tr_results_mkdir_results(void);
 int tr_results_rmdir_results(void);
 
@@ -44,5 +48,9 @@ int tr_io_delete(const char *path);
 
 int tr_io_mkdir(const char *path);
 int tr_io_rmdir(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/testutil/include/testutil/testutil.h
+++ b/libs/testutil/include/testutil/testutil.h
@@ -23,6 +23,10 @@
 #include <inttypes.h>
 #include <setjmp.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*****************************************************************************
  * Public declarations                                                       *
  *****************************************************************************/
@@ -167,6 +171,10 @@ extern jmp_buf tu_case_jb;
 #define ASSERT_IF_TEST(expr) assert(expr)
 #else
 #define ASSERT_IF_TEST(expr)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/libs/testutil/src/testutil_priv.h
+++ b/libs/testutil/src/testutil_priv.h
@@ -25,10 +25,18 @@
 
 #include "testutil/testutil.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tu_arch_restart(void);
 void tu_case_abort(void);
 
 extern tu_post_test_fn_t *tu_case_post_test_cb;
 extern void *tu_case_post_test_cb_arg;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/util/include/util/base64.h
+++ b/libs/util/include/util/base64.h
@@ -22,11 +22,19 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int base64_encode(const void *, int, char *, uint8_t);
 int base64_decode(const char *, void *buf);
 int base64_pad(char *, int);
 int base64_decode_len(const char *str);
 
 #define BASE64_ENCODE_SIZE(__size) ((((__size) * 4) / 3) + 4)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UTIL_BASE64_H__ */

--- a/libs/util/include/util/cbmem.h
+++ b/libs/util/include/util/cbmem.h
@@ -21,6 +21,10 @@
 
 #include <os/os.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct cbmem_entry_hdr {
     uint16_t ceh_len;
     uint16_t ceh_flags;
@@ -62,5 +66,9 @@ int cbmem_read(struct cbmem *cbmem, struct cbmem_entry_hdr *hdr, void *buf,
 int cbmem_walk(struct cbmem *cbmem, cbmem_walk_func_t walk_func, void *arg);
 
 int cbmem_flush(struct cbmem *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UTIL_CBMEM_H__ */

--- a/libs/util/include/util/crc16.h
+++ b/libs/util/include/util/crc16.h
@@ -30,7 +30,15 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CRC16_INITIAL_CRC       0       /* what to seed crc16 with */
 unsigned short crc16_ccitt(uint16_t initial_crc, const void *buf, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _CRC16_H_ */

--- a/libs/util/include/util/crc8.h
+++ b/libs/util/include/util/crc8.h
@@ -26,7 +26,15 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t crc8_init(void);
 uint8_t crc8_calc(uint8_t val, void *buf, int cnt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/util/include/util/datetime.h
+++ b/libs/util/include/util/datetime.h
@@ -19,6 +19,10 @@
 #ifndef __UTIL_DATETIME_H
 #define __UTIL_DATETIME_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_timeval;
 struct os_timezone;
 
@@ -46,5 +50,9 @@ int format_datetime(const struct os_timeval *utctime,
  */
 int parse_datetime(const char *input, struct os_timeval *utctime,
     struct os_timezone *tz);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* __UTIL_DATETIME_H */

--- a/libs/util/include/util/mem.h
+++ b/libs/util/include/util/mem.h
@@ -20,6 +20,10 @@
 #ifndef H_UTIL_MEM_
 #define H_UTIL_MEM_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mempool;
 struct os_mbuf_pool;
 
@@ -34,5 +38,9 @@ int mem_malloc_mbufpkt_pool(struct os_mempool *mempool,
                             struct os_mbuf_pool *mbuf_pool, int num_blocks,
                             int block_size, char *name,
                             void **out_buf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/util/include/util/tpq.h
+++ b/libs/util/include/util/tpq.h
@@ -22,6 +22,10 @@
 #include <os/queue.h>
 #include <os/os_eventq.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* A task packet queue element */
 struct tpq_elem {
     STAILQ_ENTRY(tpq_elem) tpq_next;
@@ -63,5 +67,9 @@ struct tpq_elem *tpq_get(struct tpq *tpq);
  * @return int 
  */
 void tpq_init(struct tpq *tpq, uint8_t ev_type, void *ev_arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UTIL_TPQ_H__ */

--- a/libs/util/include/util/util.h
+++ b/libs/util/include/util/util.h
@@ -19,6 +19,14 @@
 #ifndef __UTIL_H__ 
 #define __UTIL_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CTASSERT(x) typedef int __ctasssert ## __LINE__[(x) ? 1 : -1]
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UTIL_H__ */

--- a/libs/util/src/test/util_test_priv.h
+++ b/libs/util/src/test/util_test_priv.h
@@ -20,6 +20,14 @@
 #ifndef __UTIL_TEST_PRIV_
 #define __UTIL_TEST_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int cbmem_test_suite(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libs/wifi_mgmt/include/wifi_mgmt/wifi_mgmt.h
+++ b/libs/wifi_mgmt/include/wifi_mgmt/wifi_mgmt.h
@@ -19,6 +19,10 @@
 #ifndef __WIFI_MGMT_H__
 #define __WIFI_MGMT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Wi-Fi interface abstraction.
  */
@@ -78,5 +82,9 @@ int wifi_stop(struct wifi_if *w);
 int wifi_scan_start(struct wifi_if *w);
 
 int wifi_task_init(uint8_t prio, os_stack_t *stack, uint16_t stack_size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __WIFI_MGMT_H__ */

--- a/libs/wifi_mgmt/include/wifi_mgmt/wifi_mgmt_if.h
+++ b/libs/wifi_mgmt/include/wifi_mgmt/wifi_mgmt_if.h
@@ -19,6 +19,10 @@
 #ifndef __WIFI_MGMT_IF_H__
 #define __WIFI_MGMT_IF_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Interface between Wi-fi management and the driver.
  */
@@ -43,5 +47,9 @@ void wifi_scan_done(struct wifi_if *, int status);
 void wifi_connect_done(struct wifi_if *wi, int status);
 void wifi_disconnected(struct wifi_if *wi, int status);
 void wifi_dhcp_done(struct wifi_if *wi, uint8_t *ip); /* XXX more IP info */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __WIFI_MGMT_IF_H__ */

--- a/libs/wifi_mgmt/src/wifi_priv.h
+++ b/libs/wifi_mgmt/src/wifi_priv.h
@@ -20,8 +20,16 @@
 #ifndef __WIFI_PRIV_H__
 #define __WIFI_PRIV_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef SHELL_PRESENT
 extern struct shell_cmd wifi_cli_cmd;
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __WIFI_PRIV_H__ */

--- a/net/nimble/controller/include/controller/ble_hw.h
+++ b/net/nimble/controller/include/controller/ble_hw.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_HW_
 #define H_BLE_HW_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(ARCH_sim)
 #define BLE_USES_HW_WHITELIST   (0)
 #else
@@ -96,5 +100,9 @@ void ble_hw_resolv_list_disable(void);
 
 /* Returns index of resolved address; -1 if not resolved */
 int ble_hw_resolv_list_match(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_HW_ */

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -25,6 +25,10 @@
 #include "os/os_eventq.h"
 #include "nimble/nimble_opt.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Controller revision. */
 #define BLE_LL_SUB_VERS_NR      (0x0000)
 
@@ -415,6 +419,10 @@ extern uint64_t g_bletest_SKDm;
 extern uint64_t g_bletest_SKDs;
 extern uint32_t g_bletest_IVm;
 extern uint32_t g_bletest_IVs;
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* H_LL_ */

--- a/net/nimble/controller/include/controller/ble_ll_adv.h
+++ b/net/nimble/controller/include/controller/ble_ll_adv.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_LL_ADV_
 #define H_BLE_LL_ADV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * ADV event timing
  *      T_advEvent = advInterval + advDelay
@@ -161,5 +165,9 @@ void ble_ll_adv_halt(void);
 
 /* Called to determine if advertising is enabled */
 uint8_t ble_ll_adv_enabled(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_ADV_ */

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -27,6 +27,10 @@
 #include "controller/ble_ll_ctrl.h"
 #include "hal/hal_cputime.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Roles */
 #define BLE_LL_CONN_ROLE_NONE           (0)
 #define BLE_LL_CONN_ROLE_MASTER         (1)
@@ -279,5 +283,9 @@ struct ble_ll_conn_sm
  *
  */
 struct ble_ll_conn_sm *ble_ll_conn_find_active_conn(uint16_t handle);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_CONN_ */

--- a/net/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/net/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_LL_CTRL_
 #define H_BLE_LL_CTRL_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * LL control procedures. This "enumeration" is not in the specification;
  * It is used to determine which LL control procedure is currently running
@@ -246,5 +250,9 @@ void ble_ll_hci_ev_encrypt_chg(struct ble_ll_conn_sm *connsm, uint8_t status);
 int ble_ll_hci_ev_ltk_req(struct ble_ll_conn_sm *connsm);
 
 void ble_ll_calc_session_key(struct ble_ll_conn_sm *connsm);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_CTRL_ */

--- a/net/nimble/controller/include/controller/ble_ll_hci.h
+++ b/net/nimble/controller/include/controller/ble_ll_hci.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_LL_HCI_
 #define H_BLE_LL_HCI_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* For supported commands */
 #define BLE_LL_SUPP_CMD_LEN (36)
 extern const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN];
@@ -51,5 +55,9 @@ int ble_ll_hci_event_send(uint8_t *evbuf);
 /* Sends a command complete with a no-op opcode to host */
 int ble_ll_hci_send_noop(void);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_HCI_ */

--- a/net/nimble/controller/include/controller/ble_ll_resolv.h
+++ b/net/nimble/controller/include/controller/ble_ll_resolv.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_LL_RESOLV_
 #define H_BLE_LL_RESOLV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * An entry in the resolving list.
  *      The identity address is stored in little endian format.
@@ -89,5 +93,9 @@ int ble_ll_resolv_rpa(uint8_t *rpa, uint8_t *irk);
 
 /* Initialize resolv*/
 void ble_ll_resolv_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -23,6 +23,10 @@
 #include "controller/ble_ll_sched.h"
 #include "hal/hal_cputime.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * SCAN_REQ
  *      -> ScanA    (6 bytes)
@@ -138,5 +142,9 @@ void ble_ll_scan_chk_resume(void);
 
 /* Called when wait for response timer expires in scanning mode */
 void ble_ll_scan_wfr_timer_exp(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_SCAN_ */

--- a/net/nimble/controller/include/controller/ble_ll_sched.h
+++ b/net/nimble/controller/include/controller/ble_ll_sched.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_LL_SCHED_
 #define H_BLE_LL_SCHED_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Time per BLE scheduler slot */
 #define BLE_LL_SCHED_USECS_PER_SLOT (1250)
 
@@ -100,5 +104,9 @@ int ble_ll_sched_next_time(uint32_t *next_event_time);
 
 /* Stop the scheduler */
 void ble_ll_sched_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_LL_SCHED_ */

--- a/net/nimble/controller/include/controller/ble_ll_whitelist.h
+++ b/net/nimble/controller/include/controller/ble_ll_whitelist.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_LL_WHITELIST_
 #define H_BLE_LL_WHITELIST_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Clear the whitelist */
 int ble_ll_whitelist_clear(void);
 
@@ -40,5 +44,9 @@ void ble_ll_whitelist_disable(void);
 
 /* Boolean function returning true if address matches a whitelist entry */
 int ble_ll_whitelist_match(uint8_t *addr, uint8_t addr_type, int is_ident);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_WHITELIST_ */

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_PHY_
 #define H_BLE_PHY_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Forward declarations */
 struct os_mbuf;
 
@@ -147,5 +151,9 @@ void ble_phy_resolv_list_enable(void);
 
 /* Disable phy resolving list */
 void ble_phy_resolv_list_disable(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_PHY_ */

--- a/net/nimble/controller/src/ble_ll_conn_priv.h
+++ b/net/nimble/controller/src/ble_ll_conn_priv.h
@@ -22,6 +22,10 @@
 
 #include "controller/ble_ll_conn.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Definitions for max rx/tx time/bytes for connections
  *  NOTE: you get 327 usecs from 27 bytes of payload by:
@@ -157,5 +161,9 @@ void ble_ll_conn_auth_pyld_timer_start(struct ble_ll_conn_sm *connsm);
 
 int ble_ll_hci_cmd_rx(uint8_t *cmd, void *arg);
 int ble_ll_hci_acl_rx(struct os_mbuf *om, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_LL_CONN_PRIV_ */

--- a/net/nimble/drivers/native/include/ble/xcvr.h
+++ b/net/nimble/drivers/native/include/ble/xcvr.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_XCVR_
 #define H_BLE_XCVR_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Transceiver specific defintions */
 #define XCVR_RX_START_DELAY_USECS     (140)
 #define XCVR_TX_START_DELAY_USECS     (140)
@@ -34,5 +38,9 @@
  * not necessarily the size that will be used (may be smaller)
  */
 #define BLE_HW_WHITE_LIST_SIZE        (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_XCVR_ */

--- a/net/nimble/drivers/nrf51/include/ble/xcvr.h
+++ b/net/nimble/drivers/nrf51/include/ble/xcvr.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_XCVR_
 #define H_BLE_XCVR_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Transceiver specific defintions */
 #define XCVR_RX_START_DELAY_USECS     (140)
 #define XCVR_TX_START_DELAY_USECS     (140)
@@ -34,5 +38,9 @@
  * not necessarily the size that will be used (may be smaller)
  */
 #define BLE_HW_WHITE_LIST_SIZE        (8)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_XCVR_ */

--- a/net/nimble/drivers/nrf52/include/ble/xcvr.h
+++ b/net/nimble/drivers/nrf52/include/ble/xcvr.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_XCVR_
 #define H_BLE_XCVR_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Transceiver specific definitions */
 #define XCVR_RX_START_DELAY_USECS     (140)
 #define XCVR_TX_START_DELAY_USECS     (140)
@@ -34,5 +38,9 @@
  * not necessarily the size that will be used (may be smaller)
  */
 #define BLE_HW_WHITE_LIST_SIZE        (8)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_XCVR_ */

--- a/net/nimble/host/include/host/ble_att.h
+++ b/net/nimble/host/include/host/ble_att.h
@@ -21,6 +21,10 @@
 #define H_BLE_ATT_
 
 #include "os/queue.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 #define BLE_ATT_UUID_PRIMARY_SERVICE        0x2800
@@ -100,5 +104,9 @@ int ble_att_svr_write_local(uint16_t attr_handle, struct os_mbuf *om);
 uint16_t ble_att_mtu(uint16_t conn_handle);
 uint16_t ble_att_preferred_mtu(void);
 int ble_att_set_preferred_mtu(uint16_t mtu);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_eddystone.h
+++ b/net/nimble/host/include/host/ble_eddystone.h
@@ -21,6 +21,10 @@
 #define H_BLE_EDDYSTONE_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_adv_fields;
 
 #define BLE_EDDYSTONE_MAX_UUIDS16           3
@@ -52,5 +56,9 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
 int ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                    uint8_t url_scheme, char *url_body,
                                    uint8_t url_body_len, uint8_t suffix);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -22,6 +22,10 @@
 
 #include <inttypes.h>
 #include "host/ble_hs.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct hci_le_conn_complete;
 struct hci_conn_update;
 
@@ -561,5 +565,9 @@ int ble_gap_pair_initiate(uint16_t conn_handle);
 int ble_gap_encryption_initiate(uint16_t conn_handle, const uint8_t *ltk,
                                 uint16_t ediv, uint64_t rand_val, int auth);
 int ble_gap_conn_rssi(uint16_t conn_handle, int8_t *out_rssi);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -22,6 +22,10 @@
 
 #include <inttypes.h>
 #include "host/ble_att.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_conn;
 struct ble_att_error_rsp;
 struct ble_hs_cfg;
@@ -446,5 +450,9 @@ int ble_gatts_find_chr(const void *svc_uuid128, const void *chr_uuid128,
                        uint16_t *out_def_handle, uint16_t *out_val_handle);
 int ble_gatts_find_dsc(const void *svc_uuid128, const void *chr_uuid128,
                        const void *dsc_uuid128, uint16_t *out_dsc_handle);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_hs.h
+++ b/net/nimble/host/include/host/ble_hs.h
@@ -34,6 +34,10 @@
 #include "host/ble_sm.h"
 #include "host/ble_store.h"
 #include "host/ble_uuid.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_eventq;
 struct os_event;
 
@@ -243,5 +247,9 @@ extern const struct ble_hs_cfg ble_hs_cfg_dflt;
 int ble_hs_synced(void);
 int ble_hs_start(void);
 int ble_hs_init(struct os_eventq *app_evq, struct ble_hs_cfg *cfg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_hs_adv.h
+++ b/net/nimble/host/include/host/ble_hs_adv.h
@@ -22,6 +22,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Max field payload size (account for 2-byte header). */
 #define BLE_HS_ADV_MAX_FIELD_SZ     (BLE_HCI_MAX_ADV_DATA_LEN - 2)
 
@@ -173,5 +177,9 @@ struct ble_hs_adv_fields {
 #define BLE_HS_ADV_SVC_DATA_UUID32_MIN_LEN      4
 
 #define BLE_HS_ADV_SVC_DATA_UUID128_MIN_LEN     16
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_hs_id.h
+++ b/net/nimble/host/include/host/ble_hs_id.h
@@ -22,9 +22,17 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ble_hs_id_gen_rnd(int nrpa, uint8_t *out_addr);
 int ble_hs_id_set_rnd(const uint8_t *rnd_addr);
 int ble_hs_id_copy_addr(uint8_t id_addr_type, uint8_t *out_id_addr,
                         int *out_is_nrpa);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_hs_log.h
+++ b/net/nimble/host/include/host/ble_hs_log.h
@@ -21,6 +21,10 @@
 #define H_BLE_HS_LOG_
 
 #include "log/log.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 extern struct log ble_hs_log;
@@ -35,5 +39,9 @@ extern struct log ble_hs_log;
 
 void ble_hs_log_mbuf(const struct os_mbuf *om);
 void ble_hs_log_flat_buf(const void *data, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_hs_mbuf.h
+++ b/net/nimble/host/include/host/ble_hs_mbuf.h
@@ -21,11 +21,19 @@
 #define H_BLE_HS_MBUF_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 struct os_mbuf *ble_hs_mbuf_att_pkt(void);
 struct os_mbuf *ble_hs_mbuf_from_flat(const void *buf, uint16_t len);
 int ble_hs_mbuf_to_flat(const struct os_mbuf *om, void *flat, uint16_t max_len,
                         uint16_t *out_copy_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_hs_test.h
+++ b/net/nimble/host/include/host/ble_hs_test.h
@@ -21,6 +21,10 @@
 #define H_HOST_TEST_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 int ble_att_clt_test_all(void);
@@ -45,5 +49,9 @@ int ble_sm_lgcy_test_suite(void);
 int ble_sm_sc_test_suite(void);
 int ble_sm_test_all(void);
 int ble_uuid_test_all(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_ibeacon.h
+++ b/net/nimble/host/include/host/ble_ibeacon.h
@@ -20,6 +20,14 @@
 #ifndef H_BLE_IBEACON_
 #define H_BLE_IBEACON_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_l2cap.h
+++ b/net/nimble/host/include/host/ble_l2cap.h
@@ -21,6 +21,10 @@
 #define H_BLE_L2CAP_
 
 #include "nimble/nimble_opt.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_l2cap_sig_update_req;
 struct ble_hs_conn;
 
@@ -65,5 +69,9 @@ struct ble_l2cap_sig_update_params {
 int ble_l2cap_sig_update(uint16_t conn_handle,
                          struct ble_l2cap_sig_update_params *params,
                          ble_l2cap_sig_update_fn *cb, void *cb_arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/include/host/ble_sm.h
+++ b/net/nimble/host/include/host/ble_sm.h
@@ -23,6 +23,10 @@
 #include <inttypes.h>
 #include "nimble/nimble_opt.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BLE_SM_ERR_PASSKEY                      0x01
 #define BLE_SM_ERR_OOB                          0x02
 #define BLE_SM_ERR_AUTHREQ                      0x03
@@ -96,6 +100,10 @@ int ble_sm_inject_io(uint16_t conn_handle, struct ble_sm_io *pkey);
 #else
 #define ble_sm_inject_io(conn_handle, pkey) \
     ((void)(conn_handle), BLE_HS_ENOTSUP)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/net/nimble/host/include/host/ble_store.h
+++ b/net/nimble/host/include/host/ble_store.h
@@ -22,6 +22,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BLE_STORE_OBJ_TYPE_OUR_SEC      1
 #define BLE_STORE_OBJ_TYPE_PEER_SEC     2
 #define BLE_STORE_OBJ_TYPE_CCCD         3
@@ -215,4 +219,8 @@ typedef int ble_store_iterator_fn(int obj_type,
 void ble_store_iterate(int obj_type,
                        ble_store_iterator_fn *callback,
                        void *cookie);
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/net/nimble/host/include/host/ble_uuid.h
+++ b/net/nimble/host/include/host/ble_uuid.h
@@ -21,6 +21,10 @@
 #define H_BLE_UUID_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 uint16_t ble_uuid_128_to_16(const void *uuid128);
@@ -41,5 +45,9 @@ int ble_uuid_16_to_128(uint16_t uuid16, void *dst);
     0x00, 0x10, 0x00, 0x00, (uuid16) & 0xff, (((uuid16) & 0xff00) >> 8),    \
     0x00, 0x00                                                              \
 })
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _BLE_HOST_UUID_H */

--- a/net/nimble/host/services/gap/include/services/gap/ble_svc_gap.h
+++ b/net/nimble/host/services/gap/include/services/gap/ble_svc_gap.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_SVC_GAP_
 #define H_BLE_SVC_GAP_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_cfg;
 
 #define BLE_SVC_GAP_UUID16                                  0x1800
@@ -35,5 +39,9 @@ const char *ble_svc_gap_device_name(void);
 int ble_svc_gap_device_name_set(const char *name);
 
 int ble_svc_gap_init(struct ble_hs_cfg *cfg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
+++ b/net/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
@@ -20,10 +20,18 @@
 #ifndef H_BLE_SVC_GATT_
 #define H_BLE_SVC_GATT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_cfg;
 
 #define BLE_SVC_GATT_CHR_SERVICE_CHANGED_UUID16     0x2a05
 
 int ble_svc_gatt_init(struct ble_hs_cfg *cfg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/services/lls/include/services/lls/ble_svc_lls.h
+++ b/net/nimble/host/services/lls/include/services/lls/ble_svc_lls.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_SVC_LLS_
 #define H_BLE_SVC_LLS_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_cfg;
 
 #define BLE_SVC_LLS_UUID16                                  0x1803
@@ -39,6 +43,10 @@ void ble_svc_lls_on_gap_disconnect(int reason);
 int ble_svc_lls_init(struct ble_hs_cfg *cfg, 
                      uint8_t initial_alert_level,
                      ble_svc_lls_event_fn *cb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/net/nimble/host/src/ble_att_cmd_priv.h
+++ b/net/nimble/host/src/ble_att_cmd_priv.h
@@ -21,6 +21,10 @@
 #define H_BLE_ATT_CMD_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_l2cap_chan;
 
 /**
@@ -407,5 +411,9 @@ void ble_att_indicate_req_write(void *payload, int len,
 void ble_att_indicate_rsp_parse(const void *payload, int len);
 void ble_att_indicate_rsp_write(void *payload, int len);
 void ble_att_indicate_req_log(const struct ble_att_indicate_req *cmd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_att_priv.h
+++ b/net/nimble/host/src/ble_att_priv.h
@@ -24,6 +24,10 @@
 #include "stats/stats.h"
 #include "os/queue.h"
 #include "host/ble_att.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 struct ble_hs_conn;
 struct ble_l2cap_chan;
@@ -293,5 +297,9 @@ int ble_att_clt_tx_indicate(uint16_t conn_handle,
                             const struct ble_att_indicate_req *req,
                             struct os_mbuf *txom);
 int ble_att_clt_rx_indicate(uint16_t conn_handle, struct os_mbuf **rxom);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_gap_priv.h
+++ b/net/nimble/host/src/ble_gap_priv.h
@@ -23,6 +23,10 @@
 #include <inttypes.h>
 #include "stats/stats.h"
 #include "host/ble_gap.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct hci_le_conn_upd_complete;
 struct hci_le_conn_param_req;
 struct hci_le_conn_complete;
@@ -96,5 +100,9 @@ void ble_gap_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_gap_heartbeat(void);
 
 int ble_gap_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_gatt_priv.h
+++ b/net/nimble/host/src/ble_gatt_priv.h
@@ -22,6 +22,10 @@
 
 #include "stats/stats.h"
 #include "host/ble_gatt.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_att_read_type_adata;
 struct ble_att_find_type_value_hinfo;
 struct ble_att_find_info_idata;
@@ -150,5 +154,9 @@ int ble_gatts_conn_can_alloc(void);
 int ble_gatts_conn_init(struct ble_gatts_conn *gatts_conn);
 int ble_gatts_start(void);
 int ble_gatts_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_adv_priv.h
+++ b/net/nimble/host/src/ble_hs_adv_priv.h
@@ -20,11 +20,19 @@
 #ifndef H_BLE_HS_ADV_PRIV_
 #define H_BLE_HS_ADV_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ble_hs_adv_set_flat(uint8_t type, int data_len, const void *data,
                         uint8_t *dst, uint8_t *dst_len, uint8_t max_len);
 int ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
                           uint8_t *dst, uint8_t *dst_len, uint8_t max_len);
 int ble_hs_adv_parse_fields(struct ble_hs_adv_fields *adv_fields, uint8_t *src,
                             uint8_t src_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_atomic_priv.h
+++ b/net/nimble/host/src/ble_hs_atomic_priv.h
@@ -22,6 +22,10 @@
 
 #include "ble_hs_conn_priv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ble_hs_atomic_conn_delete(uint16_t conn_handle);
 void ble_hs_atomic_conn_insert(struct ble_hs_conn *conn);
 int ble_hs_atomic_conn_flags(uint16_t conn_handle,
@@ -29,5 +33,9 @@ int ble_hs_atomic_conn_flags(uint16_t conn_handle,
 int ble_hs_atomic_conn_set_flags(uint16_t conn_handle,
                                  ble_hs_conn_flags_t flags, int on);
 uint16_t ble_hs_atomic_first_conn_handle(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_conn_priv.h
+++ b/net/nimble/host/src/ble_hs_conn_priv.h
@@ -24,6 +24,10 @@
 #include "ble_l2cap_priv.h"
 #include "ble_gatt_priv.h"
 #include "ble_att_priv.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct hci_le_conn_complete;
 struct hci_create_conn;
 struct ble_l2cap_chan;
@@ -91,5 +95,9 @@ void ble_hs_conn_addrs(const struct ble_hs_conn *conn,
                        struct ble_hs_conn_addrs *addrs);
 
 int ble_hs_conn_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_dbg_priv.h
+++ b/net/nimble/host/src/ble_hs_dbg_priv.h
@@ -20,7 +20,15 @@
 #ifndef H_BLE_HS_DBG_PRIV_
 #define H_BLE_HS_DBG_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ble_hs_dbg_event_disp(uint8_t *evbuf);
 void ble_hs_dbg_set_sync_state(uint8_t sync_state);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_HOST_DBG_ */

--- a/net/nimble/host/src/ble_hs_endian_priv.h
+++ b/net/nimble/host/src/ble_hs_endian_priv.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_HS_ENDIAN_
 #define H_BLE_HS_ENDIAN_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 
 #define TOFROMLE16(x)   ((uint16_t) (x))
@@ -52,6 +56,10 @@
 
 #error Unsupported endianness.
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -21,6 +21,10 @@
 #define H_BLE_HS_HCI_PRIV_
 
 #include "nimble/hci_common.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_conn;
 struct os_mbuf;
 
@@ -154,5 +158,9 @@ int ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(
 
 int ble_hs_hci_cmd_build_set_random_addr(const uint8_t *addr,
                                          uint8_t *dst, int dst_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_id_priv.h
+++ b/net/nimble/host/src/ble_hs_id_priv.h
@@ -22,9 +22,17 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ble_hs_id_set_pub(const uint8_t *pub_addr);
 int ble_hs_id_addr(uint8_t id_addr_type, const uint8_t **out_id_addr,
                    int *out_is_nrpa);
 int ble_hs_id_use_addr(uint8_t addr_type);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_mbuf_priv.h
+++ b/net/nimble/host/src/ble_hs_mbuf_priv.h
@@ -1,11 +1,19 @@
 #ifndef H_BLE_HS_MBUF_PRIV_
 #define H_BLE_HS_MBUF_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 struct os_mbuf *ble_hs_mbuf_bare_pkt(void);
 struct os_mbuf *ble_hs_mbuf_acm_pkt(void);
 struct os_mbuf *ble_hs_mbuf_l2cap_pkt(void);
 int ble_hs_mbuf_pullup_base(struct os_mbuf **om, int base_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_priv.h
+++ b/net/nimble/host/src/ble_hs_priv.h
@@ -44,6 +44,10 @@
 #include "host/ble_hs.h"
 #include "nimble/nimble_opt.h"
 #include "stats/stats.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_conn;
 struct ble_l2cap_chan;
 struct os_mbuf;
@@ -138,6 +142,10 @@ void ble_hs_notifications_sched(void);
 #else
     #define BLE_HS_DBG_ASSERT(x)
     #define BLE_HS_DBG_ASSERT_EVAL(x) ((void)(x))
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_pvcy_priv.h
+++ b/net/nimble/host/src/ble_hs_pvcy_priv.h
@@ -22,10 +22,18 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ble_hs_pvcy_set_our_irk(const uint8_t *irk);
 int ble_hs_pvcy_our_irk(const uint8_t **out_irk);
 int ble_hs_pvcy_remove_entry(uint8_t addr_type, uint8_t *addr);
 int ble_hs_pvcy_add_entry(uint8_t *addr, uint8_t addrtype, uint8_t *irk);
 int ble_hs_pvcy_ensure_started(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_hs_startup_priv.h
+++ b/net/nimble/host/src/ble_hs_startup_priv.h
@@ -20,6 +20,14 @@
 #ifndef H_BLE_HS_STARTUP_
 #define H_BLE_HS_STARTUP_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ble_hs_startup_go(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_l2cap_priv.h
+++ b/net/nimble/host/src/ble_l2cap_priv.h
@@ -25,6 +25,10 @@
 #include "stats/stats.h"
 #include "os/queue.h"
 #include "os/os_mbuf.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_conn;
 struct hci_data_hdr;
 
@@ -105,5 +109,9 @@ int ble_l2cap_tx(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan,
                  struct os_mbuf *txom);
 
 int ble_l2cap_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_l2cap_sig_priv.h
+++ b/net/nimble/host/src/ble_l2cap_sig_priv.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_L2CAP_SIG_
 #define H_BLE_L2CAP_SIG_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BLE_L2CAP_SIG_MTU           100  /* This is our own default. */
 
 #define BLE_L2CAP_SIG_HDR_SZ                4
@@ -84,5 +88,9 @@ void ble_l2cap_sig_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_l2cap_sig_heartbeat(void);
 struct ble_l2cap_chan *ble_l2cap_sig_create_chan(void);
 int ble_l2cap_sig_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/ble_sm_priv.h
+++ b/net/nimble/host/src/ble_sm_priv.h
@@ -24,6 +24,10 @@
 #include "os/queue.h"
 #include "nimble/nimble_opt.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_gap_sec_state;
 struct hci_le_lt_key_req;
 struct hci_encrypt_change;
@@ -480,6 +484,10 @@ int ble_sm_init(void);
 
 #define ble_sm_init() 0
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/net/nimble/host/src/ble_uuid_priv.h
+++ b/net/nimble/host/src/ble_uuid_priv.h
@@ -20,9 +20,17 @@
 #ifndef H_BLE_UUID_PRIV_
 #define H_BLE_UUID_PRIV_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 int ble_uuid_append(struct os_mbuf *om, const void *uuid128);
 int ble_uuid_extract(struct os_mbuf *om, int off, void *uuid128);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/test/ble_hs_test_util.h
+++ b/net/nimble/host/src/test/ble_hs_test_util.h
@@ -24,6 +24,10 @@
 #include "host/ble_gap.h"
 #include "ble_hs_priv.h"
 #include "ble_hs_test_util_store.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hs_conn;
 struct ble_l2cap_chan;
 struct hci_disconn_complete;
@@ -192,5 +196,9 @@ void ble_hs_test_util_assert_mbufs_freed(
     const struct ble_hs_test_util_mbuf_params *params);
 void ble_hs_test_util_post_test(void *arg);
 void ble_hs_test_util_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/test/ble_hs_test_util_store.h
+++ b/net/nimble/host/src/test/ble_hs_test_util_store.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_HS_TEST_UTIL_STORE_
 #define H_BLE_HS_TEST_UTIL_STORE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 union ble_store_value;
 union ble_store_key;
 
@@ -32,5 +36,9 @@ void ble_hs_test_util_store_init(int max_our_ltks, int max_peer_ltks,
 int ble_hs_test_util_store_read(int obj_type, union ble_store_key *key,
                                 union ble_store_value *dst);
 int ble_hs_test_util_store_write(int obj_type, union ble_store_value *value);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/src/test/ble_sm_test_util.h
+++ b/net/nimble/host/src/test/ble_sm_test_util.h
@@ -20,6 +20,10 @@
 #ifndef H_BLE_SM_TEST_UTIL_
 #define H_BLE_SM_TEST_UTIL_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_sm_test_passkey_info {
     struct ble_sm_io passkey;
     uint32_t exp_numcmp;
@@ -115,5 +119,9 @@ void ble_sm_test_util_peer_bonding_bad(uint16_t ediv, uint64_t rand_num);
 void ble_sm_test_util_peer_sc_good(struct ble_sm_test_params *params);
 void ble_sm_test_util_us_sc_good(struct ble_sm_test_params *params);
 void ble_sm_test_util_us_fail_inval(struct ble_sm_test_params *params);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/host/store/ram/include/store/ram/ble_store_ram.h
+++ b/net/nimble/host/store/ram/include/store/ram/ble_store_ram.h
@@ -20,11 +20,19 @@
 #ifndef H_BLE_STORE_RAM_
 #define H_BLE_STORE_RAM_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 union ble_store_key;
 union ble_store_value;
 
 int ble_store_ram_read(int obj_type, union ble_store_key *key,
                        union ble_store_value *value);
 int ble_store_ram_write(int obj_type, union ble_store_value *val);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -21,6 +21,10 @@
 #define H_BLE_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* XXX: some or all of these should not be here */
 #include "os/os.h"
 
@@ -228,5 +232,9 @@ enum ble_error_codes
 #define BLE_ADDR_TYPE_RPA_RND_DEFAULT   (3)
 
 int ble_err_from_os(int os_err);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_ */

--- a/net/nimble/include/nimble/ble_hci_trans.h
+++ b/net/nimble/include/nimble/ble_hci_trans.h
@@ -21,6 +21,10 @@
 #define H_HCI_TRANSPORT_
 
 #include <inttypes.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct os_mbuf;
 
 #define BLE_HCI_TRANS_CMD_SZ        260
@@ -165,5 +169,9 @@ void ble_hci_trans_cfg_hs(ble_hci_trans_rx_cmd_fn *cmd_cb,
  *                              A BLE_ERR_[...] error code on failure.
  */
 int ble_hci_trans_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_HCI_TRANSPORT_ */

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -22,6 +22,10 @@
 
 #include "ble.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * HCI Command Header
  *
@@ -762,5 +766,9 @@ struct hci_add_dev_to_resolving_list {
 
 /* External data structures */
 extern const uint8_t g_ble_hci_le_cmd_len[BLE_HCI_NUM_LE_CMDS];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* H_BLE_HCI_COMMON_ */

--- a/net/nimble/include/nimble/nimble_opt.h
+++ b/net/nimble/include/nimble/nimble_opt.h
@@ -20,6 +20,10 @@
 #ifndef H_NIMBLE_OPT_
 #define H_NIMBLE_OPT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** HOST / CONTROLLER: Maximum number of concurrent connections. */
 
 #ifndef NIMBLE_OPT_MAX_CONNECTIONS
@@ -413,5 +417,9 @@
 
 /* Include automatically-generated settings. */
 #include "nimble/nimble_opt_auto.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/include/nimble/nimble_opt_auto.h
+++ b/net/nimble/include/nimble/nimble_opt_auto.h
@@ -22,6 +22,10 @@
 
 #include "nimble/nimble_opt.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /***
  * Automatic options.
  * 
@@ -101,6 +105,10 @@
 #if NIMBLE_OPT_SM_SC
 #undef NIMBLE_OPT_SM
 #define NIMBLE_OPT_SM                           1
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/net/nimble/transport/ram/include/transport/ram/ble_hci_ram.h
+++ b/net/nimble/transport/ram/include/transport/ram/ble_hci_ram.h
@@ -3,6 +3,10 @@
 
 #include "nimble/ble_hci_trans.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hci_ram_cfg {
     /** Number of high-priority event buffers. */
     uint16_t num_evt_hi_bufs;
@@ -26,5 +30,9 @@ struct ble_hci_ram_cfg {
 extern const struct ble_hci_ram_cfg ble_hci_ram_cfg_dflt;
 
 int ble_hci_ram_init(const struct ble_hci_ram_cfg *cfg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/net/nimble/transport/uart/include/transport/uart/ble_hci_uart.h
+++ b/net/nimble/transport/uart/include/transport/uart/ble_hci_uart.h
@@ -1,6 +1,10 @@
 #ifndef H_BLE_HCI_UART_
 #define H_BLE_HCI_UART_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ble_hci_uart_cfg {
     uint32_t baud;
     uint16_t num_evt_bufs;
@@ -15,5 +19,9 @@ struct ble_hci_uart_cfg {
 extern const struct ble_hci_uart_cfg ble_hci_uart_cfg_dflt;
 
 int ble_hci_uart_init(const struct ble_hci_uart_cfg *cfg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -22,6 +22,10 @@
 #include <os/queue.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CONF_MAX_DIR_DEPTH	8	/* max depth of config tree */
 #define CONF_MAX_NAME_LEN	(8 * CONF_MAX_DIR_DEPTH)
 #define CONF_MAX_VAL_LEN	256
@@ -93,5 +97,9 @@ struct conf_store {
     SLIST_ENTRY(conf_store) cs_next;
     const struct conf_store_itf *cs_itf;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_CONFIG_H_ */

--- a/sys/config/include/config/config_fcb.h
+++ b/sys/config/include/config/config_fcb.h
@@ -21,6 +21,10 @@
 
 #include "config/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct conf_fcb {
     struct conf_store cf_store;
     struct fcb cf_fcb;
@@ -28,5 +32,9 @@ struct conf_fcb {
 
 int conf_fcb_src(struct conf_fcb *fcb);
 int conf_fcb_dst(struct conf_fcb *fcb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_CONFIG_FCB_H_ */

--- a/sys/config/include/config/config_file.h
+++ b/sys/config/include/config/config_file.h
@@ -21,6 +21,10 @@
 
 #include "config/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CONF_FILE_NAME_MAX      32      /* max length for config filename */
 
 struct fs_file;
@@ -33,5 +37,9 @@ struct conf_file {
 
 int conf_file_src(struct conf_file *);  /* register file to be source of cfg */
 int conf_file_dst(struct conf_file *);  /* cfg saves go to a file */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_CONFIG_FILE_H_ */

--- a/sys/config/src/config_priv.h
+++ b/sys/config/src/config_priv.h
@@ -20,6 +20,10 @@
 #ifndef __CONFIG_PRIV_H_
 #define __CONFIG_PRIV_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int conf_cli_register(void);
 int conf_nmgr_register(void);
 
@@ -50,5 +54,9 @@ extern struct conf_store_head conf_load_srcs;
 SLIST_HEAD(conf_handler_head, conf_handler);
 extern struct conf_handler_head conf_handlers;
 extern struct conf_store *conf_save_dst;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CONFIG_PRIV_H_ */

--- a/sys/config/src/test/conf_test.h
+++ b/sys/config/src/test/conf_test.h
@@ -20,6 +20,14 @@
 #ifndef _CONF_TEST_H_
 #define _CONF_TEST_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void config_test_all(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _CONF_TEST_H_ */

--- a/sys/config/src/test/config_test.h
+++ b/sys/config/src/test/config_test.h
@@ -19,6 +19,14 @@
 #ifndef _CONFIG_TEST_H_
 #define _CONFIG_TEST_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int config_test_all();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/fcb/include/fcb/fcb.h
+++ b/sys/fcb/include/fcb/fcb.h
@@ -19,6 +19,10 @@
 #ifndef __SYS_FCB_H_
 #define __SYS_FCB_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Flash circular buffer.
  */
@@ -120,5 +124,9 @@ fcb_offset_last_n(struct fcb *fcb, uint8_t entries, uint32_t *last_n_off);
  * Clears FCB passed to it
  */
 int fcb_clear(struct fcb *fcb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_FLASHVAR_H_ */

--- a/sys/fcb/src/fcb_priv.h
+++ b/sys/fcb/src/fcb_priv.h
@@ -19,6 +19,10 @@
 #ifndef __SYS_FCB_PRIV_H_
 #define __SYS_FCB_PRIV_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define FCB_CRC_SZ	sizeof(uint8_t)
 #define FCB_TMP_BUF_SZ	32
 
@@ -53,5 +57,9 @@ int fcb_elem_crc8(struct fcb *, struct fcb_entry *loc, uint8_t *crc8p);
 int fcb_sector_hdr_init(struct fcb *, struct flash_area *fap, uint16_t id);
 int fcb_sector_hdr_read(struct fcb *, struct flash_area *fap,
   struct fcb_disk_area *fdap);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -20,6 +20,10 @@
 #ifndef __SYS_ID_H__
 #define __SYS_ID_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Maximum configurable serial number.
  */
@@ -29,5 +33,9 @@
  * Initialize manufacturing info storage/reporting.
  */
 int id_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/log/include/log/ignore.h
+++ b/sys/log/include/log/ignore.h
@@ -20,6 +20,10 @@
 #ifndef H_IGNORE_
 #define H_IGNORE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * These macros prevent the "set but not used" warnings for log writes below
  * the log level.
@@ -52,5 +56,9 @@
     GET_MACRO(__VA_ARGS__, IGN_20, IGN_19, IGN_18, IGN_17, IGN_16, IGN_15, \
               IGN_14, IGN_13, IGN_12, IGN_11, IGN_10, IGN_9, IGN_8, IGN_7, \
               IGN_6, IGN_5, IGN_4, IGN_3, IGN_2, IGN_1)(__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/log/include/log/log.h
+++ b/sys/log/include/log/log.h
@@ -24,6 +24,10 @@
 
 #include <os/queue.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Global log info */
 struct log_info {
     int64_t li_timestamp;
@@ -194,6 +198,10 @@ int log_fcb_handler_init(struct log_handler *, struct fcb *,
 /* Private */
 #ifdef NEWTMGR_PRESENT
 int log_nmgr_register_group(void);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __LOG_H__ */

--- a/sys/mn_socket/include/mn_socket/mn_socket.h
+++ b/sys/mn_socket/include/mn_socket/mn_socket.h
@@ -21,6 +21,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Address/protocol family.
  */
@@ -142,5 +146,9 @@ int mn_close(struct mn_socket *);
  * Address conversion
  */
 int mn_inet_pton(int af, const char *src, void *dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_MN_SOCKET_H_ */

--- a/sys/mn_socket/include/mn_socket/mn_socket_ops.h
+++ b/sys/mn_socket/include/mn_socket/mn_socket_ops.h
@@ -21,6 +21,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Interface for socket providers.
  * - mso_create() creates a socket, memory allocation has to be done by
@@ -78,5 +82,9 @@ mn_socket_newconn(struct mn_socket *s, struct mn_socket *new)
         return -1;
     }
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_MN_SOCKET_OPS_H_ */

--- a/sys/reboot/include/reboot/log_reboot.h
+++ b/sys/reboot/include/reboot/log_reboot.h
@@ -19,6 +19,10 @@
 #ifndef __LOG_REBOOT_H__
 #define __LOG_REBOOT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define  SOFT_REBOOT (0)
 #define  HARD_REBOOT (1)
 #define  GEN_CORE    (2)
@@ -31,5 +35,9 @@
 
 int reboot_init_handler(int log_type, uint8_t entries);
 int log_reboot(int reason);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _LOG_REBOOT_H__ */

--- a/sys/stats/include/stats/stats.h
+++ b/sys/stats/include/stats/stats.h
@@ -22,6 +22,10 @@
 #include <os/queue.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct stats_name_map {
     uint16_t snm_off;
     char *snm_name;
@@ -123,6 +127,10 @@ int stats_nmgr_register_group(void);
 #endif 
 #ifdef SHELL_PRESENT
 int stats_shell_register(void);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __UTIL_STATS_H__ */


### PR DESCRIPTION
This commit adds them to every header, except one:

    libs\baselibc\src\baselibc_test\unittests.h

Because the hack I used looks for normal #include guards for its place to put the C++ ones, and that file doesn't have any.

Also some files don't really have any functions or variables defined in them, so the guards are not strictly necessary, but they
don't hurt either and adding them everywhere makes it easier to see where they are missing.