### PR TITLE
NXP FRDM-K64F HW support patchset

### DIFF
--- a/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
@@ -1,0 +1,266 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x10000;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x00008000, LENGTH = 0x00000420
+  m_flash_config        (RX)  : ORIGIN = 0x00008420, LENGTH = 0x00000010
+  m_text                (RX)  : ORIGIN = 0x00008430, LENGTH = 0x00100000-0x8430
+  m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
+  m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  .imghdr (NOLOAD):
+  {
+    . = . + 0x20;
+  } > m_interrupts
+
+  /* The startup code goes first into internal flash */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  .flash_config :
+  {
+    . = ALIGN(4);
+    KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
+    . = ALIGN(4);
+  } > m_flash_config
+
+  /* The program code and other data goes into internal flash */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .interrupts_ram :
+  {
+    . = ALIGN(4);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(4);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_data
+
+  __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
+  __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    . = ALIGN(512);
+    USB_RAM_START = .;
+    . += USB_RAM_GAP;
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data_2
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data_2
+
+  m_usb_bdt USB_RAM_START (NOLOAD) :
+  {
+    *(m_usb_bdt)
+    USB_RAM_BDT_END = .;
+  }
+
+  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  {
+    *(m_usb_global)
+  }
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data_2) + LENGTH(m_data_2);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
+}

--- a/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
@@ -1,0 +1,261 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x10000;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
+  m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
+  m_text                (RX)  : ORIGIN = 0x00000410, LENGTH = 0x000FFBF0
+  m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
+  m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal flash */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  .flash_config :
+  {
+    . = ALIGN(4);
+    KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
+    . = ALIGN(4);
+  } > m_flash_config
+
+  /* The program code and other data goes into internal flash */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .interrupts_ram :
+  {
+    . = ALIGN(4);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(4);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_data
+
+  __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
+  __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    . = ALIGN(512);
+    USB_RAM_START = .;
+    . += USB_RAM_GAP;
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data_2
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data_2
+
+  m_usb_bdt USB_RAM_START (NOLOAD) :
+  {
+    *(m_usb_bdt)
+    USB_RAM_BDT_END = .;
+  }
+
+  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  {
+    *(m_usb_global)
+  }
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data_2) + LENGTH(m_data_2);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
+}

--- a/hw/bsp/frdm-k64f/bsp.yml
+++ b/hw/bsp/frdm-k64f/bsp.yml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.arch: cortex_m4
+bsp.compiler: compiler/arm-none-eabi-m4
+bsp.linkerscript: "MK64FN1M0xxx12_flash.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE: "boot-MK64FN1M0xxx12_flash.ld"
+bsp.downloadscript: frdm-k64_download.sh
+bsp.debugscript: frdm-k64_debug.sh
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x00000000
+            size: 24kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x00006000
+            size: 8kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x00008000
+            size: 480kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x00080000
+            size: 480kB
+
+        # User areas
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x000F8000
+            size: 16kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x000FC000
+            size: 16kB

--- a/hw/bsp/frdm-k64f/frdm-k64_debug.sh
+++ b/hw/bsp/frdm-k64f/frdm-k64_debug.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Called: $0 <bsp_directory_path> <binary> [features...]
+#  - bsp_directory_path is absolute path to hw/bsp/bsp_name
+#  - binary is the path to prefix to target binary, .elf appended to name is
+#    the ELF file
+#  - identities is the project identities string.
+#
+if [ $# -lt 1 ]; then
+    echo "Need binary to debug"
+    exit 1
+fi
+
+FILE_NAME=$2.elf
+GDB_CMD_FILE=.gdb_cmds
+
+echo "Debugging" $FILE_NAME
+
+#
+# Block Ctrl-C from getting passed to openocd.
+# Exit openocd when gdb detaches.
+#
+set -m
+pyocd-gdbserver &
+set +m
+
+echo "target remote localhost:3333" > $GDB_CMD_FILE
+arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
+rm $GDB_CMD_FILE

--- a/hw/bsp/frdm-k64f/frdm-k64_download.sh
+++ b/hw/bsp/frdm-k64f/frdm-k64_download.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Called with following variables set:
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#
+
+if [ -z "${BIN_BASENAME}" ]; then
+    echo "Need binary to download"
+    exit 1
+fi
+
+if [ -z "${IMAGE_SLOT}" ]; then
+    echo "Need image slot to download"
+    exit 1
+fi
+
+IS_BOOTLOADER=0
+USE_OPENOCD=0
+GDB_CMD_FILE=.gdb_cmds
+
+# Look for 'bootloader' in FEATURES
+for feature in ${FEATURES}; do
+    if [ ${feature} == "BOOT_LOADER" ]; then
+	IS_BOOTLOADER=1
+    fi
+    if [ ${feature} = "openocd_debug" ]; then
+	USE_OPENOCD=1
+    fi
+done
+
+if [ ${IS_BOOTLOADER} -eq 1 ]; then
+    FLASH_OFFSET=0x00000000
+    FILE_NAME=${BIN_BASENAME}.elf.bin
+else
+    FLASH_OFFSET=0x00008000
+    FILE_NAME=${BIN_BASENAME}.elf.bin
+fi
+
+echo "Downloading" ${FILE_NAME} "to" ${FLASH_OFFSET}
+
+pyocd-flashtool -se --address ${FLASH_OFFSET} ${FILE_NAME}

--- a/hw/bsp/frdm-k64f/include/bsp/bsp.h
+++ b/hw/bsp/frdm-k64f/include/bsp/bsp.h
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern uint8_t __DATA_ROM;
+#define RAM_SIZE            0x40000
+
+/* LED pins */
+#define LED_BLINK_PIN       (54)
+
+/* UART info */
+#define CONSOLE_UART        "uart0"
+#define CONSOLE_UART_SPEED  115200
+
+/* This defines the maximum NFFS areas (block) are in the BSPs NFS file
+ * system space.  This in conjunction with flash map determines how
+ * many NFS blocks there will be.  A minimum is the number of individually
+ * erasable sectors in the flash area and the maximum is this number. If
+ * your max is less than the number of sectors then the NFFS will combine
+ * multiple sectors into an NFFS area */
+#define NFFS_AREA_MAX    (8)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/frdm-k64f/include/bsp/bsp_sysid.h
+++ b/hw/bsp/frdm-k64f/include/bsp/bsp_sysid.h
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef BSP_SYSID_H
+#define BSP_SYSID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum system_device_id
+{
+        NONE = 0,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BSP_SYSID_H */

--- a/hw/bsp/frdm-k64f/include/bsp/cmsis_nvic.h
+++ b/hw/bsp/frdm-k64f/include/bsp/cmsis_nvic.h
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* mbed Microcontroller Library - cmsis_nvic
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */
+
+#ifndef CMSIS_NVIC_H
+#define CMSIS_NVIC_H
+
+#include <stdint.h>
+
+#define NVIC_NUM_VECTORS      (16 + 101)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
+/*
+ * include board definition file which includes: cmsis-core/core_cm4.h
+ * this fixes missing CORTEX_M* definition in cmsis_nvic.c
+ */
+#include "MK64F12.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_Relocate(void);
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/bsp/frdm-k64f/pkg.yml
+++ b/hw/bsp/frdm-k64f/pkg.yml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "hw/bsp/frdm-k64f"
+pkg.type: bsp
+pkg.description: BSP definition for NXP FRDM-K64F with 1Mb flash.
+pkg.keywords:
+    - frdm-k64f
+    - nxp
+
+pkg.cflags: -DDEBUG -fno-builtin -fno-common -ffreestanding -mfloat-abi=hard -mfpu=fpv4-sp-d16 -DCPU_MK64FN1M0VMD12 -DPRINTF_FLOAT_ENABLE=0 -DSCANF_FLOAT_ENABLE=0 -DPRINTF_ADVANCED_ENABLE=0 -DSCANF_ADVANCED_ENABLE=0 -DFRDM_K64F -DFREEDOM -DUSE_RAM_VECTOR_TABLE -Wl,--defsym=__ram_vector_table__=1
+
+pkg.deps:
+    - boot/bootutil
+    - hw/mcu/nxp/MK64F12
+    - libc/baselibc
+    - sys/flash_map
+
+pkg.deps.UART_0:
+    - hw/drivers/uart/uart_hal
+
+pkg.deps.UART_1:
+    - hw/drivers/uart/uart_hal
+
+pkg.deps.UART_2:
+    - hw/drivers/uart/uart_hal
+
+pkg.deps.UART_3:
+    - hw/drivers/uart/uart_hal
+
+pkg.deps.UART_4:
+    - hw/drivers/uart/uart_hal
+
+pkg.deps.UART_5:
+    - hw/drivers/uart/uart_hal

--- a/hw/bsp/frdm-k64f/src/arch/cortex_m4/startup_MK64F12.S
+++ b/hw/bsp/frdm-k64f/src/arch/cortex_m4/startup_MK64F12.S
@@ -1,0 +1,997 @@
+/* ---------------------------------------------------------------------------------------*/
+/*  @file:    startup_MK64F12.s                                                           */
+/*  @purpose: CMSIS Cortex-M4 Core Device Startup File                                    */
+/*            MK64F12                                                                     */
+/*  @version: 2.9                                                                         */
+/*  @date:    2016-3-21                                                                   */
+/*  @build:   b160321                                                                     */
+/* ---------------------------------------------------------------------------------------*/
+/*                                                                                        */
+/* Copyright (c) 1997 - 2016 , Freescale Semiconductor, Inc.                              */
+/* All rights reserved.                                                                   */
+/*                                                                                        */
+/* Redistribution and use in source and binary forms, with or without modification,       */
+/* are permitted provided that the following conditions are met:                          */
+/*                                                                                        */
+/* o Redistributions of source code must retain the above copyright notice, this list     */
+/*   of conditions and the following disclaimer.                                          */
+/*                                                                                        */
+/* o Redistributions in binary form must reproduce the above copyright notice, this       */
+/*   list of conditions and the following disclaimer in the documentation and/or          */
+/*   other materials provided with the distribution.                                      */
+/*                                                                                        */
+/* o Neither the name of Freescale Semiconductor, Inc. nor the names of its               */
+/*   contributors may be used to endorse or promote products derived from this            */
+/*   software without specific prior written permission.                                  */
+/*                                                                                        */
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND        */
+/* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED          */
+/* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                 */
+/* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR       */
+/* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         */
+/* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;           */
+/* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON         */
+/* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                */
+/* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS          */
+/* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/*****************************************************************************/
+/* Version: GCC for ARM Embedded Processors                                  */
+/*****************************************************************************/
+    .syntax unified
+    .arch armv7-m
+
+    .section .isr_vector, "a"
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long   __StackTop                                      /* Top of Stack */
+    .long   Reset_Handler                                   /* Reset Handler */
+    .long   NMI_Handler                                     /* NMI Handler*/
+    .long   HardFault_Handler                               /* Hard Fault Handler*/
+    .long   MemManage_Handler                               /* MPU Fault Handler*/
+    .long   BusFault_Handler                                /* Bus Fault Handler*/
+    .long   UsageFault_Handler                              /* Usage Fault Handler*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   SVC_Handler                                     /* SVCall Handler*/
+    .long   DebugMon_Handler                                /* Debug Monitor Handler*/
+    .long   0                                               /* Reserved*/
+    .long   PendSV_Handler                                  /* PendSV Handler*/
+    .long   SysTick_Handler                                 /* SysTick Handler*/
+
+                                                            /* External Interrupts*/
+    .long   DMA0_IRQHandler                                 /* DMA Channel 0 Transfer Complete*/
+    .long   DMA1_IRQHandler                                 /* DMA Channel 1 Transfer Complete*/
+    .long   DMA2_IRQHandler                                 /* DMA Channel 2 Transfer Complete*/
+    .long   DMA3_IRQHandler                                 /* DMA Channel 3 Transfer Complete*/
+    .long   DMA4_IRQHandler                                 /* DMA Channel 4 Transfer Complete*/
+    .long   DMA5_IRQHandler                                 /* DMA Channel 5 Transfer Complete*/
+    .long   DMA6_IRQHandler                                 /* DMA Channel 6 Transfer Complete*/
+    .long   DMA7_IRQHandler                                 /* DMA Channel 7 Transfer Complete*/
+    .long   DMA8_IRQHandler                                 /* DMA Channel 8 Transfer Complete*/
+    .long   DMA9_IRQHandler                                 /* DMA Channel 9 Transfer Complete*/
+    .long   DMA10_IRQHandler                                /* DMA Channel 10 Transfer Complete*/
+    .long   DMA11_IRQHandler                                /* DMA Channel 11 Transfer Complete*/
+    .long   DMA12_IRQHandler                                /* DMA Channel 12 Transfer Complete*/
+    .long   DMA13_IRQHandler                                /* DMA Channel 13 Transfer Complete*/
+    .long   DMA14_IRQHandler                                /* DMA Channel 14 Transfer Complete*/
+    .long   DMA15_IRQHandler                                /* DMA Channel 15 Transfer Complete*/
+    .long   DMA_Error_IRQHandler                            /* DMA Error Interrupt*/
+    .long   MCM_IRQHandler                                  /* Normal Interrupt*/
+    .long   FTFE_IRQHandler                                 /* FTFE Command complete interrupt*/
+    .long   Read_Collision_IRQHandler                       /* Read Collision Interrupt*/
+    .long   LVD_LVW_IRQHandler                              /* Low Voltage Detect, Low Voltage Warning*/
+    .long   LLWU_IRQHandler                                 /* Low Leakage Wakeup Unit*/
+    .long   WDOG_EWM_IRQHandler                             /* WDOG Interrupt*/
+    .long   RNG_IRQHandler                                  /* RNG Interrupt*/
+    .long   I2C0_IRQHandler                                 /* I2C0 interrupt*/
+    .long   I2C1_IRQHandler                                 /* I2C1 interrupt*/
+    .long   SPI0_IRQHandler                                 /* SPI0 Interrupt*/
+    .long   SPI1_IRQHandler                                 /* SPI1 Interrupt*/
+    .long   I2S0_Tx_IRQHandler                              /* I2S0 transmit interrupt*/
+    .long   I2S0_Rx_IRQHandler                              /* I2S0 receive interrupt*/
+    .long   UART0_LON_IRQHandler                            /* UART0 LON interrupt*/
+    .long   UART0_RX_TX_IRQHandler                          /* UART0 Receive/Transmit interrupt*/
+    .long   UART0_ERR_IRQHandler                            /* UART0 Error interrupt*/
+    .long   UART1_RX_TX_IRQHandler                          /* UART1 Receive/Transmit interrupt*/
+    .long   UART1_ERR_IRQHandler                            /* UART1 Error interrupt*/
+    .long   UART2_RX_TX_IRQHandler                          /* UART2 Receive/Transmit interrupt*/
+    .long   UART2_ERR_IRQHandler                            /* UART2 Error interrupt*/
+    .long   UART3_RX_TX_IRQHandler                          /* UART3 Receive/Transmit interrupt*/
+    .long   UART3_ERR_IRQHandler                            /* UART3 Error interrupt*/
+    .long   ADC0_IRQHandler                                 /* ADC0 interrupt*/
+    .long   CMP0_IRQHandler                                 /* CMP0 interrupt*/
+    .long   CMP1_IRQHandler                                 /* CMP1 interrupt*/
+    .long   FTM0_IRQHandler                                 /* FTM0 fault, overflow and channels interrupt*/
+    .long   FTM1_IRQHandler                                 /* FTM1 fault, overflow and channels interrupt*/
+    .long   FTM2_IRQHandler                                 /* FTM2 fault, overflow and channels interrupt*/
+    .long   CMT_IRQHandler                                  /* CMT interrupt*/
+    .long   RTC_IRQHandler                                  /* RTC interrupt*/
+    .long   RTC_Seconds_IRQHandler                          /* RTC seconds interrupt*/
+    .long   PIT0_IRQHandler                                 /* PIT timer channel 0 interrupt*/
+    .long   PIT1_IRQHandler                                 /* PIT timer channel 1 interrupt*/
+    .long   PIT2_IRQHandler                                 /* PIT timer channel 2 interrupt*/
+    .long   PIT3_IRQHandler                                 /* PIT timer channel 3 interrupt*/
+    .long   PDB0_IRQHandler                                 /* PDB0 Interrupt*/
+    .long   USB0_IRQHandler                                 /* USB0 interrupt*/
+    .long   USBDCD_IRQHandler                               /* USBDCD Interrupt*/
+    .long   Reserved71_IRQHandler                           /* Reserved interrupt 71*/
+    .long   DAC0_IRQHandler                                 /* DAC0 interrupt*/
+    .long   MCG_IRQHandler                                  /* MCG Interrupt*/
+    .long   LPTMR0_IRQHandler                               /* LPTimer interrupt*/
+    .long   PORTA_IRQHandler                                /* Port A interrupt*/
+    .long   PORTB_IRQHandler                                /* Port B interrupt*/
+    .long   PORTC_IRQHandler                                /* Port C interrupt*/
+    .long   PORTD_IRQHandler                                /* Port D interrupt*/
+    .long   PORTE_IRQHandler                                /* Port E interrupt*/
+    .long   SWI_IRQHandler                                  /* Software interrupt*/
+    .long   SPI2_IRQHandler                                 /* SPI2 Interrupt*/
+    .long   UART4_RX_TX_IRQHandler                          /* UART4 Receive/Transmit interrupt*/
+    .long   UART4_ERR_IRQHandler                            /* UART4 Error interrupt*/
+    .long   UART5_RX_TX_IRQHandler                          /* UART5 Receive/Transmit interrupt*/
+    .long   UART5_ERR_IRQHandler                            /* UART5 Error interrupt*/
+    .long   CMP2_IRQHandler                                 /* CMP2 interrupt*/
+    .long   FTM3_IRQHandler                                 /* FTM3 fault, overflow and channels interrupt*/
+    .long   DAC1_IRQHandler                                 /* DAC1 interrupt*/
+    .long   ADC1_IRQHandler                                 /* ADC1 interrupt*/
+    .long   I2C2_IRQHandler                                 /* I2C2 interrupt*/
+    .long   CAN0_ORed_Message_buffer_IRQHandler             /* CAN0 OR'd message buffers interrupt*/
+    .long   CAN0_Bus_Off_IRQHandler                         /* CAN0 bus off interrupt*/
+    .long   CAN0_Error_IRQHandler                           /* CAN0 error interrupt*/
+    .long   CAN0_Tx_Warning_IRQHandler                      /* CAN0 Tx warning interrupt*/
+    .long   CAN0_Rx_Warning_IRQHandler                      /* CAN0 Rx warning interrupt*/
+    .long   CAN0_Wake_Up_IRQHandler                         /* CAN0 wake up interrupt*/
+    .long   SDHC_IRQHandler                                 /* SDHC interrupt*/
+    .long   ENET_1588_Timer_IRQHandler                      /* Ethernet MAC IEEE 1588 Timer Interrupt*/
+    .long   ENET_Transmit_IRQHandler                        /* Ethernet MAC Transmit Interrupt*/
+    .long   ENET_Receive_IRQHandler                         /* Ethernet MAC Receive Interrupt*/
+    .long   ENET_Error_IRQHandler                           /* Ethernet MAC Error and miscelaneous Interrupt*/
+    .long   DefaultISR                                      /* 102*/
+    .long   DefaultISR                                      /* 103*/
+    .long   DefaultISR                                      /* 104*/
+    .long   DefaultISR                                      /* 105*/
+    .long   DefaultISR                                      /* 106*/
+    .long   DefaultISR                                      /* 107*/
+    .long   DefaultISR                                      /* 108*/
+    .long   DefaultISR                                      /* 109*/
+    .long   DefaultISR                                      /* 110*/
+    .long   DefaultISR                                      /* 111*/
+    .long   DefaultISR                                      /* 112*/
+    .long   DefaultISR                                      /* 113*/
+    .long   DefaultISR                                      /* 114*/
+    .long   DefaultISR                                      /* 115*/
+    .long   DefaultISR                                      /* 116*/
+    .long   DefaultISR                                      /* 117*/
+    .long   DefaultISR                                      /* 118*/
+    .long   DefaultISR                                      /* 119*/
+    .long   DefaultISR                                      /* 120*/
+    .long   DefaultISR                                      /* 121*/
+    .long   DefaultISR                                      /* 122*/
+    .long   DefaultISR                                      /* 123*/
+    .long   DefaultISR                                      /* 124*/
+    .long   DefaultISR                                      /* 125*/
+    .long   DefaultISR                                      /* 126*/
+    .long   DefaultISR                                      /* 127*/
+    .long   DefaultISR                                      /* 128*/
+    .long   DefaultISR                                      /* 129*/
+    .long   DefaultISR                                      /* 130*/
+    .long   DefaultISR                                      /* 131*/
+    .long   DefaultISR                                      /* 132*/
+    .long   DefaultISR                                      /* 133*/
+    .long   DefaultISR                                      /* 134*/
+    .long   DefaultISR                                      /* 135*/
+    .long   DefaultISR                                      /* 136*/
+    .long   DefaultISR                                      /* 137*/
+    .long   DefaultISR                                      /* 138*/
+    .long   DefaultISR                                      /* 139*/
+    .long   DefaultISR                                      /* 140*/
+    .long   DefaultISR                                      /* 141*/
+    .long   DefaultISR                                      /* 142*/
+    .long   DefaultISR                                      /* 143*/
+    .long   DefaultISR                                      /* 144*/
+    .long   DefaultISR                                      /* 145*/
+    .long   DefaultISR                                      /* 146*/
+    .long   DefaultISR                                      /* 147*/
+    .long   DefaultISR                                      /* 148*/
+    .long   DefaultISR                                      /* 149*/
+    .long   DefaultISR                                      /* 150*/
+    .long   DefaultISR                                      /* 151*/
+    .long   DefaultISR                                      /* 152*/
+    .long   DefaultISR                                      /* 153*/
+    .long   DefaultISR                                      /* 154*/
+    .long   DefaultISR                                      /* 155*/
+    .long   DefaultISR                                      /* 156*/
+    .long   DefaultISR                                      /* 157*/
+    .long   DefaultISR                                      /* 158*/
+    .long   DefaultISR                                      /* 159*/
+    .long   DefaultISR                                      /* 160*/
+    .long   DefaultISR                                      /* 161*/
+    .long   DefaultISR                                      /* 162*/
+    .long   DefaultISR                                      /* 163*/
+    .long   DefaultISR                                      /* 164*/
+    .long   DefaultISR                                      /* 165*/
+    .long   DefaultISR                                      /* 166*/
+    .long   DefaultISR                                      /* 167*/
+    .long   DefaultISR                                      /* 168*/
+    .long   DefaultISR                                      /* 169*/
+    .long   DefaultISR                                      /* 170*/
+    .long   DefaultISR                                      /* 171*/
+    .long   DefaultISR                                      /* 172*/
+    .long   DefaultISR                                      /* 173*/
+    .long   DefaultISR                                      /* 174*/
+    .long   DefaultISR                                      /* 175*/
+    .long   DefaultISR                                      /* 176*/
+    .long   DefaultISR                                      /* 177*/
+    .long   DefaultISR                                      /* 178*/
+    .long   DefaultISR                                      /* 179*/
+    .long   DefaultISR                                      /* 180*/
+    .long   DefaultISR                                      /* 181*/
+    .long   DefaultISR                                      /* 182*/
+    .long   DefaultISR                                      /* 183*/
+    .long   DefaultISR                                      /* 184*/
+    .long   DefaultISR                                      /* 185*/
+    .long   DefaultISR                                      /* 186*/
+    .long   DefaultISR                                      /* 187*/
+    .long   DefaultISR                                      /* 188*/
+    .long   DefaultISR                                      /* 189*/
+    .long   DefaultISR                                      /* 190*/
+    .long   DefaultISR                                      /* 191*/
+    .long   DefaultISR                                      /* 192*/
+    .long   DefaultISR                                      /* 193*/
+    .long   DefaultISR                                      /* 194*/
+    .long   DefaultISR                                      /* 195*/
+    .long   DefaultISR                                      /* 196*/
+    .long   DefaultISR                                      /* 197*/
+    .long   DefaultISR                                      /* 198*/
+    .long   DefaultISR                                      /* 199*/
+    .long   DefaultISR                                      /* 200*/
+    .long   DefaultISR                                      /* 201*/
+    .long   DefaultISR                                      /* 202*/
+    .long   DefaultISR                                      /* 203*/
+    .long   DefaultISR                                      /* 204*/
+    .long   DefaultISR                                      /* 205*/
+    .long   DefaultISR                                      /* 206*/
+    .long   DefaultISR                                      /* 207*/
+    .long   DefaultISR                                      /* 208*/
+    .long   DefaultISR                                      /* 209*/
+    .long   DefaultISR                                      /* 210*/
+    .long   DefaultISR                                      /* 211*/
+    .long   DefaultISR                                      /* 212*/
+    .long   DefaultISR                                      /* 213*/
+    .long   DefaultISR                                      /* 214*/
+    .long   DefaultISR                                      /* 215*/
+    .long   DefaultISR                                      /* 216*/
+    .long   DefaultISR                                      /* 217*/
+    .long   DefaultISR                                      /* 218*/
+    .long   DefaultISR                                      /* 219*/
+    .long   DefaultISR                                      /* 220*/
+    .long   DefaultISR                                      /* 221*/
+    .long   DefaultISR                                      /* 222*/
+    .long   DefaultISR                                      /* 223*/
+    .long   DefaultISR                                      /* 224*/
+    .long   DefaultISR                                      /* 225*/
+    .long   DefaultISR                                      /* 226*/
+    .long   DefaultISR                                      /* 227*/
+    .long   DefaultISR                                      /* 228*/
+    .long   DefaultISR                                      /* 229*/
+    .long   DefaultISR                                      /* 230*/
+    .long   DefaultISR                                      /* 231*/
+    .long   DefaultISR                                      /* 232*/
+    .long   DefaultISR                                      /* 233*/
+    .long   DefaultISR                                      /* 234*/
+    .long   DefaultISR                                      /* 235*/
+    .long   DefaultISR                                      /* 236*/
+    .long   DefaultISR                                      /* 237*/
+    .long   DefaultISR                                      /* 238*/
+    .long   DefaultISR                                      /* 239*/
+    .long   DefaultISR                                      /* 240*/
+    .long   DefaultISR                                      /* 241*/
+    .long   DefaultISR                                      /* 242*/
+    .long   DefaultISR                                      /* 243*/
+    .long   DefaultISR                                      /* 244*/
+    .long   DefaultISR                                      /* 245*/
+    .long   DefaultISR                                      /* 246*/
+    .long   DefaultISR                                      /* 247*/
+    .long   DefaultISR                                      /* 248*/
+    .long   DefaultISR                                      /* 249*/
+    .long   DefaultISR                                      /* 250*/
+    .long   DefaultISR                                      /* 251*/
+    .long   DefaultISR                                      /* 252*/
+    .long   DefaultISR                                      /* 253*/
+    .long   DefaultISR                                      /* 254*/
+    .long   0xFFFFFFFF                                      /*  Reserved for user TRIM value*/
+
+    .size    __isr_vector, . - __isr_vector
+
+/* Flash Configuration */
+    .section .FlashConfig, "a"
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFE
+
+    .text
+    .thumb
+
+/* Reset Handler */
+
+    .thumb_func
+    .align 2
+    .globl   Reset_Handler
+    .weak    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    cpsid   i               /* Mask interrupts */
+    .equ    VTOR, 0xE000ED08
+    ldr     r0, =VTOR
+#ifdef USE_RAM_VECTOR_TABLE
+    ldr     r1, =__interrupts_ram_start__
+#else
+    ldr     r1, =__isr_vector
+#endif
+    str     r1, [r0]
+#ifndef __NO_SYSTEM_INIT
+    ldr   r0,=SystemInit
+    blx   r0
+#endif
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+#if 1
+/* Here are two copies of loop implemenations. First one favors code size
+ * and the second one favors performance. Default uses the first one.
+ * Change to "#if 0" to use the second one */
+.LC0:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC0
+#else
+    subs    r3, r2
+    ble    .LC1
+.LC0:
+    subs    r3, #4
+    ldr    r0, [r1, r3]
+    str    r0, [r2, r3]
+    bgt    .LC0
+.LC1:
+#endif
+
+#ifdef __STARTUP_CLEAR_BSS
+/*     This part of work usually is done in C library startup code. Otherwise,
+ *     define this macro to enable it in this startup.
+ *
+ *     Loop to zero out BSS section, which uses following symbols
+ *     in linker script:
+ *      __bss_start__: start of BSS section. Must align to 4
+ *      __bss_end__: end of BSS section. Must align to 4
+ */
+    ldr r1, =__bss_start__
+    ldr r2, =__bss_end__
+
+    movs    r0, 0
+.LC2:
+    cmp     r1, r2
+    itt    lt
+    strlt   r0, [r1], #4
+    blt    .LC2
+#endif /* __STARTUP_CLEAR_BSS */
+
+    cpsie   i               /* Unmask interrupts */
+#ifndef __START
+#define __START _start
+#endif
+#ifndef __ATOLLIC__
+    ldr   r0,=__START
+    blx   r0
+#else
+    ldr   r0,=__libc_init_array
+    blx   r0
+    ldr   r0,=main
+    bx    r0
+#endif
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .align  1
+    .thumb_func
+    .weak DefaultISR
+    .type DefaultISR, %function
+DefaultISR:
+    b DefaultISR
+    .size DefaultISR, . - DefaultISR
+
+    .align 1
+    .thumb_func
+    .weak NMI_Handler
+    .type NMI_Handler, %function
+NMI_Handler:
+    ldr   r0,=NMI_Handler
+    bx    r0
+    .size NMI_Handler, . - NMI_Handler
+
+    .align 1
+    .thumb_func
+    .weak HardFault_Handler
+    .type HardFault_Handler, %function
+HardFault_Handler:
+    ldr   r0,=HardFault_Handler
+    bx    r0
+    .size HardFault_Handler, . - HardFault_Handler
+
+    .align 1
+    .thumb_func
+    .weak SVC_Handler
+    .type SVC_Handler, %function
+SVC_Handler:
+    ldr   r0,=SVC_Handler
+    bx    r0
+    .size SVC_Handler, . - SVC_Handler
+
+    .align 1
+    .thumb_func
+    .weak PendSV_Handler
+    .type PendSV_Handler, %function
+PendSV_Handler:
+    ldr   r0,=PendSV_Handler
+    bx    r0
+    .size PendSV_Handler, . - PendSV_Handler
+
+    .align 1
+    .thumb_func
+    .weak SysTick_Handler
+    .type SysTick_Handler, %function
+SysTick_Handler:
+    ldr   r0,=SysTick_Handler
+    bx    r0
+    .size SysTick_Handler, . - SysTick_Handler
+
+    .align 1
+    .thumb_func
+    .weak DMA0_IRQHandler
+    .type DMA0_IRQHandler, %function
+DMA0_IRQHandler:
+    ldr   r0,=DMA0_DriverIRQHandler
+    bx    r0
+    .size DMA0_IRQHandler, . - DMA0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA1_IRQHandler
+    .type DMA1_IRQHandler, %function
+DMA1_IRQHandler:
+    ldr   r0,=DMA1_DriverIRQHandler
+    bx    r0
+    .size DMA1_IRQHandler, . - DMA1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA2_IRQHandler
+    .type DMA2_IRQHandler, %function
+DMA2_IRQHandler:
+    ldr   r0,=DMA2_DriverIRQHandler
+    bx    r0
+    .size DMA2_IRQHandler, . - DMA2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_IRQHandler
+    .type DMA3_IRQHandler, %function
+DMA3_IRQHandler:
+    ldr   r0,=DMA3_DriverIRQHandler
+    bx    r0
+    .size DMA3_IRQHandler, . - DMA3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_IRQHandler
+    .type DMA4_IRQHandler, %function
+DMA4_IRQHandler:
+    ldr   r0,=DMA4_DriverIRQHandler
+    bx    r0
+    .size DMA4_IRQHandler, . - DMA4_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA5_IRQHandler
+    .type DMA5_IRQHandler, %function
+DMA5_IRQHandler:
+    ldr   r0,=DMA5_DriverIRQHandler
+    bx    r0
+    .size DMA5_IRQHandler, . - DMA5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA6_IRQHandler
+    .type DMA6_IRQHandler, %function
+DMA6_IRQHandler:
+    ldr   r0,=DMA6_DriverIRQHandler
+    bx    r0
+    .size DMA6_IRQHandler, . - DMA6_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA7_IRQHandler
+    .type DMA7_IRQHandler, %function
+DMA7_IRQHandler:
+    ldr   r0,=DMA7_DriverIRQHandler
+    bx    r0
+    .size DMA7_IRQHandler, . - DMA7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA8_IRQHandler
+    .type DMA8_IRQHandler, %function
+DMA8_IRQHandler:
+    ldr   r0,=DMA8_DriverIRQHandler
+    bx    r0
+    .size DMA8_IRQHandler, . - DMA8_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA9_IRQHandler
+    .type DMA9_IRQHandler, %function
+DMA9_IRQHandler:
+    ldr   r0,=DMA9_DriverIRQHandler
+    bx    r0
+    .size DMA9_IRQHandler, . - DMA9_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA10_IRQHandler
+    .type DMA10_IRQHandler, %function
+DMA10_IRQHandler:
+    ldr   r0,=DMA10_DriverIRQHandler
+    bx    r0
+    .size DMA10_IRQHandler, . - DMA10_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA11_IRQHandler
+    .type DMA11_IRQHandler, %function
+DMA11_IRQHandler:
+    ldr   r0,=DMA11_DriverIRQHandler
+    bx    r0
+    .size DMA11_IRQHandler, . - DMA11_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA12_IRQHandler
+    .type DMA12_IRQHandler, %function
+DMA12_IRQHandler:
+    ldr   r0,=DMA12_DriverIRQHandler
+    bx    r0
+    .size DMA12_IRQHandler, . - DMA12_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA13_IRQHandler
+    .type DMA13_IRQHandler, %function
+DMA13_IRQHandler:
+    ldr   r0,=DMA13_DriverIRQHandler
+    bx    r0
+    .size DMA13_IRQHandler, . - DMA13_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA14_IRQHandler
+    .type DMA14_IRQHandler, %function
+DMA14_IRQHandler:
+    ldr   r0,=DMA14_DriverIRQHandler
+    bx    r0
+    .size DMA14_IRQHandler, . - DMA14_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA15_IRQHandler
+    .type DMA15_IRQHandler, %function
+DMA15_IRQHandler:
+    ldr   r0,=DMA15_DriverIRQHandler
+    bx    r0
+    .size DMA15_IRQHandler, . - DMA15_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA_Error_IRQHandler
+    .type DMA_Error_IRQHandler, %function
+DMA_Error_IRQHandler:
+    ldr   r0,=DMA_Error_DriverIRQHandler
+    bx    r0
+    .size DMA_Error_IRQHandler, . - DMA_Error_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2C0_IRQHandler
+    .type I2C0_IRQHandler, %function
+I2C0_IRQHandler:
+    ldr   r0,=I2C0_DriverIRQHandler
+    bx    r0
+    .size I2C0_IRQHandler, . - I2C0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2C1_IRQHandler
+    .type I2C1_IRQHandler, %function
+I2C1_IRQHandler:
+    ldr   r0,=I2C1_DriverIRQHandler
+    bx    r0
+    .size I2C1_IRQHandler, . - I2C1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SPI0_IRQHandler
+    .type SPI0_IRQHandler, %function
+SPI0_IRQHandler:
+    ldr   r0,=SPI0_DriverIRQHandler
+    bx    r0
+    .size SPI0_IRQHandler, . - SPI0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SPI1_IRQHandler
+    .type SPI1_IRQHandler, %function
+SPI1_IRQHandler:
+    ldr   r0,=SPI1_DriverIRQHandler
+    bx    r0
+    .size SPI1_IRQHandler, . - SPI1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2S0_Tx_IRQHandler
+    .type I2S0_Tx_IRQHandler, %function
+I2S0_Tx_IRQHandler:
+    ldr   r0,=I2S0_Tx_DriverIRQHandler
+    bx    r0
+    .size I2S0_Tx_IRQHandler, . - I2S0_Tx_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2S0_Rx_IRQHandler
+    .type I2S0_Rx_IRQHandler, %function
+I2S0_Rx_IRQHandler:
+    ldr   r0,=I2S0_Rx_DriverIRQHandler
+    bx    r0
+    .size I2S0_Rx_IRQHandler, . - I2S0_Rx_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART0_LON_IRQHandler
+    .type UART0_LON_IRQHandler, %function
+UART0_LON_IRQHandler:
+    ldr   r0,=UART0_LON_DriverIRQHandler
+    bx    r0
+    .size UART0_LON_IRQHandler, . - UART0_LON_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART0_RX_TX_IRQHandler
+    .type UART0_RX_TX_IRQHandler, %function
+UART0_RX_TX_IRQHandler:
+    ldr   r0,=UART0_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART0_RX_TX_IRQHandler, . - UART0_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART0_ERR_IRQHandler
+    .type UART0_ERR_IRQHandler, %function
+UART0_ERR_IRQHandler:
+    ldr   r0,=UART0_ERR_DriverIRQHandler
+    bx    r0
+    .size UART0_ERR_IRQHandler, . - UART0_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART1_RX_TX_IRQHandler
+    .type UART1_RX_TX_IRQHandler, %function
+UART1_RX_TX_IRQHandler:
+    ldr   r0,=UART1_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART1_RX_TX_IRQHandler, . - UART1_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART1_ERR_IRQHandler
+    .type UART1_ERR_IRQHandler, %function
+UART1_ERR_IRQHandler:
+    ldr   r0,=UART1_ERR_DriverIRQHandler
+    bx    r0
+    .size UART1_ERR_IRQHandler, . - UART1_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART2_RX_TX_IRQHandler
+    .type UART2_RX_TX_IRQHandler, %function
+UART2_RX_TX_IRQHandler:
+    ldr   r0,=UART2_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART2_RX_TX_IRQHandler, . - UART2_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART2_ERR_IRQHandler
+    .type UART2_ERR_IRQHandler, %function
+UART2_ERR_IRQHandler:
+    ldr   r0,=UART2_ERR_DriverIRQHandler
+    bx    r0
+    .size UART2_ERR_IRQHandler, . - UART2_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART3_RX_TX_IRQHandler
+    .type UART3_RX_TX_IRQHandler, %function
+UART3_RX_TX_IRQHandler:
+    ldr   r0,=UART3_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART3_RX_TX_IRQHandler, . - UART3_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART3_ERR_IRQHandler
+    .type UART3_ERR_IRQHandler, %function
+UART3_ERR_IRQHandler:
+    ldr   r0,=UART3_ERR_DriverIRQHandler
+    bx    r0
+    .size UART3_ERR_IRQHandler, . - UART3_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SPI2_IRQHandler
+    .type SPI2_IRQHandler, %function
+SPI2_IRQHandler:
+    ldr   r0,=SPI2_DriverIRQHandler
+    bx    r0
+    .size SPI2_IRQHandler, . - SPI2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART4_RX_TX_IRQHandler
+    .type UART4_RX_TX_IRQHandler, %function
+UART4_RX_TX_IRQHandler:
+    ldr   r0,=UART4_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART4_RX_TX_IRQHandler, . - UART4_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART4_ERR_IRQHandler
+    .type UART4_ERR_IRQHandler, %function
+UART4_ERR_IRQHandler:
+    ldr   r0,=UART4_ERR_DriverIRQHandler
+    bx    r0
+    .size UART4_ERR_IRQHandler, . - UART4_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART5_RX_TX_IRQHandler
+    .type UART5_RX_TX_IRQHandler, %function
+UART5_RX_TX_IRQHandler:
+    ldr   r0,=UART5_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART5_RX_TX_IRQHandler, . - UART5_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART5_ERR_IRQHandler
+    .type UART5_ERR_IRQHandler, %function
+UART5_ERR_IRQHandler:
+    ldr   r0,=UART5_ERR_DriverIRQHandler
+    bx    r0
+    .size UART5_ERR_IRQHandler, . - UART5_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2C2_IRQHandler
+    .type I2C2_IRQHandler, %function
+I2C2_IRQHandler:
+    ldr   r0,=I2C2_DriverIRQHandler
+    bx    r0
+    .size I2C2_IRQHandler, . - I2C2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_ORed_Message_buffer_IRQHandler
+    .type CAN0_ORed_Message_buffer_IRQHandler, %function
+CAN0_ORed_Message_buffer_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_ORed_Message_buffer_IRQHandler, . - CAN0_ORed_Message_buffer_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Bus_Off_IRQHandler
+    .type CAN0_Bus_Off_IRQHandler, %function
+CAN0_Bus_Off_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Bus_Off_IRQHandler, . - CAN0_Bus_Off_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Error_IRQHandler
+    .type CAN0_Error_IRQHandler, %function
+CAN0_Error_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Error_IRQHandler, . - CAN0_Error_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Tx_Warning_IRQHandler
+    .type CAN0_Tx_Warning_IRQHandler, %function
+CAN0_Tx_Warning_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Tx_Warning_IRQHandler, . - CAN0_Tx_Warning_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Rx_Warning_IRQHandler
+    .type CAN0_Rx_Warning_IRQHandler, %function
+CAN0_Rx_Warning_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Rx_Warning_IRQHandler, . - CAN0_Rx_Warning_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Wake_Up_IRQHandler
+    .type CAN0_Wake_Up_IRQHandler, %function
+CAN0_Wake_Up_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Wake_Up_IRQHandler, . - CAN0_Wake_Up_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SDHC_IRQHandler
+    .type SDHC_IRQHandler, %function
+SDHC_IRQHandler:
+    ldr   r0,=SDHC_DriverIRQHandler
+    bx    r0
+    .size SDHC_IRQHandler, . - SDHC_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_1588_Timer_IRQHandler
+    .type ENET_1588_Timer_IRQHandler, %function
+ENET_1588_Timer_IRQHandler:
+    ldr   r0,=ENET_1588_Timer_DriverIRQHandler
+    bx    r0
+    .size ENET_1588_Timer_IRQHandler, . - ENET_1588_Timer_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_Transmit_IRQHandler
+    .type ENET_Transmit_IRQHandler, %function
+ENET_Transmit_IRQHandler:
+    ldr   r0,=ENET_Transmit_DriverIRQHandler
+    bx    r0
+    .size ENET_Transmit_IRQHandler, . - ENET_Transmit_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_Receive_IRQHandler
+    .type ENET_Receive_IRQHandler, %function
+ENET_Receive_IRQHandler:
+    ldr   r0,=ENET_Receive_DriverIRQHandler
+    bx    r0
+    .size ENET_Receive_IRQHandler, . - ENET_Receive_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_Error_IRQHandler
+    .type ENET_Error_IRQHandler, %function
+ENET_Error_IRQHandler:
+    ldr   r0,=ENET_Error_DriverIRQHandler
+    bx    r0
+    .size ENET_Error_IRQHandler, . - ENET_Error_IRQHandler
+
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro def_irq_handler  handler_name
+    .weak \handler_name
+    .set  \handler_name, DefaultISR
+    .endm
+
+/* Exception Handlers */
+    def_irq_handler    MemManage_Handler
+    def_irq_handler    BusFault_Handler
+    def_irq_handler    UsageFault_Handler
+    def_irq_handler    DebugMon_Handler
+    def_irq_handler    DMA0_DriverIRQHandler
+    def_irq_handler    DMA1_DriverIRQHandler
+    def_irq_handler    DMA2_DriverIRQHandler
+    def_irq_handler    DMA3_DriverIRQHandler
+    def_irq_handler    DMA4_DriverIRQHandler
+    def_irq_handler    DMA5_DriverIRQHandler
+    def_irq_handler    DMA6_DriverIRQHandler
+    def_irq_handler    DMA7_DriverIRQHandler
+    def_irq_handler    DMA8_DriverIRQHandler
+    def_irq_handler    DMA9_DriverIRQHandler
+    def_irq_handler    DMA10_DriverIRQHandler
+    def_irq_handler    DMA11_DriverIRQHandler
+    def_irq_handler    DMA12_DriverIRQHandler
+    def_irq_handler    DMA13_DriverIRQHandler
+    def_irq_handler    DMA14_DriverIRQHandler
+    def_irq_handler    DMA15_DriverIRQHandler
+    def_irq_handler    DMA_Error_DriverIRQHandler
+    def_irq_handler    MCM_IRQHandler
+    def_irq_handler    FTFE_IRQHandler
+    def_irq_handler    Read_Collision_IRQHandler
+    def_irq_handler    LVD_LVW_IRQHandler
+    def_irq_handler    LLWU_IRQHandler
+    def_irq_handler    WDOG_EWM_IRQHandler
+    def_irq_handler    RNG_IRQHandler
+    def_irq_handler    I2C0_DriverIRQHandler
+    def_irq_handler    I2C1_DriverIRQHandler
+    def_irq_handler    SPI0_DriverIRQHandler
+    def_irq_handler    SPI1_DriverIRQHandler
+    def_irq_handler    I2S0_Tx_DriverIRQHandler
+    def_irq_handler    I2S0_Rx_DriverIRQHandler
+    def_irq_handler    UART0_LON_DriverIRQHandler
+    def_irq_handler    UART0_RX_TX_DriverIRQHandler
+    def_irq_handler    UART0_ERR_DriverIRQHandler
+    def_irq_handler    UART1_RX_TX_DriverIRQHandler
+    def_irq_handler    UART1_ERR_DriverIRQHandler
+    def_irq_handler    UART2_RX_TX_DriverIRQHandler
+    def_irq_handler    UART2_ERR_DriverIRQHandler
+    def_irq_handler    UART3_RX_TX_DriverIRQHandler
+    def_irq_handler    UART3_ERR_DriverIRQHandler
+    def_irq_handler    ADC0_IRQHandler
+    def_irq_handler    CMP0_IRQHandler
+    def_irq_handler    CMP1_IRQHandler
+    def_irq_handler    FTM0_IRQHandler
+    def_irq_handler    FTM1_IRQHandler
+    def_irq_handler    FTM2_IRQHandler
+    def_irq_handler    CMT_IRQHandler
+    def_irq_handler    RTC_IRQHandler
+    def_irq_handler    RTC_Seconds_IRQHandler
+    def_irq_handler    PIT0_IRQHandler
+    def_irq_handler    PIT1_IRQHandler
+    def_irq_handler    PIT2_IRQHandler
+    def_irq_handler    PIT3_IRQHandler
+    def_irq_handler    PDB0_IRQHandler
+    def_irq_handler    USB0_IRQHandler
+    def_irq_handler    USBDCD_IRQHandler
+    def_irq_handler    Reserved71_IRQHandler
+    def_irq_handler    DAC0_IRQHandler
+    def_irq_handler    MCG_IRQHandler
+    def_irq_handler    LPTMR0_IRQHandler
+    def_irq_handler    PORTA_IRQHandler
+    def_irq_handler    PORTB_IRQHandler
+    def_irq_handler    PORTC_IRQHandler
+    def_irq_handler    PORTD_IRQHandler
+    def_irq_handler    PORTE_IRQHandler
+    def_irq_handler    SWI_IRQHandler
+    def_irq_handler    SPI2_DriverIRQHandler
+    def_irq_handler    UART4_RX_TX_DriverIRQHandler
+    def_irq_handler    UART4_ERR_DriverIRQHandler
+    def_irq_handler    UART5_RX_TX_DriverIRQHandler
+    def_irq_handler    UART5_ERR_DriverIRQHandler
+    def_irq_handler    CMP2_IRQHandler
+    def_irq_handler    FTM3_IRQHandler
+    def_irq_handler    DAC1_IRQHandler
+    def_irq_handler    ADC1_IRQHandler
+    def_irq_handler    I2C2_DriverIRQHandler
+    def_irq_handler    CAN0_DriverIRQHandler
+    def_irq_handler    SDHC_DriverIRQHandler
+    def_irq_handler    ENET_1588_Timer_DriverIRQHandler
+    def_irq_handler    ENET_Transmit_DriverIRQHandler
+    def_irq_handler    ENET_Receive_DriverIRQHandler
+    def_irq_handler    ENET_Error_DriverIRQHandler
+
+    .end

--- a/hw/bsp/frdm-k64f/src/clock_config.c
+++ b/hw/bsp/frdm-k64f/src/clock_config.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_common.h"
+#include "fsl_smc.h"
+
+#include "clock_config.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*! @brief Clock configuration structure. */
+typedef struct _clock_config
+{
+    mcg_config_t mcgConfig;       /*!< MCG configuration.      */
+    sim_clock_config_t simConfig; /*!< SIM configuration.      */
+    osc_config_t oscConfig;       /*!< OSC configuration.      */
+    uint32_t coreClock;           /*!< core clock frequency.   */
+} clock_config_t;
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/* Configuration for enter VLPR mode. Core clock = 4MHz. */
+const clock_config_t g_defaultClockConfigVlpr = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModeBLPI,            /* Work in BLPI mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /* MCGIRCLK enable. */
+            .ircs = kMCG_IrcFast,                /* Select IRC4M. */
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+
+            .frdiv = 0U,
+            .drs = kMCG_DrsLow,         /* Low frequency range. */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25%. */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC. */
+
+            .pll0Config =
+                {
+                    .enableMode = 0U, /* Don't eanble PLL. */
+                    .prdiv = 0U,
+                    .vdiv = 0U,
+                },
+        },
+    .simConfig =
+        {
+            .pllFllSel = 3U,        /* PLLFLLSEL select IRC48MCLK. */
+            .er32kSrc = 2U,         /* ERCLK32K selection, use RTC. */
+            .clkdiv1 = 0x00040000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig = {.freq = BOARD_XTAL0_CLK_HZ,
+                  .capLoad = 0,
+                  .workMode = kOSC_ModeExt,
+                  .oscerConfig =
+                      {
+                          .enableMode = kOSC_ErClkEnable,
+#if (defined(FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER) && FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER)
+                          .erclkDiv = 0U,
+#endif
+                      }},
+    .coreClock = 4000000U, /* Core clock frequency */
+};
+
+/* Configuration for enter RUN mode. Core clock = 120MHz. */
+const clock_config_t g_defaultClockConfigRun = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModePEE,             /* Work in PEE mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /* MCGIRCLK enable. */
+            .ircs = kMCG_IrcSlow,                /* Select IRC32k. */
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+
+            .frdiv = 7U,
+            .drs = kMCG_DrsLow,         /* Low frequency range. */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25%. */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC. */
+
+            .pll0Config =
+                {
+                    .enableMode = 0U, .prdiv = 0x13U, .vdiv = 0x18U,
+                },
+        },
+    .simConfig =
+        {
+            .pllFllSel = 1U,        /* PLLFLLSEL select PLL. */
+            .er32kSrc = 2U,         /* ERCLK32K selection, use RTC. */
+            .clkdiv1 = 0x01140000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig = {.freq = BOARD_XTAL0_CLK_HZ,
+                  .capLoad = 0,
+                  .workMode = kOSC_ModeExt,
+                  .oscerConfig =
+                      {
+                          .enableMode = kOSC_ErClkEnable,
+#if (defined(FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER) && FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER)
+                          .erclkDiv = 0U,
+#endif
+                      }},
+    .coreClock = 120000000U, /* Core clock frequency */
+};
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. CLOCK_SetSimSafeDivs, to make sure core clock, bus clock, flexbus clock
+ *    and flash clock are in allowed range during clock mode switch.
+ *
+ * 2. Call CLOCK_Osc0Init to setup OSC clock, if it is used in target mode.
+ *
+ * 3. Set MCG configuration, MCG includes three parts: FLL clock, PLL clock and
+ *    internal reference clock(MCGIRCLK). Follow the steps to setup:
+ *
+ *    1). Call CLOCK_BootToXxxMode to set MCG to target mode.
+ *
+ *    2). If target mode is FBI/BLPI/PBI mode, the MCGIRCLK has been configured
+ *        correctly. For other modes, need to call CLOCK_SetInternalRefClkConfig
+ *        explicitly to setup MCGIRCLK.
+ *
+ *    3). Don't need to configure FLL explicitly, because if target mode is FLL
+ *        mode, then FLL has been configured by the function CLOCK_BootToXxxMode,
+ *        if the target mode is not FLL mode, the FLL is disabled.
+ *
+ *    4). If target mode is PEE/PBE/PEI/PBI mode, then the related PLL has been
+ *        setup by CLOCK_BootToXxxMode. In FBE/FBI/FEE/FBE mode, the PLL could
+ *        be enabled independently, call CLOCK_EnablePll0 explicitly in this case.
+ *
+ * 4. Call CLOCK_SetSimConfig to set the clock configuration in SIM.
+ */
+
+void BOARD_BootClockVLPR(void)
+{
+    CLOCK_SetSimSafeDivs();
+
+    CLOCK_BootToBlpiMode(g_defaultClockConfigVlpr.mcgConfig.fcrdiv, g_defaultClockConfigVlpr.mcgConfig.ircs,
+                         g_defaultClockConfigVlpr.mcgConfig.irclkEnableMode);
+
+    CLOCK_SetSimConfig(&g_defaultClockConfigVlpr.simConfig);
+
+    SystemCoreClock = g_defaultClockConfigVlpr.coreClock;
+
+    SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
+    SMC_SetPowerModeVlpr(SMC, false);
+    while (SMC_GetPowerModeState(SMC) != kSMC_PowerStateVlpr)
+    {
+    }
+}
+
+void BOARD_BootClockRUN(void)
+{
+    CLOCK_SetSimSafeDivs();
+
+    CLOCK_InitOsc0(&g_defaultClockConfigRun.oscConfig);
+    CLOCK_SetXtal0Freq(BOARD_XTAL0_CLK_HZ);
+
+    CLOCK_BootToPeeMode(g_defaultClockConfigRun.mcgConfig.oscsel, kMCG_PllClkSelPll0,
+                        &g_defaultClockConfigRun.mcgConfig.pll0Config);
+
+    CLOCK_SetInternalRefClkConfig(g_defaultClockConfigRun.mcgConfig.irclkEnableMode,
+                                  g_defaultClockConfigRun.mcgConfig.ircs, g_defaultClockConfigRun.mcgConfig.fcrdiv);
+
+    CLOCK_SetSimConfig(&g_defaultClockConfigRun.simConfig);
+
+    SystemCoreClock = g_defaultClockConfigRun.coreClock;
+}

--- a/hw/bsp/frdm-k64f/src/clock_config.h
+++ b/hw/bsp/frdm-k64f/src/clock_config.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+/*******************************************************************************
+ * DEFINITION
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ 50000000U
+#define BOARD_XTAL32K_CLK_HZ 32768U
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+void BOARD_BootClockVLPR(void);
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/hw/bsp/frdm-k64f/src/hal_bsp.c
+++ b/hw/bsp/frdm-k64f/src/hal_bsp.c
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "bsp/bsp.h"
+#include "flash_map/flash_map.h"
+
+#include "hal/hal_bsp.h"
+#include "hal/hal_flash_int.h"
+
+#include "mcu/frdm-k64f_hal.h"
+
+/*
+ * What memory to include in coredump.
+ */
+static const struct bsp_mem_dump dump_cfg[] = {
+    [0] = {
+	.bmd_start = &__DATA_ROM,
+        .bmd_size = RAM_SIZE
+    }
+};
+
+const struct hal_flash *bsp_flash_dev(uint8_t id)
+{
+    /*
+     * Internal flash mapped to id 0.
+     */
+    if (id != 0) {
+        return NULL;
+    }
+    return &mk64f12_flash_dev;
+}
+
+const struct bsp_mem_dump *
+bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
+    return dump_cfg;
+}
+
+int
+hal_bsp_power_state(int state)
+{
+    return (0);
+}
+
+/*!
+ * @brief Function to override ARMGCC default function _sbrk
+ *
+ * _sbrk is called by malloc. ARMGCC default _sbrk compares "SP" register and
+ * heap end, if heap end is larger than "SP", then _sbrk returns error and
+ * memory allocation failed. This function changes to compare __HeapLimit with
+ * heap end.
+ */
+void *_sbrk(int incr)
+{
+    extern char end __asm("end");
+    extern char heap_limit __asm("__HeapLimit");
+    static char *heap_end;
+    char *prev_heap_end;
+
+    if (heap_end == NULL)
+        heap_end = &end;
+
+    prev_heap_end = heap_end;
+
+    if (heap_end + incr > &heap_limit)
+    {
+        errno = ENOMEM;
+        return (void *)-1;
+    }
+
+    heap_end += incr;
+
+    return (void *)prev_heap_end;
+}

--- a/hw/bsp/frdm-k64f/src/libc_stubs.c
+++ b/hw/bsp/frdm-k64f/src/libc_stubs.c
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <hal/hal_system.h>
+
+void * _sbrk(int c);
+int _close(int fd);
+int _fstat(int fd, void *s);
+void _exit(int s);
+int _kill(int pid, int sig);
+int _isatty(int c);
+int _lseek(int fd, int off, int w);
+int _getpid(void);
+
+int
+_close(int fd)
+{
+    return -1;
+}
+
+int
+_fstat(int fd, void *s)
+{
+    return -1;
+}
+
+
+void
+_exit(int s)
+{
+    system_reset();
+}
+
+int
+_kill(int pid, int sig)
+{
+    return -1;
+}
+
+int
+_isatty(int c)
+{
+    return -1;
+}
+
+int
+_lseek(int fd, int off, int w)
+{
+    return -1;
+}
+
+int
+_getpid(void) {
+    return -1;
+}

--- a/hw/bsp/frdm-k64f/src/os_bsp.c
+++ b/hw/bsp/frdm-k64f/src/os_bsp.c
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <sys/types.h>
+#include <stdio.h>
+
+#include "os/os_dev.h"
+#include "syscfg/syscfg.h"
+
+#include "flash_map/flash_map.h"
+#include "hal/hal_flash.h"
+#include "uart/uart.h"
+#include "uart_hal/uart_hal.h"
+#include "hal/hal_uart.h"
+
+#include "bsp/cmsis_nvic.h"
+
+#include "mcu/frdm-k64f_hal.h"
+#include "fsl_device_registers.h"
+#include "fsl_common.h"
+#include "fsl_clock.h"
+#include "fsl_port.h"
+
+#include "clock_config.h"
+
+#if MYNEWT_VAL(UART_0)
+static struct uart_dev os_bsp_uart0;
+#endif
+#if MYNEWT_VAL(UART_1)
+static struct uart_dev os_bsp_uart1;
+#endif
+#if MYNEWT_VAL(UART_2)
+static struct uart_dev os_bsp_uart2;
+#endif
+#if MYNEWT_VAL(UART_3)
+static struct uart_dev os_bsp_uart3;
+#endif
+#if MYNEWT_VAL(UART_4)
+static struct uart_dev os_bsp_uart4;
+#endif
+#if MYNEWT_VAL(UART_5)
+static struct uart_dev os_bsp_uart5;
+#endif
+
+static void init_hardware(void)
+{
+    // Disable the MPU otherwise USB cannot access the bus
+    MPU->CESR = 0;
+
+    // Enable all the ports
+    SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK | SIM_SCGC5_PORTB_MASK | SIM_SCGC5_PORTC_MASK | SIM_SCGC5_PORTD_MASK |
+                   SIM_SCGC5_PORTE_MASK);
+}
+
+extern void BOARD_BootClockRUN(void);
+
+void bsp_init(void)
+{
+    int rc = 0;
+
+    // Init pinmux and other hardware setup.
+    init_hardware();
+    BOARD_BootClockRUN();
+
+#if MYNEWT_VAL(UART_0)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_1)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart1, "uart1",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_2)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart2, "uart2",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_3)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart3, "uart3",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_4)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart4, "uart4",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_5)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart5, "uart5",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+}

--- a/hw/bsp/frdm-k64f/syscfg.yml
+++ b/hw/bsp/frdm-k64f/syscfg.yml
@@ -1,0 +1,114 @@
+# Package: hw/bsp/frdm-k64f
+
+syscfg.defs:
+    BSP_MK64F12:
+        description: 'TBD'
+        value: 1
+
+    # UART0 PINS on CMSIS-DAP Interface
+    UART_0:
+        description: 'TBD'
+        value:  1
+    UART_0_PORT:
+        description: 'TBD'
+        value:  PORTB
+    UART_0_PORT_CLOCK:
+        description: 'TBD'
+        value:  kCLOCK_PortB
+    UART_0_PIN_TX:
+        description: 'TBD'
+        value:  16
+    UART_0_PIN_RX:
+        description: 'TBD'
+        value:  17
+
+    # PINS conflict with SPI0 must choose 1
+    UART_1:
+        description: 'TBD'
+        value:  0
+    UART_1_PORT:
+        description: 'TBD'
+        value:  PORTC
+    UART_1_PORT_CLOCK:
+        description: 'TBD'
+        value:  kCLOCK_PortC
+    UART_1_PIN_TX:
+        description: 'TBD'
+        value:  3
+    UART_1_PIN_RX:
+        description: 'TBD'
+        value:  4
+
+    # PINS conflict with SPI0 must choose 1
+    UART_2:
+        description: 'TBD'
+        value:  0
+    UART_2_PORT:
+        description: 'TBD'
+        value:  PORTD
+    UART_2_PORT_CLOCK:
+        description: 'TBD'
+        value:  kCLOCK_PortD
+    UART_2_PIN_TX:
+        description: 'TBD'
+        value:  2
+    UART_2_PIN_RX:
+        description: 'TBD'
+        value:  3
+
+    # PINS conflict with ENET0 must choose 1
+    UART_3:
+        description: 'TBD'
+        value:  0
+    UART_3_PORT:
+        description: 'TBD'
+        value:  PORTC
+    UART_3_PORT_CLOCK:
+        description: 'TBD'
+        value:  kCLOCK_PortC
+    UART_3_PIN_TX:
+        description: 'TBD'
+        value:  16
+    UART_3_PIN_RX:
+        description: 'TBD'
+        value:  17
+
+    # PINS conflict with ENET0 must choose 1
+    UART_4:
+        description: 'TBD'
+        value:  0
+    UART_4_PORT:
+        description: 'TBD'
+        value:  PORTC
+    UART_4_PORT_CLOCK:
+        description: 'TBD'
+        value:  kCLOCK_PortC
+    UART_4_PIN_TX:
+        description: 'TBD'
+        value:  14
+    UART_4_PIN_RX:
+        description: 'TBD'
+        value:  15
+
+    # PINS conflict with I2S0 must choose 1
+    UART_5:
+        description: 'TBD'
+        value:  0
+    UART_5_PORT:
+        description: 'TBD'
+        value:  PORTE
+    UART_5_PORT_CLOCK:
+        description: 'TBD'
+        value:  kCLOCK_PortE
+    UART_5_PIN_TX:
+        description: 'TBD'
+        value:  9
+    UART_5_PIN_RX:
+        description: 'TBD'
+        value:  8
+
+syscfg.vals:
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    NFFS_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1

--- a/hw/mcu/nxp/MK64F12/include/mcu/cortex_m4.h
+++ b/hw/mcu/nxp/MK64F12/include/mcu/cortex_m4.h
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_CORTEX_M4_H__
+#define __MCU_CORTEX_M4_H__
+
+/*
+ * include board definition file here so that
+ * SCB register can be defined for os_fault.c
+ */
+#include "MK64F12.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OS_TICKS_PER_SEC	(1000)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_CORTEX_M4_H__ */

--- a/hw/mcu/nxp/MK64F12/include/mcu/frdm-k64f_hal.h
+++ b/hw/mcu/nxp/MK64F12/include/mcu/frdm-k64f_hal.h
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_FRDMK64F_BSP_H_
+#define __MCU_FRDMK64F_BSP_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+struct hal_flash;
+extern const struct hal_flash mk64f12_flash_dev;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_FRDMK64F_BSP_H_ */

--- a/hw/mcu/nxp/MK64F12/pkg.yml
+++ b/hw/mcu/nxp/MK64F12/pkg.yml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/mcu/nxp/MK64F12
+pkg.description: MCU definition for NXP K64F ARM Cortex-M4 chip
+pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+
+pkg.deps:
+    - hw/hal
+    - hw/cmsis-core
+    - hw/mcu/nxp
+    - compiler/arm-none-eabi-m4

--- a/hw/mcu/nxp/MK64F12/src/hal_flash.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_flash.c
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Internal flash for MK64F12.
+ * Size of the flash depends on the MCU model, flash is memory mapped
+ * and is divided to 2k sectors throughout.
+ * Programming is done 2 bytes at a time.
+ */
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+#include <hal/hal_flash_int.h>
+
+#include "MK64F12.h"
+#include "fsl_flash.h"
+
+static int mk64f12_flash_read(uint32_t address, void *dst, uint32_t num_bytes);
+static int mk64f12_flash_write(uint32_t address, const void *src,
+  uint32_t num_bytes);
+static int mk64f12_flash_erase_sector(uint32_t sector_address);
+static int mk64f12_flash_sector_info(int idx, uint32_t *addr, uint32_t *sz);
+static int mk64f12_flash_init(void);
+
+static const struct hal_flash_funcs mk64f12_flash_funcs = {
+    .hff_read = mk64f12_flash_read,
+    .hff_write = mk64f12_flash_write,
+    .hff_erase_sector = mk64f12_flash_erase_sector,
+    .hff_sector_info = mk64f12_flash_sector_info,
+    .hff_init = mk64f12_flash_init
+};
+
+static flash_config_t mk64f12_config;
+
+struct hal_flash mk64f12_flash_dev = {
+    /* Most items are set after FLASH_Init() */
+    .hf_itf = &mk64f12_flash_funcs,
+    .hf_align = 4
+};
+
+static int
+mk64f12_flash_read(uint32_t address, void *dst, uint32_t num_bytes)
+{
+    memcpy(dst, (void *)address, num_bytes);
+    return 0;
+}
+
+static int
+mk64f12_flash_write(uint32_t address, const void *src, uint32_t len)
+{
+    if (address % sizeof(uint32_t)) {
+        /*
+         * Unaligned write.
+         */
+        return -1;
+    }
+
+    if (FLASH_Program(&mk64f12_config, address, (uint32_t *)src, len) == kStatus_Success)
+        return 0;
+    return -1;
+}
+
+static int
+mk64f12_flash_erase_sector(uint32_t sector_address)
+{
+    if (FLASH_Erase(&mk64f12_config, sector_address, mk64f12_config.PFlashSectorSize,
+                    kFLASH_apiEraseKey) == kStatus_Success)
+        return 0;
+    return -1;
+}
+
+static int
+mk64f12_flash_sector_info(int idx, uint32_t *addr, uint32_t *sz)
+{
+    *addr = mk64f12_config.PFlashBlockBase + (idx * mk64f12_config.PFlashSectorSize);
+    *sz = mk64f12_config.PFlashSectorSize;
+    return 0;
+}
+
+static int
+mk64f12_flash_init(void)
+{
+    if (FLASH_Init(&mk64f12_config) == kStatus_Success) {
+        mk64f12_flash_dev.hf_base_addr = mk64f12_config.PFlashBlockBase;
+        mk64f12_flash_dev.hf_size = mk64f12_config.PFlashTotalSize;
+        mk64f12_flash_dev.hf_sector_cnt = (mk64f12_config.PFlashTotalSize / mk64f12_config.PFlashSectorSize);
+    }
+    return 0;
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_gpio.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_gpio.c
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "hal/hal_gpio.h"
+#include "bsp/cmsis_nvic.h"
+#include <stdlib.h>
+#include <assert.h>
+
+#include "fsl_common.h"
+#include "fsl_clock.h"
+#include "fsl_gpio.h"
+#include "fsl_port.h"
+
+/* Each GPIO port has pins from 0 to 31 */
+#define GPIO_INDEX(pin)     ((pin) & 0x1F)
+#define GPIO_PORT(pin)      (((pin) >> 5) & 0x07)
+#define GPIO_MASK(pin)      (1 << GPIO_INDEX(pin))
+#define GPIO_PIN(port, pin)  ((((port) & 0x07) << 5) | ((pin) & 0x1F))
+
+static GPIO_Type *const s_gpioBases[] = GPIO_BASE_PTRS;
+static PORT_Type *const s_portBases[] = PORT_BASE_PTRS;
+static clock_ip_name_t const s_portClocks[] = PORT_CLOCKS;
+
+uint16_t hal_to_fsl_pull(gpio_pull_t pull)
+{
+    switch ((int)pull)
+    {
+    case GPIO_PULL_UP:
+        return kPORT_PullUp;
+    case GPIO_PULL_DOWN:
+        return kPORT_PullDown;
+    default:
+        return kPORT_PullDisable;
+    }
+}
+
+int hal_gpio_init_in(int pin, gpio_pull_t pull)
+{
+    gpio_pin_config_t gconfig;
+    port_pin_config_t pconfig;
+
+    gconfig.pinDirection = kGPIO_DigitalInput;
+    pconfig.pullSelect = hal_to_fsl_pull(pull);
+    pconfig.mux = kPORT_MuxAsGpio;
+
+    CLOCK_EnableClock(s_portClocks[GPIO_PORT(pin)]);
+    PORT_SetPinConfig(s_portBases[GPIO_PORT(pin)], GPIO_INDEX(pin), &pconfig);
+    GPIO_PinInit(s_gpioBases[GPIO_PORT(pin)], GPIO_INDEX(pin), &gconfig);
+
+    return 0;
+}
+
+int hal_gpio_init_out(int pin, int val)
+{
+    gpio_pin_config_t gconfig;
+    port_pin_config_t pconfig;
+
+    gconfig.pinDirection = kGPIO_DigitalOutput;
+    pconfig.mux = kPORT_MuxAsGpio;
+
+    CLOCK_EnableClock(s_portClocks[GPIO_PORT(pin)]);
+    PORT_SetPinConfig(s_portBases[GPIO_PORT(pin)], GPIO_INDEX(pin), &pconfig);
+    GPIO_PinInit(s_gpioBases[GPIO_PORT(pin)], GPIO_INDEX(pin), &gconfig);
+
+    return 0;
+}
+
+void hal_gpio_set(int pin)
+{
+    GPIO_WritePinOutput(s_gpioBases[GPIO_PORT(pin)], GPIO_INDEX(pin), 1);
+}
+
+void hal_gpio_clear(int pin)
+{
+    GPIO_WritePinOutput(s_gpioBases[GPIO_PORT(pin)], GPIO_INDEX(pin), 0);
+}
+
+void hal_gpio_write(int pin, int val)
+{
+    GPIO_WritePinOutput(s_gpioBases[GPIO_PORT(pin)], GPIO_INDEX(pin), val);
+}
+
+int hal_gpio_read(int pin)
+{
+    return (int)GPIO_ReadPinInput(s_gpioBases[GPIO_PORT(pin)], GPIO_INDEX(pin));
+}
+
+int hal_gpio_toggle(int pin)
+{
+    GPIO_TogglePinsOutput(s_gpioBases[GPIO_PORT(pin)], 1 << GPIO_INDEX(pin));
+
+    return 0;
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_hw_id.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_hw_id.c
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <string.h>
+
+#include <hal/hal_bsp.h>
+
+#include "MK64F12.h"
+
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+/*
+ * TODO: Use serial# registers
+ */
+int bsp_hw_id(uint8_t *id, int max_len)
+{
+    memcpy(id, (void *)"ABCDEFG", 8);
+
+    return 7;
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_os_tick.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_os_tick.c
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <os/os.h>
+#include <hal/hal_os_tick.h>
+
+#include "bsp/cmsis_nvic.h"
+
+#include "fsl_pit.h"
+
+static void nxp_pit0_timer_handler(void)
+{
+    uint32_t sr;
+
+    OS_ENTER_CRITICAL(sr);
+
+    /* Clear interrupt flag.*/
+    PIT_ClearStatusFlags(PIT, kPIT_Chnl_0, PIT_TFLG_TIF_MASK);
+    os_time_advance(1);
+
+    OS_EXIT_CRITICAL(sr);
+}
+
+void os_tick_idle(os_time_t ticks)
+{
+    OS_ASSERT_CRITICAL();
+
+    __DSB();
+    __WFI();
+}
+
+void os_tick_init(uint32_t os_ticks_per_sec, int prio)
+{
+    pit_config_t pitConfig;
+    uint32_t sr;
+
+    uint32_t ticks_per_ostick = 1000000U / os_ticks_per_sec; /* 1000/s */
+
+    PIT_GetDefaultConfig(&pitConfig);
+    pitConfig.enableRunInDebug = true;
+    PIT_Init(PIT, &pitConfig);
+
+    /* Clear interrupt flag.*/
+    PIT_ClearStatusFlags(PIT, kPIT_Chnl_0, PIT_TFLG_TIF_MASK);
+
+    /* Set timer period for channel 0 */
+    PIT_SetTimerPeriod(PIT, kPIT_Chnl_0, USEC_TO_COUNT(ticks_per_ostick, CLOCK_GetFreq(kCLOCK_BusClk)));
+
+    /* Enable timer interrupts for channel 0 */
+    PIT_EnableInterrupts(PIT, kPIT_Chnl_0, kPIT_TimerInterruptEnable);
+
+    /* disable interrupts */
+    OS_ENTER_CRITICAL(sr);
+
+    /* Set isr in vector table and enable interrupt */
+    NVIC_SetPriority(PIT0_IRQn, prio);
+    NVIC_SetVector(PIT0_IRQn, (uint32_t)nxp_pit0_timer_handler);
+    /* Enable at the NVIC */
+    EnableIRQ(PIT0_IRQn);
+
+    /* Start channel 0 */
+    PIT_StartTimer(PIT, kPIT_Chnl_0);
+
+    OS_EXIT_CRITICAL(sr);
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_system.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_system.c
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <mcu/cortex_m4.h>
+#include "hal/hal_system.h"
+
+int system_debugger_connected(void)
+{
+    return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+}
+
+void system_reset(void)
+{
+    while (1) {
+        if (system_debugger_connected()) {
+            /*
+             * If debugger is attached, breakpoint here.
+             */
+            asm("bkpt");
+        }
+        NVIC_SystemReset();
+    }
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_system_start.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_system_start.c
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stddef.h>
+#include <inttypes.h>
+#include <mcu/cortex_m4.h>
+
+/**
+ * Boots the image described by the supplied image header.
+ *
+ * @param hdr                   The header for the image to boot.
+ */
+void
+system_start(void *img_start)
+{
+    /* Turn off interrupts. */
+    __disable_irq();
+
+    /* Set the VTOR to default. */
+    SCB->VTOR = 0;
+
+    // Memory barriers for good measure.
+    __ISB();
+    __DSB();
+
+    /* First word contains initial MSP value. */
+    __set_MSP(*(uint32_t *)img_start);
+    __set_PSP(*(uint32_t *)img_start);
+
+    /* Second word contains address of entry point (Reset_Handler). */
+    void (*entry)(void) = (void (*)(void))*(uint32_t *)(img_start + 4);
+
+    /* Jump to image. */
+    entry();
+
+    /* Should never reach this point */
+    while (1)
+        ;
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_uart.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_uart.c
@@ -1,0 +1,403 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "syscfg/syscfg.h"
+#include "hal/hal_uart.h"
+#include "hal/hal_gpio.h"
+#include "hal/hal_system.h"
+#include "bsp/cmsis_nvic.h"
+#include "bsp/bsp.h"
+#include "os/os.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "mcu/frdm-k64f_hal.h"
+#include "MK64F12.h"
+#include "fsl_port.h"
+#include "fsl_uart.h"
+#include "fsl_debug_console.h"
+
+#include "hal_uart_nxp.h"
+
+/*! @brief Ring buffer size (Unit: Byte). */
+#define TX_BUF_SZ  32
+#define RX_BUF_SZ  128
+
+struct uart_ring {
+    uint16_t ur_head;
+    uint16_t ur_tail;
+    uint16_t ur_size;
+    uint8_t _pad;
+    uint8_t *ur_buf;
+};
+
+struct hal_uart {
+    UART_Type       *u_base;
+    clock_name_t     clk_src;
+    uint32_t         u_irq;
+    PORT_Type       *p_base;
+    clock_ip_name_t  p_clock;
+    int  u_pin_rx;
+    int  u_pin_tx;
+    /* TODO: support flow control pins */
+    hal_uart_rx_char u_rx_func;
+    hal_uart_tx_char u_tx_func;
+    hal_uart_tx_done u_tx_done;
+    void *u_func_arg;
+    uint8_t u_configured:1;
+    uint8_t u_open:1;
+    uint8_t u_tx_started:1;
+    struct uart_ring ur_tx;
+    uint8_t tx_buffer[TX_BUF_SZ];
+    struct uart_ring ur_rx;
+    uint8_t rx_buffer[RX_BUF_SZ];
+};
+
+/* UART configurations */
+static struct hal_uart uarts[FSL_FEATURE_SOC_UART_COUNT];
+
+static uint8_t const s_uartExists[] = NXP_UART_EXISTS;
+static uint8_t const s_uartEnabled[] = NXP_UART_ENABLED;
+static UART_Type *const s_uartBases[] = UART_BASE_PTRS;
+static clock_name_t s_uartClocks[] = NXP_UART_CLOCKS;
+static uint8_t const s_uartIRQ[] = UART_RX_TX_IRQS;
+static PORT_Type *const s_uartPort[] = NXP_UART_PORTS;
+static clock_ip_name_t const s_uartPortClocks[] = NXP_UART_PORT_CLOCKS;
+static uint8_t const s_uartPIN_RX[] = NXP_UART_PIN_RX;
+static uint8_t const s_uartPIN_TX[] = NXP_UART_PIN_TX;
+
+/*
+ * RING BUFFER FUNCTIONS
+ */
+
+static uint8_t ur_is_empty(struct uart_ring *ur)
+{
+    return (ur->ur_head == ur->ur_tail);;
+}
+
+static uint8_t ur_is_full(struct uart_ring *ur)
+{
+    return (((ur->ur_tail + 1) % ur->ur_size) == ur->ur_head);
+}
+
+static void ur_bump(struct uart_ring *ur)
+{
+    if (!ur_is_empty(ur)) {
+        ur->ur_head++;
+        ur->ur_head %= ur->ur_size;
+        return;
+    }
+}
+
+static uint8_t ur_read(struct uart_ring *ur)
+{
+    return ur->ur_buf[ur->ur_head];
+}
+
+static int ur_queue(struct uart_ring *ur, uint8_t data)
+{
+    if (!ur_is_full(ur)) {
+        ur->ur_buf[ur->ur_tail] = data;
+        ur->ur_tail++;
+        ur->ur_tail %= ur->ur_size;
+        return 0;
+    }
+    return -1;
+}
+
+/*
+ * END RING BUFFER FUNCTIONS
+ */
+
+int hal_uart_init_cbs(int port, hal_uart_tx_char tx_func,
+  hal_uart_tx_done tx_done, hal_uart_rx_char rx_func, void *arg)
+{
+    struct hal_uart *u;
+
+    if (port >= FSL_FEATURE_SOC_UART_COUNT) {
+        return -1;
+    }
+    u = &uarts[port];
+    u->u_rx_func = rx_func;
+    u->u_tx_func = tx_func;
+    u->u_tx_done = tx_done;
+    u->u_func_arg = arg;
+
+    return 0;
+}
+
+void hal_uart_blocking_tx(int port, uint8_t byte)
+{
+    struct hal_uart *u;
+
+    if (port >= FSL_FEATURE_SOC_UART_COUNT) {
+        return;
+    }
+    u = &uarts[port];
+    if (!u->u_configured || !u->u_open) {
+        return;
+    }
+
+    UART_WriteBlocking(u->u_base, &byte, 1);
+}
+
+static int
+hal_uart_tx_fill_buf(struct hal_uart *u)
+{
+    int data = 0;
+    int i = 0;
+    os_sr_t sr;
+
+    OS_ENTER_CRITICAL(sr);
+    while (!ur_is_full(&u->ur_tx)) {
+        if (u->u_tx_func)
+            data = u->u_tx_func(u->u_func_arg);
+        if (data <= 0) {
+            break;
+        }
+        i++;
+        ur_queue(&u->ur_tx, data);
+    }
+    OS_EXIT_CRITICAL(sr);
+    return i;
+}
+
+void hal_uart_start_tx(int port)
+{
+    struct hal_uart *u;
+    int data = -1;
+    int rc;
+
+    if (port >= FSL_FEATURE_SOC_UART_COUNT) {
+        return;
+    }
+    u = &uarts[port];
+    if (!u->u_configured || !u->u_open) {
+        return;
+    }
+
+    /* main loop */
+    while (true)
+    {
+        /* add data to TX ring buffer */
+        if (u->u_tx_started == 0) {
+            rc = hal_uart_tx_fill_buf(u);
+            if (rc > 0)
+                u->u_tx_started = 1;
+        }
+
+        /* Send data only when UART TX register is empty and TX ring buffer has data to send out. */
+        while (!ur_is_empty(&u->ur_tx) &&
+               (kUART_TxDataRegEmptyFlag & UART_GetStatusFlags(u->u_base)))
+        {
+            data = ur_read(&u->ur_tx);
+            UART_WriteByte(u->u_base, data);
+            ur_bump(&u->ur_tx);
+        }
+
+        if (ur_is_empty(&u->ur_tx)) {
+            if (u->u_tx_done)
+                u->u_tx_done(u->u_func_arg);
+            u->u_tx_started = 0;
+            break;
+        }
+    }
+}
+
+void hal_uart_start_rx(int port)
+{
+    struct hal_uart *u;
+    os_sr_t sr;
+    int rc = 0;
+
+    if (port >= FSL_FEATURE_SOC_UART_COUNT) {
+        return;
+    }
+    u = &uarts[port];
+    if (!u->u_configured || !u->u_open) {
+        return;
+    }
+
+    /* Send back what's in the RX ring buffer until it's empty or we get an error */
+    while ((rc >= 0) && !ur_is_empty(&u->ur_rx))
+    {
+        OS_ENTER_CRITICAL(sr);
+        rc = u->u_rx_func(u->u_func_arg, ur_read(&u->ur_rx));
+        if (rc >= 0)
+            ur_bump(&u->ur_rx);
+        OS_EXIT_CRITICAL(sr);
+    }
+}
+
+void uart_irq_handler(void)
+{
+    struct hal_uart *u;
+    int port;
+    uint8_t data;
+
+    for (port = 0; port < FSL_FEATURE_SOC_UART_COUNT; port++) {
+        u = &uarts[port];
+        if (u->u_configured && u->u_open) {
+            /* Check for RX data */
+            if ((kUART_RxDataRegFullFlag | kUART_RxOverrunFlag) &
+                    UART_GetStatusFlags(u->u_base)) {
+                data = UART_ReadByte(u->u_base);
+                ur_queue(&u->ur_rx, data);
+            }
+            /* Check for TX complete */
+            if (kUART_TxDataRegEmptyFlag & UART_GetStatusFlags(u->u_base)) {
+                if (u->u_tx_started) {
+                    u->u_tx_started = 0;
+                    if (u->u_tx_done)
+                        u->u_tx_done(u->u_func_arg);
+                }
+            }
+        }
+    }
+}
+
+int hal_uart_config(int port, int32_t speed, uint8_t databits, uint8_t stopbits,
+                    enum hal_uart_parity parity, enum hal_uart_flow_ctl flow_ctl)
+{
+    struct hal_uart *u;
+    uart_config_t uconfig;
+
+    if (port >= FSL_FEATURE_SOC_UART_COUNT) {
+        return -1;
+    }
+    u = &uarts[port];
+    if (!u->u_configured || u->u_open) {
+        return -1;
+    }
+
+    /* PIN config (all UARTs use kPORT_MuxAlt3) */
+    CLOCK_EnableClock(u->p_clock);
+    PORT_SetPinMux(u->p_base, u->u_pin_rx, kPORT_MuxAlt3);
+    PORT_SetPinMux(u->p_base, u->u_pin_tx, kPORT_MuxAlt3);
+
+    /* UART CONFIG */
+    UART_GetDefaultConfig(&uconfig);
+    uconfig.baudRate_Bps = speed;
+
+    /* TODO: only handles 8 databits currently */
+
+    switch (stopbits) {
+    case 1:
+        uconfig.stopBitCount = kUART_OneStopBit;
+        break;
+    case 2:
+        uconfig.stopBitCount = kUART_TwoStopBit;
+        break;
+    default:
+        return -1;
+    }
+
+    switch (parity) {
+    case HAL_UART_PARITY_NONE:
+        uconfig.parityMode = kUART_ParityDisabled;
+        break;
+    case HAL_UART_PARITY_ODD:
+        uconfig.parityMode = kUART_ParityOdd;
+        break;
+    case HAL_UART_PARITY_EVEN:
+        uconfig.parityMode = kUART_ParityEven;
+        break;
+    }
+
+    /* TODO: HW flow control not supported */
+    assert(flow_ctl == HAL_UART_FLOW_CTL_NONE);
+
+    u->u_open = 1;
+    u->u_tx_started = 0;
+
+    NVIC_SetVector(u->u_irq, (uint32_t)uart_irq_handler);
+
+    /* Initialize UART device */
+    if (port != 0) {
+        UART_Init(u->u_base, &uconfig, CLOCK_GetFreq(u->clk_src));
+        UART_EnableTx(u->u_base, true);
+        UART_EnableRx(u->u_base, true);
+        UART_EnableInterrupts(u->u_base,
+                              kUART_RxDataRegFullInterruptEnable
+                              | kUART_RxOverrunInterruptEnable);
+        EnableIRQ(u->u_irq);
+    }
+
+    return 0;
+}
+
+int hal_uart_close(int port)
+{
+    struct hal_uart *u;
+
+    if (port >= FSL_FEATURE_SOC_UART_COUNT) {
+        return -1;
+    }
+    u = &uarts[port];
+    if (!u->u_open) {
+        return -1;
+    }
+
+    u->u_open = 0;
+    UART_DisableInterrupts(u->u_base, kUART_RxDataRegFullInterruptEnable | kUART_RxOverrunInterruptEnable | kUART_TxDataRegEmptyInterruptEnable);
+    DisableIRQ(u->u_irq);
+    UART_EnableTx(u->u_base, false);
+    UART_EnableRx(u->u_base, false);
+
+    return 0;
+}
+
+int hal_uart_init(int port, void *cfg)
+{
+    if (s_uartExists[port]) {
+        if (s_uartEnabled[port]) {
+            uarts[port].u_base        = s_uartBases[port];
+            uarts[port].clk_src       = s_uartClocks[port];
+            uarts[port].u_irq         = s_uartIRQ[port];
+            uarts[port].p_base        = s_uartPort[port];
+            uarts[port].p_clock       = s_uartPortClocks[port];
+            uarts[port].u_pin_rx      = s_uartPIN_RX[port];
+            uarts[port].u_pin_tx      = s_uartPIN_TX[port];
+            uarts[port].ur_tx.ur_buf  = uarts[port].tx_buffer;
+            uarts[port].ur_tx.ur_size = TX_BUF_SZ;
+            uarts[port].ur_tx.ur_head = 0;
+            uarts[port].ur_tx.ur_tail = 0;
+            uarts[port].ur_rx.ur_buf  = uarts[port].rx_buffer;
+            uarts[port].ur_rx.ur_size = RX_BUF_SZ;
+            uarts[port].ur_rx.ur_head = 0;
+            uarts[port].ur_rx.ur_tail = 0;
+            uarts[port].u_configured  = 1;
+        }
+        else {
+            uarts[port].u_configured = 0;
+        }
+    }
+
+    if (port == 0) {
+        CLOCK_EnableClock(uarts[0].p_clock);
+        PORT_SetPinMux(uarts[0].p_base, uarts[0].u_pin_rx, kPORT_MuxAlt3);
+        PORT_SetPinMux(uarts[0].p_base, uarts[0].u_pin_tx, kPORT_MuxAlt3);
+        DbgConsole_Init((uint32_t)uarts[0].u_base, 115200,
+                        DEBUG_CONSOLE_DEVICE_TYPE_UART, CLOCK_GetFreq(uarts[0].clk_src));
+        PRINTF("UART%d CONFIGURED\r\n", port);
+    }
+
+    return 0;
+}

--- a/hw/mcu/nxp/MK64F12/src/hal_uart_nxp.h
+++ b/hw/mcu/nxp/MK64F12/src/hal_uart_nxp.h
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_FRDMK64F_HAL_UART_H_
+#define __MCU_FRDMK64F_HAL_UART_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#define NXP_UART_EXISTS      { 1, \
+                               1, \
+                               (FSL_FEATURE_SOC_UART_COUNT > 2U), \
+                               (FSL_FEATURE_SOC_UART_COUNT > 3U), \
+                               (FSL_FEATURE_SOC_UART_COUNT > 4U), \
+                               (FSL_FEATURE_SOC_UART_COUNT > 5U) }
+
+#define NXP_UART_ENABLED     { MYNEWT_VAL(UART_0), \
+                               MYNEWT_VAL(UART_1), \
+                               MYNEWT_VAL(UART_2), \
+                               MYNEWT_VAL(UART_3), \
+                               MYNEWT_VAL(UART_4), \
+                               MYNEWT_VAL(UART_5) }
+
+#define NXP_UART_CLOCKS      { UART0_CLK_SRC, \
+                               UART1_CLK_SRC, \
+                               UART2_CLK_SRC, \
+                               UART3_CLK_SRC, \
+                               UART4_CLK_SRC, \
+                               UART5_CLK_SRC }
+
+#define NXP_UART_PORTS       { MYNEWT_VAL(UART_0_PORT), \
+                               MYNEWT_VAL(UART_1_PORT), \
+                               MYNEWT_VAL(UART_2_PORT), \
+                               MYNEWT_VAL(UART_3_PORT), \
+                               MYNEWT_VAL(UART_4_PORT), \
+                               MYNEWT_VAL(UART_5_PORT) }
+
+#define NXP_UART_PORT_CLOCKS { MYNEWT_VAL(UART_0_PORT_CLOCK), \
+                               MYNEWT_VAL(UART_1_PORT_CLOCK), \
+                               MYNEWT_VAL(UART_2_PORT_CLOCK), \
+                               MYNEWT_VAL(UART_3_PORT_CLOCK), \
+                               MYNEWT_VAL(UART_4_PORT_CLOCK), \
+                               MYNEWT_VAL(UART_5_PORT_CLOCK) }
+
+#define NXP_UART_PIN_RX      { MYNEWT_VAL(UART_0_PIN_RX), \
+                               MYNEWT_VAL(UART_1_PIN_RX), \
+                               MYNEWT_VAL(UART_2_PIN_RX), \
+                               MYNEWT_VAL(UART_3_PIN_RX), \
+                               MYNEWT_VAL(UART_4_PIN_RX), \
+                               MYNEWT_VAL(UART_5_PIN_RX) }
+
+#define NXP_UART_PIN_TX      { MYNEWT_VAL(UART_0_PIN_TX), \
+                               MYNEWT_VAL(UART_1_PIN_TX), \
+                               MYNEWT_VAL(UART_2_PIN_TX), \
+                               MYNEWT_VAL(UART_3_PIN_TX), \
+                               MYNEWT_VAL(UART_4_PIN_TX), \
+                               MYNEWT_VAL(UART_5_PIN_TX) }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_FRDMK64F_HAL_UART_H_ */

--- a/hw/mcu/nxp/MK64F12/src/hal_watchdog.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_watchdog.c
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "hal/hal_watchdog.h"
+#include "bsp/cmsis_nvic.h"
+
+#include <assert.h>
+
+#include "fsl_wdog.h"
+#include "fsl_rcm.h"
+
+/* #define WATCHDOG_STUB */
+
+#ifndef WATCHDOG_STUB
+static WDOG_Type *wdog_base = WDOG;
+
+static void nxp_hal_wdt_default_handler(void)
+{
+    assert(0);
+}
+
+/**@brief WDT interrupt handler. */
+static void nxp_wdt_irq_handler(void)
+{
+    if (WDOG_GetStatusFlags(wdog_base) && kWDOG_RunningFlag) {
+        WDOG_ClearStatusFlags(wdog_base, kWDOG_TimeoutFlag);
+        nxp_hal_wdt_default_handler();
+    }
+}
+#endif
+
+int hal_watchdog_init(uint32_t expire_msecs)
+{
+#ifndef WATCHDOG_STUB
+    wdog_config_t config;
+
+    NVIC_SetVector(WDOG_EWM_IRQn, (uint32_t) nxp_wdt_irq_handler);
+    WDOG_GetDefaultConfig(&config);
+    config.timeoutValue = (expire_msecs * 32768ULL) / 1000;
+    config.enableUpdate = true;
+    WDOG_Init(wdog_base, &config);
+#endif
+
+    return (0);
+}
+
+void hal_watchdog_enable(void)
+{
+#ifndef WATCHDOG_STUB
+    WDOG_EnableInterrupts(wdog_base, kWDOG_InterruptEnable);
+#endif
+}
+
+void hal_watchdog_tickle(void)
+{
+#ifndef WATCHDOG_STUB
+    WDOG_Refresh(wdog_base);
+#endif
+}

--- a/hw/mcu/nxp/pkg.yml
+++ b/hw/mcu/nxp/pkg.yml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/mcu/nxp
+pkg.description: Common MCU definitions for NXP K6x series chips.
+pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - nxp
+    - frdm-k64f
+    - MK64F12
+
+pkg.type: sdk
+
+pkg.ign_files.BSP_MK64F12:
+    - "fsl_sbrk.c"
+
+pkg.src_dirs:
+    - "src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12"
+    - "src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers"
+    - "src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc"
+    - "src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities"
+
+pkg.cflags: -std=gnu99 -D__assert_func=__assert_func_nxp
+
+pkg.deps:
+    - hw/hal
+    - hw/cmsis-core

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/FRDM-K64F_manifest.xml
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/FRDM-K64F_manifest.xml
@@ -1,0 +1,6141 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ksdk:manifest xmlns:ksdk="http://nxp.com/ksdk/2.0/ksdk_manifest.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://nxp.com/ksdk/2.0/ksdk_manifest.xsd http://nxp.com/ksdk/2.0/ksdk_manifest.xsd" format_version="2.2">
+  <ksdk id="KSDK200" name="KSDK 2.0.0" version="2.0.0"/>
+  <api version="2.0.0"/>
+  <compilers>
+    <compiler name="gcc"/>
+  </compilers>
+  <tools>
+    <tool id="armgcc" name="GCC ARM Embedded" version="4.9.2015.3" vendor="GCC ARM Embedded" vendor_url="http://launchpad.net/gcc-arm-embedded"/>
+  </tools>
+  <boards>
+    <board id="FRDM_K64F" name="frdmk64f" package="MK64FN1M0VLL12" user_name="FRDM-K64F" version="1.0.0">
+      <examples>
+        <example name="adc_low_power" category="demo_apps" description="" dependency="MK64F12_startup adc16 clock common debug_console gpio lptmr pmc port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/adc_low_power" type="binary">
+            <files mask="adc_low_power.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/adc_low_power" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/adc_low_power" type="src">
+            <files mask="adc_low_power.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/adc_low_power" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/adc_low_power/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/adc_low_power/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/adc_low_power/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bubble" category="demo_apps" description="" dependency="MK64F12_startup clock common debug_console ftm gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/bubble" type="binary">
+            <files mask="bubble.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/bubble" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/bubble" type="src">
+            <files mask="board.c"/>
+            <files mask="fsl_fxos.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="bubble.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/bubble" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_fxos.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/bubble/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/bubble/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/bubble/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="dac_adc" category="demo_apps" description="" dependency="MK64F12_startup adc16 clock common dac debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/dac_adc" type="binary">
+            <files mask="dac_adc.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/dac_adc" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/dac_adc" type="src">
+            <files mask="dac_adc.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/dac_adc" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/dac_adc/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/dac_adc/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/dac_adc/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="ecompass" category="demo_apps" description="" dependency="MK64F12_startup clock common debug_console gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/ecompass" type="binary">
+            <files mask="ecompass.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/ecompass" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/ecompass" type="src">
+            <files mask="ecompass.c"/>
+            <files mask="board.c"/>
+            <files mask="fsl_fxos.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/ecompass" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_fxos.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/ecompass/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/ecompass/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/ecompass/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="hello_world" category="demo_apps" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/hello_world" type="binary">
+            <files mask="hello_world.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/hello_world" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/hello_world" type="src">
+            <files mask="hello_world.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/hello_world" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/hello_world/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/hello_world/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/hello_world/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="demo_apps/lwip/lwip_httpsrv" description="" dependency="MK64F12_startup clock common debug_console enet gpio lwip pit port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm" type="binary">
+            <files mask="lwip_httpsrv_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm" type="src">
+            <files mask="lwip_httpsrv_bm.c"/>
+            <files mask="fs.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="fsl_phy.c"/>
+            <files mask="fsdata.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm" type="c_include">
+            <files mask="httpd_structs.h"/>
+            <files mask="board.h"/>
+            <files mask="httpd.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="web_html.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_phy.h"/>
+            <files mask="fs.h"/>
+            <files mask="fsdata.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_httpsrv/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="demo_apps/lwip/lwip_ping" description="" dependency="MK64F12_startup clock common debug_console enet gpio lwip pit port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm" type="binary">
+            <files mask="lwip_ping_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm" type="src">
+            <files mask="lwip_ping_bm.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="fsl_phy.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_phy.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_ping/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="demo_apps/lwip/lwip_tcpecho" description="" dependency="MK64F12_startup clock common debug_console enet gpio lwip pit port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm" type="binary">
+            <files mask="lwip_tcpecho_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm" type="src">
+            <files mask="lwip_tcpecho_bm.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="fsl_phy.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm" type="c_include">
+            <files mask="echo.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_phy.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_tcpecho/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="demo_apps/lwip/lwip_udpecho" description="" dependency="MK64F12_startup clock common debug_console enet gpio lwip pit port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm" type="binary">
+            <files mask="lwip_udpecho_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm" type="src">
+            <files mask="lwip_udpecho_bm.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="fsl_phy.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_phy.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/lwip/lwip_udpecho/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="power_manager" category="demo_apps" description="" dependency="MK64F12_startup clock common debug_console gpio llwu lptmr notifier pmc port rcm smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/power_manager" type="binary">
+            <files mask="power_manager.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_manager" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_manager" type="src">
+            <files mask="clock_mcg.c"/>
+            <files mask="power_manager.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_manager" type="c_include">
+            <files mask="power_manager.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_manager/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_manager/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_manager/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="power_mode_switch" category="demo_apps" description="" dependency="MK64F12_startup clock common debug_console gpio llwu lptmr pmc port rcm smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch" type="binary">
+            <files mask="power_mode_switch.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch" type="src">
+            <files mask="clock_mcg.c"/>
+            <files mask="power_mode_switch.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch" type="c_include">
+            <files mask="power_mode_switch.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/power_mode_switch/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="rtc_func" category="demo_apps" description="" dependency="MK64F12_startup clock common debug_console gpio port rtc smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/demo_apps/rtc_func" type="binary">
+            <files mask="rtc_func.bin"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/rtc_func" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/rtc_func" type="src">
+            <files mask="rtc_func.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/rtc_func" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/rtc_func/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/rtc_func/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/demo_apps/rtc_func/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt" category="driver_examples/adc16" description="" dependency="MK64F12_startup adc16 clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/adc16/interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/interrupt" type="src">
+            <files mask="adc16_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="polling" category="driver_examples/adc16" description="" dependency="MK64F12_startup adc16 clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/adc16/polling" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/polling" type="src">
+            <files mask="adc16_polling.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/polling" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/polling/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/polling/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/adc16/polling/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt" category="driver_examples/cmp" description="" dependency="MK64F12_startup clock cmp common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/cmp/interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/interrupt" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="cmp_interrupt.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="polling" category="driver_examples/cmp" description="" dependency="MK64F12_startup clock cmp common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/cmp/polling" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/polling" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="cmp_polling.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/polling" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/polling/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/polling/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmp/polling/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="cmt" category="driver_examples" description="" dependency="MK64F12_startup clock cmt common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/cmt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmt" type="src">
+            <files mask="cmt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/cmt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="crc" category="driver_examples" description="" dependency="MK64F12_startup clock common crc debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/crc" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/crc" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="crc.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/crc" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/crc/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/crc/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/crc/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="basic" category="driver_examples/dac" description="" dependency="MK64F12_startup clock common dac debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/dac/basic" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/basic" type="src">
+            <files mask="dac_basic.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/basic" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/basic/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/basic/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/basic/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="buffer_interrupt" category="driver_examples/dac" description="" dependency="MK64F12_startup clock common dac debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/dac/buffer_interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/buffer_interrupt" type="src">
+            <files mask="dac_buffer_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/buffer_interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/buffer_interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/buffer_interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dac/buffer_interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="edma_transfer" category="driver_examples/dspi" description="" dependency="MK64F12_startup clock common debug_console dmamux dspi edma gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/dspi/edma_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/edma_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="dspi_edma_transfer.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/edma_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/edma_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/edma_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/edma_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt" category="driver_examples/dspi" description="" dependency="MK64F12_startup clock common debug_console dspi gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt" type="src">
+            <files mask="dspi_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt_transfer" category="driver_examples/dspi" description="" dependency="MK64F12_startup clock common debug_console dspi gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="dspi_interrupt_transfer.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/interrupt_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="polling_transfer" category="driver_examples/dspi" description="" dependency="MK64F12_startup clock common debug_console dspi gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/dspi/polling_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/polling_transfer" type="src">
+            <files mask="dspi_polling_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/polling_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/polling_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/polling_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/dspi/polling_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="memory_to_memory" category="driver_examples/edma" description="" dependency="MK64F12_startup clock common debug_console dmamux edma gpio port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/edma/memory_to_memory" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/memory_to_memory" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="edma_memory_to_memory.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/memory_to_memory" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/memory_to_memory/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/memory_to_memory/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/memory_to_memory/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="scatter_gather" category="driver_examples/edma" description="" dependency="MK64F12_startup clock common debug_console dmamux edma gpio port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/edma/scatter_gather" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/scatter_gather" type="src">
+            <files mask="edma_scatter_gather.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/scatter_gather" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/scatter_gather/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/scatter_gather/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/edma/scatter_gather/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="txrx_ptp1588_transfer" category="driver_examples/enet" description="" dependency="MK64F12_startup clock common debug_console enet gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_ptp1588_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_ptp1588_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="enet_txrx_ptp1588_transfer.c"/>
+            <files mask="fsl_phy.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_ptp1588_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_phy.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_ptp1588_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_ptp1588_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_ptp1588_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="txrx_transfer" category="driver_examples/enet" description="" dependency="MK64F12_startup clock common debug_console enet gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_transfer" type="src">
+            <files mask="enet_txrx_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="fsl_phy.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="fsl_phy.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/enet/txrx_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="ewm" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console ewm gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/ewm" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/ewm" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="ewm.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/ewm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/ewm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/ewm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/ewm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="flash_erase_program_verify" category="driver_examples/flash" description="" dependency="MK64F12_startup clock common debug_console flash gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/flash/flash_erase_program_verify" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flash/flash_erase_program_verify" type="src">
+            <files mask="flash_erase_program_verify.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flash/flash_erase_program_verify" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flash/flash_erase_program_verify/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flash/flash_erase_program_verify/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flash/flash_erase_program_verify/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="loopback" category="driver_examples/flexcan" description="" dependency="MK64F12_startup clock common debug_console flexcan gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback" type="src">
+            <files mask="flexcan_loopback.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="loopback_transfer" category="driver_examples/flexcan" description="" dependency="MK64F12_startup clock common debug_console flexcan gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="flexcan_loopback_transfer.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/flexcan/loopback_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="input_interrupt" category="driver_examples/gpio" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/gpio/input_interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/input_interrupt" type="src">
+            <files mask="gpio_input_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/input_interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/input_interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/input_interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/input_interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="led_output" category="driver_examples/gpio" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/gpio/led_output" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/led_output" type="src">
+            <files mask="gpio_led_output.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/led_output" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/led_output/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/led_output/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/gpio/led_output/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="edma_transfer" category="driver_examples/i2c" description="" dependency="MK64F12_startup clock common debug_console dma_manager dmamux edma gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/i2c/edma_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/edma_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="i2c_edma_transfer.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/edma_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/edma_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/edma_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/edma_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt" category="driver_examples/i2c" description="" dependency="MK64F12_startup clock common debug_console gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="i2c_interrupt.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt_transfer" category="driver_examples/i2c" description="" dependency="MK64F12_startup clock common debug_console gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="i2c_interrupt_transfer.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/interrupt_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="polling_transfer" category="driver_examples/i2c" description="" dependency="MK64F12_startup clock common debug_console gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/i2c/polling_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/polling_transfer" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="i2c_polling_transfer.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/polling_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/polling_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/polling_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/polling_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="read_accel_value_transfer" category="driver_examples/i2c" description="" dependency="MK64F12_startup clock common debug_console gpio i2c port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/i2c/read_accel_value_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/read_accel_value_transfer" type="src">
+            <files mask="i2c_read_accel_value_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/read_accel_value_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/read_accel_value_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/read_accel_value_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/i2c/read_accel_value_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="lptmr" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console gpio lptmr port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/lptmr" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/lptmr" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="lptmr.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/lptmr" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/lptmr/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/lptmr/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/lptmr/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="fee_blpe" category="driver_examples/mcg" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpe" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpe" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="mcg_fee_blpe.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpe" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpe/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpe/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpe/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="fee_blpi" category="driver_examples/mcg" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpi" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpi" type="src">
+            <files mask="mcg_fee_blpi.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpi" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpi/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpi/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fee_blpi/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="fei_blpi" category="driver_examples/mcg" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/mcg/fei_blpi" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fei_blpi" type="src">
+            <files mask="mcg_fei_blpi.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fei_blpi" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fei_blpi/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fei_blpi/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/fei_blpi/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="pee_blpe" category="driver_examples/mcg" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpe" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpe" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="mcg_pee_blpe.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpe" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpe/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpe/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpe/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="pee_blpi" category="driver_examples/mcg" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpi" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpi" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="mcg_pee_blpi.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpi" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpi/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpi/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mcg/pee_blpi/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="mpu" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/mpu" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mpu" type="src">
+            <files mask="mpu.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mpu" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mpu/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mpu/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/mpu/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="adc16_trigger" category="driver_examples/pdb" description="" dependency="MK64F12_startup adc16 clock common debug_console gpio pdb port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/pdb/adc16_trigger" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/adc16_trigger" type="src">
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="pdb_adc16_trigger.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/adc16_trigger" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/adc16_trigger/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/adc16_trigger/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/adc16_trigger/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="dac_trigger" category="driver_examples/pdb" description="" dependency="MK64F12_startup clock common dac debug_console gpio pdb port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/pdb/dac_trigger" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/dac_trigger" type="src">
+            <files mask="pdb_dac_trigger.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/dac_trigger" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/dac_trigger/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/dac_trigger/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/dac_trigger/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="delay_interrupt" category="driver_examples/pdb" description="" dependency="MK64F12_startup clock common debug_console gpio pdb port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/pdb/delay_interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/delay_interrupt" type="src">
+            <files mask="pdb_delay_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/delay_interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/delay_interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/delay_interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pdb/delay_interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="pit" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console gpio pit port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/pit" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pit" type="src">
+            <files mask="pit.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pit" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pit/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pit/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/pit/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="random" category="driver_examples/rnga" description="" dependency="MK64F12_startup clock common debug_console gpio port rnga smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/rnga/random" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rnga/random" type="src">
+            <files mask="rnga_random.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rnga/random" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rnga/random/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rnga/random/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rnga/random/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="rtc" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console gpio port rtc smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/rtc" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rtc" type="src">
+            <files mask="rtc.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rtc" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rtc/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rtc/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/rtc/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt" category="driver_examples/sdcard" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sdhc sdmmc smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/sdcard/interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/interrupt" type="src">
+            <files mask="event.c"/>
+            <files mask="sdcard_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="event.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="polling" category="driver_examples/sdcard" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sdhc sdmmc smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/sdcard/polling" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/polling" type="src">
+            <files mask="event.c"/>
+            <files mask="sdcard_polling.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/polling" type="c_include">
+            <files mask="board.h"/>
+            <files mask="event.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/polling/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/polling/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard/polling/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="sdcard_fatfs" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console fatfs gpio mpu port sdhc sdmmc smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/sdcard_fatfs" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard_fatfs" type="src">
+            <files mask="sdcard_fatfs.c"/>
+            <files mask="event.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard_fatfs" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="ffconf.h"/>
+            <files mask="sdhc_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard_fatfs/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard_fatfs/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/sdcard_fatfs/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="edma_transfer" category="driver_examples/uart" description="" dependency="MK64F12_startup clock common debug_console dma_manager dmamux edma gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/uart/edma_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/edma_transfer" type="src">
+            <files mask="uart_edma_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/edma_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/edma_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/edma_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/edma_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt" category="driver_examples/uart" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt" type="src">
+            <files mask="uart_interrupt.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt_ring_buffer_transfer" category="driver_examples/uart" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_ring_buffer_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_ring_buffer_transfer" type="src">
+            <files mask="uart_interrupt_ring_buffer_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_ring_buffer_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_ring_buffer_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_ring_buffer_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_ring_buffer_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="interrupt_transfer" category="driver_examples/uart" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_transfer" type="src">
+            <files mask="uart_interrupt_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/interrupt_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="polling_transfer" category="driver_examples/uart" description="" dependency="MK64F12_startup clock common debug_console gpio port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/uart/polling_transfer" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/polling_transfer" type="src">
+            <files mask="uart_polling_transfer.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/polling_transfer" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/polling_transfer/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/polling_transfer/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/uart/polling_transfer/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="wdog" category="driver_examples" description="" dependency="MK64F12_startup clock common debug_console gpio port rcm smc uart wdog" device="MK64F12">
+          <source path="boards/frdmk64f/driver_examples/wdog" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/wdog" type="src">
+            <files mask="board.c"/>
+            <files mask="wdog.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/wdog" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/wdog/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/wdog/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/driver_examples/wdog/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="mmcau_api" category="mmcau" description="" dependency="MK64F12_startup clock common debug_console gpio mmcau port smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/mmcau/mmcau_api" type="doc">
+            <files mask="readme.txt"/>
+            <files mask="readme.txt"/>
+          </source>
+          <source path="boards/frdmk64f/mmcau/mmcau_api" type="src">
+            <files mask="mmcau_api.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/mmcau/mmcau_api" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/mmcau/mmcau_api/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/mmcau/mmcau_api/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/mmcau/mmcau_api/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_audio_generator" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator/bm" type="src">
+            <files mask="usb_device_audio.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="audio_data.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="audio_generator.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator/bm" type="c_include">
+            <files mask="audio_generator.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_audio.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_audio_generator_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm" type="binary">
+            <files mask="dev_audio_generator_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm" type="src">
+            <files mask="usb_device_audio.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="audio_data.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="audio_generator.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm" type="c_include">
+            <files mask="audio_generator.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_audio.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_audio_generator_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_cdc_vcom" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/bm" type="src">
+            <files mask="virtual_com.c"/>
+            <files mask="usb_device_cdc_acm.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="virtual_com.h"/>
+            <files mask="usb_device_cdc_acm.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="inf" category="usb_examples/usb_device_cdc_vcom" description="">
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom/inf" type="configuration">
+            <files mask="fsl_ucwxp.inf"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_cdc_vcom_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm" type="binary">
+            <files mask="dev_cdc_vcom_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm" type="src">
+            <files mask="virtual_com.c"/>
+            <files mask="usb_device_cdc_acm.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="virtual_com.h"/>
+            <files mask="usb_device_cdc_acm.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="inf" category="usb_examples/usb_device_cdc_vcom_lite" description="">
+          <source path="boards/frdmk64f/usb_examples/usb_device_cdc_vcom_lite/inf" type="configuration">
+            <files mask="fsl_ucwxp.inf"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_composite_cdc_msc" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/bm" type="src">
+            <files mask="virtual_com.c"/>
+            <files mask="usb_device_msc.c"/>
+            <files mask="usb_device_msc_ufi.c"/>
+            <files mask="usb_device_cdc_acm.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="disk.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="composite.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/bm" type="c_include">
+            <files mask="usb_device_msc.h"/>
+            <files mask="composite.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="disk.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="virtual_com.h"/>
+            <files mask="usb_device_cdc_acm.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="usb_device_msc_ufi.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="inf" category="usb_examples/usb_device_composite_cdc_msc" description="">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc/inf" type="configuration">
+            <files mask="fsl_ucwxp.inf"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_composite_cdc_msc_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm" type="binary">
+            <files mask="dev_composite_cdc_msc_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm" type="src">
+            <files mask="virtual_com.c"/>
+            <files mask="usb_device_msc.c"/>
+            <files mask="usb_device_msc_ufi.c"/>
+            <files mask="usb_device_cdc_acm.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="disk.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="composite.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm" type="c_include">
+            <files mask="usb_device_msc.h"/>
+            <files mask="composite.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="disk.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="virtual_com.h"/>
+            <files mask="usb_device_cdc_acm.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="usb_device_msc_ufi.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="inf" category="usb_examples/usb_device_composite_cdc_msc_lite" description="">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_cdc_msc_lite/inf" type="configuration">
+            <files mask="fsl_ucwxp.inf"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_composite_hid_audio" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio/bm" type="src">
+            <files mask="mouse.c"/>
+            <files mask="usb_device_audio.c"/>
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="audio_data.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="audio_generator.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="composite.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio/bm" type="c_include">
+            <files mask="audio_generator.h"/>
+            <files mask="composite.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_audio.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="mouse.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_composite_hid_audio_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm" type="binary">
+            <files mask="dev_composite_hid_audio_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm" type="src">
+            <files mask="mouse.c"/>
+            <files mask="usb_device_audio.c"/>
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="audio_data.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="audio_generator.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="composite.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm" type="c_include">
+            <files mask="audio_generator.h"/>
+            <files mask="composite.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_audio.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="mouse.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_audio_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_composite_hid_mouse_hid_keyboard" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard/bm" type="src">
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="hid_mouse.c"/>
+            <files mask="board.c"/>
+            <files mask="hid_keyboard.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="composite.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard/bm" type="c_include">
+            <files mask="hid_keyboard.h"/>
+            <files mask="composite.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="hid_mouse.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm" type="binary">
+            <files mask="dev_composite_hid_mouse_hid_keyboard_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm" type="src">
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="hid_mouse.c"/>
+            <files mask="board.c"/>
+            <files mask="hid_keyboard.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="composite.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm" type="c_include">
+            <files mask="hid_keyboard.h"/>
+            <files mask="composite.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="hid_mouse.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_composite_hid_mouse_hid_keyboard_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_hid_generic" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic/bm" type="src">
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="hid_generic.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="hid_generic.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_hid_generic_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm" type="binary">
+            <files mask="dev_hid_generic_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm" type="src">
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="hid_generic.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="hid_generic.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_generic_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_hid_mouse" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse/bm" type="src">
+            <files mask="mouse.c"/>
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="mouse.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_hid_mouse_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm" type="binary">
+            <files mask="dev_hid_mouse_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm" type="src">
+            <files mask="mouse.c"/>
+            <files mask="usb_device_hid.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_hid.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="mouse.h"/>
+            <files mask="usb_device_descriptor.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_hid_mouse_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_msc_ramdisk" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk/bm" type="src">
+            <files mask="usb_device_msc.c"/>
+            <files mask="usb_device_msc_ufi.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="disk.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk/bm" type="c_include">
+            <files mask="usb_device_msc.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="disk.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="usb_device_msc_ufi.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_msc_ramdisk_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm" type="binary">
+            <files mask="dev_msc_ramdisk_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm" type="src">
+            <files mask="usb_device_msc.c"/>
+            <files mask="usb_device_msc_ufi.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="disk.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm" type="c_include">
+            <files mask="usb_device_msc.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="disk.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="usb_device_msc_ufi.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_ramdisk_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_msc_sdcard" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sdhc sdmmc sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard/bm" type="src">
+            <files mask="usb_device_msc.c"/>
+            <files mask="event.c"/>
+            <files mask="disk_sdcard.c"/>
+            <files mask="usb_device_msc_ufi.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard/bm" type="c_include">
+            <files mask="usb_device_msc.h"/>
+            <files mask="board.h"/>
+            <files mask="event.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="disk_sdcard.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="usb_device_msc_ufi.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_msc_sdcard_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sdhc sdmmc sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard_lite/bm" type="src">
+            <files mask="usb_device_msc.c"/>
+            <files mask="event.c"/>
+            <files mask="disk_sdcard.c"/>
+            <files mask="usb_device_msc_ufi.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard_lite/bm" type="c_include">
+            <files mask="usb_device_msc.h"/>
+            <files mask="board.h"/>
+            <files mask="event.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="disk_sdcard.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="usb_device_msc_ufi.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_msc_sdcard_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_phdc_weighscale" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale/bm" type="src">
+            <files mask="weighscale.c"/>
+            <files mask="ieee11073_timer.c"/>
+            <files mask="usb_device_phdc.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="ieee11073_agent.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_shim_agent.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="ieee11073_agent.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_phdc.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="ieee11073_types.h"/>
+            <files mask="usb_shim_agent.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="ieee11073_timer.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="weighscale.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_phdc_weighscale_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm" type="binary">
+            <files mask="dev_phdc_weighscale_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm" type="src">
+            <files mask="weighscale.c"/>
+            <files mask="ieee11073_timer.c"/>
+            <files mask="usb_device_phdc.c"/>
+            <files mask="usb_device_ch9.c"/>
+            <files mask="board.c"/>
+            <files mask="ieee11073_agent.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_shim_agent.c"/>
+            <files mask="usb_device_descriptor.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="ieee11073_agent.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_phdc.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="ieee11073_types.h"/>
+            <files mask="usb_shim_agent.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="ieee11073_timer.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="weighscale.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_phdc_weighscale_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_video_virtual_camera" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera/bm" type="src">
+            <files mask="usb_device_ch9.c"/>
+            <files mask="virtual_camera.c"/>
+            <files mask="video_data.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_class.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="usb_device_video.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera/bm" type="c_include">
+            <files mask="video_data.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_class.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_video.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="virtual_camera.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_device_video_virtual_camera_lite" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm" type="binary">
+            <files mask="dev_video_virtual_camera_lite_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm" type="src">
+            <files mask="usb_device_ch9.c"/>
+            <files mask="virtual_camera.c"/>
+            <files mask="video_data.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_device_descriptor.c"/>
+            <files mask="usb_device_video.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm" type="c_include">
+            <files mask="video_data.h"/>
+            <files mask="board.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="usb_device_ch9.h"/>
+            <files mask="usb_device_config.h"/>
+            <files mask="usb_device_video.h"/>
+            <files mask="usb_device_descriptor.h"/>
+            <files mask="virtual_camera.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_device_video_virtual_camera_lite/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_audio_speaker" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm" type="binary">
+            <files mask="host_audio_speaker_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm" type="src">
+            <files mask="app.c"/>
+            <files mask="audio8k16S.c"/>
+            <files mask="audio_speaker.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="host_keypad.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm" type="c_include">
+            <files mask="audio_speaker.h"/>
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="host_keypad.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_audio_speaker/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_cdc" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm" type="binary">
+            <files mask="host_cdc_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm" type="src">
+            <files mask="host_cdc.c"/>
+            <files mask="app.c"/>
+            <files mask="usb_lpuart_drv.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="usb_uart_drv.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="host_cdc.h"/>
+            <files mask="usb_uart_drv.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_cdc/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_hid_generic" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm" type="binary">
+            <files mask="host_hid_generic_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm" type="src">
+            <files mask="host_hid_generic.c"/>
+            <files mask="app.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="host_hid_generic.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_generic/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_hid_mouse" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm" type="binary">
+            <files mask="host_hid_mouse_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm" type="src">
+            <files mask="app.c"/>
+            <files mask="host_mouse.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="host_mouse.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_hid_mouse_keyboard" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm" type="binary">
+            <files mask="host_hid_mouse_keyboard_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm" type="src">
+            <files mask="app.c"/>
+            <files mask="host_keyboard.c"/>
+            <files mask="host_mouse.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm" type="c_include">
+            <files mask="host_keyboard.h"/>
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="host_mouse.h"/>
+            <files mask="host_keyboard_mouse.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_hid_mouse_keyboard/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_msd_command" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm" type="binary">
+            <files mask="host_msd_command_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm" type="src">
+            <files mask="host_msd_command.c"/>
+            <files mask="app.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="host_msd_command.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_command/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_msd_fatfs" description="" dependency="MK64F12_startup clock common debug_console fatfs gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm" type="binary">
+            <files mask="host_msd_fatfs_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm" type="src">
+            <files mask="app.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+            <files mask="host_msd_fatfs.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="ffconf.h"/>
+            <files mask="host_msd_fatfs.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_msd_fatfs/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+        <example name="bm" category="usb_examples/usb_host_phdc_manager" description="" dependency="MK64F12_startup clock common debug_console gpio mpu port sim smc uart" device="MK64F12">
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm" type="binary">
+            <files mask="host_phdc_manager_bm.bin"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm" type="doc">
+            <files mask="readme.pdf"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm" type="src">
+            <files mask="app.c"/>
+            <files mask="ieee11073_nomenclature.c"/>
+            <files mask="host_phdc_manager.c"/>
+            <files mask="board.c"/>
+            <files mask="pin_mux.c"/>
+            <files mask="clock_config.c"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm" type="c_include">
+            <files mask="board.h"/>
+            <files mask="usb_host_config.h"/>
+            <files mask="pin_mux.h"/>
+            <files mask="clock_config.h"/>
+            <files mask="ieee11073_types.h"/>
+            <files mask="ieee11073_nomenclature.h"/>
+            <files mask="host_phdc_manager.h"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm/armgcc" type="script" tool="armgcc">
+            <files mask="build_all.sh"/>
+            <files mask="build_release.sh"/>
+            <files mask="build_release.bat"/>
+            <files mask="clean.bat"/>
+            <files mask="build_debug.sh"/>
+            <files mask="build_debug.bat"/>
+            <files mask="clean.sh"/>
+            <files mask="build_all.bat"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm/armgcc" type="doc" tool="armgcc">
+            <files mask="CMakeLists.txt"/>
+          </source>
+          <source path="boards/frdmk64f/usb_examples/usb_host_phdc_manager/bm/armgcc" type="linker" tool="armgcc">
+            <files mask="MK64FN1M0xxx12_flash.ld"/>
+          </source>
+        </example>
+      </examples>
+    </board>
+  </boards>
+  <devices>
+    <device full_name="MK64FN1M0xxx12" name="MK64F12" version="1.0.0">
+      <core fpu="true" name="cm4"/>
+      <memory flash_size_kb="1024" ram_size_kb="256"/>
+      <package name="MK64FN1M0VDC12"/>
+      <package name="MK64FN1M0VLL12"/>
+      <package name="MK64FN1M0VLQ12"/>
+      <package name="MK64FN1M0VMD12"/>
+      <package name="MK64FN1M0CAJ12"/>
+      <evaluation_boards>
+        <evaluation_board name="FRDM-K64F"/>
+        <evaluation_board name="TWR-K64F120M"/>
+      </evaluation_boards>
+    </device>
+  </devices>
+  <components>
+    <component name="adc16" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_adc16.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_adc16.h"/>
+      </source>
+    </component>
+    <component name="clock" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_clock.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_clock.h"/>
+      </source>
+    </component>
+    <component name="cmp" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_cmp.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_cmp.h"/>
+      </source>
+    </component>
+    <component name="cmt" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_cmt.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_cmt.h"/>
+      </source>
+    </component>
+    <component name="common" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_common.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_common.h"/>
+      </source>
+    </component>
+    <component name="crc" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_crc.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_crc.h"/>
+      </source>
+    </component>
+    <component name="dac" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_dac.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_dac.h"/>
+      </source>
+    </component>
+    <component name="dmamux" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_dmamux.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_dmamux.h"/>
+      </source>
+    </component>
+    <component name="dspi" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_dspi.c"/>
+        <files mask="fsl_dspi_edma.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_dspi.h"/>
+        <files mask="fsl_dspi_edma.h"/>
+      </source>
+    </component>
+    <component name="edma" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_edma.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_edma.h"/>
+      </source>
+    </component>
+    <component name="enet" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_enet.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_enet.h"/>
+      </source>
+    </component>
+    <component name="ewm" type="driver" device="MK64F12" version="2.0.1">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_ewm.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_ewm.h"/>
+      </source>
+    </component>
+    <component name="flash" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_flash.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_flash.h"/>
+      </source>
+    </component>
+    <component name="flexbus" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_flexbus.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_flexbus.h"/>
+      </source>
+    </component>
+    <component name="flexcan" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_flexcan.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_flexcan.h"/>
+      </source>
+    </component>
+    <component name="ftm" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_ftm.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_ftm.h"/>
+      </source>
+    </component>
+    <component name="gpio" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_gpio.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_gpio.h"/>
+      </source>
+    </component>
+    <component name="i2c" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_i2c.c"/>
+        <files mask="fsl_i2c_edma.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_i2c.h"/>
+        <files mask="fsl_i2c_edma.h"/>
+      </source>
+    </component>
+    <component name="llwu" type="driver" device="MK64F12" version="2.0.1">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_llwu.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_llwu.h"/>
+      </source>
+    </component>
+    <component name="lptmr" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_lptmr.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_lptmr.h"/>
+      </source>
+    </component>
+    <component name="mpu" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_mpu.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_mpu.h"/>
+      </source>
+    </component>
+    <component name="pdb" type="driver" device="MK64F12" version="2.0.1">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_pdb.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_pdb.h"/>
+      </source>
+    </component>
+    <component name="pit" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_pit.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_pit.h"/>
+      </source>
+    </component>
+    <component name="pmc" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_pmc.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_pmc.h"/>
+      </source>
+    </component>
+    <component name="port" type="driver" device="MK64F12" version="2.0.1">
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_port.h"/>
+      </source>
+    </component>
+    <component name="rcm" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_rcm.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_rcm.h"/>
+      </source>
+    </component>
+    <component name="rnga" type="driver" device="MK64F12" version="2.0.1">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_rnga.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_rnga.h"/>
+      </source>
+    </component>
+    <component name="rtc" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_rtc.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_rtc.h"/>
+      </source>
+    </component>
+    <component name="sai" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_sai.c"/>
+        <files mask="fsl_sai_edma.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_sai.h"/>
+        <files mask="fsl_sai_edma.h"/>
+      </source>
+    </component>
+    <component name="sdhc" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_sdhc.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_sdhc.h"/>
+      </source>
+    </component>
+    <component name="sim" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_sim.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_sim.h"/>
+      </source>
+    </component>
+    <component name="smc" type="driver" device="MK64F12" version="2.0.1">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_smc.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_smc.h"/>
+      </source>
+    </component>
+    <component name="uart" type="driver" device="MK64F12" version="2.1.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_uart.c"/>
+        <files mask="fsl_uart_edma.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_uart.h"/>
+        <files mask="fsl_uart_edma.h"/>
+      </source>
+    </component>
+    <component name="vref" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_vref.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_vref.h"/>
+      </source>
+    </component>
+    <component name="wdog" type="driver" device="MK64F12" version="2.0.0">
+      <source path="devices/MK64F12/drivers" type="src">
+        <files mask="fsl_wdog.c"/>
+      </source>
+      <source path="devices/MK64F12/drivers" type="c_include">
+        <files mask="fsl_wdog.h"/>
+      </source>
+    </component>
+    <component name="debug_console" type="utilities" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12/utilities" type="src">
+        <files mask="fsl_debug_console.c"/>
+      </source>
+      <source path="devices/MK64F12/utilities" type="c_include">
+        <files mask="fsl_debug_console.h"/>
+      </source>
+    </component>
+    <component name="misc_utilities" type="utilities" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12/utilities" type="src">
+        <files mask="fsl_sbrk.c"/>
+      </source>
+    </component>
+    <component name="notifier" type="utilities" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12/utilities" type="src">
+        <files mask="fsl_notifier.c"/>
+      </source>
+      <source path="devices/MK64F12/utilities" type="c_include">
+        <files mask="fsl_notifier.h"/>
+      </source>
+    </component>
+    <component name="device" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/device" type="src">
+        <files mask="usb_device_dci.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/device" type="c_include">
+        <files mask="usb_device.h"/>
+        <files mask="usb_device_dci.h"/>
+      </source>
+    </component>
+    <component name="device_khci" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/device" type="src">
+        <files mask="usb_device_khci.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/device" type="c_include">
+        <files mask="usb_device_khci.h"/>
+      </source>
+    </component>
+    <component name="host" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host" type="src">
+        <files mask="usb_host_devices.c"/>
+        <files mask="usb_host_framework.c"/>
+        <files mask="usb_host_hci.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host" type="c_include">
+        <files mask="usb_host.h"/>
+        <files mask="usb_host_devices.h"/>
+        <files mask="usb_host_framework.h"/>
+        <files mask="usb_host_hci.h"/>
+      </source>
+    </component>
+    <component name="audio" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host/class" type="src">
+        <files mask="usb_host_audio.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host/class" type="c_include">
+        <files mask="usb_host_audio.h"/>
+      </source>
+    </component>
+    <component name="cdc" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host/class" type="src">
+        <files mask="usb_host_cdc.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host/class" type="c_include">
+        <files mask="usb_host_cdc.h"/>
+      </source>
+    </component>
+    <component name="host_khci" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host" type="src">
+        <files mask="usb_host_khci.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host" type="c_include">
+        <files mask="usb_host_khci.h"/>
+      </source>
+    </component>
+    <component name="hid" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host/class" type="src">
+        <files mask="usb_host_hid.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host/class" type="c_include">
+        <files mask="usb_host_hid.h"/>
+      </source>
+    </component>
+    <component name="hub" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host/class" type="src">
+        <files mask="usb_host_hub.c"/>
+        <files mask="usb_host_hub_app.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host/class" type="c_include">
+        <files mask="usb_host_hub.h"/>
+        <files mask="usb_host_hub_app.h"/>
+      </source>
+    </component>
+    <component name="msd" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host/class" type="src">
+        <files mask="usb_host_msd.c"/>
+        <files mask="usb_host_msd_ufi.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host/class" type="c_include">
+        <files mask="usb_host_msd.h"/>
+      </source>
+    </component>
+    <component name="phdc" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/host/class" type="src">
+        <files mask="usb_host_phdc.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/host/class" type="c_include">
+        <files mask="usb_host_phdc.h"/>
+      </source>
+    </component>
+    <component name="include_common" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/include" type="c_include">
+        <files mask="usb.h"/>
+        <files mask="usb_misc.h"/>
+        <files mask="usb_spec.h"/>
+      </source>
+    </component>
+    <component name="include_khci" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/include" type="c_include">
+        <files mask="usb.h"/>
+        <files mask="usb_khci.h"/>
+        <files mask="usb_misc.h"/>
+      </source>
+    </component>
+    <component name="bm" type="other" device="MK64F12" version="1.0.0">
+      <source path="middleware/usb_1.0.0/osa" type="src">
+        <files mask="usb_osa_bm.c"/>
+      </source>
+      <source path="middleware/usb_1.0.0/osa" type="c_include">
+        <files mask="usb_osa.h"/>
+        <files mask="usb_osa_bm.h"/>
+      </source>
+    </component>
+    <component name="CMSIS" type="other" version="4.5.0">
+      <source path="CMSIS" type="doc">
+        <files mask="index.html"/>
+        <files mask="CMSIS_END_USER_LICENCE_AGREEMENT.pdf"/>
+        <files mask="CMSIS_END_USER_LICENCE_AGREEMENT.rtf"/>
+      </source>
+      <source path="CMSIS/DSP_Lib" type="doc">
+        <files mask="license.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM" type="project">
+        <files mask="arm_class_marks_example.uvoptx"/>
+        <files mask="arm_class_marks_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM" type="src">
+        <files mask="arm_class_marks_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM" type="configuration">
+        <files mask="arm_class_marks_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC" type="project">
+        <files mask="arm_class_marks_example.uvopt"/>
+        <files mask="arm_class_marks_example.uvproj"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC" type="src">
+        <files mask="arm_class_marks_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC" type="configuration">
+        <files mask="arm_class_marks_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC/Startup" type="linker">
+        <files mask="ARMCMx.ld"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC/Startup" type="asm_include">
+        <files mask="startup_ARMCM0.S"/>
+        <files mask="startup_ARMCM4.S"/>
+        <files mask="startup_ARMCM3.S"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_class_marks_example/GCC/Startup" type="src">
+        <files mask="system_ARMCM0.c"/>
+        <files mask="system_ARMCM3.c"/>
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM" type="project">
+        <files mask="arm_convolution_example.uvoptx"/>
+        <files mask="arm_convolution_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM" type="src">
+        <files mask="arm_convolution_example_f32.c"/>
+        <files mask="math_helper.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM" type="configuration">
+        <files mask="arm_convolution_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC" type="project">
+        <files mask="arm_convolution_example.uvopt"/>
+        <files mask="arm_convolution_example.uvproj"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC" type="src">
+        <files mask="arm_convolution_example_f32.c"/>
+        <files mask="math_helper.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC" type="configuration">
+        <files mask="arm_convolution_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC/Startup" type="linker">
+        <files mask="ARMCMx.ld"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC/Startup" type="asm_include">
+        <files mask="startup_ARMCM0.S"/>
+        <files mask="startup_ARMCM4.S"/>
+        <files mask="startup_ARMCM3.S"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_convolution_example/GCC/Startup" type="src">
+        <files mask="system_ARMCM0.c"/>
+        <files mask="system_ARMCM3.c"/>
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM" type="project">
+        <files mask="arm_dotproduct_example.uvoptx"/>
+        <files mask="arm_dotproduct_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM" type="src">
+        <files mask="arm_dotproduct_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM" type="configuration">
+        <files mask="arm_dotproduct_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC" type="project">
+        <files mask="arm_dotproduct_example.uvopt"/>
+        <files mask="arm_dotproduct_example.uvproj"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC" type="src">
+        <files mask="arm_dotproduct_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC" type="configuration">
+        <files mask="arm_dotproduct_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC/Startup" type="linker">
+        <files mask="ARMCMx.ld"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC/Startup" type="asm_include">
+        <files mask="startup_ARMCM0.S"/>
+        <files mask="startup_ARMCM4.S"/>
+        <files mask="startup_ARMCM3.S"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_dotproduct_example/GCC/Startup" type="src">
+        <files mask="system_ARMCM0.c"/>
+        <files mask="system_ARMCM3.c"/>
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM" type="project">
+        <files mask="arm_fft_bin_example.uvoptx"/>
+        <files mask="arm_fft_bin_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM" type="src">
+        <files mask="arm_fft_bin_example_f32.c"/>
+        <files mask="arm_fft_bin_data.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM" type="configuration">
+        <files mask="arm_fft_bin_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC" type="project">
+        <files mask="arm_fft_bin_example.uvopt"/>
+        <files mask="arm_fft_bin_example.uvproj"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC" type="src">
+        <files mask="arm_fft_bin_example_f32.c"/>
+        <files mask="arm_fft_bin_data.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC" type="configuration">
+        <files mask="arm_fft_bin_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC/Startup" type="linker">
+        <files mask="ARMCMx.ld"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC/Startup" type="asm_include">
+        <files mask="startup_ARMCM0.S"/>
+        <files mask="startup_ARMCM4.S"/>
+        <files mask="startup_ARMCM3.S"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fft_bin_example/GCC/Startup" type="src">
+        <files mask="system_ARMCM0.c"/>
+        <files mask="system_ARMCM3.c"/>
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM" type="project">
+        <files mask="arm_fir_example.uvoptx"/>
+        <files mask="arm_fir_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM" type="src">
+        <files mask="math_helper.c"/>
+        <files mask="arm_fir_data.c"/>
+        <files mask="arm_fir_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM" type="configuration">
+        <files mask="arm_fir_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_fir_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM" type="project">
+        <files mask="arm_graphic_equalizer_example.uvoptx"/>
+        <files mask="arm_graphic_equalizer_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM" type="src">
+        <files mask="arm_graphic_equalizer_data.c"/>
+        <files mask="arm_graphic_equalizer_example_q31.c"/>
+        <files mask="math_helper.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM" type="configuration">
+        <files mask="arm_graphic_equalizer_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_graphic_equalizer_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM" type="project">
+        <files mask="arm_linear_interp_example.uvoptx"/>
+        <files mask="arm_linear_interp_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM" type="src">
+        <files mask="math_helper.c"/>
+        <files mask="arm_linear_interp_data.c"/>
+        <files mask="arm_linear_interp_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM" type="configuration">
+        <files mask="arm_linear_interp_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_linear_interp_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM" type="project">
+        <files mask="arm_matrix_example.uvoptx"/>
+        <files mask="arm_matrix_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM" type="src">
+        <files mask="math_helper.c"/>
+        <files mask="arm_matrix_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM" type="configuration">
+        <files mask="arm_matrix_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_matrix_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM" type="project">
+        <files mask="arm_signal_converge_example.uvoptx"/>
+        <files mask="arm_signal_converge_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM" type="src">
+        <files mask="arm_signal_converge_example_f32.c"/>
+        <files mask="math_helper.c"/>
+        <files mask="arm_signal_converge_data.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM" type="configuration">
+        <files mask="arm_signal_converge_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM" type="c_include">
+        <files mask="math_helper.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_signal_converge_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM" type="project">
+        <files mask="arm_sin_cos_example.uvoptx"/>
+        <files mask="arm_sin_cos_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM" type="src">
+        <files mask="arm_sin_cos_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM" type="configuration">
+        <files mask="arm_sin_cos_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_sin_cos_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM" type="doc">
+        <files mask="Abstract.txt"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM" type="project">
+        <files mask="arm_variance_example.uvoptx"/>
+        <files mask="arm_variance_example.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM" type="src">
+        <files mask="arm_variance_example_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM" type="configuration">
+        <files mask="arm_variance_example.ini"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE" type="c_include">
+        <files mask="RTE_Components.h"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM0" type="asm_include">
+        <files mask="startup_ARMCM0.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM0" type="src">
+        <files mask="system_ARMCM0.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM3" type="asm_include">
+        <files mask="startup_ARMCM3.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM3" type="src">
+        <files mask="system_ARMCM3.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM4_FP" type="asm_include">
+        <files mask="startup_ARMCM4.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM4_FP" type="src">
+        <files mask="system_ARMCM4.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM7_SP" type="asm_include">
+        <files mask="startup_ARMCM7.s"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Examples/arm_variance_example/ARM/RTE/Device/ARMCM7_SP" type="src">
+        <files mask="system_ARMCM7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/ARM" type="script">
+        <files mask="getSizeInfo.bat"/>
+        <files mask="arm_cortexM_math_Build.bat"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/ARM" type="project">
+        <files mask="arm_cortexM_math.uvoptx"/>
+        <files mask="arm_cortexM_math.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/BasicMathFunctions" type="src">
+        <files mask="arm_offset_q15.c"/>
+        <files mask="arm_shift_q31.c"/>
+        <files mask="arm_offset_q7.c"/>
+        <files mask="arm_mult_q7.c"/>
+        <files mask="arm_dot_prod_q15.c"/>
+        <files mask="arm_shift_q15.c"/>
+        <files mask="arm_abs_q15.c"/>
+        <files mask="arm_mult_q15.c"/>
+        <files mask="arm_negate_q31.c"/>
+        <files mask="arm_scale_q31.c"/>
+        <files mask="arm_sub_f32.c"/>
+        <files mask="arm_dot_prod_q31.c"/>
+        <files mask="arm_negate_f32.c"/>
+        <files mask="arm_scale_q15.c"/>
+        <files mask="arm_add_q15.c"/>
+        <files mask="arm_abs_q7.c"/>
+        <files mask="arm_scale_q7.c"/>
+        <files mask="arm_sub_q15.c"/>
+        <files mask="arm_dot_prod_q7.c"/>
+        <files mask="arm_offset_f32.c"/>
+        <files mask="arm_dot_prod_f32.c"/>
+        <files mask="arm_negate_q15.c"/>
+        <files mask="arm_scale_f32.c"/>
+        <files mask="arm_add_q31.c"/>
+        <files mask="arm_mult_f32.c"/>
+        <files mask="arm_abs_f32.c"/>
+        <files mask="arm_add_q7.c"/>
+        <files mask="arm_sub_q7.c"/>
+        <files mask="arm_add_f32.c"/>
+        <files mask="arm_shift_q7.c"/>
+        <files mask="arm_negate_q7.c"/>
+        <files mask="arm_sub_q31.c"/>
+        <files mask="arm_mult_q31.c"/>
+        <files mask="arm_offset_q31.c"/>
+        <files mask="arm_abs_q31.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/CommonTables" type="src">
+        <files mask="arm_const_structs.c"/>
+        <files mask="arm_common_tables.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/ComplexMathFunctions" type="src">
+        <files mask="arm_cmplx_mult_cmplx_q15.c"/>
+        <files mask="arm_cmplx_mult_real_q15.c"/>
+        <files mask="arm_cmplx_mult_cmplx_q31.c"/>
+        <files mask="arm_cmplx_mult_real_f32.c"/>
+        <files mask="arm_cmplx_mag_q15.c"/>
+        <files mask="arm_cmplx_mult_real_q31.c"/>
+        <files mask="arm_cmplx_mag_squared_f32.c"/>
+        <files mask="arm_cmplx_dot_prod_f32.c"/>
+        <files mask="arm_cmplx_mag_f32.c"/>
+        <files mask="arm_cmplx_conj_q31.c"/>
+        <files mask="arm_cmplx_mult_cmplx_f32.c"/>
+        <files mask="arm_cmplx_dot_prod_q15.c"/>
+        <files mask="arm_cmplx_mag_squared_q15.c"/>
+        <files mask="arm_cmplx_mag_q31.c"/>
+        <files mask="arm_cmplx_mag_squared_q31.c"/>
+        <files mask="arm_cmplx_dot_prod_q31.c"/>
+        <files mask="arm_cmplx_conj_f32.c"/>
+        <files mask="arm_cmplx_conj_q15.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/ControllerFunctions" type="src">
+        <files mask="arm_pid_init_q31.c"/>
+        <files mask="arm_pid_init_q15.c"/>
+        <files mask="arm_pid_reset_q15.c"/>
+        <files mask="arm_pid_reset_q31.c"/>
+        <files mask="arm_sin_cos_q31.c"/>
+        <files mask="arm_pid_reset_f32.c"/>
+        <files mask="arm_pid_init_f32.c"/>
+        <files mask="arm_sin_cos_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/FastMathFunctions" type="src">
+        <files mask="arm_cos_q15.c"/>
+        <files mask="arm_cos_f32.c"/>
+        <files mask="arm_cos_q31.c"/>
+        <files mask="arm_sin_f32.c"/>
+        <files mask="arm_sin_q15.c"/>
+        <files mask="arm_sqrt_q15.c"/>
+        <files mask="arm_sin_q31.c"/>
+        <files mask="arm_sqrt_q31.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/FilteringFunctions" type="src">
+        <files mask="arm_lms_norm_init_f32.c"/>
+        <files mask="arm_fir_fast_q31.c"/>
+        <files mask="arm_fir_decimate_init_q15.c"/>
+        <files mask="arm_correlate_f32.c"/>
+        <files mask="arm_fir_sparse_init_f32.c"/>
+        <files mask="arm_iir_lattice_q15.c"/>
+        <files mask="arm_lms_f32.c"/>
+        <files mask="arm_biquad_cascade_df1_q31.c"/>
+        <files mask="arm_fir_fast_q15.c"/>
+        <files mask="arm_conv_partial_fast_q15.c"/>
+        <files mask="arm_fir_lattice_f32.c"/>
+        <files mask="arm_lms_q15.c"/>
+        <files mask="arm_fir_init_f32.c"/>
+        <files mask="arm_iir_lattice_f32.c"/>
+        <files mask="arm_correlate_q15.c"/>
+        <files mask="arm_fir_sparse_q7.c"/>
+        <files mask="arm_correlate_q31.c"/>
+        <files mask="arm_correlate_fast_opt_q15.c"/>
+        <files mask="arm_lms_init_q15.c"/>
+        <files mask="arm_fir_lattice_q31.c"/>
+        <files mask="arm_lms_q31.c"/>
+        <files mask="arm_conv_f32.c"/>
+        <files mask="arm_iir_lattice_init_f32.c"/>
+        <files mask="arm_biquad_cascade_df2T_f64.c"/>
+        <files mask="arm_fir_sparse_f32.c"/>
+        <files mask="arm_biquad_cascade_df1_32x64_q31.c"/>
+        <files mask="arm_fir_interpolate_q15.c"/>
+        <files mask="arm_conv_fast_opt_q15.c"/>
+        <files mask="arm_lms_norm_q15.c"/>
+        <files mask="arm_conv_q15.c"/>
+        <files mask="arm_conv_partial_f32.c"/>
+        <files mask="arm_fir_sparse_q15.c"/>
+        <files mask="arm_fir_init_q7.c"/>
+        <files mask="arm_correlate_opt_q7.c"/>
+        <files mask="arm_fir_decimate_init_q31.c"/>
+        <files mask="arm_fir_decimate_q31.c"/>
+        <files mask="arm_biquad_cascade_df1_init_f32.c"/>
+        <files mask="arm_iir_lattice_q31.c"/>
+        <files mask="arm_biquad_cascade_df1_f32.c"/>
+        <files mask="arm_fir_interpolate_f32.c"/>
+        <files mask="arm_fir_decimate_fast_q15.c"/>
+        <files mask="arm_correlate_fast_q31.c"/>
+        <files mask="arm_fir_q31.c"/>
+        <files mask="arm_lms_norm_init_q31.c"/>
+        <files mask="arm_lms_norm_q31.c"/>
+        <files mask="arm_fir_sparse_q31.c"/>
+        <files mask="arm_fir_lattice_init_q31.c"/>
+        <files mask="arm_biquad_cascade_df2T_init_f32.c"/>
+        <files mask="arm_correlate_fast_q15.c"/>
+        <files mask="arm_iir_lattice_init_q15.c"/>
+        <files mask="arm_biquad_cascade_df1_fast_q15.c"/>
+        <files mask="arm_fir_init_q31.c"/>
+        <files mask="arm_conv_partial_fast_opt_q15.c"/>
+        <files mask="arm_biquad_cascade_stereo_df2T_init_f32.c"/>
+        <files mask="arm_lms_norm_f32.c"/>
+        <files mask="arm_lms_init_q31.c"/>
+        <files mask="arm_correlate_opt_q15.c"/>
+        <files mask="arm_fir_sparse_init_q15.c"/>
+        <files mask="arm_biquad_cascade_df1_init_q31.c"/>
+        <files mask="arm_conv_partial_opt_q15.c"/>
+        <files mask="arm_conv_opt_q15.c"/>
+        <files mask="arm_conv_partial_opt_q7.c"/>
+        <files mask="arm_conv_q31.c"/>
+        <files mask="arm_correlate_q7.c"/>
+        <files mask="arm_biquad_cascade_df1_init_q15.c"/>
+        <files mask="arm_biquad_cascade_stereo_df2T_f32.c"/>
+        <files mask="arm_fir_q15.c"/>
+        <files mask="arm_fir_sparse_init_q31.c"/>
+        <files mask="arm_fir_decimate_q15.c"/>
+        <files mask="arm_fir_interpolate_q31.c"/>
+        <files mask="arm_fir_init_q15.c"/>
+        <files mask="arm_iir_lattice_init_q31.c"/>
+        <files mask="arm_biquad_cascade_df2T_f32.c"/>
+        <files mask="arm_fir_interpolate_init_f32.c"/>
+        <files mask="arm_fir_lattice_init_q15.c"/>
+        <files mask="arm_conv_partial_q31.c"/>
+        <files mask="arm_lms_norm_init_q15.c"/>
+        <files mask="arm_fir_decimate_init_f32.c"/>
+        <files mask="arm_fir_f32.c"/>
+        <files mask="arm_fir_decimate_f32.c"/>
+        <files mask="arm_conv_opt_q7.c"/>
+        <files mask="arm_conv_fast_q31.c"/>
+        <files mask="arm_fir_lattice_q15.c"/>
+        <files mask="arm_conv_q7.c"/>
+        <files mask="arm_biquad_cascade_df1_fast_q31.c"/>
+        <files mask="arm_conv_fast_q15.c"/>
+        <files mask="arm_fir_interpolate_init_q15.c"/>
+        <files mask="arm_fir_sparse_init_q7.c"/>
+        <files mask="arm_conv_partial_q15.c"/>
+        <files mask="arm_conv_partial_fast_q31.c"/>
+        <files mask="arm_fir_lattice_init_f32.c"/>
+        <files mask="arm_biquad_cascade_df1_q15.c"/>
+        <files mask="arm_conv_partial_q7.c"/>
+        <files mask="arm_biquad_cascade_df1_32x64_init_q31.c"/>
+        <files mask="arm_fir_decimate_fast_q31.c"/>
+        <files mask="arm_lms_init_f32.c"/>
+        <files mask="arm_biquad_cascade_df2T_init_f64.c"/>
+        <files mask="arm_fir_q7.c"/>
+        <files mask="arm_fir_interpolate_init_q31.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/GCC" type="script">
+        <files mask="getSizeInfo.bat"/>
+        <files mask="arm_cortexM_math_Build.bat"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/GCC" type="project">
+        <files mask="arm_cortexM_math.uvoptx"/>
+        <files mask="arm_cortexM_math.uvprojx"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/MatrixFunctions" type="src">
+        <files mask="arm_mat_init_f32.c"/>
+        <files mask="arm_mat_sub_q31.c"/>
+        <files mask="arm_mat_scale_q31.c"/>
+        <files mask="arm_mat_sub_q15.c"/>
+        <files mask="arm_mat_add_f32.c"/>
+        <files mask="arm_mat_cmplx_mult_f32.c"/>
+        <files mask="arm_mat_mult_q31.c"/>
+        <files mask="arm_mat_sub_f32.c"/>
+        <files mask="arm_mat_trans_q31.c"/>
+        <files mask="arm_mat_mult_fast_q15.c"/>
+        <files mask="arm_mat_scale_q15.c"/>
+        <files mask="arm_mat_init_q31.c"/>
+        <files mask="arm_mat_trans_f32.c"/>
+        <files mask="arm_mat_add_q15.c"/>
+        <files mask="arm_mat_trans_q15.c"/>
+        <files mask="arm_mat_inverse_f32.c"/>
+        <files mask="arm_mat_cmplx_mult_q15.c"/>
+        <files mask="arm_mat_init_q15.c"/>
+        <files mask="arm_mat_mult_fast_q31.c"/>
+        <files mask="arm_mat_scale_f32.c"/>
+        <files mask="arm_mat_mult_f32.c"/>
+        <files mask="arm_mat_inverse_f64.c"/>
+        <files mask="arm_mat_add_q31.c"/>
+        <files mask="arm_mat_cmplx_mult_q31.c"/>
+        <files mask="arm_mat_mult_q15.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/StatisticsFunctions" type="src">
+        <files mask="arm_min_q31.c"/>
+        <files mask="arm_mean_q7.c"/>
+        <files mask="arm_max_q15.c"/>
+        <files mask="arm_var_q31.c"/>
+        <files mask="arm_power_q31.c"/>
+        <files mask="arm_min_q7.c"/>
+        <files mask="arm_max_q31.c"/>
+        <files mask="arm_var_q15.c"/>
+        <files mask="arm_rms_f32.c"/>
+        <files mask="arm_var_f32.c"/>
+        <files mask="arm_power_f32.c"/>
+        <files mask="arm_std_q31.c"/>
+        <files mask="arm_mean_q15.c"/>
+        <files mask="arm_min_q15.c"/>
+        <files mask="arm_std_f32.c"/>
+        <files mask="arm_rms_q15.c"/>
+        <files mask="arm_mean_f32.c"/>
+        <files mask="arm_mean_q31.c"/>
+        <files mask="arm_power_q7.c"/>
+        <files mask="arm_max_f32.c"/>
+        <files mask="arm_min_f32.c"/>
+        <files mask="arm_power_q15.c"/>
+        <files mask="arm_std_q15.c"/>
+        <files mask="arm_rms_q31.c"/>
+        <files mask="arm_max_q7.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/SupportFunctions" type="src">
+        <files mask="arm_q7_to_q15.c"/>
+        <files mask="arm_fill_q7.c"/>
+        <files mask="arm_copy_q15.c"/>
+        <files mask="arm_float_to_q31.c"/>
+        <files mask="arm_q15_to_q31.c"/>
+        <files mask="arm_q15_to_float.c"/>
+        <files mask="arm_copy_q7.c"/>
+        <files mask="arm_q31_to_q7.c"/>
+        <files mask="arm_copy_q31.c"/>
+        <files mask="arm_q15_to_q7.c"/>
+        <files mask="arm_fill_q15.c"/>
+        <files mask="arm_q7_to_float.c"/>
+        <files mask="arm_q31_to_q15.c"/>
+        <files mask="arm_q7_to_q31.c"/>
+        <files mask="arm_float_to_q15.c"/>
+        <files mask="arm_fill_q31.c"/>
+        <files mask="arm_q31_to_float.c"/>
+        <files mask="arm_copy_f32.c"/>
+        <files mask="arm_float_to_q7.c"/>
+        <files mask="arm_fill_f32.c"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/TransformFunctions" type="asm_include">
+        <files mask="arm_bitreversal2.S"/>
+      </source>
+      <source path="CMSIS/DSP_Lib/Source/TransformFunctions" type="src">
+        <files mask="arm_cfft_radix2_q15.c"/>
+        <files mask="arm_rfft_f32.c"/>
+        <files mask="arm_rfft_q15.c"/>
+        <files mask="arm_rfft_init_q31.c"/>
+        <files mask="arm_cfft_radix4_q31.c"/>
+        <files mask="arm_cfft_radix8_f32.c"/>
+        <files mask="arm_cfft_q31.c"/>
+        <files mask="arm_cfft_radix2_q31.c"/>
+        <files mask="arm_cfft_q15.c"/>
+        <files mask="arm_cfft_radix2_init_q31.c"/>
+        <files mask="arm_dct4_q31.c"/>
+        <files mask="arm_dct4_init_q31.c"/>
+        <files mask="arm_cfft_f32.c"/>
+        <files mask="arm_cfft_radix4_q15.c"/>
+        <files mask="arm_dct4_q15.c"/>
+        <files mask="arm_rfft_fast_f32.c"/>
+        <files mask="arm_bitreversal.c"/>
+        <files mask="arm_rfft_q31.c"/>
+        <files mask="arm_rfft_fast_init_f32.c"/>
+        <files mask="arm_cfft_radix4_f32.c"/>
+        <files mask="arm_dct4_init_f32.c"/>
+        <files mask="arm_cfft_radix4_init_q15.c"/>
+        <files mask="arm_dct4_f32.c"/>
+        <files mask="arm_cfft_radix2_f32.c"/>
+        <files mask="arm_cfft_radix2_init_f32.c"/>
+        <files mask="arm_rfft_init_f32.c"/>
+        <files mask="arm_cfft_radix2_init_q15.c"/>
+        <files mask="arm_cfft_radix4_init_q31.c"/>
+        <files mask="arm_rfft_init_q15.c"/>
+        <files mask="arm_cfft_radix4_init_f32.c"/>
+        <files mask="arm_dct4_init_q15.c"/>
+      </source>
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_sc000.h"/>
+        <files mask="cmsis_armcc.h"/>
+        <files mask="arm_common_tables.h"/>
+        <files mask="cmsis_gcc.h"/>
+        <files mask="core_cmFunc.h"/>
+        <files mask="core_cm0.h"/>
+        <files mask="core_cmInstr.h"/>
+        <files mask="core_cm7.h"/>
+        <files mask="core_sc300.h"/>
+        <files mask="arm_const_structs.h"/>
+        <files mask="core_cm3.h"/>
+        <files mask="core_cmSimd.h"/>
+        <files mask="cmsis_armcc_V6.h"/>
+        <files mask="core_cm0plus.h"/>
+        <files mask="arm_math.h"/>
+        <files mask="core_cm4.h"/>
+      </source>
+      <source path="CMSIS/Driver/Include" type="c_include">
+        <files mask="Driver_Common.h"/>
+        <files mask="Driver_ETH_PHY.h"/>
+        <files mask="Driver_USBH.h"/>
+        <files mask="Driver_I2C.h"/>
+        <files mask="Driver_CAN.h"/>
+        <files mask="Driver_ETH.h"/>
+        <files mask="Driver_Flash.h"/>
+        <files mask="Driver_NAND.h"/>
+        <files mask="Driver_SPI.h"/>
+        <files mask="Driver_USB.h"/>
+        <files mask="Driver_SAI.h"/>
+        <files mask="Driver_USART.h"/>
+        <files mask="Driver_MCI.h"/>
+        <files mask="Driver_ETH_MAC.h"/>
+        <files mask="Driver_USBD.h"/>
+      </source>
+      <source path="CMSIS/Lib" type="doc">
+        <files mask="license.txt"/>
+      </source>
+      <source path="CMSIS/Lib/ARM" type="lib">
+        <files mask="arm_cortexM7lfdp_math.lib"/>
+        <files mask="arm_cortexM7bfsp_math.lib"/>
+        <files mask="arm_cortexM0b_math.lib"/>
+        <files mask="arm_cortexM7l_math.lib"/>
+        <files mask="arm_cortexM3b_math.lib"/>
+        <files mask="arm_cortexM7lfsp_math.lib"/>
+        <files mask="arm_cortexM4lf_math.lib"/>
+        <files mask="arm_cortexM7bfdp_math.lib"/>
+        <files mask="arm_cortexM3l_math.lib"/>
+        <files mask="arm_cortexM0l_math.lib"/>
+        <files mask="arm_cortexM4bf_math.lib"/>
+        <files mask="arm_cortexM7b_math.lib"/>
+        <files mask="arm_cortexM4l_math.lib"/>
+        <files mask="arm_cortexM4b_math.lib"/>
+      </source>
+      <source path="CMSIS/Lib/GCC" type="lib">
+        <files mask="libarm_cortexM7lfdp_math.a"/>
+        <files mask="libarm_cortexM3l_math.a"/>
+        <files mask="libarm_cortexM7lfsp_math.a"/>
+        <files mask="libarm_cortexM7l_math.a"/>
+        <files mask="libarm_cortexM4l_math.a"/>
+        <files mask="libarm_cortexM4lf_math.a"/>
+        <files mask="libarm_cortexM0l_math.a"/>
+      </source>
+    </component>
+    <component name="tools" type="other" version="1.0.0">
+      <source path="tools/cmake_toolchain_files" type="script">
+        <files mask="armgcc.cmake"/>
+        <files mask="armgcc_force_cpp.cmake"/>
+      </source>
+    </component>
+    <component name="dma_manager" type="middleware" device="MK64F12" dependency="edma" version="2.0.0">
+      <source path="middleware/dma_manager_2.0.0" type="src">
+        <files mask="fsl_dma_manager.c"/>
+      </source>
+      <source path="middleware/dma_manager_2.0.0" type="c_include">
+        <files mask="fsl_dma_manager.h"/>
+      </source>
+    </component>
+    <component name="fatfs" type="middleware" device="MK64F12" version="0.11">
+      <source path="middleware/fatfs_0.11a/doc" type="doc">
+        <files mask="css_j.css"/>
+        <files mask="css_e.css"/>
+        <files mask="00index_e.html"/>
+        <files mask="00index_j.html"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/doc/en" type="doc">
+        <files mask="dioctl.html"/>
+        <files mask="sfatfs.html"/>
+        <files mask="fattime.html"/>
+        <files mask="read.html"/>
+        <files mask="rename.html"/>
+        <files mask="findnext.html"/>
+        <files mask="readdir.html"/>
+        <files mask="truncate.html"/>
+        <files mask="puts.html"/>
+        <files mask="dinit.html"/>
+        <files mask="mkfs.html"/>
+        <files mask="findfirst.html"/>
+        <files mask="close.html"/>
+        <files mask="getfree.html"/>
+        <files mask="tell.html"/>
+        <files mask="config.html"/>
+        <files mask="mkdir.html"/>
+        <files mask="appnote.html"/>
+        <files mask="write.html"/>
+        <files mask="chmod.html"/>
+        <files mask="setlabel.html"/>
+        <files mask="error.html"/>
+        <files mask="size.html"/>
+        <files mask="sync.html"/>
+        <files mask="getcwd.html"/>
+        <files mask="sdir.html"/>
+        <files mask="filename.html"/>
+        <files mask="sfile.html"/>
+        <files mask="opendir.html"/>
+        <files mask="dread.html"/>
+        <files mask="closedir.html"/>
+        <files mask="gets.html"/>
+        <files mask="lseek.html"/>
+        <files mask="fdisk.html"/>
+        <files mask="mount.html"/>
+        <files mask="putc.html"/>
+        <files mask="chdrive.html"/>
+        <files mask="chdir.html"/>
+        <files mask="forward.html"/>
+        <files mask="unlink.html"/>
+        <files mask="eof.html"/>
+        <files mask="rc.html"/>
+        <files mask="dstat.html"/>
+        <files mask="sfileinfo.html"/>
+        <files mask="utime.html"/>
+        <files mask="printf.html"/>
+        <files mask="open.html"/>
+        <files mask="stat.html"/>
+        <files mask="dwrite.html"/>
+        <files mask="getlabel.html"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/doc/img" type="image">
+        <files mask="rwtest2.png"/>
+        <files mask="f1.png"/>
+        <files mask="f4.png"/>
+        <files mask="layers2.png"/>
+        <files mask="f2.png"/>
+        <files mask="rwtest3.png"/>
+        <files mask="layers3.png"/>
+        <files mask="layers1.png"/>
+        <files mask="f7.png"/>
+        <files mask="layers.png"/>
+        <files mask="f5.png"/>
+        <files mask="rwtest.png"/>
+        <files mask="funcs.png"/>
+        <files mask="modules.png"/>
+        <files mask="f6.png"/>
+        <files mask="f3.png"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/doc/img" type="src">
+        <files mask="app4.c"/>
+        <files mask="app2.c"/>
+        <files mask="app3.c"/>
+        <files mask="app1.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/doc/img" type="archive">
+        <files mask="mkfatimg.zip"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/doc/ja" type="doc">
+        <files mask="dioctl.html"/>
+        <files mask="sfatfs.html"/>
+        <files mask="fattime.html"/>
+        <files mask="read.html"/>
+        <files mask="rename.html"/>
+        <files mask="findnext.html"/>
+        <files mask="readdir.html"/>
+        <files mask="truncate.html"/>
+        <files mask="puts.html"/>
+        <files mask="dinit.html"/>
+        <files mask="mkfs.html"/>
+        <files mask="findfirst.html"/>
+        <files mask="close.html"/>
+        <files mask="getfree.html"/>
+        <files mask="tell.html"/>
+        <files mask="config.html"/>
+        <files mask="mkdir.html"/>
+        <files mask="appnote.html"/>
+        <files mask="write.html"/>
+        <files mask="chmod.html"/>
+        <files mask="setlabel.html"/>
+        <files mask="error.html"/>
+        <files mask="size.html"/>
+        <files mask="sync.html"/>
+        <files mask="getcwd.html"/>
+        <files mask="sdir.html"/>
+        <files mask="filename.html"/>
+        <files mask="sfile.html"/>
+        <files mask="opendir.html"/>
+        <files mask="dread.html"/>
+        <files mask="closedir.html"/>
+        <files mask="gets.html"/>
+        <files mask="lseek.html"/>
+        <files mask="fdisk.html"/>
+        <files mask="mount.html"/>
+        <files mask="putc.html"/>
+        <files mask="chdrive.html"/>
+        <files mask="chdir.html"/>
+        <files mask="forward.html"/>
+        <files mask="unlink.html"/>
+        <files mask="eof.html"/>
+        <files mask="rc.html"/>
+        <files mask="dstat.html"/>
+        <files mask="sfileinfo.html"/>
+        <files mask="utime.html"/>
+        <files mask="printf.html"/>
+        <files mask="open.html"/>
+        <files mask="stat.html"/>
+        <files mask="dwrite.html"/>
+        <files mask="getlabel.html"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src" type="doc">
+        <files mask="00history.txt"/>
+        <files mask="00readme.txt"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src" type="src">
+        <files mask="ff.c"/>
+        <files mask="diskio.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src" type="c_include">
+        <files mask="integer.h"/>
+        <files mask="diskio.h"/>
+        <files mask="ffconf_template.h"/>
+        <files mask="ff.h"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_mmc_disk" type="src">
+        <files mask="fsl_mmc_disk.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_mmc_disk" type="c_include">
+        <files mask="fsl_mmc_disk.h"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_option" type="src">
+        <files mask="freertos_syscall.c"/>
+        <files mask="ucosiii_syscall.c"/>
+        <files mask="ucosii_syscall.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_sd_disk" type="src">
+        <files mask="fsl_sd_disk.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_sd_disk" type="c_include">
+        <files mask="fsl_sd_disk.h"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_sdspi_disk" type="src">
+        <files mask="fsl_sdspi_disk.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_sdspi_disk" type="c_include">
+        <files mask="fsl_sdspi_disk.h"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_ram_disk" type="src">
+        <files mask="fsl_ram_disk.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_ram_disk" type="c_include">
+        <files mask="fsl_ram_disk.h"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_usb_disk" type="src">
+        <files mask="fsl_usb_disk_freertos.c"/>
+        <files mask="fsl_usb_disk_bm.c"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/fsl_usb_disk" type="c_include">
+        <files mask="fsl_usb_disk.h"/>
+      </source>
+      <source path="middleware/fatfs_0.11a/src/option" type="src">
+        <files mask="unicode.c"/>
+        <files mask="cc932.c"/>
+        <files mask="ccsbcs.c"/>
+        <files mask="cc950.c"/>
+        <files mask="syscall.c"/>
+        <files mask="cc949.c"/>
+        <files mask="cc936.c"/>
+      </source>
+    </component>
+    <component name="mmcau" type="middleware" device="MK64F12" version="2.0.0">
+      <source path="middleware/mmcau_2.0.0/asm-cm0p" type="lib">
+        <files mask="lib_mmcau-cm0p.a"/>
+        <files mask="lib_mmcau-cm0p.lib"/>
+      </source>
+      <source path="middleware/mmcau_2.0.0/asm-cm4-cm7" type="lib">
+        <files mask="lib_mmcau.a"/>
+        <files mask="lib_mmcau.lib"/>
+      </source>
+      <source path="middleware/mmcau_2.0.0/asm-cm0p/src" type="asm_include">
+        <files mask="cau2_defines.hdr"/>
+        <files mask="mmcau_aes_functions.s"/>
+        <files mask="mmcau_des_functions.s"/>
+        <files mask="mmcau_md5_functions.s"/>
+        <files mask="mmcau_sha1_functions.s"/>
+        <files mask="mmcau_sha256_functions.s"/>
+      </source>
+      <source path="middleware/mmcau_2.0.0/asm-cm4-cm7/src" type="asm_include">
+        <files mask="cau2_defines.hdr"/>
+        <files mask="mmcau_aes_functions.s"/>
+        <files mask="mmcau_des_functions.s"/>
+        <files mask="mmcau_md5_functions.s"/>
+        <files mask="mmcau_sha1_functions.s"/>
+        <files mask="mmcau_sha256_functions.s"/>
+      </source>
+      <source path="middleware/mmcau_2.0.0" type="doc">
+        <files mask="README.txt"/>
+      </source>
+      <source path="middleware/mmcau_2.0.0" type="src">
+        <files mask="fsl_mmcau.c"/>
+      </source>
+      <source path="middleware/mmcau_2.0.0" type="c_include">
+        <files mask="cau_api.h"/>
+        <files mask="fsl_mmcau.h"/>
+        <files mask="cau_api.h"/>
+      </source>
+    </component>
+    <component name="sdmmc" type="middleware" device="MK64F12" dependency="dspi sdhc" version="2.0.0">
+      <source path="middleware/sdmmc_2.0.0/inc" type="c_include">
+        <files mask="fsl_specification.h"/>
+        <files mask="fsl_sdspi.h"/>
+        <files mask="fsl_card.h"/>
+        <files mask="fsl_sdmmc.h"/>
+      </source>
+      <source path="middleware/sdmmc_2.0.0/src" type="src">
+        <files mask="fsl_sdspi.c"/>
+        <files mask="fsl_sdmmc.c"/>
+        <files mask="fsl_mmc.c"/>
+        <files mask="fsl_sd.c"/>
+      </source>
+    </component>
+    <component name="lwip" type="middleware" device="MK64F12" dependency="enet" version="1.4.1">
+      <source path="middleware/lwip_1.4.1/port" type="src">
+        <files mask="ethernetif.c"/>
+        <files mask="sys_arch.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/port" type="c_include">
+        <files mask="lwipopts.h"/>
+        <files mask="ethernetif.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/port/arch" type="c_include">
+        <files mask="sys_arch.h"/>
+        <files mask="perf.h"/>
+        <files mask="cc.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/api" type="src">
+        <files mask="netifapi.c"/>
+        <files mask="tcpip.c"/>
+        <files mask="netdb.c"/>
+        <files mask="api_msg.c"/>
+        <files mask="sockets.c"/>
+        <files mask="netbuf.c"/>
+        <files mask="err.c"/>
+        <files mask="api_lib.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/core" type="src">
+        <files mask="sys.c"/>
+        <files mask="dns.c"/>
+        <files mask="udp.c"/>
+        <files mask="init.c"/>
+        <files mask="def.c"/>
+        <files mask="memp.c"/>
+        <files mask="pbuf.c"/>
+        <files mask="tcp_out.c"/>
+        <files mask="netif.c"/>
+        <files mask="raw.c"/>
+        <files mask="stats.c"/>
+        <files mask="mem.c"/>
+        <files mask="dhcp.c"/>
+        <files mask="tcp_in.c"/>
+        <files mask="tcp.c"/>
+        <files mask="lwip_timers.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/core/ipv4" type="src">
+        <files mask="autoip.c"/>
+        <files mask="ip_frag.c"/>
+        <files mask="ip.c"/>
+        <files mask="ip_addr.c"/>
+        <files mask="inet_chksum.c"/>
+        <files mask="inet.c"/>
+        <files mask="icmp.c"/>
+        <files mask="igmp.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/core/ipv6" type="src">
+        <files mask="inet6.c"/>
+        <files mask="icmp6.c"/>
+        <files mask="ip6_addr.c"/>
+        <files mask="ip6.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/core/snmp" type="src">
+        <files mask="mib2.c"/>
+        <files mask="msg_in.c"/>
+        <files mask="msg_out.c"/>
+        <files mask="mib_structs.c"/>
+        <files mask="asn1_enc.c"/>
+        <files mask="asn1_dec.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/include/ipv4/lwip" type="c_include">
+        <files mask="ip_frag.h"/>
+        <files mask="autoip.h"/>
+        <files mask="ip_addr.h"/>
+        <files mask="ip.h"/>
+        <files mask="icmp.h"/>
+        <files mask="inet.h"/>
+        <files mask="igmp.h"/>
+        <files mask="inet_chksum.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/include/ipv6/lwip" type="c_include">
+        <files mask="ip_addr.h"/>
+        <files mask="ip.h"/>
+        <files mask="icmp.h"/>
+        <files mask="inet.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/include/lwip" type="c_include">
+        <files mask="init.h"/>
+        <files mask="def.h"/>
+        <files mask="memp.h"/>
+        <files mask="arch.h"/>
+        <files mask="timers.h"/>
+        <files mask="api.h"/>
+        <files mask="tcpip.h"/>
+        <files mask="dhcp.h"/>
+        <files mask="snmp_structs.h"/>
+        <files mask="api_msg.h"/>
+        <files mask="stats.h"/>
+        <files mask="tcp_impl.h"/>
+        <files mask="netbuf.h"/>
+        <files mask="snmp.h"/>
+        <files mask="snmp_asn1.h"/>
+        <files mask="debug.h"/>
+        <files mask="opt.h"/>
+        <files mask="memp_std.h"/>
+        <files mask="netif.h"/>
+        <files mask="mem.h"/>
+        <files mask="dns.h"/>
+        <files mask="pbuf.h"/>
+        <files mask="raw.h"/>
+        <files mask="err.h"/>
+        <files mask="snmp_msg.h"/>
+        <files mask="sys.h"/>
+        <files mask="netdb.h"/>
+        <files mask="sio.h"/>
+        <files mask="sockets.h"/>
+        <files mask="udp.h"/>
+        <files mask="tcp.h"/>
+        <files mask="netifapi.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/include/netif" type="c_include">
+        <files mask="slipif.h"/>
+        <files mask="etharp.h"/>
+        <files mask="ppp_oe.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/include/posix" type="c_include">
+        <files mask="netdb.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/include/posix/sys" type="c_include">
+        <files mask="socket.h"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/netif" type="src">
+        <files mask="etharp.c"/>
+        <files mask="slipif.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/netif/ppp" type="src">
+        <files mask="ppp.c"/>
+        <files mask="chpms.c"/>
+        <files mask="auth.c"/>
+        <files mask="lcp.c"/>
+        <files mask="ppp_oe.c"/>
+        <files mask="magic.c"/>
+        <files mask="fsm.c"/>
+        <files mask="ipcp.c"/>
+        <files mask="chap.c"/>
+        <files mask="pap.c"/>
+        <files mask="ppp_md5.c"/>
+        <files mask="md5.c"/>
+        <files mask="randm.c"/>
+        <files mask="vj.c"/>
+      </source>
+      <source path="middleware/lwip_1.4.1/src/netif/ppp" type="c_include">
+        <files mask="randm.h"/>
+        <files mask="auth.h"/>
+        <files mask="chpms.h"/>
+        <files mask="chap.h"/>
+        <files mask="md5.h"/>
+        <files mask="ipcp.h"/>
+        <files mask="ppp.h"/>
+        <files mask="ppp_impl.h"/>
+        <files mask="magic.h"/>
+        <files mask="lcp.h"/>
+        <files mask="pppdebug.h"/>
+        <files mask="pap.h"/>
+        <files mask="fsm.h"/>
+        <files mask="vj.h"/>
+      </source>
+    </component>
+    <component name="Include_common" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="arm_common_tables.h"/>
+        <files mask="arm_const_structs.h"/>
+        <files mask="arm_math.h"/>
+        <files mask="cmsis_armcc.h"/>
+        <files mask="cmsis_armcc_V6.h"/>
+        <files mask="cmsis_gcc.h"/>
+        <files mask="core_cmFunc.h"/>
+        <files mask="core_cmInstr.h"/>
+        <files mask="core_cmSimd.h"/>
+      </source>
+    </component>
+    <component name="Include_core_cm0" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_cm0.h"/>
+      </source>
+    </component>
+    <component name="Include_core_cm0plus" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_cm0plus.h"/>
+      </source>
+    </component>
+    <component name="Include_core_cm3" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_cm3.h"/>
+      </source>
+    </component>
+    <component name="Include_core_cm4" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_cm4.h"/>
+      </source>
+    </component>
+    <component name="Include_core_cm7" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_cm7.h"/>
+      </source>
+    </component>
+    <component name="Include_core_sc000" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_sc000.h"/>
+      </source>
+    </component>
+    <component name="Include_core_sc300" type="CMSIS" version="4.5.0">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="core_sc300.h"/>
+      </source>
+    </component>
+    <component name="MK64F12_CMSIS" type="CMSIS" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12" type="c_include">
+        <files mask="fsl_device_registers.h"/>
+        <files mask="MK64F12.h"/>
+        <files mask="MK64F12_features.h"/>
+      </source>
+    </component>
+    <component name="MK64F12_linker" type="linker" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12/gcc" type="linker" compiler="gcc">
+        <files mask="MK64FN1M0xxx12_flash.ld"/>
+        <files mask="MK64FN1M0xxx12_ram.ld"/>
+        <files mask="MK64FX512xxx12_flash.ld"/>
+        <files mask="MK64FX512xxx12_ram.ld"/>
+      </source>
+    </component>
+    <component name="MK64F12_startup" type="startup" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12/gcc" type="asm_include" compiler="gcc">
+        <files mask="startup_MK64F12.S"/>
+      </source>
+      <source path="devices/MK64F12" type="src">
+        <files mask="system_MK64F12.c"/>
+      </source>
+      <source path="devices/MK64F12" type="c_include">
+        <files mask="system_MK64F12.h"/>
+      </source>
+    </component>
+    <component name="MK64F12_debugger" type="debugger" device="MK64F12" version="1.0.0">
+      <source path="devices/MK64F12" type="debug">
+        <files mask="MK64F12.svd"/>
+      </source>
+    </component>
+    <component name="ISSDK" type="documentation" device="MK64F12" version="1.0.0">
+      <source path="docs/ISSDK/SensorFusion" type="doc">
+        <files mask="AN5286 v1p0.pdf"/>
+        <files mask="AN5016 v2p0.pdf"/>
+        <files mask="AN5017 v2p0.pdf"/>
+        <files mask="NSFK_DS.pdf"/>
+        <files mask="AN5022 v2p0.pdf"/>
+        <files mask="AN5018 v2p0.pdf"/>
+        <files mask="AN5021 v2p0.pdf"/>
+        <files mask="AN5020 v2p0.pdf"/>
+        <files mask="AN5023 v2p0.pdf"/>
+        <files mask="NSFK_Prod_UG.pdf"/>
+        <files mask="AN5019 v2p0.pdf"/>
+      </source>
+      <source path="docs/ISSDK/SensorFusion" type="archive">
+        <files mask="Sensor Fusion V7 API Reference Manual.zip"/>
+      </source>
+      <source path="docs/ISSDK/ISSDK" type="doc">
+        <files mask="ISSDKGETSTARTEDUG.pdf"/>
+      </source>
+      <source path="docs/ISSDK/ISSDK" type="archive">
+        <files mask="ISSDK V1.0 API Reference Manual.zip"/>
+      </source>
+    </component>
+    <component name="KSDK" type="documentation" version="1.0.0">
+      <source path="docs" type="doc">
+        <files mask="Getting Started with Kinetis SDK (KSDK) v.2.0.pdf"/>
+        <files mask="Kinetis SDK v.2.0 API Reference Manual.pdf"/>
+        <files mask="Kinetis SDK v.2.0.0 Release Notes for K22 K24 and K64 Devices.pdf"/>
+      </source>
+      <source path="docs/Kinetis SDK v.2.0 API Reference Manual" type="script">
+        <files mask="group__pmc.js"/>
+        <files mask="group__flexio__uart.js"/>
+        <files mask="jquery.js"/>
+        <files mask="navtree.js"/>
+        <files mask="group__lpi2c__driver.js"/>
+        <files mask="group__smartcard__uart__driver.js"/>
+        <files mask="group__lpi2c__slave__driver.js"/>
+        <files mask="group__rnga__driver.js"/>
+        <files mask="group__flexio__dma__i2s.js"/>
+        <files mask="navtreeindex6.js"/>
+        <files mask="group__trng__driver.js"/>
+        <files mask="group__adc16.js"/>
+        <files mask="group__enet.js"/>
+        <files mask="group__pit__driver.js"/>
+        <files mask="group__dmamux.js"/>
+        <files mask="group__ltc__driver__hash.js"/>
+        <files mask="group__dspi__ucosiii__driver.js"/>
+        <files mask="navtreeindex18.js"/>
+        <files mask="group__uart__freertos__driver.js"/>
+        <files mask="group__mpu.js"/>
+        <files mask="group__qspi__edma.js"/>
+        <files mask="navtreeindex12.js"/>
+        <files mask="group__ewm__driver.js"/>
+        <files mask="group__crc__driver.js"/>
+        <files mask="navtreeindex10.js"/>
+        <files mask="navtreeindex19.js"/>
+        <files mask="group__flexio__edma__camera.js"/>
+        <files mask="group__flexio__driver.js"/>
+        <files mask="group__flexbus.js"/>
+        <files mask="group__flexcan__edma__driver.js"/>
+        <files mask="group__rtc__driver.js"/>
+        <files mask="group__cmt.js"/>
+        <files mask="group__ltc__driver__des.js"/>
+        <files mask="group__lpuart__ucosiii__driver.js"/>
+        <files mask="group__ltc__driver__pkha.js"/>
+        <files mask="group__uart__ucosiii__driver.js"/>
+        <files mask="group__qspi.js"/>
+        <files mask="navtreeindex0.js"/>
+        <files mask="group__lmem__cache.js"/>
+        <files mask="group__sai__edma.js"/>
+        <files mask="group__gpio__driver.js"/>
+        <files mask="group__i2c__ucosii__driver.js"/>
+        <files mask="group__tpm__driver.js"/>
+        <files mask="group__spi__driver.js"/>
+        <files mask="group__sdhc.js"/>
+        <files mask="navtreeindex21.js"/>
+        <files mask="group__mcglite.js"/>
+        <files mask="navtreeindex20.js"/>
+        <files mask="resize.js"/>
+        <files mask="group__lpuart__freertos__driver.js"/>
+        <files mask="navtreeindex23.js"/>
+        <files mask="navtreeindex15.js"/>
+        <files mask="group__slcd.js"/>
+        <files mask="group__vref.js"/>
+        <files mask="navtreeindex7.js"/>
+        <files mask="navtreeindex4.js"/>
+        <files mask="group__cmp.js"/>
+        <files mask="group__ltc__driver__synchronous__blocking.js"/>
+        <files mask="group__rcm.js"/>
+        <files mask="group__i2c__edma__driver.js"/>
+        <files mask="group__tsi.js"/>
+        <files mask="group__lpuart__dma__driver.js"/>
+        <files mask="group__lpuart__driver.js"/>
+        <files mask="group__flexio__edma__uart.js"/>
+        <files mask="group__dspi__ucosii__driver.js"/>
+        <files mask="group__tsi__v4__driver.js"/>
+        <files mask="group__dspi.js"/>
+        <files mask="navtreeindex8.js"/>
+        <files mask="navtreeindex22.js"/>
+        <files mask="group__spi__ucosii__driver.js"/>
+        <files mask="group__flexcan.js"/>
+        <files mask="group__flash__driver.js"/>
+        <files mask="group__lpi2c__ucosii__driver.js"/>
+        <files mask="navtreeindex16.js"/>
+        <files mask="group__smartcard__phy__ncn8025__driver.js"/>
+        <files mask="group__spi__ucosiii__driver.js"/>
+        <files mask="group__lpuart.js"/>
+        <files mask="group__sai.js"/>
+        <files mask="group__sai__dma.js"/>
+        <files mask="group__lpuart__edma__driver.js"/>
+        <files mask="group__i2c__dma__driver.js"/>
+        <files mask="group__flexio__edma__i2s.js"/>
+        <files mask="group__port__driver.js"/>
+        <files mask="group__gpio.js"/>
+        <files mask="navtreeindex5.js"/>
+        <files mask="group__ltc__driver__aes.js"/>
+        <files mask="group__smartcard.js"/>
+        <files mask="group__ftm__driver.js"/>
+        <files mask="group__flexio__i2s.js"/>
+        <files mask="navtreeindex11.js"/>
+        <files mask="group__uart__ucosii__driver.js"/>
+        <files mask="group__lptmr__driver.js"/>
+        <files mask="navtreeindex2.js"/>
+        <files mask="group__notifier.js"/>
+        <files mask="navtreeindex3.js"/>
+        <files mask="navtreeindex1.js"/>
+        <files mask="group__uart__driver.js"/>
+        <files mask="navtreeindex17.js"/>
+        <files mask="group__smartcard__emvsim__driver.js"/>
+        <files mask="group__wdog__driver.js"/>
+        <files mask="group__uart__edma__driver.js"/>
+        <files mask="group__lpi2c__master__driver.js"/>
+        <files mask="group__smartcard__freertos__driver.js"/>
+        <files mask="group__sim.js"/>
+        <files mask="dynsections.js"/>
+        <files mask="group__i2c__freertos__driver.js"/>
+        <files mask="group__smartcard__ucosii__driver.js"/>
+        <files mask="navtreeindex9.js"/>
+        <files mask="group__spi__dma__driver.js"/>
+        <files mask="group__flexio__dma__uart.js"/>
+        <files mask="group__flexio__dma__spi.js"/>
+        <files mask="navtreeindex14.js"/>
+        <files mask="group__spi.js"/>
+        <files mask="group__i2c__driver.js"/>
+        <files mask="group__dspi__freertos__driver.js"/>
+        <files mask="group__ltc__driver.js"/>
+        <files mask="group__lpuart__ucosii__driver.js"/>
+        <files mask="group__uart.js"/>
+        <files mask="group__trgmux__driver.js"/>
+        <files mask="group__dspi__edma__driver.js"/>
+        <files mask="group__flexio__spi.js"/>
+        <files mask="group__i2c.js"/>
+        <files mask="group__pdb.js"/>
+        <files mask="group__sdramc.js"/>
+        <files mask="group__lpi2c__master__edma__driver.js"/>
+        <files mask="group__flexio__i2c__master.js"/>
+        <files mask="group__tsi__v2__driver.js"/>
+        <files mask="group__lpi2c__freertos__driver.js"/>
+        <files mask="group__dspi__driver.js"/>
+        <files mask="group__flexcan__driver.js"/>
+        <files mask="group__dac.js"/>
+        <files mask="modules.js"/>
+        <files mask="group__flexio.js"/>
+        <files mask="group__uart__dma__driver.js"/>
+        <files mask="group__ltc__edma__driver.js"/>
+        <files mask="group__ltc__edma__driver__des.js"/>
+        <files mask="group__flexio__edma__spi.js"/>
+        <files mask="group__cop__driver.js"/>
+        <files mask="group__ltc__edma__driver__aes.js"/>
+        <files mask="group__smc.js"/>
+        <files mask="group__smartcard__ucosiii__driver.js"/>
+        <files mask="group__clock.js"/>
+        <files mask="group__dma__driver.js"/>
+        <files mask="group__dspi__dma__driver.js"/>
+        <files mask="navtreeindex13.js"/>
+        <files mask="group__flexio__camera.js"/>
+        <files mask="group__llwu.js"/>
+        <files mask="group__edma__driver.js"/>
+        <files mask="group__spi__freertos__driver.js"/>
+        <files mask="group__smartcard__phy__emvsim__driver.js"/>
+        <files mask="group__smartcard__phy__gpio__driver.js"/>
+        <files mask="group__lpi2c__ucosiii__driver.js"/>
+      </source>
+      <source path="docs/Kinetis SDK v.2.0 API Reference Manual" type="doc">
+        <files mask="tabs.css"/>
+        <files mask="doxygen.css"/>
+        <files mask="customdoxygen.css"/>
+        <files mask="navtree.css"/>
+        <files mask="group__flexio__dma__i2s.html"/>
+        <files mask="group__tsi__v4__driver.html"/>
+        <files mask="group__tsi.html"/>
+        <files mask="dir_9986937d5c2d55a7e5d1d4820166229f.html"/>
+        <files mask="group__pit__driver.html"/>
+        <files mask="dir_b33ed5b80b075b6e24b0f1f0112a8b04.html"/>
+        <files mask="group__sai__dma.html"/>
+        <files mask="dir_5c96277754ed418959ea3b47c456d5c0.html"/>
+        <files mask="group__cop__driver.html"/>
+        <files mask="group__lpi2c__freertos__driver.html"/>
+        <files mask="group__spi__freertos__driver.html"/>
+        <files mask="group__lpuart__ucosii__driver.html"/>
+        <files mask="group__dmamux.html"/>
+        <files mask="group__dspi__dma__driver.html"/>
+        <files mask="dir_cac61d4c063aa297ebf4006623d62dc6.html"/>
+        <files mask="group__ltc__driver.html"/>
+        <files mask="group__sdhc.html"/>
+        <files mask="group__qspi__edma.html"/>
+        <files mask="group__ltc__edma__driver__des.html"/>
+        <files mask="group__spi__driver.html"/>
+        <files mask="group__sim.html"/>
+        <files mask="group__dma__driver.html"/>
+        <files mask="dir_b60bc431cd2d2a4b7e645c1f73116460.html"/>
+        <files mask="group__flexcan__edma__driver.html"/>
+        <files mask="group__flexio__edma__i2s.html"/>
+        <files mask="group__llwu.html"/>
+        <files mask="group__uart__dma__driver.html"/>
+        <files mask="group__crc__driver.html"/>
+        <files mask="group__lpuart__ucosiii__driver.html"/>
+        <files mask="dir_a58638a16d63b3fca53dfe05c0e7858e.html"/>
+        <files mask="group__pdb.html"/>
+        <files mask="group__port__driver.html"/>
+        <files mask="group__flexio__i2c__master.html"/>
+        <files mask="dir_c40c443a376df1bc90d73c3b618643fe.html"/>
+        <files mask="group__flexio__camera.html"/>
+        <files mask="group__smartcard__phy__gpio__driver.html"/>
+        <files mask="group__vref.html"/>
+        <files mask="dir_06373449363973f517fad80acb2c28ea.html"/>
+        <files mask="drv_err.html"/>
+        <files mask="dir_69dfaad17da969c8438974f479e71af4.html"/>
+        <files mask="dir_58e102d2449f7b3d87d5edc08313c5d7.html"/>
+        <files mask="group__i2c__ucosiii__driver.html"/>
+        <files mask="group__smartcard__uart__driver.html"/>
+        <files mask="group__i2c__freertos__driver.html"/>
+        <files mask="group__i2c__dma__driver.html"/>
+        <files mask="group__spi__ucosiii__driver.html"/>
+        <files mask="group__rtc__driver.html"/>
+        <files mask="dir_59300d18bce9f4e353291fbf36391815.html"/>
+        <files mask="group__uart.html"/>
+        <files mask="dir_61bc899aee3999e613a40efe387422e4.html"/>
+        <files mask="group__lpi2c__slave__driver.html"/>
+        <files mask="group__ftm__driver.html"/>
+        <files mask="group__ltc__driver__hash.html"/>
+        <files mask="group__lpuart.html"/>
+        <files mask="dir_9108bfa6c83c7c513e3e0128411a10b0.html"/>
+        <files mask="group__smartcard__ucosiii__driver.html"/>
+        <files mask="group__lpi2c__master__driver.html"/>
+        <files mask="group__tsi__v2__driver.html"/>
+        <files mask="group__flexio__dma__uart.html"/>
+        <files mask="group__ewm__driver.html"/>
+        <files mask="group__dac.html"/>
+        <files mask="dir_bebc14e255be79244de9e03d794361f1.html"/>
+        <files mask="group__trng__driver.html"/>
+        <files mask="group__debug__console.html"/>
+        <files mask="dir_4eaab06f456111991ff05c9b9cb737cb.html"/>
+        <files mask="group__mcglite.html"/>
+        <files mask="dir_13e7b449b29780a4af8c8692d20059c8.html"/>
+        <files mask="group__flexio__edma__spi.html"/>
+        <files mask="dir_95bc3e7ac98e4e44438a28d0eb625bbb.html"/>
+        <files mask="group__uart__edma__driver.html"/>
+        <files mask="group__clock.html"/>
+        <files mask="group__flexio__spi.html"/>
+        <files mask="group__lpuart__freertos__driver.html"/>
+        <files mask="index.html"/>
+        <files mask="group__sai__edma.html"/>
+        <files mask="dir_09f9dadd705c180f0f6fcba2157ed2a9.html"/>
+        <files mask="group__ltc__driver__pkha.html"/>
+        <files mask="dir_9d7943276f7f59eae0f94ff2d28103c6.html"/>
+        <files mask="dir_83c4f67939b2e50b6dc50fe3fc259b2d.html"/>
+        <files mask="group__lpi2c__slave__edma__driver.html"/>
+        <files mask="dir_27520577c3d33edf81ffa63786490c32.html"/>
+        <files mask="group__i2c.html"/>
+        <files mask="group__dspi__edma__driver.html"/>
+        <files mask="dir_ea5f9633cc51d3e2a6a258aee7e636f0.html"/>
+        <files mask="dir_b7cb47371a1a46acc29ef8a09ae9887f.html"/>
+        <files mask="dir_e5df8f928019563db5aab1a9cbbfeae5.html"/>
+        <files mask="group__tpm__driver.html"/>
+        <files mask="group__flexio__uart.html"/>
+        <files mask="group__cmt.html"/>
+        <files mask="dir_48dd3c62d7c86167056c35ed6b546d27.html"/>
+        <files mask="group__ltc__edma__driver.html"/>
+        <files mask="group__lpuart__edma__driver.html"/>
+        <files mask="group__dspi__ucosii__driver.html"/>
+        <files mask="dir_ceb1318614fac7b51868fff54187d808.html"/>
+        <files mask="group__spi__dma__driver.html"/>
+        <files mask="group__ltc__edma__driver__aes.html"/>
+        <files mask="group__i2c__ucosii__driver.html"/>
+        <files mask="arch.html"/>
+        <files mask="group__dspi__freertos__driver.html"/>
+        <files mask="group__flexio__driver.html"/>
+        <files mask="dir_2a63c290ba62f47e9fa3ca999b719a29.html"/>
+        <files mask="group__smartcard__freertos__driver.html"/>
+        <files mask="group__pmc.html"/>
+        <files mask="group__flexio__dma__spi.html"/>
+        <files mask="group__ltc__driver__synchronous__blocking.html"/>
+        <files mask="group__dspi__ucosiii__driver.html"/>
+        <files mask="group__flexio__edma__uart.html"/>
+        <files mask="group__i2c__edma__driver.html"/>
+        <files mask="dir_07b86ffc266b39efa5bbdc0e9fdb330a.html"/>
+        <files mask="tm.html"/>
+        <files mask="group__lpi2c__ucosiii__driver.html"/>
+        <files mask="group__smartcard__phy__ncn8025__driver.html"/>
+        <files mask="group__mpu.html"/>
+        <files mask="dir_50c0f6d3977876a8fb6acc75ece63018.html"/>
+        <files mask="group__dspi__driver.html"/>
+        <files mask="dir_b1c03c584dc84f3f7667d569a16f41a9.html"/>
+        <files mask="group__sdramc.html"/>
+        <files mask="group__lpi2c__master__edma__driver.html"/>
+        <files mask="dir_3426deb2dd7b86c400852d77edf21315.html"/>
+        <files mask="group__notifier.html"/>
+        <files mask="dir_252e093e644d88ecffac71708c50cbfe.html"/>
+        <files mask="group__fgpio__driver.html"/>
+        <files mask="group__uart__ucosiii__driver.html"/>
+        <files mask="group__flexio__edma__camera.html"/>
+        <files mask="dir_b788973f4ee043dc132897d15bbb49be.html"/>
+        <files mask="group__flexbus.html"/>
+        <files mask="dir_89fd88b21369a8fc685427310a5a5fe7.html"/>
+        <files mask="group__lpi2c__ucosii__driver.html"/>
+        <files mask="dir_516e9bc8864e0ff8939750a47792c97a.html"/>
+        <files mask="group__slcd.html"/>
+        <files mask="dir_416fc20155a03b7bbc5728a57d236b9f.html"/>
+        <files mask="group__flexio.html"/>
+        <files mask="group__sai.html"/>
+        <files mask="dir_bda58036682f346ab3d015dd2d42b321.html"/>
+        <files mask="group__gpio__driver.html"/>
+        <files mask="group__lptmr__driver.html"/>
+        <files mask="dir_81cd625641a90df482300fc494d26ddb.html"/>
+        <files mask="dir_a3133d333b1a52973d87e73438740fd6.html"/>
+        <files mask="group__spi.html"/>
+        <files mask="modules.html"/>
+        <files mask="group__cmp.html"/>
+        <files mask="group__smc.html"/>
+        <files mask="group__smartcard.html"/>
+        <files mask="group__lpuart__driver.html"/>
+        <files mask="dir_ecffafb520acb36fbf6168a58c2439ed.html"/>
+        <files mask="dir_fa5fdb8d20f935f25433a14a3646651d.html"/>
+        <files mask="group__i2c__driver.html"/>
+        <files mask="dir_b1c4d21f93a7826ef4aed70b30552b97.html"/>
+        <files mask="dir_848ba48fec923bc3c0bf8c7926036968.html"/>
+        <files mask="group__flexio__i2s.html"/>
+        <files mask="group__enet.html"/>
+        <files mask="dir_3c8ef24bd02dc25b699b901733412397.html"/>
+        <files mask="group__flexcan__driver.html"/>
+        <files mask="group__edma__driver.html"/>
+        <files mask="group__uart__ucosii__driver.html"/>
+        <files mask="group__ltc__driver__des.html"/>
+        <files mask="dir_b07b1803b08e3bfa8752acf7d436415b.html"/>
+        <files mask="group__spi__ucosii__driver.html"/>
+        <files mask="group__uart__freertos__driver.html"/>
+        <files mask="group__lpuart__dma__driver.html"/>
+        <files mask="dir_bad28ac3823c219acc551076247427f0.html"/>
+        <files mask="group__smartcard__phy__emvsim__driver.html"/>
+        <files mask="group__smartcard__ucosii__driver.html"/>
+        <files mask="dir_ac7a2beb2464fcf2f50409acf0bc6e08.html"/>
+        <files mask="pages.html"/>
+        <files mask="group__adc16.html"/>
+        <files mask="dir_941917524c95f00c85ae4653cfaa2b49.html"/>
+        <files mask="dir_374e18622866037be9365632d7f326d3.html"/>
+        <files mask="group__uart__driver.html"/>
+        <files mask="group__gpio.html"/>
+        <files mask="dir_bf71e8795d5ec3bf1a04b9a740296e07.html"/>
+        <files mask="group__dspi.html"/>
+        <files mask="group__flexcan.html"/>
+        <files mask="group__lpi2c__driver.html"/>
+        <files mask="dir_d0b0cea4c1afa919405231e98537b73c.html"/>
+        <files mask="dir_c5a52a81292cf9a5167198f4f346d6d9.html"/>
+        <files mask="group__rcm.html"/>
+        <files mask="group__ltc__driver__aes.html"/>
+        <files mask="group__rnga__driver.html"/>
+        <files mask="dir_e78230b9814187c44d2cfec602885c0a.html"/>
+        <files mask="group__flash__driver.html"/>
+        <files mask="group__qspi.html"/>
+        <files mask="group__trgmux__driver.html"/>
+        <files mask="group__smartcard__emvsim__driver.html"/>
+        <files mask="dir_b38072318156de4984ac57667f7c931f.html"/>
+        <files mask="dir_b5759f6cd324301c8d375e44421eccc5.html"/>
+        <files mask="group__wdog__driver.html"/>
+        <files mask="group__lmem__cache.html"/>
+        <files mask="dir_c938a579b44771c570cc4401caca1213.html"/>
+      </source>
+      <source path="docs/Kinetis SDK v.2.0 API Reference Manual" type="image">
+        <files mask="Kinetis_SDK_Block_Diagram.jpg"/>
+        <files mask="tab_b.png"/>
+        <files mask="open.png"/>
+        <files mask="ftv2blank.png"/>
+        <files mask="ftv2folderclosed.png"/>
+        <files mask="ftv2splitbar.png"/>
+        <files mask="arm_logo.png"/>
+        <files mask="tab_a.png"/>
+        <files mask="ftv2mnode.png"/>
+        <files mask="nav_h.png"/>
+        <files mask="ftv2folderopen.png"/>
+        <files mask="sync_on.png"/>
+        <files mask="ftv2plastnode.png"/>
+        <files mask="ftv2mo.png"/>
+        <files mask="ftv2ns.png"/>
+        <files mask="nav_g.png"/>
+        <files mask="ftv2lastnode.png"/>
+        <files mask="ftv2link.png"/>
+        <files mask="tab_s.png"/>
+        <files mask="doxygen.png"/>
+        <files mask="ftv2cl.png"/>
+        <files mask="ftv2node.png"/>
+        <files mask="sync_off.png"/>
+        <files mask="ftv2vertline.png"/>
+        <files mask="nav_f.png"/>
+        <files mask="tab_h.png"/>
+        <files mask="bdwn.png"/>
+        <files mask="ftv2mlastnode.png"/>
+        <files mask="closed.png"/>
+        <files mask="bc_s.png"/>
+        <files mask="ftv2pnode.png"/>
+        <files mask="ftv2doc.png"/>
+      </source>
+      <source path="docs/Kinetis SDK v.2.0 API Reference Manual/search" type="script">
+        <files mask="functions_3.js"/>
+        <files mask="functions_d.js"/>
+        <files mask="all_6.js"/>
+        <files mask="variables_14.js"/>
+        <files mask="groups_d.js"/>
+        <files mask="groups_11.js"/>
+        <files mask="enums_e.js"/>
+        <files mask="variables_1.js"/>
+        <files mask="classes_6.js"/>
+        <files mask="functions_9.js"/>
+        <files mask="all_15.js"/>
+        <files mask="enums_12.js"/>
+        <files mask="groups_e.js"/>
+        <files mask="pages_1.js"/>
+        <files mask="all_17.js"/>
+        <files mask="variables_7.js"/>
+        <files mask="typedefs_6.js"/>
+        <files mask="variables_0.js"/>
+        <files mask="all_a.js"/>
+        <files mask="functions_4.js"/>
+        <files mask="groups_f.js"/>
+        <files mask="variables_6.js"/>
+        <files mask="functions_8.js"/>
+        <files mask="typedefs_5.js"/>
+        <files mask="all_8.js"/>
+        <files mask="all_4.js"/>
+        <files mask="variables_e.js"/>
+        <files mask="all_1.js"/>
+        <files mask="variables_15.js"/>
+        <files mask="classes_a.js"/>
+        <files mask="functions_f.js"/>
+        <files mask="classes_8.js"/>
+        <files mask="classes_12.js"/>
+        <files mask="variables_17.js"/>
+        <files mask="functions_7.js"/>
+        <files mask="classes_1.js"/>
+        <files mask="classes_4.js"/>
+        <files mask="classes_2.js"/>
+        <files mask="enums_10.js"/>
+        <files mask="all_18.js"/>
+        <files mask="groups_8.js"/>
+        <files mask="classes_b.js"/>
+        <files mask="variables_10.js"/>
+        <files mask="variables_a.js"/>
+        <files mask="functions_a.js"/>
+        <files mask="all_11.js"/>
+        <files mask="enums_b.js"/>
+        <files mask="functions_1.js"/>
+        <files mask="variables_b.js"/>
+        <files mask="typedefs_0.js"/>
+        <files mask="typedefs_4.js"/>
+        <files mask="enums_7.js"/>
+        <files mask="enums_c.js"/>
+        <files mask="typedefs_2.js"/>
+        <files mask="groups_a.js"/>
+        <files mask="groups_6.js"/>
+        <files mask="classes_9.js"/>
+        <files mask="enums_3.js"/>
+        <files mask="groups_b.js"/>
+        <files mask="typedefs_7.js"/>
+        <files mask="enums_6.js"/>
+        <files mask="enums_8.js"/>
+        <files mask="enums_4.js"/>
+        <files mask="all_0.js"/>
+        <files mask="classes_d.js"/>
+        <files mask="enums_11.js"/>
+        <files mask="typedefs_3.js"/>
+        <files mask="variables_c.js"/>
+        <files mask="functions_6.js"/>
+        <files mask="classes_5.js"/>
+        <files mask="classes_11.js"/>
+        <files mask="variables_13.js"/>
+        <files mask="variables_12.js"/>
+        <files mask="variables_f.js"/>
+        <files mask="enums_13.js"/>
+        <files mask="variables_8.js"/>
+        <files mask="enums_5.js"/>
+        <files mask="groups_3.js"/>
+        <files mask="enums_f.js"/>
+        <files mask="classes_c.js"/>
+        <files mask="enums_1.js"/>
+        <files mask="groups_5.js"/>
+        <files mask="variables_d.js"/>
+        <files mask="enumvalues_0.js"/>
+        <files mask="all_5.js"/>
+        <files mask="groups_c.js"/>
+        <files mask="enums_a.js"/>
+        <files mask="all_10.js"/>
+        <files mask="functions_2.js"/>
+        <files mask="all_14.js"/>
+        <files mask="functions_e.js"/>
+        <files mask="groups_1.js"/>
+        <files mask="search.js"/>
+        <files mask="groups_0.js"/>
+        <files mask="variables_16.js"/>
+        <files mask="variables_5.js"/>
+        <files mask="pages_2.js"/>
+        <files mask="enums_2.js"/>
+        <files mask="variables_2.js"/>
+        <files mask="functions_5.js"/>
+        <files mask="pages_3.js"/>
+        <files mask="all_d.js"/>
+        <files mask="all_13.js"/>
+        <files mask="all_7.js"/>
+        <files mask="variables_3.js"/>
+        <files mask="functions_0.js"/>
+        <files mask="all_f.js"/>
+        <files mask="classes_f.js"/>
+        <files mask="variables_11.js"/>
+        <files mask="all_c.js"/>
+        <files mask="typedefs_1.js"/>
+        <files mask="groups_4.js"/>
+        <files mask="functions_11.js"/>
+        <files mask="typedefs_8.js"/>
+        <files mask="all_e.js"/>
+        <files mask="classes_e.js"/>
+        <files mask="pages_0.js"/>
+        <files mask="all_3.js"/>
+        <files mask="functions_c.js"/>
+        <files mask="classes_0.js"/>
+        <files mask="functions_b.js"/>
+        <files mask="groups_7.js"/>
+        <files mask="variables_9.js"/>
+        <files mask="enums_9.js"/>
+        <files mask="classes_13.js"/>
+        <files mask="variables_4.js"/>
+        <files mask="all_2.js"/>
+        <files mask="enums_0.js"/>
+        <files mask="all_12.js"/>
+        <files mask="functions_12.js"/>
+        <files mask="classes_7.js"/>
+        <files mask="functions_10.js"/>
+        <files mask="classes_10.js"/>
+        <files mask="groups_9.js"/>
+        <files mask="all_16.js"/>
+        <files mask="groups_10.js"/>
+        <files mask="enums_d.js"/>
+        <files mask="groups_2.js"/>
+        <files mask="all_b.js"/>
+        <files mask="all_9.js"/>
+        <files mask="classes_3.js"/>
+      </source>
+      <source path="docs/Kinetis SDK v.2.0 API Reference Manual/search" type="doc">
+        <files mask="search.css"/>
+        <files mask="functions_1.html"/>
+        <files mask="classes_1.html"/>
+        <files mask="functions_c.html"/>
+        <files mask="variables_11.html"/>
+        <files mask="groups_c.html"/>
+        <files mask="all_4.html"/>
+        <files mask="all_17.html"/>
+        <files mask="classes_2.html"/>
+        <files mask="variables_14.html"/>
+        <files mask="enums_3.html"/>
+        <files mask="enums_8.html"/>
+        <files mask="groups_d.html"/>
+        <files mask="classes_d.html"/>
+        <files mask="functions_10.html"/>
+        <files mask="all_8.html"/>
+        <files mask="groups_1.html"/>
+        <files mask="all_14.html"/>
+        <files mask="variables_7.html"/>
+        <files mask="all_7.html"/>
+        <files mask="all_13.html"/>
+        <files mask="all_a.html"/>
+        <files mask="typedefs_6.html"/>
+        <files mask="enums_f.html"/>
+        <files mask="variables_17.html"/>
+        <files mask="variables_12.html"/>
+        <files mask="classes_5.html"/>
+        <files mask="pages_3.html"/>
+        <files mask="enums_5.html"/>
+        <files mask="variables_2.html"/>
+        <files mask="classes_7.html"/>
+        <files mask="functions_f.html"/>
+        <files mask="typedefs_5.html"/>
+        <files mask="functions_5.html"/>
+        <files mask="groups_9.html"/>
+        <files mask="classes_0.html"/>
+        <files mask="variables_9.html"/>
+        <files mask="all_3.html"/>
+        <files mask="functions_9.html"/>
+        <files mask="all_f.html"/>
+        <files mask="functions_7.html"/>
+        <files mask="functions_e.html"/>
+        <files mask="typedefs_2.html"/>
+        <files mask="all_16.html"/>
+        <files mask="variables_5.html"/>
+        <files mask="groups_6.html"/>
+        <files mask="classes_8.html"/>
+        <files mask="functions_6.html"/>
+        <files mask="classes_6.html"/>
+        <files mask="variables_a.html"/>
+        <files mask="all_10.html"/>
+        <files mask="enums_13.html"/>
+        <files mask="variables_8.html"/>
+        <files mask="functions_4.html"/>
+        <files mask="nomatches.html"/>
+        <files mask="groups_11.html"/>
+        <files mask="functions_a.html"/>
+        <files mask="all_15.html"/>
+        <files mask="all_12.html"/>
+        <files mask="classes_4.html"/>
+        <files mask="variables_e.html"/>
+        <files mask="variables_4.html"/>
+        <files mask="variables_6.html"/>
+        <files mask="all_b.html"/>
+        <files mask="functions_3.html"/>
+        <files mask="all_11.html"/>
+        <files mask="pages_1.html"/>
+        <files mask="enums_2.html"/>
+        <files mask="enums_1.html"/>
+        <files mask="groups_2.html"/>
+        <files mask="classes_e.html"/>
+        <files mask="enumvalues_0.html"/>
+        <files mask="typedefs_3.html"/>
+        <files mask="enums_11.html"/>
+        <files mask="classes_b.html"/>
+        <files mask="variables_15.html"/>
+        <files mask="enums_4.html"/>
+        <files mask="functions_b.html"/>
+        <files mask="enums_7.html"/>
+        <files mask="enums_6.html"/>
+        <files mask="all_9.html"/>
+        <files mask="classes_3.html"/>
+        <files mask="all_e.html"/>
+        <files mask="functions_d.html"/>
+        <files mask="groups_10.html"/>
+        <files mask="typedefs_0.html"/>
+        <files mask="typedefs_7.html"/>
+        <files mask="pages_0.html"/>
+        <files mask="typedefs_1.html"/>
+        <files mask="all_c.html"/>
+        <files mask="variables_f.html"/>
+        <files mask="all_5.html"/>
+        <files mask="typedefs_8.html"/>
+        <files mask="classes_13.html"/>
+        <files mask="variables_0.html"/>
+        <files mask="variables_3.html"/>
+        <files mask="variables_b.html"/>
+        <files mask="enums_d.html"/>
+        <files mask="groups_f.html"/>
+        <files mask="functions_2.html"/>
+        <files mask="functions_0.html"/>
+        <files mask="groups_a.html"/>
+        <files mask="functions_8.html"/>
+        <files mask="enums_12.html"/>
+        <files mask="classes_9.html"/>
+        <files mask="pages_2.html"/>
+        <files mask="classes_f.html"/>
+        <files mask="all_d.html"/>
+        <files mask="variables_1.html"/>
+        <files mask="variables_d.html"/>
+        <files mask="variables_16.html"/>
+        <files mask="classes_12.html"/>
+        <files mask="enums_9.html"/>
+        <files mask="classes_10.html"/>
+        <files mask="variables_13.html"/>
+        <files mask="classes_11.html"/>
+        <files mask="groups_e.html"/>
+        <files mask="all_6.html"/>
+        <files mask="enums_0.html"/>
+        <files mask="groups_b.html"/>
+        <files mask="all_18.html"/>
+        <files mask="groups_3.html"/>
+        <files mask="classes_a.html"/>
+        <files mask="typedefs_4.html"/>
+        <files mask="groups_5.html"/>
+        <files mask="classes_c.html"/>
+        <files mask="variables_10.html"/>
+        <files mask="functions_11.html"/>
+        <files mask="groups_4.html"/>
+        <files mask="functions_12.html"/>
+        <files mask="enums_e.html"/>
+        <files mask="enums_b.html"/>
+        <files mask="groups_0.html"/>
+        <files mask="all_2.html"/>
+        <files mask="groups_8.html"/>
+        <files mask="enums_c.html"/>
+        <files mask="variables_c.html"/>
+        <files mask="all_1.html"/>
+        <files mask="groups_7.html"/>
+        <files mask="enums_10.html"/>
+        <files mask="enums_a.html"/>
+        <files mask="all_0.html"/>
+      </source>
+      <source path="docs/Kinetis SDK v.2.0 API Reference Manual/search" type="image">
+        <files mask="search_l.png"/>
+        <files mask="close.png"/>
+        <files mask="mag_sel.png"/>
+        <files mask="search_m.png"/>
+        <files mask="search_r.png"/>
+      </source>
+    </component>
+    <component name="USB" type="documentation" version="1.0.0">
+      <source path="docs/usb" type="doc">
+        <files mask="USB Stack User's Guide.pdf"/>
+        <files mask="USB Stack Composite Device User's Guide.pdf"/>
+        <files mask="USB Stack Host Reference Manual.pdf"/>
+        <files mask="USB Stack Device Reference Manual.pdf"/>
+      </source>
+    </component>
+    <component name="lwip" type="documentation" dependency="enet lwip" device="MK64F12" version="1.0.0">
+      <source path="docs/lwip" type="doc">
+        <files mask="lwIP TCPIP Stack and Kinetis SDK Integration User's Guide.pdf"/>
+      </source>
+    </component>
+    <component name="SCR" type="SCR" version="1.0.0">
+      <source path="" type="doc">
+        <files mask="SW-Content-Register-KSDK_2.0.0_GA.txt"/>
+      </source>
+    </component>
+    <component name="EULA" type="EULA" version="1.0.0">
+      <source path="" type="doc">
+        <files mask="LA_OPT_Base_License.htm"/>
+      </source>
+    </component>
+    <component name="Include" type="CMSIS">
+      <source path="CMSIS/Include" type="c_include">
+        <files mask="*$|core|*.h"/>
+        <files mask="*cmSimd.h"/>
+        <files mask="*cmFunc.h"/>
+        <files mask="*cmInstr.h"/>
+        <files mask="arm*.h"/>
+        <files mask="cmsis_*.h"/>
+      </source>
+      <source path="devices/$|device|" type="c_include">
+        <files mask="fsl_device_registers.h"/>
+        <files mask="$|device|.h"/>
+        <files mask="$|device|_features.h"/>
+      </source>
+    </component>
+    <component name="startup" type="startup">
+      <source path="devices/$|device|/$|compiler|" type="asm_include">
+        <files mask="*.s"/>
+        <files mask="*.S"/>
+      </source>
+      <source path="devices/$|device|" type="c_include">
+        <files mask="system_$|device|.h"/>
+      </source>
+      <source path="devices/$|device|" type="src">
+        <files mask="system_$|device|.c"/>
+      </source>
+    </component>
+    <component name="linker" type="linker">
+      <source path="devices/$|device|/$|compiler|" type="linker" variant="flash">
+        <files mask="$|device_full_name|_flash.*"/>
+      </source>
+      <source path="devices/$|device|/$|compiler|" type="linker" variant="ram">
+        <files mask="$|device_full_name|_ram.*"/>
+      </source>
+    </component>
+  </components>
+</ksdk:manifest>

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/LA_OPT_Base_License.htm
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/LA_OPT_Base_License.htm
@@ -1,0 +1,1102 @@
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=windows-1252">
+<meta name=Generator content="Microsoft Word 15 (filtered)">
+<style>
+<!--
+ /* Font Definitions */
+ @font-face
+	{font-family:Wingdings;
+	panose-1:5 0 0 0 0 0 0 0 0 0;}
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+@font-face
+	{font-family:"Segoe UI";
+	panose-1:2 11 5 2 4 2 4 2 2 3;}
+ /* Style Definitions */
+ p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin-top:0in;
+	margin-right:0in;
+	margin-bottom:8.0pt;
+	margin-left:0in;
+	line-height:107%;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;}
+a:link, span.MsoHyperlink
+	{color:blue;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{color:#954F72;
+	text-decoration:underline;}
+p.MsoDocumentMap, li.MsoDocumentMap, div.MsoDocumentMap
+	{mso-style-link:"Document Map Char";
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:8.0pt;
+	margin-left:0in;
+	line-height:107%;
+	font-size:12.0pt;
+	font-family:"Times New Roman",serif;}
+p.MsoAcetate, li.MsoAcetate, div.MsoAcetate
+	{mso-style-link:"Balloon Text Char";
+	margin:0in;
+	margin-bottom:.0001pt;
+	font-size:9.0pt;
+	font-family:"Segoe UI",sans-serif;}
+span.baec5a81-e4d6-4674-97f3-e9220f0136c1
+	{mso-style-name:baec5a81-e4d6-4674-97f3-e9220f0136c1;}
+span.BalloonTextChar
+	{mso-style-name:"Balloon Text Char";
+	mso-style-link:"Balloon Text";
+	font-family:"Segoe UI",sans-serif;}
+span.DocumentMapChar
+	{mso-style-name:"Document Map Char";
+	mso-style-link:"Document Map";
+	font-family:"Times New Roman",serif;}
+@page WordSection1
+	{size:8.5in 11.0in;
+	margin:1.0in 1.0in 1.0in 1.0in;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+ ol
+	{margin-bottom:0in;}
+ul
+	{margin-bottom:0in;}
+-->
+</style>
+
+</head>
+
+<body lang=EN-US link=blue vlink="#954F72">
+
+<div class=WordSection1>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
+normal'><a name="OLE_LINK5"></a><a name="OLE_LINK4"><span lang=EN-GB
+style='font-size:10.0pt'>LA_OPT_BASE_LICENSE v13 March 2016</span></a></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
+normal'><b>&nbsp;</b></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
+normal'><b>IMPORTANT. &nbsp;Read the following NXP Semiconductors Software
+License Agreement (“Agreement”) completely.&nbsp; &nbsp;&nbsp;By selecting the
+“I Accept” button at the end of this page, you indicate that you accept the
+terms of the Agreement and you acknowledge that you have the authority, for
+yourself or on behalf of your company, to bind your company to these
+terms.&nbsp; You may then download or install the file. </b></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
+normal'>&nbsp;</p>
+
+<p class=MsoNormal align=center style='margin-bottom:0in;margin-bottom:.0001pt;
+text-align:center;line-height:normal;page-break-after:avoid'><b><u>NXP
+SEMICONDUCTORS&nbsp;SOFTWARE LICENSE AGREEMENT</u></b></p>
+
+<p class=MsoNormal align=center style='margin-bottom:0in;margin-bottom:.0001pt;
+text-align:center;line-height:normal;page-break-after:avoid'>&nbsp;</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>This is a
+legal agreement between you, as an authorized representative of your employer,
+or if you have no employer, as an individual (together “you”), and Freescale
+Semiconductor, Inc<a name="OLE_LINK14"></a><a name="OLE_LINK13">., a
+wholly-owned subsidiary of NXP Semiconductors N.V. (“NXP”)</a>.&nbsp; It
+concerns your rights to use the software identified in the Software Content
+Register and provided to you in binary or source code form and any accompanying
+written materials (the “Licensed Software”). The Licensed Software may include
+any updates or error corrections or documentation relating to the Licensed
+Software provided to you by NXP under this License. In consideration for NXP
+allowing you to access the Licensed Software, you are agreeing to be bound by
+the terms of this Agreement. If you do not agree to all of the terms of this Agreement,
+do not download or install the Licensed Software. If you change your mind
+later, stop using the Licensed Software and delete all copies of the Licensed
+Software in your possession or control. Any copies of the Licensed Software
+that you have already distributed, where permitted, and do not destroy will
+continue to be governed by this Agreement. Your prior use will also continue to
+be governed by this Agreement.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>1.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>DEFINITIONS</u></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>1.1.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>“Affiliates” means, any corporation, or entity directly or indirectly
+controlled by, controlling, or under common control with <a name="OLE_LINK16"></a><a
+name="OLE_LINK15">NXP Semiconductors N.V.</a></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>1.2.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>“Essential Patent” means&nbsp;a patent to the limited extent that
+infringement of such patent cannot be avoided in remaining compliant with the
+technology standards&nbsp;implicated by the usage of any of the&nbsp;Licensed
+Software, including optional implementation of the standards, on technical but
+not commercial grounds, taking into account normal technical practice and the
+state of the art generally available at the time of standardization.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>1.3.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>“Intellectual Property Rights” means any and all rights under statute,
+common law or equity in and&nbsp;under copyrights, trade secrets, and patents
+(including utility models), and analogous rights throughout the
+world,&nbsp;including any applications for and the right to apply for, any of
+the foregoing.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>1.4.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>“Software Content Register” means the documentation accompanying the
+Licensed Software which identifies the contents of the Licensed Software, including
+but not limited to identification of any Third Party Software.&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>1.5.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>“Third Party Software” means, any software included in the Licensed
+Software that is not NXP Proprietary software, and is not open source software,
+and to which different license terms may apply. </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+style='font-size:10.5pt;line-height:115%'>2.</span><span style='font-size:7.0pt;
+line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>LICENSE GRANT.&nbsp; </u></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>2.1.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Separate license grants to Third Party Software, or other terms
+applicable to the Licensed Software if different from those granted in this
+Section 2, are contained in Appendix A.&nbsp; The Licensed Software is
+accompanied by a Software Content Register which will identify that portion of
+the Licensed Software, if any, that is subject to the different terms in
+Appendix A.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>2.2.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Exclusively in connection with your development and distribution of
+product containing a programmable processing unit (e.g. a microprocessor,
+microcontroller, sensor or digital signal processor) supplied directly or
+indirectly from NXP (“Authorized System”) NXP grants you a world-wide,
+personal, non-transferable, non-exclusive, non-sublicensable, license, under NXP’s
+Intellectual Property Rights:</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.75in;line-height:
+115%'>(a)<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;
+</span>to use and reproduce the Licensed Software only as part of, or
+integrated within, Authorized Systems and not on a standalone basis;</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.75in;line-height:
+115%'>(b)<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;
+</span>to directly or indirectly manufacture, demonstrate, copy, distribute,
+market and sell the Licensed Software in object code (machine readable) only as
+part of, or embedded within, Authorized Systems in object code form and not on
+a standalone basis.&nbsp; Notwithstanding the foregoing, those files marked as
+.h files (“Header files”) may be distributed in source or object code form, but
+only as part of, or embedded within Authorized Systems. </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.75in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>(c)</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;
+</span>to copy, use and distribute as needed, solely in connection with an
+Authorized System, proprietary NXP information associated with the Licensed
+Software for the purpose of developing, maintaining and supporting Authorized
+Systems with which the Licensed Software is integrated or associated.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>2.3.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>For NXP Licensed Software provided to you in source code form (human
+readable), NXP further grants to you a worldwide, personal, non-transferable,
+non-exclusive, non-sublicensable, license, under NXP’s Intellectual Property
+Rights:</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.75in;line-height:
+115%'>(a)<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;
+</span>to prepare derivative works of the Licensed Software, only as part of,
+or integrated within, Authorized Systems and not on a standalone basis;</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.75in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>(b)</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;
+</span>to use, demonstrate, copy, distribute, market and sell the derivative
+works of the Licensed Software in object code (machine readable) only as part of,
+or integrated within, Authorized Systems and not on a standalone basis.
+&nbsp;Notwithstanding the foregoing, those files marked as .h files (“Header
+files”) may be distributed in source or object code form, but only as part of,
+or embedded within Authorized Systems.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>2.4.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>You may use subcontractors on your premises to exercise your rights
+under Section 2.2 and 2.3 so long as you have an agreement in place with the
+subcontractor containing confidentiality restrictions no less stringent than
+those contained in this Agreement.&nbsp; You will remain liable for your
+subcontractors’ adherence to the terms of this Agreement and for any and all
+acts and omissions of such subcontractors with respect to this Agreement and
+the Licensed Software.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>3.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>LICENSE LIMITATIONS AND RESTRICTIONS.&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.1.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>The licenses granted above in Section 2.3 only extend to NXP
+intellectual property rights that would be infringed by the Licensed Software
+prior to your preparation of any derivative work.&nbsp;&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.2.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>The Licensed Software is licensed to you, not sold.&nbsp; Title to
+Licensed Software delivered hereunder remains vested in NXP or NXP's licensor
+and cannot be assigned or transferred.&nbsp; You are expressly forbidden from
+selling or otherwise distributing the Licensed Software, or any portion
+thereof, except as expressly permitted herein.&nbsp; This Agreement does not
+grant to you any implied rights under any NXP or third party intellectual
+property.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.3.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>You may not translate, reverse engineer, decompile, or disassemble the
+Licensed Software except to the extent applicable law specifically prohibits
+such restriction.&nbsp; You must prohibit your sub-licensees from translating,
+reverse engineering, decompiling, or disassembling the Licensed Software except
+to the extent applicable law specifically prohibits such restriction.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.4.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>You must reproduce any and all of NXP's (or its third party licensor’s)
+copyright notices and other proprietary legends on copies of Licensed
+Software.&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.5.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>If you distribute the Licensed Software to the United States Government,
+then the Licensed Software is “restricted computer software” and is subject to
+FAR 52.227-19 (c)(1) and (c)(2).&nbsp;&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.6.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>You grant to NXP a non-exclusive, non-transferable, irrevocable,
+perpetual, worldwide, royalty-free, sub-licensable license under your
+Intellectual Property Rights to use without restriction and for any purpose any
+suggestion, comment or other feedback related to the Licensed Software
+(including, but not limited to, error corrections and bug fixes).</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>3.7.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>You will not take or fail to take any action that could subject the
+Licensed Software to an Excluded License. An Excluded License means any license
+that requires, as a condition of use, modification or distribution of software
+subject to the Excluded License, that such software or other software combined
+and/or distributed with the software be (i) disclosed or distributed in source
+code form; (ii) licensed for the purpose of making derivative works; or (iii)
+redistributable at no charge.&nbsp;</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>3.8.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span style='font-size:10.5pt;line-height:115%'>You may not publish or
+distribute information, results or data associated with the use of the Licensed
+Software to anyone other than NXP; however, you must advise NXP of any results
+obtained including any problems or suggested improvements thereof.&nbsp; NXP
+retains the right to use such results and related information in any manner it
+deems appropriate. </span></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>4.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>OPEN SOURCE</u>.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Open
+source software included in the Licensed Software is not licensed under the
+terms of this Agreement, but is instead licensed under the terms of the
+applicable open source license(s), such as the BSD License, Apache License or
+the GNU Lesser General Public License.&nbsp; Your use of the open source
+software is subject to the terms of each applicable license.&nbsp; You must
+agree to the terms of each applicable license, or you cannot use the open
+source software.&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>5.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>INTELLECTUAL PROPERTY RIGHTS</u>. &nbsp;&nbsp; Subject to NXP’s
+ownership interest in the underlying Licensed Software, all intellectual
+property rights associated with, and title to, your Authorized System will be
+retained by or will vest in you. Your modifications to the Licensed Software,
+and all intellectual property rights associated with, and title thereto, will
+be the property of NXP.&nbsp; Upon request, you must provide NXP the source
+code of any derivative of the Licensed Software.&nbsp; You agree to assign all,
+and hereby do assign all rights, title, and interest to any such modifications
+to the Licensed Software to NXP and agree to provide all assistance reasonably
+requested by NXP to establish, preserve or enforce such right.&nbsp; Further,
+you agree to waive all moral rights relating to your modifications to the
+Licensed Software, including, without limitation, all rights of identification
+of authorship and all rights of approval, restriction, or limitation on use or
+subsequent modification.&nbsp; Notwithstanding the foregoing, you will have the
+license rights granted in Section 2 hereto to any such modifications made by
+you or your licensees.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>6.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>PATENT COVENANT NOT TO SUE</u>. As partial, material consideration
+for the rights granted to you under this Agreement, you covenant not to sue or
+otherwise assert your patents against NXP, a NXP Affiliate or subsidiary, or a NXP
+licensee of the Licensed Software for infringement of your Intellectual
+Property Rights by the manufacture, use, sale, offer for sale, importation or
+other disposition or promotion of the Licensed Software and/or any
+redistributed portions of the Licensed Software.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>7.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>ESSENTIAL PATENTS</u>.&nbsp; You are solely responsible for obtaining
+licenses for any relevant Essential Patents for your use in connection with
+technology that you incorporate into your product (whether as part of the
+Licensed Software or not).</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>8.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>TERM AND TERMINATION</u>.&nbsp;&nbsp; This Agreement will remain in
+effect unless terminated as provided in this Section 8.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>8.1.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>You may terminate this Agreement immediately upon written notice to NXP
+at the address provided below.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>8.2.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Either party may terminate this Agreement if the other party is in
+default of any of the terms and conditions of this Agreement, and termination
+is effective if the defaulting party fails to correct such default within 30
+days after written notice thereof by the non-defaulting party to the defaulting
+party at the address below.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>8.3.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span style='font-size:10.5pt;line-height:115%'>Notwithstanding the
+foregoing, NXP may terminate this Agreement immediately upon written notice if
+you: breach any of your confidentiality obligations or the license restrictions
+under this Agreement;&nbsp; become bankrupt, insolvent, or file a petition for
+bankruptcy or insolvency, make an assignment for the benefit of its creditors;
+enter proceedings for winding up or dissolution ;are dissolved; or</span> are
+nationalized or become subject to the expropriation of all or substantially all
+of its business or assets.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>8.4.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Upon termination of this Agreement, all licenses granted under Section 2
+will expire, except that any licenses extended to end-users pursuant to
+Sections 2.2(b), 2.2(c), and 2.3(b), which have been granted prior to such
+termination will survive.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>8.5.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>After termination of this Agreement by either party and upon NXP’s
+written request, you will, at your discretion, return to the NXP any
+confidential information including all copies thereof or furnish to NXP at the
+address below, a statement certifying, with respect to the Licensed Software
+delivered hereunder that the original and all copies, except for archival
+copies to be used solely for dispute resolution purposes, in whole or in part,
+in any form, of the Licensed Software have been destroyed.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>8.6.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Notwithstanding the termination of this Agreement for any reason, the
+terms of Sections 1, 3, 5 through 25 will survive.&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>9.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>SUPPORT</u>.&nbsp; NXP is not obligated to provide any support,
+upgrades or new releases of the Licensed Software under this Agreement. If you
+wish, you may contact NXP and report problems and provide suggestions regarding
+the Licensed Software. NXP has no obligation to respond to such a problem
+report or suggestion. NXP may make changes to the Licensed Software at any
+time, without any obligation to notify or provide updated versions of the
+Licensed Software to you.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>10.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>NO WARRANTY</u>.&nbsp; To the maximum extent permitted by law, NXP
+expressly disclaims any warranty for the Licensed Software.&nbsp; The Licensed
+Software is provided “AS IS”, without warranty of any kind, either express or
+implied, including without limitation the implied warranties of
+merchantability, fitness for a particular purpose, or non-infringement.&nbsp;
+You assume the entire risk arising out of the use or performance of the
+licensed software, or any systems you design using the licensed software (if
+any).</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>11.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>INDEMNITY</u>. You agree to fully defend and indemnify NXP from all
+claims, liabilities, and costs (including reasonable attorney’s fees) related
+to (1) your use (including your contractors or distributee’s use, if permitted)
+of the Licensed Software or (2) your violation of the terms and conditions of
+this Agreement.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>12.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>LIMITATION OF LIABILITY</u>.&nbsp; EXCLUDING LIABILITY FOR A BREACH
+OF SECTION&nbsp;2 (LICENSE GRANTS), SECTION 3 (LICENSE LIMITATIONS AND
+RESTRICTIONS), SECTION 17 (CONFIDENTIAL INFORMATION), OR CLAIMS UNDER SECTION
+11(INDEMNITY), IN NO EVENT WILL EITHER PARTY BE LIABLE, WHETHER IN CONTRACT,
+TORT, OR OTHERWISE, FOR ANY INCIDENTAL, SPECIAL, INDIRECT, CONSEQUENTIAL OR
+PUNITIVE DAMAGES, INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR ANY LOSS OF USE,
+LOSS OF TIME, INCONVENIENCE, COMMERCIAL LOSS, OR LOST PROFITS, SAVINGS, OR
+REVENUES, TO THE FULL EXTENT SUCH MAY BE DISCLAIMED BY LAW.&nbsp; NXP’S TOTAL
+LIABILITY FOR ALL COSTS, DAMAGES, CLAIMS, OR LOSSES WHATSOEVER ARISING OUT OF
+OR IN CONNECTION WITH THIS AGREEMENT OR PRODUCT(S) SUPPLIED UNDER THIS
+AGREEMENT IS LIMITED TO THE AGGREGATE AMOUNT PAID BY YOU TO NXP IN CONNECTION
+WITH THE LICENSED SOFTWARE TO WHICH LOSSES OR DAMAGES ARE CLAIMED.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+style='font-size:10.5pt;line-height:115%'>13.</span><span style='font-size:
+7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>EXPORT <a name="OLE_LINK18"></a><a name="OLE_LINK17">COMPLIANCE. Each
+party shall comply with all applicable export and import control laws and
+regulations including but not limited to the US Export Administration
+Regulations (including prohibited party lists issued by other federal
+governments), Catch-all regulations and all national and international
+embargoes. Each party further agrees that it will not knowingly transfer,
+divert, export or re-export, directly or indirectly, any product, software,
+including software source code, or technology restricted by such regulations or
+by other applicable national regulations, received from the other party under
+this Agreement, or any direct product of such software or technical data to any
+person, firm, entity, country or destination to which such transfer, diversion,
+export or re-export is restricted or prohibited, without obtaining prior written
+authorization from the applicable competent government authorities to the
+extent required by those laws</a>.</u></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>14.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;
+</span><u>GOVERNMENT CONTRACT COMPLIANCE.</u></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'><span style='font-size:10.5pt;line-height:115%'>14.1.</span><span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>If you sell Authorized Systems directly to any government or public
+entity, including U.S., state, local, foreign or international governments or
+public entities, or indirectly via a prime contractor or subcontractor of such
+governments or entities, NXP makes no representations, certifications, or
+warranties whatsoever about compliance with government or public entity
+acquisition statutes or regulations, including, without limitation, statutes or
+regulations that may relate to pricing, quality, origin or content.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>14.2.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>The Licensed Software has been developed at private expense and is a “Commercial
+Item” as defined in 48 C.F.R. §2.101, consisting of “Commercial Computer
+Software”, and/or “Commercial Computer Software Documentation,” as such terms
+are used in 48 C.F.R. §12.212 (or 48 C.F.R. §227.7202, as applicable) and may
+only be licensed to or shared with U.S. Government end users in object code
+form as part of, or embedded within, Authorized Systems.&nbsp; Any agreement
+pursuant to which you share the Licensed Software will include a provision that
+reiterates the limitations of this document and requires all sub-agreements to
+similarly contain such limitations. </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>15.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u><span style='font-size:10.5pt;line-height:115%'>SAFETY CRITICAL
+APPLICATIONS</span></u></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>15.1.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>In some cases, NXP may promote certain Licensed Software for use in
+safety-related applications. NXP’s goal is to educate licensees so that they
+can design their own end-product solutions to meet applicable functional safety
+standards and requirements.&nbsp; You make the ultimate design decisions
+regarding your products and are solely responsible for compliance with all legal,
+regulatory, safety, and security related requirements concerning your products,
+regardless of any information or support that may be provided by NXP.&nbsp;
+Accordingly, you will indemnify and hold NXP harmless from any claims,
+liabilities, damages and associated costs and expenses (including attorneys’
+fees) that NXP may incur related to your incorporation of any product in a
+safety-critical application or system.&nbsp; </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>15.2.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Only Licensed Software that NXP has specifically designated as
+“Automotive Qualified” is intended for use in automotive, military, or
+aerospace applications or environments.&nbsp; If you use Licensed Software that
+has not been designated as “Automotive Qualified” in an automotive, military,
+or aerospace application or environment, you do so at your own risk.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;text-indent:.25in;line-height:
+115%'>15.3.<span style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Licensed Software is not intended or authorized for any use in
+anti-personnel landmines. </p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+style='font-size:12.0pt;line-height:115%'>16.</span><span style='font-size:
+7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>CHOICE OF LAW; VENUE</u>.&nbsp; This Agreement will be governed by,
+construed, and enforced in accordance with the laws of the State of Texas, USA,
+without regard to conflicts of laws principles, will apply to all matters
+relating to this Agreement or the Licensed Software, and you agree that any
+litigation will be subject to the exclusive jurisdiction of the state or
+federal courts Texas, USA.&nbsp; <span style='font-size:12.0pt;line-height:
+115%'>The United Nations Convention on Contracts for the International Sale of
+Goods will not apply to this document. </span></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>17.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>CONFIDENTIAL INFORMATION</u>.&nbsp; Subject to the license grants and
+restrictions contained herein, you must treat the Licensed Software as
+confidential information and you agree to retain the Licensed Software in
+confidence perpetually, with respect to Licensed Software in source code form
+(human readable), or for a period of five (5) years from the date of termination
+of this Agreement, with respect to all other parts of the Licensed
+Software.&nbsp; During this period, you may not disclose any part of the
+Licensed Software to anyone other than employees who have a need to know of the
+Licensed Software and who have executed written agreements obligating them to
+protect such Licensed Software to at least the same degree of care as in this
+Agreement.&nbsp; You agree to use the same degree of care, but no less than a
+reasonable degree of care, with the Licensed Software as you do with your own
+confidential information. You may disclose Licensed Software to the extent
+required by a court or under operation of law or order provided that you notify
+NXP of such requirement prior to disclosure, which you only disclose
+information required, and that you allow NXP the opportunity to object to such
+court or other legal body requiring such disclosure.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>18.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>TRADEMARKS</u>.&nbsp; You are not authorized to use any NXP
+trademarks, brand names, or logos.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>19.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>ENTIRE AGREEMENT</u>.&nbsp; This Agreement constitutes the entire
+agreement between you and NXP regarding the subject matter of this Agreement,
+and supersedes all prior communications, negotiations, understandings,
+agreements or representations, either written or oral, if any.&nbsp; This Agreement
+may only be amended in written form, signed by you and NXP.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>20.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>SEVERABILITY</u>.&nbsp; If any provision of this Agreement is held
+for any reason to be invalid or unenforceable, then the remaining provisions of
+this Agreement will be unimpaired and, unless a modification or replacement of
+the invalid or unenforceable provision is further held to deprive you or NXP of
+a material benefit, in which case the Agreement will immediately terminate, the
+invalid or unenforceable provision will be replaced with a provision that is
+valid and enforceable and that comes closest to the intention underlying the
+invalid or unenforceable provision.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>21.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>NO WAIVER</u>.&nbsp; The waiver by NXP of any breach of any provision
+of this Agreement will not operate or be construed as a waiver of any other or
+a subsequent breach of the same or a different provision.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>22.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u><span style='font-size:10.5pt;line-height:115%'>AUDIT</span></u><span
+style='font-size:10.5pt;line-height:115%'>.&nbsp; You will keep full, clear and
+accurate records with respect to your compliance with the limited license
+rights granted under this Agreement for three years following expiration or
+termination of this Agreement. NXP will have the right, either itself or
+through an independent certified public accountant to examine and audit, at NXP’s
+expense, not more than once a year, and during normal business hours, all such
+records that may bear upon your compliance with the limited license rights
+granted above. </span>You must make prompt adjustment to compensate for any
+errors and/or omissions disclosed by such examination or audit.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>23.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>NOTICES</u>.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+All notices and&nbsp;communications under this Agreement will be made in
+writing, and will be effective when received at the following addresses: </p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;text-align:
+justify;text-indent:.5in;line-height:115%'><span lang=EN-GB style='font-size:
+12.0pt;line-height:115%'>NXP:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Freescale Semiconductor, Inc.</span></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;text-align:
+justify;text-indent:.5in;line-height:115%'><span lang=EN-GB style='font-size:
+12.0pt;line-height:115%'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;6501
+William Cannon West&nbsp;&nbsp;&nbsp; OE62</span></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;text-align:
+justify;text-indent:.5in;line-height:115%'><span lang=EN-GB style='font-size:
+12.0pt;line-height:115%'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Austin,
+Texas 78735</span></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;text-align:
+justify;text-indent:.5in;line-height:115%'><span lang=EN-GB style='font-size:
+12.0pt;line-height:115%'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ATTN:
+Legal Department</span></p>
+
+<p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;text-align:
+justify;text-indent:.5in;line-height:115%'><span lang=EN-GB style='font-size:
+12.0pt;line-height:115%'>&nbsp;</span></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+You:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The
+address provided at registration will be used.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+style='font-size:10.5pt;line-height:115%'>24.</span><span style='font-size:
+7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>RELATIONSHIP OF THE PARTIES</u>.&nbsp;&nbsp;&nbsp;&nbsp; The parties
+are independent contractors.&nbsp; Nothing in this Agreement will be construed
+to create any partnership, joint venture, or similar relationship.&nbsp;
+Neither party is authorized to bind the other to any obligations with third
+parties.</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>25.<span
+style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><u>SUCCESSION AND ASSIGNMENT</u>.&nbsp;&nbsp; This Agreement will be
+binding upon and inure to the benefit of the parties and their permitted
+successors and assigns.&nbsp; You may not assign this Agreement, or any part of
+this Agreement, without the prior written approval of NXP, which approval will
+not be unreasonably withheld or delayed.</p>
+
+<span style='font-size:11.0pt;font-family:"Calibri",sans-serif'><br clear=all
+style='page-break-before:always'>
+</span>
+
+<p class=MsoNormal style='margin-top:.25in;margin-right:0in;margin-bottom:6.0pt;
+margin-left:.5in;text-indent:-.5in;line-height:normal'>&nbsp;</p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+style='font-size:10.5pt;line-height:115%'>&nbsp;</span></p>
+
+<p class=MsoNormal align=center style='margin-bottom:10.0pt;text-align:center;
+line-height:115%'><span lang=EN-GB>APPENDIX A</span></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><u><span
+lang=EN-GB>Other License Grants and Restrictions:</span></u></p>
+
+<p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+lang=EN-GB>The Licensed Software may include some or all of the following
+software, which is either 1) not NXP proprietary software or 2) NXP proprietary
+software subject to different terms than those in the Agreement.&nbsp; If the
+Software Content Register that accompanies the Licensed Software identifies any
+of the following Third Party Software or specific components of the NXP
+Proprietary Software, the following terms apply to the extent they deviate from
+the terms in the Agreement:</span></p>
+
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+ style='border-collapse:collapse'>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><a name="OLE_LINK6"></a><a name="OLE_LINK7"></a><b><span lang=EN-GB
+  style='color:black'>Third Party Software</span></b></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border:solid windowtext 1.0pt;
+  border-left:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal align=center style='margin-bottom:10.0pt;text-align:center;
+  line-height:115%'><b><span lang=EN-GB style='color:black'>Use Restrictions</span></b></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Atheros</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Use of Atheros software is limited to
+  evaluation and demonstration only.&nbsp; </span><span style='color:black'>Permitted
+  distributions must be similarly limited.</span><span lang=EN-GB
+  style='color:black'> Further rights must be obtained directly from
+  Atheros.&nbsp; </span><span lang=EN-GB>&nbsp;</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>ATI (AMD)</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Distribution of ATI software must be </span>a
+  part of, or embedded within, Authorized Systems that include a ATI graphics
+  processor core.&nbsp;</p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Broadcom Corporation</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Your use of Broadcom Corporation software is
+  restricted to Authorized Systems that incorporate a compatible integrated
+  circuit device manufactured or sold by Broadcom.&nbsp;</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Cirque Corporation</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  style='color:black'>Use of Cirque Corporation technology is limited to
+  evaluation, demonstration, or certification testing only. Permitted
+  distributions must be similarly limited. Further rights, including but not
+  limited to ANY commercial distribution rights, must be obtained directly from
+  Cirque Corporation.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Coding Technologies (Dolby Labs) </span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Use of CTS software is limited to evaluation
+  and demonstration only.&nbsp; </span><span style='color:black'>Permitted
+  distributions must be similarly limited. </span><span lang=EN-GB
+  style='color:black'>Further rights must be obtained </span><span lang=EN-GB>from
+  Dolby Laboratories.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB>CSR</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB>Use of Cambridge Silicon Radio, Inc. (“CSR”) software is limited
+  to evaluation and demonstration only.&nbsp; Permitted distributions must be
+  similarly limited.&nbsp; Further rights must be obtained directly from CSR</span>.</p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>NXP Wireless
+  Charging Library</p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>License to
+  the Software is limited to use in inductive coupling or wireless charging
+  applications</p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB>Global Locate (Broadcom Corporation)</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB>Use of Global Locate, Inc. software is limited to evaluation and
+  demonstration only.&nbsp; Permitted distributions must be similarly
+  limited.&nbsp; Further rights must be obtained from Global
+  Locate.&nbsp;&nbsp; </span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  style='color:black'>Imagination Technologies Limited (IMG)</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>If the
+  Licensed Software includes proprietary software developed by IMG, your rights
+  are limited to a non-exclusive, world-wide right and non-transferrable and
+  non-sub-licensable license (i) to use and modify the Licensed Software and
+  documentation and (ii) to copy and distribute the Licensed Software only in
+  object code form solely for use on NXP Rayleigh products.&nbsp; If you are
+  provided with the Licensed Software in source code format, you are restricted
+  to accessing only those deliverables in source code format which are
+  necessary for you to carry out either specific customization or porting work
+  in association with NXP’s Rayleigh products or your Authorized System.</p>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>The
+  confidentiality restrictions shall continue in force without limit in time
+  notwithstanding the termination or expiration of this Agreement.</p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>Micrium</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>uC/OS-II and
+  uC/OS-III is provided in source form for FREE short-term evaluation, for
+  educational use or for peaceful research.&nbsp; If you plan or intend to use
+  uC/OS-II or uC/OS-III in a commercial application/product then, you need to
+  contact Micrium to properly license uC/OS-II or uC/OS-III for its use in your
+  application/product.&nbsp;&nbsp; We provide ALL the source code for your
+  convenience and to help you experience uC/OS-II or uC/OS-III.&nbsp; The fact
+  that the source is provided does NOT mean that you can use it commercially
+  without paying a licensing fee.</p>
+  </td>
+ </tr>
+ <tr style='height:368.5pt'>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt;height:368.5pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB>Microsoft</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt;height:368.5pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>If the
+  Licensed Software includes software owned by Microsoft Corporation
+  (“Microsoft”), it is subject to the terms of your license with Microsoft (the
+  “Microsoft Underlying Licensed Software”) and as such, NXP grants no license
+  to you, beyond evaluation and demonstration in connection with NXP
+  processors, in the Microsoft Underlying Licensed Software.&nbsp; You must
+  separately obtain rights beyond evaluation and demonstration in connection
+  with the Microsoft Underlying Licensed Software from Microsoft.</p>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>Microsoft
+  does not provide support services for the components provided to you through
+  this Agreement.&nbsp; If you have any questions or require technical assistance,
+  please contact NXP.&nbsp; Microsoft Corporation is a third party beneficiary
+  to this Agreement with the right to enforce the terms of this
+  Agreement.&nbsp; TO THE MAXIMUM EXTENT PERMITTED BY LAW, MICROSOFT AND ITS
+  AFFILIATES DISCLAIM ANY WARRANTIES FOR THE MICROSOFT UNDERLYING LICENSED
+  SOFTWARE.&nbsp; TO THE MAXIMUM EXTENT PERMITTED BY LAW, NEITHER MICROSOFT NOR
+  ITS AFFILIATES WILL BE LIABLE, WHETHER IN CONTRACT, TORT, OR OTHERWISE, FOR
+  ANY DIRECT, INCIDENTAL, SPECIAL, INDIRECT, CONSEQUENTIAL OR PUNITIVE DAMAGES,
+  INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR ANY LOSS OF USE, LOSS OF TIME,
+  INCONVENIENCE, COMMERCIAL LOSS, OR LOST PROFITS, SAVINGS, OR REVENUES,
+  ARISING FROM THE FROM THE USE OF THE MICROSOFT UNDERLYING LICENSED
+  SOFTWARE.&nbsp; </p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>MindTree</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Notwithstanding the terms contained in Section
+  2.3 (a), if the Licensed Software includes proprietary software of MindTree
+  in source code format, Licensee may make modifications and create derivative
+  works only to the extent necessary for debugging of the Licensed Software.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>MPEG LA</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Use of MPEG LA audio or video codec technology
+  is limited to evaluation and demonstration only . </span><span
+  style='color:black'>Permitted distributions must be similarly limited. </span><span
+  lang=EN-GB style='color:black'>Further rights must be obtained directly from
+  MPEG LA. </span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>MQX RTOS Code</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  style='font-size:10.5pt;line-height:115%;color:black'>MQX RTOS source code
+  may not be re-distributed by any FSL Licensee under any circumstance, even by
+  a signed written amendment to this Agreement.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>Opus</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  style='font-size:10.5pt;line-height:115%;color:black'>Use of Opus software
+  must be consistent with the terms of the Opus license which can be found at: </span><a
+  href="http://www.opus-codec.org/license/"><span style='font-size:10.5pt;
+  line-height:115%'>http://www.opus-codec.org/license/</span></a></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  style='color:black'>Real Networks - its GStreamer Optimized Real Format
+  Client Code implementation or OpenMax Optimized Real Format Client Code</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>Use of the
+  GStreamer Optimized Real Format Client Code, or OpenMax Optimized Real Format
+  Client code is restricted to applications in the automotive market.&nbsp;
+  Licensee must be a final manufacturer in good standing with a current license
+  with Real Networks for the commercial use and distribution of products
+  containing the GStreamer Optimized Real Format Client Code implementation or
+  OpenMax Optimized Real Format Client Code</p>
+  </td>
+ </tr>
+ <tr style='height:308.65pt'>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt;height:308.65pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB>SanDisk Corporation</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt;height:308.65pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB>If the Licensed Software includes software developed by SanDisk
+  Corporation (“SanDisk”), you must separately obtain the rights to reproduce
+  and distribute this software in source code form from SanDisk.&nbsp; Please
+  follow these easy steps to obtain the license and software:&nbsp;</span></p>
+  <p class=MsoNormal style='margin-top:0in;margin-right:0in;margin-bottom:10.0pt;
+  margin-left:.5in;text-indent:-.25in;line-height:115%'>1.<span
+  style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  </span><span lang=EN-GB>Contact your local SanDisk sales representative to
+  obtain the SanDisk License Agreement. </span></p>
+  <p class=MsoNormal style='margin-top:0in;margin-right:0in;margin-bottom:0in;
+  margin-left:.5in;margin-bottom:.0001pt;text-indent:-.25in;line-height:115%'><span
+  lang=EN-GB>2.</span><span lang=EN-GB style='font-size:7.0pt;line-height:115%;
+  font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span><span
+  lang=EN-GB>Sign the license agreement.&nbsp; Fax the signed agreement to
+  SanDisk USA marketing department at 408-542-0403.&nbsp; The license will be
+  valid when fully executed by SanDisk.</span></p>
+  <p class=MsoNormal style='margin-top:0in;margin-right:0in;margin-bottom:10.0pt;
+  margin-left:.5in;text-indent:-.25in;line-height:115%'><span lang=EN-GB>3.</span><span
+  lang=EN-GB style='font-size:7.0pt;line-height:115%;font-family:"Times New Roman",serif'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  </span><span lang=EN-GB>If you have specific questions, please send an email
+  to sales@sandisk.com</span></p>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><a
+  name="OLE_LINK1"></a><a name="OLE_LINK2"></a><span lang=EN-GB>You may only
+  use the SanDisk Corporation Licensed Software on products compatible with a
+  SanDisk Secure Digital Card.&nbsp; </span><span lang=EN-GB>You may not use
+  the SanDisk Corporation Licensed Software on any memory device product.&nbsp;
+  SanDisk retains all rights to any modifications or derivative works to the SanDisk
+  Corporation Licensed Software that you may create.</span></p>
+  </td>
+ </tr>
+ <tr style='height:215.0pt'>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt;height:215.0pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'>Synopsys/Target Compiler Technologies</p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt;height:215.0pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>Your use of
+  the Synopsys/Target Compiler Technologies Licensed Software and related
+  documentation is subject to the following:</p>
+  <ul style='margin-top:0in' type=disc>
+   <li class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>Duration
+       of the license for the Licensed Software is limited to 12 months, unless
+       otherwise specified in the license file.</li>
+   <li class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>The
+       Licensed Software is usable by one user at a time on a single designated
+       computer, unless otherwise agreed by Synopsys.&nbsp;</li>
+   <li class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>Licensed
+       Software and documentation are to be used only on a designated computer
+       at the designated physical address provided by you on the APEX license
+       form.</li>
+   <li class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'>The
+       Licensed Software is not sub-licensable.</li>
+  </ul>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>Texas Instruments</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB>Your use of Texas Instruments Inc. WiLink8 Licensed Software is
+  restricted to NXP SoC based systems that include a compatible connectivity
+  device manufactured by TI.&nbsp;</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=166 valign=top style='width:124.45pt;border:solid windowtext 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;text-align:justify;line-height:
+  115%'><span lang=EN-GB style='color:black'>Vivante</span></p>
+  </td>
+  <td width=465 valign=top style='width:348.95pt;border-top:none;border-left:
+  none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt'>
+  <p class=MsoNormal style='margin-bottom:10.0pt;line-height:115%'><span
+  lang=EN-GB style='color:black'>Distribution of Vivante software must be </span>a
+  part of, or embedded within, Authorized Systems that include a Vivante
+  Graphics Processing Unit.&nbsp;</p>
+  </td>
+ </tr>
+</table>
+
+<p class=MsoNormal style='line-height:106%'>&nbsp;</p>
+
+<p class=MsoNormal style='line-height:106%'><a name="OLE_LINK3"></a><a
+name="OLE_LINK9"></a>&nbsp;</p>
+
+<p class=MsoNormal>&nbsp;</p>
+
+</div>
+
+</body>
+
+</html>

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/SW-Content-Register-KSDK_2.0.0_GA.txt
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/SW-Content-Register-KSDK_2.0.0_GA.txt
@@ -1,0 +1,161 @@
+Release Name: KSDK_2.0.0_GA
+Kinetis Software Development Kit (SDK) Package - Kinetis SDK
+
+KSDK Peripheral Drivers    Description: Peripheral drivers are designed for t
+                           he most common use cases identified for the underl
+                           ying hardware block.
+                           Author: Freescale
+                           version: 2.x.x
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           Location: devices/<device_name>/drivers
+
+CMSIS Core header files    Description: Industry-standard header files distri
+                           butes by ARM for cortex-M cores
+                           Author: ARM
+                           version: 4.3 (CMSIS Download 4.5)
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           URL: http://silver.arm.com
+                           Location: CMSIS/Include
+
+CMSIS Driver header files  Description: Industry-standard header files distri
+                           butes by ARM for cortex-M cores containing Driver
+                           definitions
+                           Author: ARM
+                           version: 4.3 (CMSIS Download 4.5)
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           URL: http://silver.arm.com
+                           Location: CMSIS/Driver/Include
+
+CMSIS DSP Library          Description: A digital signal processing library f
+                           or Cortex-M cores from ARM
+                           Author: ARM
+                           version: 1.4.5 (CMSIS download 4.5)
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           URL: http://silver.arm.com
+                           Location: CMSIS/DSP_Lib
+
+FreeRTOS(tm)               Description: A real-time operating system(RTOS) fr
+                           om Real Time Engineers, Ltd.
+                           Author: Real Time Engineers, Ltd.
+                           version: 8.2.3
+                           License: Modified GPLv2. See rtos/freertos/License
+                           /license.txt.
+                           Format: source code
+                           URL: http://www.freertos.org
+                           Location: rtos/freertos_8.2.3
+
+uC/OS-II(R)                Description: A real-time operating system(RTOS) fr
+                           om Micrium
+                           Author: Micrium, Inc.
+                           version: 2.92.11
+                           License: Proprietary. See LA_OPT_Base_License.htm,
+                            Appendix A, Micrium.
+                           Format: source code
+                           URL: http://micrium.com
+                           Location: rtos/ucosii_2.92.11
+
+uC/OS-III(R)               Description: A real-time operating system(RTOS) fr
+                           om Micrium
+                           Author: Micrium, Inc.
+                           version: 3.05.01
+                           License: Proprietary. See LA_OPT_Base_License.htm,
+                            Appendix A, Micrium.
+                           Format: source code
+                           URL: http://micrium.com
+                           Location: rtos/ucosiii_3.05.01
+
+SD MMC Card middleware     Description: A software componnet support SD card,
+                            eMMC card.
+                           Author: Freescale
+                           version: 2.0.0
+                           License: Open Source - BSC-3-Clause
+                           Format: source code
+                           Location: middleware/sdmmc_2.0.0
+
+MBED TLS stack             Description: Cryptographic and SSL/TLS Library
+                           Author: ARM
+                           version: 2.1.2
+                           License: Apache-2-Clause
+                           Format: source code
+                           URL: https://tls.mbed.org/
+                           Location: middleware/mbedtls_2.1.2
+
+DMA Manager                Description: A software component used for manage
+                           on-chip DMA channel resources.
+                           Author: Freescale
+                           version: 2.0.0
+                           License: Open Source - BSC-3-Clause
+                           Format: source code
+                           Location: middleware/dma_manager_2.0.0
+
+USB                        Description: Freescale USB stack. This is a versio
+                           n of the USB stack that has been integrated with t
+                           he Kinetis SDK.
+                           Author: Freescale
+                           version: 1.0.0
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           Location: middleware/usb_1.0.0
+
+ISSDK                      Description: Freescale IoT Sensing SDK. It combines
+                           a set of robust Sensor Drivers and Algorithms along
+                           with example applications for standard kits.
+                           Author: Freescale
+                           version: 1.0
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           Location: middleware/issdk_1.0
+
+lwIP TCP/IP Stack          Description: A light-weight TCP/IP stack
+                           Author: Swedish Institute of Computer Science
+                           version: 1.4.1
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           URL: http://savannah.nongnu.org/projects/lwip
+                           Location: middleware/lwip_1.4.1
+
+wolfSSL                    Description: wolfSSL is cryptography and SSL/TLS l
+                           ibrary
+                           Author: wolfSSL Inc.
+                           version: 3.6.8
+                           License: 3rd party evaluation. See middleware/wolf
+                           ssl_3.6.8/wolfSSL_cyaSSL_evaluation_license_agreem
+                           ent.pdf
+                           Format: source code
+                           URL: https://www.wolfssl.com
+                           Location: middleware/wolfssl_3.6.8
+
+mmCAU S/W Library          Description: S/W library that works with the memor
+                           y-mapped cryptographic acceleration unit present o
+                           n some Kinetis SoCs
+                           Author: Freescale
+                           version: 2.0.0
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           Location: middleware/mmcau_2.0.0
+
+EMV L1 stack               Description: The EMV (Europay-MasterCard-Visa) L1
+                           stack which complies to EMV_v4.3_Book_1 specificat
+                           ion.
+                           Author: Freescale
+                           version: 2.0.0
+                           License: Open Source - BSD-3-Clause
+                           Format: source code
+                           Location: middleware/emv_2.0.0
+
+
+FatFs                      Description: FatFs is a generic FAT file system mo
+                           dule for small embedded systems.
+                           Author: Electronic Lives Mfg. by ChaN of Ageo city
+                           , Japan (hobbyist)
+                           version: 0.11a
+                           License: Open Source - FatFs License, middleware/f
+                           atfs/doc/en/appnote.html
+                           Format: source code
+                           URL: http://elm-chan.org/fsw/ff/00index_e.html
+                           Approved Open Source License: Yes
+                           Location: middleware/fatfs_0.11a

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/MK64F12.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/MK64F12.h
@@ -1,0 +1,12722 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**                          MK64FX512VDC12
+**                          MK64FX512VLL12
+**                          MK64FX512VLQ12
+**                          MK64FX512VMD12
+**
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         CMSIS Peripheral Access Layer for MK64F12
+**
+**     Copyright (c) 1997 - 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2013-08-12)
+**         Initial version.
+**     - rev. 2.0 (2013-10-29)
+**         Register accessor macros added to the memory map.
+**         Symbols for Processor Expert memory map compatibility added to the memory map.
+**         Startup file for gcc has been updated according to CMSIS 3.2.
+**         System initialization updated.
+**         MCG - registers updated.
+**         PORTA, PORTB, PORTC, PORTE - registers for digital filter removed.
+**     - rev. 2.1 (2013-10-30)
+**         Definition of BITBAND macros updated to support peripherals with 32-bit acces disabled.
+**     - rev. 2.2 (2013-12-09)
+**         DMA - EARS register removed.
+**         AIPS0, AIPS1 - MPRA register updated.
+**     - rev. 2.3 (2014-01-24)
+**         Update according to reference manual rev. 2
+**         ENET, MCG, MCM, SIM, USB - registers updated
+**     - rev. 2.4 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**     - rev. 2.5 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**         Module access macro module_BASES replaced by module_BASE_PTRS.
+**     - rev. 2.6 (2014-08-28)
+**         Update of system files - default clock configuration changed.
+**         Update of startup files - possibility to override DefaultISR added.
+**     - rev. 2.7 (2014-10-14)
+**         Interrupt INT_LPTimer renamed to INT_LPTMR0, interrupt INT_Watchdog renamed to INT_WDOG_EWM.
+**     - rev. 2.8 (2015-02-19)
+**         Renamed interrupt vector LLW to LLWU.
+**     - rev. 2.9 (2016-03-21)
+**         Added MK64FN1M0CAJ12 part.
+**         GPIO - renamed port instances: PTx -> GPIOx.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MK64F12.h
+ * @version 2.9
+ * @date 2016-03-21
+ * @brief CMSIS Peripheral Access Layer for MK64F12
+ *
+ * CMSIS Peripheral Access Layer for MK64F12
+ */
+
+#ifndef _MK64F12_H_
+#define _MK64F12_H_                              /**< Symbol preventing repeated inclusion */
+
+/** Memory map major version (memory maps with equal major version number are
+ * compatible) */
+#define MCU_MEM_MAP_VERSION 0x0200U
+/** Memory map minor version */
+#define MCU_MEM_MAP_VERSION_MINOR 0x0009U
+
+/**
+ * @brief Macro to calculate address of an aliased word in the peripheral
+ *        bitband area for a peripheral register and bit (bit band region 0x40000000 to
+ *        0x400FFFFF).
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return  Address of the aliased word in the peripheral bitband area.
+ */
+#define BITBAND_REGADDR(Reg,Bit) (0x42000000u + (32u*((uint32_t)&(Reg) - (uint32_t)0x40000000u)) + (4u*((uint32_t)(Bit))))
+/**
+ * @brief Macro to access a single bit of a peripheral register (bit band region
+ *        0x40000000 to 0x400FFFFF) using the bit-band alias region access. Can
+ *        be used for peripherals with 32bit access allowed.
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return Value of the targeted bit in the bit band region.
+ */
+#define BITBAND_REG32(Reg,Bit) (*((uint32_t volatile*)(BITBAND_REGADDR((Reg),(Bit)))))
+#define BITBAND_REG(Reg,Bit) (BITBAND_REG32((Reg),(Bit)))
+/**
+ * @brief Macro to access a single bit of a peripheral register (bit band region
+ *        0x40000000 to 0x400FFFFF) using the bit-band alias region access. Can
+ *        be used for peripherals with 16bit access allowed.
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return Value of the targeted bit in the bit band region.
+ */
+#define BITBAND_REG16(Reg,Bit) (*((uint16_t volatile*)(BITBAND_REGADDR((Reg),(Bit)))))
+/**
+ * @brief Macro to access a single bit of a peripheral register (bit band region
+ *        0x40000000 to 0x400FFFFF) using the bit-band alias region access. Can
+ *        be used for peripherals with 8bit access allowed.
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return Value of the targeted bit in the bit band region.
+ */
+#define BITBAND_REG8(Reg,Bit) (*((uint8_t volatile*)(BITBAND_REGADDR((Reg),(Bit)))))
+
+/* ----------------------------------------------------------------------------
+   -- Interrupt vector numbers
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Interrupt_vector_numbers Interrupt vector numbers
+ * @{
+ */
+
+/** Interrupt Number Definitions */
+#define NUMBER_OF_INT_VECTORS 102                /**< Number of interrupts in the Vector table */
+
+typedef enum IRQn {
+  /* Auxiliary constants */
+  NotAvail_IRQn                = -128,             /**< Not available device specific interrupt */
+
+  /* Core interrupts */
+  NonMaskableInt_IRQn          = -14,              /**< Non Maskable Interrupt */
+  HardFault_IRQn               = -13,              /**< Cortex-M4 SV Hard Fault Interrupt */
+  MemoryManagement_IRQn        = -12,              /**< Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn                = -11,              /**< Cortex-M4 Bus Fault Interrupt */
+  UsageFault_IRQn              = -10,              /**< Cortex-M4 Usage Fault Interrupt */
+  SVCall_IRQn                  = -5,               /**< Cortex-M4 SV Call Interrupt */
+  DebugMonitor_IRQn            = -4,               /**< Cortex-M4 Debug Monitor Interrupt */
+  PendSV_IRQn                  = -2,               /**< Cortex-M4 Pend SV Interrupt */
+  SysTick_IRQn                 = -1,               /**< Cortex-M4 System Tick Interrupt */
+
+  /* Device specific interrupts */
+  DMA0_IRQn                    = 0,                /**< DMA Channel 0 Transfer Complete */
+  DMA1_IRQn                    = 1,                /**< DMA Channel 1 Transfer Complete */
+  DMA2_IRQn                    = 2,                /**< DMA Channel 2 Transfer Complete */
+  DMA3_IRQn                    = 3,                /**< DMA Channel 3 Transfer Complete */
+  DMA4_IRQn                    = 4,                /**< DMA Channel 4 Transfer Complete */
+  DMA5_IRQn                    = 5,                /**< DMA Channel 5 Transfer Complete */
+  DMA6_IRQn                    = 6,                /**< DMA Channel 6 Transfer Complete */
+  DMA7_IRQn                    = 7,                /**< DMA Channel 7 Transfer Complete */
+  DMA8_IRQn                    = 8,                /**< DMA Channel 8 Transfer Complete */
+  DMA9_IRQn                    = 9,                /**< DMA Channel 9 Transfer Complete */
+  DMA10_IRQn                   = 10,               /**< DMA Channel 10 Transfer Complete */
+  DMA11_IRQn                   = 11,               /**< DMA Channel 11 Transfer Complete */
+  DMA12_IRQn                   = 12,               /**< DMA Channel 12 Transfer Complete */
+  DMA13_IRQn                   = 13,               /**< DMA Channel 13 Transfer Complete */
+  DMA14_IRQn                   = 14,               /**< DMA Channel 14 Transfer Complete */
+  DMA15_IRQn                   = 15,               /**< DMA Channel 15 Transfer Complete */
+  DMA_Error_IRQn               = 16,               /**< DMA Error Interrupt */
+  MCM_IRQn                     = 17,               /**< Normal Interrupt */
+  FTFE_IRQn                    = 18,               /**< FTFE Command complete interrupt */
+  Read_Collision_IRQn          = 19,               /**< Read Collision Interrupt */
+  LVD_LVW_IRQn                 = 20,               /**< Low Voltage Detect, Low Voltage Warning */
+  LLWU_IRQn                    = 21,               /**< Low Leakage Wakeup Unit */
+  WDOG_EWM_IRQn                = 22,               /**< WDOG Interrupt */
+  RNG_IRQn                     = 23,               /**< RNG Interrupt */
+  I2C0_IRQn                    = 24,               /**< I2C0 interrupt */
+  I2C1_IRQn                    = 25,               /**< I2C1 interrupt */
+  SPI0_IRQn                    = 26,               /**< SPI0 Interrupt */
+  SPI1_IRQn                    = 27,               /**< SPI1 Interrupt */
+  I2S0_Tx_IRQn                 = 28,               /**< I2S0 transmit interrupt */
+  I2S0_Rx_IRQn                 = 29,               /**< I2S0 receive interrupt */
+  UART0_LON_IRQn               = 30,               /**< UART0 LON interrupt */
+  UART0_RX_TX_IRQn             = 31,               /**< UART0 Receive/Transmit interrupt */
+  UART0_ERR_IRQn               = 32,               /**< UART0 Error interrupt */
+  UART1_RX_TX_IRQn             = 33,               /**< UART1 Receive/Transmit interrupt */
+  UART1_ERR_IRQn               = 34,               /**< UART1 Error interrupt */
+  UART2_RX_TX_IRQn             = 35,               /**< UART2 Receive/Transmit interrupt */
+  UART2_ERR_IRQn               = 36,               /**< UART2 Error interrupt */
+  UART3_RX_TX_IRQn             = 37,               /**< UART3 Receive/Transmit interrupt */
+  UART3_ERR_IRQn               = 38,               /**< UART3 Error interrupt */
+  ADC0_IRQn                    = 39,               /**< ADC0 interrupt */
+  CMP0_IRQn                    = 40,               /**< CMP0 interrupt */
+  CMP1_IRQn                    = 41,               /**< CMP1 interrupt */
+  FTM0_IRQn                    = 42,               /**< FTM0 fault, overflow and channels interrupt */
+  FTM1_IRQn                    = 43,               /**< FTM1 fault, overflow and channels interrupt */
+  FTM2_IRQn                    = 44,               /**< FTM2 fault, overflow and channels interrupt */
+  CMT_IRQn                     = 45,               /**< CMT interrupt */
+  RTC_IRQn                     = 46,               /**< RTC interrupt */
+  RTC_Seconds_IRQn             = 47,               /**< RTC seconds interrupt */
+  PIT0_IRQn                    = 48,               /**< PIT timer channel 0 interrupt */
+  PIT1_IRQn                    = 49,               /**< PIT timer channel 1 interrupt */
+  PIT2_IRQn                    = 50,               /**< PIT timer channel 2 interrupt */
+  PIT3_IRQn                    = 51,               /**< PIT timer channel 3 interrupt */
+  PDB0_IRQn                    = 52,               /**< PDB0 Interrupt */
+  USB0_IRQn                    = 53,               /**< USB0 interrupt */
+  USBDCD_IRQn                  = 54,               /**< USBDCD Interrupt */
+  Reserved71_IRQn              = 55,               /**< Reserved interrupt 71 */
+  DAC0_IRQn                    = 56,               /**< DAC0 interrupt */
+  MCG_IRQn                     = 57,               /**< MCG Interrupt */
+  LPTMR0_IRQn                  = 58,               /**< LPTimer interrupt */
+  PORTA_IRQn                   = 59,               /**< Port A interrupt */
+  PORTB_IRQn                   = 60,               /**< Port B interrupt */
+  PORTC_IRQn                   = 61,               /**< Port C interrupt */
+  PORTD_IRQn                   = 62,               /**< Port D interrupt */
+  PORTE_IRQn                   = 63,               /**< Port E interrupt */
+  SWI_IRQn                     = 64,               /**< Software interrupt */
+  SPI2_IRQn                    = 65,               /**< SPI2 Interrupt */
+  UART4_RX_TX_IRQn             = 66,               /**< UART4 Receive/Transmit interrupt */
+  UART4_ERR_IRQn               = 67,               /**< UART4 Error interrupt */
+  UART5_RX_TX_IRQn             = 68,               /**< UART5 Receive/Transmit interrupt */
+  UART5_ERR_IRQn               = 69,               /**< UART5 Error interrupt */
+  CMP2_IRQn                    = 70,               /**< CMP2 interrupt */
+  FTM3_IRQn                    = 71,               /**< FTM3 fault, overflow and channels interrupt */
+  DAC1_IRQn                    = 72,               /**< DAC1 interrupt */
+  ADC1_IRQn                    = 73,               /**< ADC1 interrupt */
+  I2C2_IRQn                    = 74,               /**< I2C2 interrupt */
+  CAN0_ORed_Message_buffer_IRQn = 75,              /**< CAN0 OR'd message buffers interrupt */
+  CAN0_Bus_Off_IRQn            = 76,               /**< CAN0 bus off interrupt */
+  CAN0_Error_IRQn              = 77,               /**< CAN0 error interrupt */
+  CAN0_Tx_Warning_IRQn         = 78,               /**< CAN0 Tx warning interrupt */
+  CAN0_Rx_Warning_IRQn         = 79,               /**< CAN0 Rx warning interrupt */
+  CAN0_Wake_Up_IRQn            = 80,               /**< CAN0 wake up interrupt */
+  SDHC_IRQn                    = 81,               /**< SDHC interrupt */
+  ENET_1588_Timer_IRQn         = 82,               /**< Ethernet MAC IEEE 1588 Timer Interrupt */
+  ENET_Transmit_IRQn           = 83,               /**< Ethernet MAC Transmit Interrupt */
+  ENET_Receive_IRQn            = 84,               /**< Ethernet MAC Receive Interrupt */
+  ENET_Error_IRQn              = 85                /**< Ethernet MAC Error and miscelaneous Interrupt */
+} IRQn_Type;
+
+/*!
+ * @}
+ */ /* end of group Interrupt_vector_numbers */
+
+
+/* ----------------------------------------------------------------------------
+   -- Cortex M4 Core Configuration
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Cortex_Core_Configuration Cortex M4 Core Configuration
+ * @{
+ */
+
+#define __MPU_PRESENT                  0         /**< Defines if an MPU is present or not */
+#define __NVIC_PRIO_BITS               4         /**< Number of priority bits implemented in the NVIC */
+#define __Vendor_SysTickConfig         0         /**< Vendor specific implementation of SysTickConfig is defined */
+#define __FPU_PRESENT                  1         /**< Defines if an FPU is present or not */
+
+#include "core_cm4.h"                  /* Core Peripheral Access Layer */
+#include "system_MK64F12.h"            /* Device specific configuration file */
+
+/*!
+ * @}
+ */ /* end of group Cortex_Core_Configuration */
+
+
+/* ----------------------------------------------------------------------------
+   -- Mapping Information
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Mapping_Information Mapping Information
+ * @{
+ */
+
+/** Mapping Information */
+/*!
+ * @addtogroup edma_request
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*!
+ * @brief Structure for the DMA hardware request
+ *
+ * Defines the structure for the DMA hardware request collections. The user can configure the
+ * hardware request into DMAMUX to trigger the DMA transfer accordingly. The index
+ * of the hardware request varies according  to the to SoC.
+ */
+typedef enum _dma_request_source
+{
+    kDmaRequestMux0Disable          = 0|0x100U,    /**< DMAMUX TriggerDisabled. */
+    kDmaRequestMux0Reserved1        = 1|0x100U,    /**< Reserved1 */
+    kDmaRequestMux0UART0Rx          = 2|0x100U,    /**< UART0 Receive. */
+    kDmaRequestMux0UART0Tx          = 3|0x100U,    /**< UART0 Transmit. */
+    kDmaRequestMux0UART1Rx          = 4|0x100U,    /**< UART1 Receive. */
+    kDmaRequestMux0UART1Tx          = 5|0x100U,    /**< UART1 Transmit. */
+    kDmaRequestMux0UART2Rx          = 6|0x100U,    /**< UART2 Receive. */
+    kDmaRequestMux0UART2Tx          = 7|0x100U,    /**< UART2 Transmit. */
+    kDmaRequestMux0UART3Rx          = 8|0x100U,    /**< UART3 Receive. */
+    kDmaRequestMux0UART3Tx          = 9|0x100U,    /**< UART3 Transmit. */
+    kDmaRequestMux0UART4            = 10|0x100U,   /**< UART4 Transmit or Receive. */
+    kDmaRequestMux0UART5            = 11|0x100U,   /**< UART5 Transmit or Receive. */
+    kDmaRequestMux0I2S0Rx           = 12|0x100U,   /**< I2S0 Receive. */
+    kDmaRequestMux0I2S0Tx           = 13|0x100U,   /**< I2S0 Transmit. */
+    kDmaRequestMux0SPI0Rx           = 14|0x100U,   /**< SPI0 Receive. */
+    kDmaRequestMux0SPI0Tx           = 15|0x100U,   /**< SPI0 Transmit. */
+    kDmaRequestMux0SPI1             = 16|0x100U,   /**< SPI1 Transmit or Receive. */
+    kDmaRequestMux0SPI2             = 17|0x100U,   /**< SPI2 Transmit or Receive. */
+    kDmaRequestMux0I2C0             = 18|0x100U,   /**< I2C0. */
+    kDmaRequestMux0I2C1I2C2         = 19|0x100U,   /**< I2C1 and I2C2. */
+    kDmaRequestMux0I2C1             = 19|0x100U,   /**< I2C1 and I2C2. */
+    kDmaRequestMux0I2C2             = 19|0x100U,   /**< I2C1 and I2C2. */
+    kDmaRequestMux0FTM0Channel0     = 20|0x100U,   /**< FTM0 C0V. */
+    kDmaRequestMux0FTM0Channel1     = 21|0x100U,   /**< FTM0 C1V. */
+    kDmaRequestMux0FTM0Channel2     = 22|0x100U,   /**< FTM0 C2V. */
+    kDmaRequestMux0FTM0Channel3     = 23|0x100U,   /**< FTM0 C3V. */
+    kDmaRequestMux0FTM0Channel4     = 24|0x100U,   /**< FTM0 C4V. */
+    kDmaRequestMux0FTM0Channel5     = 25|0x100U,   /**< FTM0 C5V. */
+    kDmaRequestMux0FTM0Channel6     = 26|0x100U,   /**< FTM0 C6V. */
+    kDmaRequestMux0FTM0Channel7     = 27|0x100U,   /**< FTM0 C7V. */
+    kDmaRequestMux0FTM1Channel0     = 28|0x100U,   /**< FTM1 C0V. */
+    kDmaRequestMux0FTM1Channel1     = 29|0x100U,   /**< FTM1 C1V. */
+    kDmaRequestMux0FTM2Channel0     = 30|0x100U,   /**< FTM2 C0V. */
+    kDmaRequestMux0FTM2Channel1     = 31|0x100U,   /**< FTM2 C1V. */
+    kDmaRequestMux0FTM3Channel0     = 32|0x100U,   /**< FTM3 C0V. */
+    kDmaRequestMux0FTM3Channel1     = 33|0x100U,   /**< FTM3 C1V. */
+    kDmaRequestMux0FTM3Channel2     = 34|0x100U,   /**< FTM3 C2V. */
+    kDmaRequestMux0FTM3Channel3     = 35|0x100U,   /**< FTM3 C3V. */
+    kDmaRequestMux0FTM3Channel4     = 36|0x100U,   /**< FTM3 C4V. */
+    kDmaRequestMux0FTM3Channel5     = 37|0x100U,   /**< FTM3 C5V. */
+    kDmaRequestMux0FTM3Channel6     = 38|0x100U,   /**< FTM3 C6V. */
+    kDmaRequestMux0FTM3Channel7     = 39|0x100U,   /**< FTM3 C7V. */
+    kDmaRequestMux0ADC0             = 40|0x100U,   /**< ADC0. */
+    kDmaRequestMux0ADC1             = 41|0x100U,   /**< ADC1. */
+    kDmaRequestMux0CMP0             = 42|0x100U,   /**< CMP0. */
+    kDmaRequestMux0CMP1             = 43|0x100U,   /**< CMP1. */
+    kDmaRequestMux0CMP2             = 44|0x100U,   /**< CMP2. */
+    kDmaRequestMux0DAC0             = 45|0x100U,   /**< DAC0. */
+    kDmaRequestMux0DAC1             = 46|0x100U,   /**< DAC1. */
+    kDmaRequestMux0CMT              = 47|0x100U,   /**< CMT. */
+    kDmaRequestMux0PDB              = 48|0x100U,   /**< PDB0. */
+    kDmaRequestMux0PortA            = 49|0x100U,   /**< PTA. */
+    kDmaRequestMux0PortB            = 50|0x100U,   /**< PTB. */
+    kDmaRequestMux0PortC            = 51|0x100U,   /**< PTC. */
+    kDmaRequestMux0PortD            = 52|0x100U,   /**< PTD. */
+    kDmaRequestMux0PortE            = 53|0x100U,   /**< PTE. */
+    kDmaRequestMux0IEEE1588Timer0   = 54|0x100U,   /**< ENET IEEE 1588 timer 0. */
+    kDmaRequestMux0IEEE1588Timer1   = 55|0x100U,   /**< ENET IEEE 1588 timer 1. */
+    kDmaRequestMux0IEEE1588Timer2   = 56|0x100U,   /**< ENET IEEE 1588 timer 2. */
+    kDmaRequestMux0IEEE1588Timer3   = 57|0x100U,   /**< ENET IEEE 1588 timer 3. */
+    kDmaRequestMux0AlwaysOn58       = 58|0x100U,   /**< DMAMUX Always Enabled slot. */
+    kDmaRequestMux0AlwaysOn59       = 59|0x100U,   /**< DMAMUX Always Enabled slot. */
+    kDmaRequestMux0AlwaysOn60       = 60|0x100U,   /**< DMAMUX Always Enabled slot. */
+    kDmaRequestMux0AlwaysOn61       = 61|0x100U,   /**< DMAMUX Always Enabled slot. */
+    kDmaRequestMux0AlwaysOn62       = 62|0x100U,   /**< DMAMUX Always Enabled slot. */
+    kDmaRequestMux0AlwaysOn63       = 63|0x100U,   /**< DMAMUX Always Enabled slot. */
+} dma_request_source_t;
+
+/* @} */
+
+
+/*!
+ * @}
+ */ /* end of group Mapping_Information */
+
+
+/* ----------------------------------------------------------------------------
+   -- Device Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Peripheral_access_layer Device Peripheral Access Layer
+ * @{
+ */
+
+
+/*
+** Start of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__CWCC__)
+  #pragma push
+  #pragma cpp_extensions on
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=extended
+#else
+  #error Not supported compiler type
+#endif
+
+/* ----------------------------------------------------------------------------
+   -- ADC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Peripheral_Access_Layer ADC Peripheral Access Layer
+ * @{
+ */
+
+/** ADC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC1[2];                            /**< ADC Status and Control Registers 1, array offset: 0x0, array step: 0x4 */
+  __IO uint32_t CFG1;                              /**< ADC Configuration Register 1, offset: 0x8 */
+  __IO uint32_t CFG2;                              /**< ADC Configuration Register 2, offset: 0xC */
+  __I  uint32_t R[2];                              /**< ADC Data Result Register, array offset: 0x10, array step: 0x4 */
+  __IO uint32_t CV1;                               /**< Compare Value Registers, offset: 0x18 */
+  __IO uint32_t CV2;                               /**< Compare Value Registers, offset: 0x1C */
+  __IO uint32_t SC2;                               /**< Status and Control Register 2, offset: 0x20 */
+  __IO uint32_t SC3;                               /**< Status and Control Register 3, offset: 0x24 */
+  __IO uint32_t OFS;                               /**< ADC Offset Correction Register, offset: 0x28 */
+  __IO uint32_t PG;                                /**< ADC Plus-Side Gain Register, offset: 0x2C */
+  __IO uint32_t MG;                                /**< ADC Minus-Side Gain Register, offset: 0x30 */
+  __IO uint32_t CLPD;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x34 */
+  __IO uint32_t CLPS;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x38 */
+  __IO uint32_t CLP4;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x3C */
+  __IO uint32_t CLP3;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x40 */
+  __IO uint32_t CLP2;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x44 */
+  __IO uint32_t CLP1;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x48 */
+  __IO uint32_t CLP0;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x4C */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t CLMD;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x54 */
+  __IO uint32_t CLMS;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x58 */
+  __IO uint32_t CLM4;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x5C */
+  __IO uint32_t CLM3;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x60 */
+  __IO uint32_t CLM2;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x64 */
+  __IO uint32_t CLM1;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x68 */
+  __IO uint32_t CLM0;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x6C */
+} ADC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- ADC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Masks ADC Register Masks
+ * @{
+ */
+
+/*! @name SC1 - ADC Status and Control Registers 1 */
+#define ADC_SC1_ADCH_MASK                        (0x1FU)
+#define ADC_SC1_ADCH_SHIFT                       (0U)
+#define ADC_SC1_ADCH(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC1_ADCH_SHIFT)) & ADC_SC1_ADCH_MASK)
+#define ADC_SC1_DIFF_MASK                        (0x20U)
+#define ADC_SC1_DIFF_SHIFT                       (5U)
+#define ADC_SC1_DIFF(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC1_DIFF_SHIFT)) & ADC_SC1_DIFF_MASK)
+#define ADC_SC1_AIEN_MASK                        (0x40U)
+#define ADC_SC1_AIEN_SHIFT                       (6U)
+#define ADC_SC1_AIEN(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC1_AIEN_SHIFT)) & ADC_SC1_AIEN_MASK)
+#define ADC_SC1_COCO_MASK                        (0x80U)
+#define ADC_SC1_COCO_SHIFT                       (7U)
+#define ADC_SC1_COCO(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC1_COCO_SHIFT)) & ADC_SC1_COCO_MASK)
+
+/* The count of ADC_SC1 */
+#define ADC_SC1_COUNT                            (2U)
+
+/*! @name CFG1 - ADC Configuration Register 1 */
+#define ADC_CFG1_ADICLK_MASK                     (0x3U)
+#define ADC_CFG1_ADICLK_SHIFT                    (0U)
+#define ADC_CFG1_ADICLK(x)                       (((uint32_t)(((uint32_t)(x)) << ADC_CFG1_ADICLK_SHIFT)) & ADC_CFG1_ADICLK_MASK)
+#define ADC_CFG1_MODE_MASK                       (0xCU)
+#define ADC_CFG1_MODE_SHIFT                      (2U)
+#define ADC_CFG1_MODE(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CFG1_MODE_SHIFT)) & ADC_CFG1_MODE_MASK)
+#define ADC_CFG1_ADLSMP_MASK                     (0x10U)
+#define ADC_CFG1_ADLSMP_SHIFT                    (4U)
+#define ADC_CFG1_ADLSMP(x)                       (((uint32_t)(((uint32_t)(x)) << ADC_CFG1_ADLSMP_SHIFT)) & ADC_CFG1_ADLSMP_MASK)
+#define ADC_CFG1_ADIV_MASK                       (0x60U)
+#define ADC_CFG1_ADIV_SHIFT                      (5U)
+#define ADC_CFG1_ADIV(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CFG1_ADIV_SHIFT)) & ADC_CFG1_ADIV_MASK)
+#define ADC_CFG1_ADLPC_MASK                      (0x80U)
+#define ADC_CFG1_ADLPC_SHIFT                     (7U)
+#define ADC_CFG1_ADLPC(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_CFG1_ADLPC_SHIFT)) & ADC_CFG1_ADLPC_MASK)
+
+/*! @name CFG2 - ADC Configuration Register 2 */
+#define ADC_CFG2_ADLSTS_MASK                     (0x3U)
+#define ADC_CFG2_ADLSTS_SHIFT                    (0U)
+#define ADC_CFG2_ADLSTS(x)                       (((uint32_t)(((uint32_t)(x)) << ADC_CFG2_ADLSTS_SHIFT)) & ADC_CFG2_ADLSTS_MASK)
+#define ADC_CFG2_ADHSC_MASK                      (0x4U)
+#define ADC_CFG2_ADHSC_SHIFT                     (2U)
+#define ADC_CFG2_ADHSC(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_CFG2_ADHSC_SHIFT)) & ADC_CFG2_ADHSC_MASK)
+#define ADC_CFG2_ADACKEN_MASK                    (0x8U)
+#define ADC_CFG2_ADACKEN_SHIFT                   (3U)
+#define ADC_CFG2_ADACKEN(x)                      (((uint32_t)(((uint32_t)(x)) << ADC_CFG2_ADACKEN_SHIFT)) & ADC_CFG2_ADACKEN_MASK)
+#define ADC_CFG2_MUXSEL_MASK                     (0x10U)
+#define ADC_CFG2_MUXSEL_SHIFT                    (4U)
+#define ADC_CFG2_MUXSEL(x)                       (((uint32_t)(((uint32_t)(x)) << ADC_CFG2_MUXSEL_SHIFT)) & ADC_CFG2_MUXSEL_MASK)
+
+/*! @name R - ADC Data Result Register */
+#define ADC_R_D_MASK                             (0xFFFFU)
+#define ADC_R_D_SHIFT                            (0U)
+#define ADC_R_D(x)                               (((uint32_t)(((uint32_t)(x)) << ADC_R_D_SHIFT)) & ADC_R_D_MASK)
+
+/* The count of ADC_R */
+#define ADC_R_COUNT                              (2U)
+
+/*! @name CV1 - Compare Value Registers */
+#define ADC_CV1_CV_MASK                          (0xFFFFU)
+#define ADC_CV1_CV_SHIFT                         (0U)
+#define ADC_CV1_CV(x)                            (((uint32_t)(((uint32_t)(x)) << ADC_CV1_CV_SHIFT)) & ADC_CV1_CV_MASK)
+
+/*! @name CV2 - Compare Value Registers */
+#define ADC_CV2_CV_MASK                          (0xFFFFU)
+#define ADC_CV2_CV_SHIFT                         (0U)
+#define ADC_CV2_CV(x)                            (((uint32_t)(((uint32_t)(x)) << ADC_CV2_CV_SHIFT)) & ADC_CV2_CV_MASK)
+
+/*! @name SC2 - Status and Control Register 2 */
+#define ADC_SC2_REFSEL_MASK                      (0x3U)
+#define ADC_SC2_REFSEL_SHIFT                     (0U)
+#define ADC_SC2_REFSEL(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_SC2_REFSEL_SHIFT)) & ADC_SC2_REFSEL_MASK)
+#define ADC_SC2_DMAEN_MASK                       (0x4U)
+#define ADC_SC2_DMAEN_SHIFT                      (2U)
+#define ADC_SC2_DMAEN(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_SC2_DMAEN_SHIFT)) & ADC_SC2_DMAEN_MASK)
+#define ADC_SC2_ACREN_MASK                       (0x8U)
+#define ADC_SC2_ACREN_SHIFT                      (3U)
+#define ADC_SC2_ACREN(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_SC2_ACREN_SHIFT)) & ADC_SC2_ACREN_MASK)
+#define ADC_SC2_ACFGT_MASK                       (0x10U)
+#define ADC_SC2_ACFGT_SHIFT                      (4U)
+#define ADC_SC2_ACFGT(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_SC2_ACFGT_SHIFT)) & ADC_SC2_ACFGT_MASK)
+#define ADC_SC2_ACFE_MASK                        (0x20U)
+#define ADC_SC2_ACFE_SHIFT                       (5U)
+#define ADC_SC2_ACFE(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC2_ACFE_SHIFT)) & ADC_SC2_ACFE_MASK)
+#define ADC_SC2_ADTRG_MASK                       (0x40U)
+#define ADC_SC2_ADTRG_SHIFT                      (6U)
+#define ADC_SC2_ADTRG(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_SC2_ADTRG_SHIFT)) & ADC_SC2_ADTRG_MASK)
+#define ADC_SC2_ADACT_MASK                       (0x80U)
+#define ADC_SC2_ADACT_SHIFT                      (7U)
+#define ADC_SC2_ADACT(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_SC2_ADACT_SHIFT)) & ADC_SC2_ADACT_MASK)
+
+/*! @name SC3 - Status and Control Register 3 */
+#define ADC_SC3_AVGS_MASK                        (0x3U)
+#define ADC_SC3_AVGS_SHIFT                       (0U)
+#define ADC_SC3_AVGS(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC3_AVGS_SHIFT)) & ADC_SC3_AVGS_MASK)
+#define ADC_SC3_AVGE_MASK                        (0x4U)
+#define ADC_SC3_AVGE_SHIFT                       (2U)
+#define ADC_SC3_AVGE(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC3_AVGE_SHIFT)) & ADC_SC3_AVGE_MASK)
+#define ADC_SC3_ADCO_MASK                        (0x8U)
+#define ADC_SC3_ADCO_SHIFT                       (3U)
+#define ADC_SC3_ADCO(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC3_ADCO_SHIFT)) & ADC_SC3_ADCO_MASK)
+#define ADC_SC3_CALF_MASK                        (0x40U)
+#define ADC_SC3_CALF_SHIFT                       (6U)
+#define ADC_SC3_CALF(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC3_CALF_SHIFT)) & ADC_SC3_CALF_MASK)
+#define ADC_SC3_CAL_MASK                         (0x80U)
+#define ADC_SC3_CAL_SHIFT                        (7U)
+#define ADC_SC3_CAL(x)                           (((uint32_t)(((uint32_t)(x)) << ADC_SC3_CAL_SHIFT)) & ADC_SC3_CAL_MASK)
+
+/*! @name OFS - ADC Offset Correction Register */
+#define ADC_OFS_OFS_MASK                         (0xFFFFU)
+#define ADC_OFS_OFS_SHIFT                        (0U)
+#define ADC_OFS_OFS(x)                           (((uint32_t)(((uint32_t)(x)) << ADC_OFS_OFS_SHIFT)) & ADC_OFS_OFS_MASK)
+
+/*! @name PG - ADC Plus-Side Gain Register */
+#define ADC_PG_PG_MASK                           (0xFFFFU)
+#define ADC_PG_PG_SHIFT                          (0U)
+#define ADC_PG_PG(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_PG_PG_SHIFT)) & ADC_PG_PG_MASK)
+
+/*! @name MG - ADC Minus-Side Gain Register */
+#define ADC_MG_MG_MASK                           (0xFFFFU)
+#define ADC_MG_MG_SHIFT                          (0U)
+#define ADC_MG_MG(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_MG_MG_SHIFT)) & ADC_MG_MG_MASK)
+
+/*! @name CLPD - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLPD_CLPD_MASK                       (0x3FU)
+#define ADC_CLPD_CLPD_SHIFT                      (0U)
+#define ADC_CLPD_CLPD(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLPD_CLPD_SHIFT)) & ADC_CLPD_CLPD_MASK)
+
+/*! @name CLPS - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLPS_CLPS_MASK                       (0x3FU)
+#define ADC_CLPS_CLPS_SHIFT                      (0U)
+#define ADC_CLPS_CLPS(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLPS_CLPS_SHIFT)) & ADC_CLPS_CLPS_MASK)
+
+/*! @name CLP4 - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLP4_CLP4_MASK                       (0x3FFU)
+#define ADC_CLP4_CLP4_SHIFT                      (0U)
+#define ADC_CLP4_CLP4(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLP4_CLP4_SHIFT)) & ADC_CLP4_CLP4_MASK)
+
+/*! @name CLP3 - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLP3_CLP3_MASK                       (0x1FFU)
+#define ADC_CLP3_CLP3_SHIFT                      (0U)
+#define ADC_CLP3_CLP3(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLP3_CLP3_SHIFT)) & ADC_CLP3_CLP3_MASK)
+
+/*! @name CLP2 - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLP2_CLP2_MASK                       (0xFFU)
+#define ADC_CLP2_CLP2_SHIFT                      (0U)
+#define ADC_CLP2_CLP2(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLP2_CLP2_SHIFT)) & ADC_CLP2_CLP2_MASK)
+
+/*! @name CLP1 - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLP1_CLP1_MASK                       (0x7FU)
+#define ADC_CLP1_CLP1_SHIFT                      (0U)
+#define ADC_CLP1_CLP1(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLP1_CLP1_SHIFT)) & ADC_CLP1_CLP1_MASK)
+
+/*! @name CLP0 - ADC Plus-Side General Calibration Value Register */
+#define ADC_CLP0_CLP0_MASK                       (0x3FU)
+#define ADC_CLP0_CLP0_SHIFT                      (0U)
+#define ADC_CLP0_CLP0(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLP0_CLP0_SHIFT)) & ADC_CLP0_CLP0_MASK)
+
+/*! @name CLMD - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLMD_CLMD_MASK                       (0x3FU)
+#define ADC_CLMD_CLMD_SHIFT                      (0U)
+#define ADC_CLMD_CLMD(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLMD_CLMD_SHIFT)) & ADC_CLMD_CLMD_MASK)
+
+/*! @name CLMS - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLMS_CLMS_MASK                       (0x3FU)
+#define ADC_CLMS_CLMS_SHIFT                      (0U)
+#define ADC_CLMS_CLMS(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLMS_CLMS_SHIFT)) & ADC_CLMS_CLMS_MASK)
+
+/*! @name CLM4 - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLM4_CLM4_MASK                       (0x3FFU)
+#define ADC_CLM4_CLM4_SHIFT                      (0U)
+#define ADC_CLM4_CLM4(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLM4_CLM4_SHIFT)) & ADC_CLM4_CLM4_MASK)
+
+/*! @name CLM3 - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLM3_CLM3_MASK                       (0x1FFU)
+#define ADC_CLM3_CLM3_SHIFT                      (0U)
+#define ADC_CLM3_CLM3(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLM3_CLM3_SHIFT)) & ADC_CLM3_CLM3_MASK)
+
+/*! @name CLM2 - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLM2_CLM2_MASK                       (0xFFU)
+#define ADC_CLM2_CLM2_SHIFT                      (0U)
+#define ADC_CLM2_CLM2(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLM2_CLM2_SHIFT)) & ADC_CLM2_CLM2_MASK)
+
+/*! @name CLM1 - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLM1_CLM1_MASK                       (0x7FU)
+#define ADC_CLM1_CLM1_SHIFT                      (0U)
+#define ADC_CLM1_CLM1(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLM1_CLM1_SHIFT)) & ADC_CLM1_CLM1_MASK)
+
+/*! @name CLM0 - ADC Minus-Side General Calibration Value Register */
+#define ADC_CLM0_CLM0_MASK                       (0x3FU)
+#define ADC_CLM0_CLM0_SHIFT                      (0U)
+#define ADC_CLM0_CLM0(x)                         (((uint32_t)(((uint32_t)(x)) << ADC_CLM0_CLM0_SHIFT)) & ADC_CLM0_CLM0_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Masks */
+
+
+/* ADC - Peripheral instance base addresses */
+/** Peripheral ADC0 base address */
+#define ADC0_BASE                                (0x4003B000u)
+/** Peripheral ADC0 base pointer */
+#define ADC0                                     ((ADC_Type *)ADC0_BASE)
+/** Peripheral ADC1 base address */
+#define ADC1_BASE                                (0x400BB000u)
+/** Peripheral ADC1 base pointer */
+#define ADC1                                     ((ADC_Type *)ADC1_BASE)
+/** Array initializer of ADC peripheral base addresses */
+#define ADC_BASE_ADDRS                           { ADC0_BASE, ADC1_BASE }
+/** Array initializer of ADC peripheral base pointers */
+#define ADC_BASE_PTRS                            { ADC0, ADC1 }
+/** Interrupt vectors for the ADC peripheral type */
+#define ADC_IRQS                                 { ADC0_IRQn, ADC1_IRQn }
+
+/*!
+ * @}
+ */ /* end of group ADC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- AIPS Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AIPS_Peripheral_Access_Layer AIPS Peripheral Access Layer
+ * @{
+ */
+
+/** AIPS - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MPRA;                              /**< Master Privilege Register A, offset: 0x0 */
+       uint8_t RESERVED_0[28];
+  __IO uint32_t PACRA;                             /**< Peripheral Access Control Register, offset: 0x20 */
+  __IO uint32_t PACRB;                             /**< Peripheral Access Control Register, offset: 0x24 */
+  __IO uint32_t PACRC;                             /**< Peripheral Access Control Register, offset: 0x28 */
+  __IO uint32_t PACRD;                             /**< Peripheral Access Control Register, offset: 0x2C */
+       uint8_t RESERVED_1[16];
+  __IO uint32_t PACRE;                             /**< Peripheral Access Control Register, offset: 0x40 */
+  __IO uint32_t PACRF;                             /**< Peripheral Access Control Register, offset: 0x44 */
+  __IO uint32_t PACRG;                             /**< Peripheral Access Control Register, offset: 0x48 */
+  __IO uint32_t PACRH;                             /**< Peripheral Access Control Register, offset: 0x4C */
+  __IO uint32_t PACRI;                             /**< Peripheral Access Control Register, offset: 0x50 */
+  __IO uint32_t PACRJ;                             /**< Peripheral Access Control Register, offset: 0x54 */
+  __IO uint32_t PACRK;                             /**< Peripheral Access Control Register, offset: 0x58 */
+  __IO uint32_t PACRL;                             /**< Peripheral Access Control Register, offset: 0x5C */
+  __IO uint32_t PACRM;                             /**< Peripheral Access Control Register, offset: 0x60 */
+  __IO uint32_t PACRN;                             /**< Peripheral Access Control Register, offset: 0x64 */
+  __IO uint32_t PACRO;                             /**< Peripheral Access Control Register, offset: 0x68 */
+  __IO uint32_t PACRP;                             /**< Peripheral Access Control Register, offset: 0x6C */
+       uint8_t RESERVED_2[16];
+  __IO uint32_t PACRU;                             /**< Peripheral Access Control Register, offset: 0x80 */
+} AIPS_Type;
+
+/* ----------------------------------------------------------------------------
+   -- AIPS Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AIPS_Register_Masks AIPS Register Masks
+ * @{
+ */
+
+/*! @name MPRA - Master Privilege Register A */
+#define AIPS_MPRA_MPL5_MASK                      (0x100U)
+#define AIPS_MPRA_MPL5_SHIFT                     (8U)
+#define AIPS_MPRA_MPL5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MPL5_SHIFT)) & AIPS_MPRA_MPL5_MASK)
+#define AIPS_MPRA_MTW5_MASK                      (0x200U)
+#define AIPS_MPRA_MTW5_SHIFT                     (9U)
+#define AIPS_MPRA_MTW5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTW5_SHIFT)) & AIPS_MPRA_MTW5_MASK)
+#define AIPS_MPRA_MTR5_MASK                      (0x400U)
+#define AIPS_MPRA_MTR5_SHIFT                     (10U)
+#define AIPS_MPRA_MTR5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTR5_SHIFT)) & AIPS_MPRA_MTR5_MASK)
+#define AIPS_MPRA_MPL4_MASK                      (0x1000U)
+#define AIPS_MPRA_MPL4_SHIFT                     (12U)
+#define AIPS_MPRA_MPL4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MPL4_SHIFT)) & AIPS_MPRA_MPL4_MASK)
+#define AIPS_MPRA_MTW4_MASK                      (0x2000U)
+#define AIPS_MPRA_MTW4_SHIFT                     (13U)
+#define AIPS_MPRA_MTW4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTW4_SHIFT)) & AIPS_MPRA_MTW4_MASK)
+#define AIPS_MPRA_MTR4_MASK                      (0x4000U)
+#define AIPS_MPRA_MTR4_SHIFT                     (14U)
+#define AIPS_MPRA_MTR4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTR4_SHIFT)) & AIPS_MPRA_MTR4_MASK)
+#define AIPS_MPRA_MPL3_MASK                      (0x10000U)
+#define AIPS_MPRA_MPL3_SHIFT                     (16U)
+#define AIPS_MPRA_MPL3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MPL3_SHIFT)) & AIPS_MPRA_MPL3_MASK)
+#define AIPS_MPRA_MTW3_MASK                      (0x20000U)
+#define AIPS_MPRA_MTW3_SHIFT                     (17U)
+#define AIPS_MPRA_MTW3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTW3_SHIFT)) & AIPS_MPRA_MTW3_MASK)
+#define AIPS_MPRA_MTR3_MASK                      (0x40000U)
+#define AIPS_MPRA_MTR3_SHIFT                     (18U)
+#define AIPS_MPRA_MTR3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTR3_SHIFT)) & AIPS_MPRA_MTR3_MASK)
+#define AIPS_MPRA_MPL2_MASK                      (0x100000U)
+#define AIPS_MPRA_MPL2_SHIFT                     (20U)
+#define AIPS_MPRA_MPL2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MPL2_SHIFT)) & AIPS_MPRA_MPL2_MASK)
+#define AIPS_MPRA_MTW2_MASK                      (0x200000U)
+#define AIPS_MPRA_MTW2_SHIFT                     (21U)
+#define AIPS_MPRA_MTW2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTW2_SHIFT)) & AIPS_MPRA_MTW2_MASK)
+#define AIPS_MPRA_MTR2_MASK                      (0x400000U)
+#define AIPS_MPRA_MTR2_SHIFT                     (22U)
+#define AIPS_MPRA_MTR2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTR2_SHIFT)) & AIPS_MPRA_MTR2_MASK)
+#define AIPS_MPRA_MPL1_MASK                      (0x1000000U)
+#define AIPS_MPRA_MPL1_SHIFT                     (24U)
+#define AIPS_MPRA_MPL1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MPL1_SHIFT)) & AIPS_MPRA_MPL1_MASK)
+#define AIPS_MPRA_MTW1_MASK                      (0x2000000U)
+#define AIPS_MPRA_MTW1_SHIFT                     (25U)
+#define AIPS_MPRA_MTW1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTW1_SHIFT)) & AIPS_MPRA_MTW1_MASK)
+#define AIPS_MPRA_MTR1_MASK                      (0x4000000U)
+#define AIPS_MPRA_MTR1_SHIFT                     (26U)
+#define AIPS_MPRA_MTR1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTR1_SHIFT)) & AIPS_MPRA_MTR1_MASK)
+#define AIPS_MPRA_MPL0_MASK                      (0x10000000U)
+#define AIPS_MPRA_MPL0_SHIFT                     (28U)
+#define AIPS_MPRA_MPL0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MPL0_SHIFT)) & AIPS_MPRA_MPL0_MASK)
+#define AIPS_MPRA_MTW0_MASK                      (0x20000000U)
+#define AIPS_MPRA_MTW0_SHIFT                     (29U)
+#define AIPS_MPRA_MTW0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTW0_SHIFT)) & AIPS_MPRA_MTW0_MASK)
+#define AIPS_MPRA_MTR0_MASK                      (0x40000000U)
+#define AIPS_MPRA_MTR0_SHIFT                     (30U)
+#define AIPS_MPRA_MTR0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_MPRA_MTR0_SHIFT)) & AIPS_MPRA_MTR0_MASK)
+
+/*! @name PACRA - Peripheral Access Control Register */
+#define AIPS_PACRA_TP7_MASK                      (0x1U)
+#define AIPS_PACRA_TP7_SHIFT                     (0U)
+#define AIPS_PACRA_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP7_SHIFT)) & AIPS_PACRA_TP7_MASK)
+#define AIPS_PACRA_WP7_MASK                      (0x2U)
+#define AIPS_PACRA_WP7_SHIFT                     (1U)
+#define AIPS_PACRA_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP7_SHIFT)) & AIPS_PACRA_WP7_MASK)
+#define AIPS_PACRA_SP7_MASK                      (0x4U)
+#define AIPS_PACRA_SP7_SHIFT                     (2U)
+#define AIPS_PACRA_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP7_SHIFT)) & AIPS_PACRA_SP7_MASK)
+#define AIPS_PACRA_TP6_MASK                      (0x10U)
+#define AIPS_PACRA_TP6_SHIFT                     (4U)
+#define AIPS_PACRA_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP6_SHIFT)) & AIPS_PACRA_TP6_MASK)
+#define AIPS_PACRA_WP6_MASK                      (0x20U)
+#define AIPS_PACRA_WP6_SHIFT                     (5U)
+#define AIPS_PACRA_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP6_SHIFT)) & AIPS_PACRA_WP6_MASK)
+#define AIPS_PACRA_SP6_MASK                      (0x40U)
+#define AIPS_PACRA_SP6_SHIFT                     (6U)
+#define AIPS_PACRA_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP6_SHIFT)) & AIPS_PACRA_SP6_MASK)
+#define AIPS_PACRA_TP5_MASK                      (0x100U)
+#define AIPS_PACRA_TP5_SHIFT                     (8U)
+#define AIPS_PACRA_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP5_SHIFT)) & AIPS_PACRA_TP5_MASK)
+#define AIPS_PACRA_WP5_MASK                      (0x200U)
+#define AIPS_PACRA_WP5_SHIFT                     (9U)
+#define AIPS_PACRA_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP5_SHIFT)) & AIPS_PACRA_WP5_MASK)
+#define AIPS_PACRA_SP5_MASK                      (0x400U)
+#define AIPS_PACRA_SP5_SHIFT                     (10U)
+#define AIPS_PACRA_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP5_SHIFT)) & AIPS_PACRA_SP5_MASK)
+#define AIPS_PACRA_TP4_MASK                      (0x1000U)
+#define AIPS_PACRA_TP4_SHIFT                     (12U)
+#define AIPS_PACRA_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP4_SHIFT)) & AIPS_PACRA_TP4_MASK)
+#define AIPS_PACRA_WP4_MASK                      (0x2000U)
+#define AIPS_PACRA_WP4_SHIFT                     (13U)
+#define AIPS_PACRA_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP4_SHIFT)) & AIPS_PACRA_WP4_MASK)
+#define AIPS_PACRA_SP4_MASK                      (0x4000U)
+#define AIPS_PACRA_SP4_SHIFT                     (14U)
+#define AIPS_PACRA_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP4_SHIFT)) & AIPS_PACRA_SP4_MASK)
+#define AIPS_PACRA_TP3_MASK                      (0x10000U)
+#define AIPS_PACRA_TP3_SHIFT                     (16U)
+#define AIPS_PACRA_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP3_SHIFT)) & AIPS_PACRA_TP3_MASK)
+#define AIPS_PACRA_WP3_MASK                      (0x20000U)
+#define AIPS_PACRA_WP3_SHIFT                     (17U)
+#define AIPS_PACRA_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP3_SHIFT)) & AIPS_PACRA_WP3_MASK)
+#define AIPS_PACRA_SP3_MASK                      (0x40000U)
+#define AIPS_PACRA_SP3_SHIFT                     (18U)
+#define AIPS_PACRA_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP3_SHIFT)) & AIPS_PACRA_SP3_MASK)
+#define AIPS_PACRA_TP2_MASK                      (0x100000U)
+#define AIPS_PACRA_TP2_SHIFT                     (20U)
+#define AIPS_PACRA_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP2_SHIFT)) & AIPS_PACRA_TP2_MASK)
+#define AIPS_PACRA_WP2_MASK                      (0x200000U)
+#define AIPS_PACRA_WP2_SHIFT                     (21U)
+#define AIPS_PACRA_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP2_SHIFT)) & AIPS_PACRA_WP2_MASK)
+#define AIPS_PACRA_SP2_MASK                      (0x400000U)
+#define AIPS_PACRA_SP2_SHIFT                     (22U)
+#define AIPS_PACRA_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP2_SHIFT)) & AIPS_PACRA_SP2_MASK)
+#define AIPS_PACRA_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRA_TP1_SHIFT                     (24U)
+#define AIPS_PACRA_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP1_SHIFT)) & AIPS_PACRA_TP1_MASK)
+#define AIPS_PACRA_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRA_WP1_SHIFT                     (25U)
+#define AIPS_PACRA_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP1_SHIFT)) & AIPS_PACRA_WP1_MASK)
+#define AIPS_PACRA_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRA_SP1_SHIFT                     (26U)
+#define AIPS_PACRA_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP1_SHIFT)) & AIPS_PACRA_SP1_MASK)
+#define AIPS_PACRA_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRA_TP0_SHIFT                     (28U)
+#define AIPS_PACRA_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_TP0_SHIFT)) & AIPS_PACRA_TP0_MASK)
+#define AIPS_PACRA_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRA_WP0_SHIFT                     (29U)
+#define AIPS_PACRA_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_WP0_SHIFT)) & AIPS_PACRA_WP0_MASK)
+#define AIPS_PACRA_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRA_SP0_SHIFT                     (30U)
+#define AIPS_PACRA_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRA_SP0_SHIFT)) & AIPS_PACRA_SP0_MASK)
+
+/*! @name PACRB - Peripheral Access Control Register */
+#define AIPS_PACRB_TP7_MASK                      (0x1U)
+#define AIPS_PACRB_TP7_SHIFT                     (0U)
+#define AIPS_PACRB_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP7_SHIFT)) & AIPS_PACRB_TP7_MASK)
+#define AIPS_PACRB_WP7_MASK                      (0x2U)
+#define AIPS_PACRB_WP7_SHIFT                     (1U)
+#define AIPS_PACRB_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP7_SHIFT)) & AIPS_PACRB_WP7_MASK)
+#define AIPS_PACRB_SP7_MASK                      (0x4U)
+#define AIPS_PACRB_SP7_SHIFT                     (2U)
+#define AIPS_PACRB_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP7_SHIFT)) & AIPS_PACRB_SP7_MASK)
+#define AIPS_PACRB_TP6_MASK                      (0x10U)
+#define AIPS_PACRB_TP6_SHIFT                     (4U)
+#define AIPS_PACRB_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP6_SHIFT)) & AIPS_PACRB_TP6_MASK)
+#define AIPS_PACRB_WP6_MASK                      (0x20U)
+#define AIPS_PACRB_WP6_SHIFT                     (5U)
+#define AIPS_PACRB_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP6_SHIFT)) & AIPS_PACRB_WP6_MASK)
+#define AIPS_PACRB_SP6_MASK                      (0x40U)
+#define AIPS_PACRB_SP6_SHIFT                     (6U)
+#define AIPS_PACRB_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP6_SHIFT)) & AIPS_PACRB_SP6_MASK)
+#define AIPS_PACRB_TP5_MASK                      (0x100U)
+#define AIPS_PACRB_TP5_SHIFT                     (8U)
+#define AIPS_PACRB_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP5_SHIFT)) & AIPS_PACRB_TP5_MASK)
+#define AIPS_PACRB_WP5_MASK                      (0x200U)
+#define AIPS_PACRB_WP5_SHIFT                     (9U)
+#define AIPS_PACRB_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP5_SHIFT)) & AIPS_PACRB_WP5_MASK)
+#define AIPS_PACRB_SP5_MASK                      (0x400U)
+#define AIPS_PACRB_SP5_SHIFT                     (10U)
+#define AIPS_PACRB_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP5_SHIFT)) & AIPS_PACRB_SP5_MASK)
+#define AIPS_PACRB_TP4_MASK                      (0x1000U)
+#define AIPS_PACRB_TP4_SHIFT                     (12U)
+#define AIPS_PACRB_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP4_SHIFT)) & AIPS_PACRB_TP4_MASK)
+#define AIPS_PACRB_WP4_MASK                      (0x2000U)
+#define AIPS_PACRB_WP4_SHIFT                     (13U)
+#define AIPS_PACRB_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP4_SHIFT)) & AIPS_PACRB_WP4_MASK)
+#define AIPS_PACRB_SP4_MASK                      (0x4000U)
+#define AIPS_PACRB_SP4_SHIFT                     (14U)
+#define AIPS_PACRB_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP4_SHIFT)) & AIPS_PACRB_SP4_MASK)
+#define AIPS_PACRB_TP3_MASK                      (0x10000U)
+#define AIPS_PACRB_TP3_SHIFT                     (16U)
+#define AIPS_PACRB_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP3_SHIFT)) & AIPS_PACRB_TP3_MASK)
+#define AIPS_PACRB_WP3_MASK                      (0x20000U)
+#define AIPS_PACRB_WP3_SHIFT                     (17U)
+#define AIPS_PACRB_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP3_SHIFT)) & AIPS_PACRB_WP3_MASK)
+#define AIPS_PACRB_SP3_MASK                      (0x40000U)
+#define AIPS_PACRB_SP3_SHIFT                     (18U)
+#define AIPS_PACRB_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP3_SHIFT)) & AIPS_PACRB_SP3_MASK)
+#define AIPS_PACRB_TP2_MASK                      (0x100000U)
+#define AIPS_PACRB_TP2_SHIFT                     (20U)
+#define AIPS_PACRB_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP2_SHIFT)) & AIPS_PACRB_TP2_MASK)
+#define AIPS_PACRB_WP2_MASK                      (0x200000U)
+#define AIPS_PACRB_WP2_SHIFT                     (21U)
+#define AIPS_PACRB_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP2_SHIFT)) & AIPS_PACRB_WP2_MASK)
+#define AIPS_PACRB_SP2_MASK                      (0x400000U)
+#define AIPS_PACRB_SP2_SHIFT                     (22U)
+#define AIPS_PACRB_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP2_SHIFT)) & AIPS_PACRB_SP2_MASK)
+#define AIPS_PACRB_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRB_TP1_SHIFT                     (24U)
+#define AIPS_PACRB_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP1_SHIFT)) & AIPS_PACRB_TP1_MASK)
+#define AIPS_PACRB_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRB_WP1_SHIFT                     (25U)
+#define AIPS_PACRB_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP1_SHIFT)) & AIPS_PACRB_WP1_MASK)
+#define AIPS_PACRB_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRB_SP1_SHIFT                     (26U)
+#define AIPS_PACRB_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP1_SHIFT)) & AIPS_PACRB_SP1_MASK)
+#define AIPS_PACRB_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRB_TP0_SHIFT                     (28U)
+#define AIPS_PACRB_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_TP0_SHIFT)) & AIPS_PACRB_TP0_MASK)
+#define AIPS_PACRB_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRB_WP0_SHIFT                     (29U)
+#define AIPS_PACRB_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_WP0_SHIFT)) & AIPS_PACRB_WP0_MASK)
+#define AIPS_PACRB_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRB_SP0_SHIFT                     (30U)
+#define AIPS_PACRB_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRB_SP0_SHIFT)) & AIPS_PACRB_SP0_MASK)
+
+/*! @name PACRC - Peripheral Access Control Register */
+#define AIPS_PACRC_TP7_MASK                      (0x1U)
+#define AIPS_PACRC_TP7_SHIFT                     (0U)
+#define AIPS_PACRC_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP7_SHIFT)) & AIPS_PACRC_TP7_MASK)
+#define AIPS_PACRC_WP7_MASK                      (0x2U)
+#define AIPS_PACRC_WP7_SHIFT                     (1U)
+#define AIPS_PACRC_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP7_SHIFT)) & AIPS_PACRC_WP7_MASK)
+#define AIPS_PACRC_SP7_MASK                      (0x4U)
+#define AIPS_PACRC_SP7_SHIFT                     (2U)
+#define AIPS_PACRC_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP7_SHIFT)) & AIPS_PACRC_SP7_MASK)
+#define AIPS_PACRC_TP6_MASK                      (0x10U)
+#define AIPS_PACRC_TP6_SHIFT                     (4U)
+#define AIPS_PACRC_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP6_SHIFT)) & AIPS_PACRC_TP6_MASK)
+#define AIPS_PACRC_WP6_MASK                      (0x20U)
+#define AIPS_PACRC_WP6_SHIFT                     (5U)
+#define AIPS_PACRC_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP6_SHIFT)) & AIPS_PACRC_WP6_MASK)
+#define AIPS_PACRC_SP6_MASK                      (0x40U)
+#define AIPS_PACRC_SP6_SHIFT                     (6U)
+#define AIPS_PACRC_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP6_SHIFT)) & AIPS_PACRC_SP6_MASK)
+#define AIPS_PACRC_TP5_MASK                      (0x100U)
+#define AIPS_PACRC_TP5_SHIFT                     (8U)
+#define AIPS_PACRC_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP5_SHIFT)) & AIPS_PACRC_TP5_MASK)
+#define AIPS_PACRC_WP5_MASK                      (0x200U)
+#define AIPS_PACRC_WP5_SHIFT                     (9U)
+#define AIPS_PACRC_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP5_SHIFT)) & AIPS_PACRC_WP5_MASK)
+#define AIPS_PACRC_SP5_MASK                      (0x400U)
+#define AIPS_PACRC_SP5_SHIFT                     (10U)
+#define AIPS_PACRC_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP5_SHIFT)) & AIPS_PACRC_SP5_MASK)
+#define AIPS_PACRC_TP4_MASK                      (0x1000U)
+#define AIPS_PACRC_TP4_SHIFT                     (12U)
+#define AIPS_PACRC_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP4_SHIFT)) & AIPS_PACRC_TP4_MASK)
+#define AIPS_PACRC_WP4_MASK                      (0x2000U)
+#define AIPS_PACRC_WP4_SHIFT                     (13U)
+#define AIPS_PACRC_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP4_SHIFT)) & AIPS_PACRC_WP4_MASK)
+#define AIPS_PACRC_SP4_MASK                      (0x4000U)
+#define AIPS_PACRC_SP4_SHIFT                     (14U)
+#define AIPS_PACRC_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP4_SHIFT)) & AIPS_PACRC_SP4_MASK)
+#define AIPS_PACRC_TP3_MASK                      (0x10000U)
+#define AIPS_PACRC_TP3_SHIFT                     (16U)
+#define AIPS_PACRC_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP3_SHIFT)) & AIPS_PACRC_TP3_MASK)
+#define AIPS_PACRC_WP3_MASK                      (0x20000U)
+#define AIPS_PACRC_WP3_SHIFT                     (17U)
+#define AIPS_PACRC_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP3_SHIFT)) & AIPS_PACRC_WP3_MASK)
+#define AIPS_PACRC_SP3_MASK                      (0x40000U)
+#define AIPS_PACRC_SP3_SHIFT                     (18U)
+#define AIPS_PACRC_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP3_SHIFT)) & AIPS_PACRC_SP3_MASK)
+#define AIPS_PACRC_TP2_MASK                      (0x100000U)
+#define AIPS_PACRC_TP2_SHIFT                     (20U)
+#define AIPS_PACRC_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP2_SHIFT)) & AIPS_PACRC_TP2_MASK)
+#define AIPS_PACRC_WP2_MASK                      (0x200000U)
+#define AIPS_PACRC_WP2_SHIFT                     (21U)
+#define AIPS_PACRC_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP2_SHIFT)) & AIPS_PACRC_WP2_MASK)
+#define AIPS_PACRC_SP2_MASK                      (0x400000U)
+#define AIPS_PACRC_SP2_SHIFT                     (22U)
+#define AIPS_PACRC_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP2_SHIFT)) & AIPS_PACRC_SP2_MASK)
+#define AIPS_PACRC_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRC_TP1_SHIFT                     (24U)
+#define AIPS_PACRC_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP1_SHIFT)) & AIPS_PACRC_TP1_MASK)
+#define AIPS_PACRC_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRC_WP1_SHIFT                     (25U)
+#define AIPS_PACRC_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP1_SHIFT)) & AIPS_PACRC_WP1_MASK)
+#define AIPS_PACRC_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRC_SP1_SHIFT                     (26U)
+#define AIPS_PACRC_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP1_SHIFT)) & AIPS_PACRC_SP1_MASK)
+#define AIPS_PACRC_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRC_TP0_SHIFT                     (28U)
+#define AIPS_PACRC_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_TP0_SHIFT)) & AIPS_PACRC_TP0_MASK)
+#define AIPS_PACRC_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRC_WP0_SHIFT                     (29U)
+#define AIPS_PACRC_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_WP0_SHIFT)) & AIPS_PACRC_WP0_MASK)
+#define AIPS_PACRC_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRC_SP0_SHIFT                     (30U)
+#define AIPS_PACRC_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRC_SP0_SHIFT)) & AIPS_PACRC_SP0_MASK)
+
+/*! @name PACRD - Peripheral Access Control Register */
+#define AIPS_PACRD_TP7_MASK                      (0x1U)
+#define AIPS_PACRD_TP7_SHIFT                     (0U)
+#define AIPS_PACRD_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP7_SHIFT)) & AIPS_PACRD_TP7_MASK)
+#define AIPS_PACRD_WP7_MASK                      (0x2U)
+#define AIPS_PACRD_WP7_SHIFT                     (1U)
+#define AIPS_PACRD_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP7_SHIFT)) & AIPS_PACRD_WP7_MASK)
+#define AIPS_PACRD_SP7_MASK                      (0x4U)
+#define AIPS_PACRD_SP7_SHIFT                     (2U)
+#define AIPS_PACRD_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP7_SHIFT)) & AIPS_PACRD_SP7_MASK)
+#define AIPS_PACRD_TP6_MASK                      (0x10U)
+#define AIPS_PACRD_TP6_SHIFT                     (4U)
+#define AIPS_PACRD_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP6_SHIFT)) & AIPS_PACRD_TP6_MASK)
+#define AIPS_PACRD_WP6_MASK                      (0x20U)
+#define AIPS_PACRD_WP6_SHIFT                     (5U)
+#define AIPS_PACRD_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP6_SHIFT)) & AIPS_PACRD_WP6_MASK)
+#define AIPS_PACRD_SP6_MASK                      (0x40U)
+#define AIPS_PACRD_SP6_SHIFT                     (6U)
+#define AIPS_PACRD_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP6_SHIFT)) & AIPS_PACRD_SP6_MASK)
+#define AIPS_PACRD_TP5_MASK                      (0x100U)
+#define AIPS_PACRD_TP5_SHIFT                     (8U)
+#define AIPS_PACRD_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP5_SHIFT)) & AIPS_PACRD_TP5_MASK)
+#define AIPS_PACRD_WP5_MASK                      (0x200U)
+#define AIPS_PACRD_WP5_SHIFT                     (9U)
+#define AIPS_PACRD_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP5_SHIFT)) & AIPS_PACRD_WP5_MASK)
+#define AIPS_PACRD_SP5_MASK                      (0x400U)
+#define AIPS_PACRD_SP5_SHIFT                     (10U)
+#define AIPS_PACRD_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP5_SHIFT)) & AIPS_PACRD_SP5_MASK)
+#define AIPS_PACRD_TP4_MASK                      (0x1000U)
+#define AIPS_PACRD_TP4_SHIFT                     (12U)
+#define AIPS_PACRD_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP4_SHIFT)) & AIPS_PACRD_TP4_MASK)
+#define AIPS_PACRD_WP4_MASK                      (0x2000U)
+#define AIPS_PACRD_WP4_SHIFT                     (13U)
+#define AIPS_PACRD_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP4_SHIFT)) & AIPS_PACRD_WP4_MASK)
+#define AIPS_PACRD_SP4_MASK                      (0x4000U)
+#define AIPS_PACRD_SP4_SHIFT                     (14U)
+#define AIPS_PACRD_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP4_SHIFT)) & AIPS_PACRD_SP4_MASK)
+#define AIPS_PACRD_TP3_MASK                      (0x10000U)
+#define AIPS_PACRD_TP3_SHIFT                     (16U)
+#define AIPS_PACRD_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP3_SHIFT)) & AIPS_PACRD_TP3_MASK)
+#define AIPS_PACRD_WP3_MASK                      (0x20000U)
+#define AIPS_PACRD_WP3_SHIFT                     (17U)
+#define AIPS_PACRD_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP3_SHIFT)) & AIPS_PACRD_WP3_MASK)
+#define AIPS_PACRD_SP3_MASK                      (0x40000U)
+#define AIPS_PACRD_SP3_SHIFT                     (18U)
+#define AIPS_PACRD_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP3_SHIFT)) & AIPS_PACRD_SP3_MASK)
+#define AIPS_PACRD_TP2_MASK                      (0x100000U)
+#define AIPS_PACRD_TP2_SHIFT                     (20U)
+#define AIPS_PACRD_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP2_SHIFT)) & AIPS_PACRD_TP2_MASK)
+#define AIPS_PACRD_WP2_MASK                      (0x200000U)
+#define AIPS_PACRD_WP2_SHIFT                     (21U)
+#define AIPS_PACRD_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP2_SHIFT)) & AIPS_PACRD_WP2_MASK)
+#define AIPS_PACRD_SP2_MASK                      (0x400000U)
+#define AIPS_PACRD_SP2_SHIFT                     (22U)
+#define AIPS_PACRD_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP2_SHIFT)) & AIPS_PACRD_SP2_MASK)
+#define AIPS_PACRD_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRD_TP1_SHIFT                     (24U)
+#define AIPS_PACRD_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP1_SHIFT)) & AIPS_PACRD_TP1_MASK)
+#define AIPS_PACRD_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRD_WP1_SHIFT                     (25U)
+#define AIPS_PACRD_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP1_SHIFT)) & AIPS_PACRD_WP1_MASK)
+#define AIPS_PACRD_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRD_SP1_SHIFT                     (26U)
+#define AIPS_PACRD_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP1_SHIFT)) & AIPS_PACRD_SP1_MASK)
+#define AIPS_PACRD_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRD_TP0_SHIFT                     (28U)
+#define AIPS_PACRD_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_TP0_SHIFT)) & AIPS_PACRD_TP0_MASK)
+#define AIPS_PACRD_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRD_WP0_SHIFT                     (29U)
+#define AIPS_PACRD_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_WP0_SHIFT)) & AIPS_PACRD_WP0_MASK)
+#define AIPS_PACRD_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRD_SP0_SHIFT                     (30U)
+#define AIPS_PACRD_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRD_SP0_SHIFT)) & AIPS_PACRD_SP0_MASK)
+
+/*! @name PACRE - Peripheral Access Control Register */
+#define AIPS_PACRE_TP7_MASK                      (0x1U)
+#define AIPS_PACRE_TP7_SHIFT                     (0U)
+#define AIPS_PACRE_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP7_SHIFT)) & AIPS_PACRE_TP7_MASK)
+#define AIPS_PACRE_WP7_MASK                      (0x2U)
+#define AIPS_PACRE_WP7_SHIFT                     (1U)
+#define AIPS_PACRE_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP7_SHIFT)) & AIPS_PACRE_WP7_MASK)
+#define AIPS_PACRE_SP7_MASK                      (0x4U)
+#define AIPS_PACRE_SP7_SHIFT                     (2U)
+#define AIPS_PACRE_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP7_SHIFT)) & AIPS_PACRE_SP7_MASK)
+#define AIPS_PACRE_TP6_MASK                      (0x10U)
+#define AIPS_PACRE_TP6_SHIFT                     (4U)
+#define AIPS_PACRE_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP6_SHIFT)) & AIPS_PACRE_TP6_MASK)
+#define AIPS_PACRE_WP6_MASK                      (0x20U)
+#define AIPS_PACRE_WP6_SHIFT                     (5U)
+#define AIPS_PACRE_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP6_SHIFT)) & AIPS_PACRE_WP6_MASK)
+#define AIPS_PACRE_SP6_MASK                      (0x40U)
+#define AIPS_PACRE_SP6_SHIFT                     (6U)
+#define AIPS_PACRE_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP6_SHIFT)) & AIPS_PACRE_SP6_MASK)
+#define AIPS_PACRE_TP5_MASK                      (0x100U)
+#define AIPS_PACRE_TP5_SHIFT                     (8U)
+#define AIPS_PACRE_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP5_SHIFT)) & AIPS_PACRE_TP5_MASK)
+#define AIPS_PACRE_WP5_MASK                      (0x200U)
+#define AIPS_PACRE_WP5_SHIFT                     (9U)
+#define AIPS_PACRE_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP5_SHIFT)) & AIPS_PACRE_WP5_MASK)
+#define AIPS_PACRE_SP5_MASK                      (0x400U)
+#define AIPS_PACRE_SP5_SHIFT                     (10U)
+#define AIPS_PACRE_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP5_SHIFT)) & AIPS_PACRE_SP5_MASK)
+#define AIPS_PACRE_TP4_MASK                      (0x1000U)
+#define AIPS_PACRE_TP4_SHIFT                     (12U)
+#define AIPS_PACRE_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP4_SHIFT)) & AIPS_PACRE_TP4_MASK)
+#define AIPS_PACRE_WP4_MASK                      (0x2000U)
+#define AIPS_PACRE_WP4_SHIFT                     (13U)
+#define AIPS_PACRE_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP4_SHIFT)) & AIPS_PACRE_WP4_MASK)
+#define AIPS_PACRE_SP4_MASK                      (0x4000U)
+#define AIPS_PACRE_SP4_SHIFT                     (14U)
+#define AIPS_PACRE_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP4_SHIFT)) & AIPS_PACRE_SP4_MASK)
+#define AIPS_PACRE_TP3_MASK                      (0x10000U)
+#define AIPS_PACRE_TP3_SHIFT                     (16U)
+#define AIPS_PACRE_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP3_SHIFT)) & AIPS_PACRE_TP3_MASK)
+#define AIPS_PACRE_WP3_MASK                      (0x20000U)
+#define AIPS_PACRE_WP3_SHIFT                     (17U)
+#define AIPS_PACRE_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP3_SHIFT)) & AIPS_PACRE_WP3_MASK)
+#define AIPS_PACRE_SP3_MASK                      (0x40000U)
+#define AIPS_PACRE_SP3_SHIFT                     (18U)
+#define AIPS_PACRE_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP3_SHIFT)) & AIPS_PACRE_SP3_MASK)
+#define AIPS_PACRE_TP2_MASK                      (0x100000U)
+#define AIPS_PACRE_TP2_SHIFT                     (20U)
+#define AIPS_PACRE_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP2_SHIFT)) & AIPS_PACRE_TP2_MASK)
+#define AIPS_PACRE_WP2_MASK                      (0x200000U)
+#define AIPS_PACRE_WP2_SHIFT                     (21U)
+#define AIPS_PACRE_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP2_SHIFT)) & AIPS_PACRE_WP2_MASK)
+#define AIPS_PACRE_SP2_MASK                      (0x400000U)
+#define AIPS_PACRE_SP2_SHIFT                     (22U)
+#define AIPS_PACRE_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP2_SHIFT)) & AIPS_PACRE_SP2_MASK)
+#define AIPS_PACRE_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRE_TP1_SHIFT                     (24U)
+#define AIPS_PACRE_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP1_SHIFT)) & AIPS_PACRE_TP1_MASK)
+#define AIPS_PACRE_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRE_WP1_SHIFT                     (25U)
+#define AIPS_PACRE_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP1_SHIFT)) & AIPS_PACRE_WP1_MASK)
+#define AIPS_PACRE_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRE_SP1_SHIFT                     (26U)
+#define AIPS_PACRE_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP1_SHIFT)) & AIPS_PACRE_SP1_MASK)
+#define AIPS_PACRE_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRE_TP0_SHIFT                     (28U)
+#define AIPS_PACRE_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_TP0_SHIFT)) & AIPS_PACRE_TP0_MASK)
+#define AIPS_PACRE_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRE_WP0_SHIFT                     (29U)
+#define AIPS_PACRE_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_WP0_SHIFT)) & AIPS_PACRE_WP0_MASK)
+#define AIPS_PACRE_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRE_SP0_SHIFT                     (30U)
+#define AIPS_PACRE_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRE_SP0_SHIFT)) & AIPS_PACRE_SP0_MASK)
+
+/*! @name PACRF - Peripheral Access Control Register */
+#define AIPS_PACRF_TP7_MASK                      (0x1U)
+#define AIPS_PACRF_TP7_SHIFT                     (0U)
+#define AIPS_PACRF_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP7_SHIFT)) & AIPS_PACRF_TP7_MASK)
+#define AIPS_PACRF_WP7_MASK                      (0x2U)
+#define AIPS_PACRF_WP7_SHIFT                     (1U)
+#define AIPS_PACRF_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP7_SHIFT)) & AIPS_PACRF_WP7_MASK)
+#define AIPS_PACRF_SP7_MASK                      (0x4U)
+#define AIPS_PACRF_SP7_SHIFT                     (2U)
+#define AIPS_PACRF_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP7_SHIFT)) & AIPS_PACRF_SP7_MASK)
+#define AIPS_PACRF_TP6_MASK                      (0x10U)
+#define AIPS_PACRF_TP6_SHIFT                     (4U)
+#define AIPS_PACRF_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP6_SHIFT)) & AIPS_PACRF_TP6_MASK)
+#define AIPS_PACRF_WP6_MASK                      (0x20U)
+#define AIPS_PACRF_WP6_SHIFT                     (5U)
+#define AIPS_PACRF_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP6_SHIFT)) & AIPS_PACRF_WP6_MASK)
+#define AIPS_PACRF_SP6_MASK                      (0x40U)
+#define AIPS_PACRF_SP6_SHIFT                     (6U)
+#define AIPS_PACRF_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP6_SHIFT)) & AIPS_PACRF_SP6_MASK)
+#define AIPS_PACRF_TP5_MASK                      (0x100U)
+#define AIPS_PACRF_TP5_SHIFT                     (8U)
+#define AIPS_PACRF_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP5_SHIFT)) & AIPS_PACRF_TP5_MASK)
+#define AIPS_PACRF_WP5_MASK                      (0x200U)
+#define AIPS_PACRF_WP5_SHIFT                     (9U)
+#define AIPS_PACRF_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP5_SHIFT)) & AIPS_PACRF_WP5_MASK)
+#define AIPS_PACRF_SP5_MASK                      (0x400U)
+#define AIPS_PACRF_SP5_SHIFT                     (10U)
+#define AIPS_PACRF_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP5_SHIFT)) & AIPS_PACRF_SP5_MASK)
+#define AIPS_PACRF_TP4_MASK                      (0x1000U)
+#define AIPS_PACRF_TP4_SHIFT                     (12U)
+#define AIPS_PACRF_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP4_SHIFT)) & AIPS_PACRF_TP4_MASK)
+#define AIPS_PACRF_WP4_MASK                      (0x2000U)
+#define AIPS_PACRF_WP4_SHIFT                     (13U)
+#define AIPS_PACRF_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP4_SHIFT)) & AIPS_PACRF_WP4_MASK)
+#define AIPS_PACRF_SP4_MASK                      (0x4000U)
+#define AIPS_PACRF_SP4_SHIFT                     (14U)
+#define AIPS_PACRF_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP4_SHIFT)) & AIPS_PACRF_SP4_MASK)
+#define AIPS_PACRF_TP3_MASK                      (0x10000U)
+#define AIPS_PACRF_TP3_SHIFT                     (16U)
+#define AIPS_PACRF_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP3_SHIFT)) & AIPS_PACRF_TP3_MASK)
+#define AIPS_PACRF_WP3_MASK                      (0x20000U)
+#define AIPS_PACRF_WP3_SHIFT                     (17U)
+#define AIPS_PACRF_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP3_SHIFT)) & AIPS_PACRF_WP3_MASK)
+#define AIPS_PACRF_SP3_MASK                      (0x40000U)
+#define AIPS_PACRF_SP3_SHIFT                     (18U)
+#define AIPS_PACRF_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP3_SHIFT)) & AIPS_PACRF_SP3_MASK)
+#define AIPS_PACRF_TP2_MASK                      (0x100000U)
+#define AIPS_PACRF_TP2_SHIFT                     (20U)
+#define AIPS_PACRF_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP2_SHIFT)) & AIPS_PACRF_TP2_MASK)
+#define AIPS_PACRF_WP2_MASK                      (0x200000U)
+#define AIPS_PACRF_WP2_SHIFT                     (21U)
+#define AIPS_PACRF_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP2_SHIFT)) & AIPS_PACRF_WP2_MASK)
+#define AIPS_PACRF_SP2_MASK                      (0x400000U)
+#define AIPS_PACRF_SP2_SHIFT                     (22U)
+#define AIPS_PACRF_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP2_SHIFT)) & AIPS_PACRF_SP2_MASK)
+#define AIPS_PACRF_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRF_TP1_SHIFT                     (24U)
+#define AIPS_PACRF_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP1_SHIFT)) & AIPS_PACRF_TP1_MASK)
+#define AIPS_PACRF_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRF_WP1_SHIFT                     (25U)
+#define AIPS_PACRF_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP1_SHIFT)) & AIPS_PACRF_WP1_MASK)
+#define AIPS_PACRF_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRF_SP1_SHIFT                     (26U)
+#define AIPS_PACRF_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP1_SHIFT)) & AIPS_PACRF_SP1_MASK)
+#define AIPS_PACRF_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRF_TP0_SHIFT                     (28U)
+#define AIPS_PACRF_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_TP0_SHIFT)) & AIPS_PACRF_TP0_MASK)
+#define AIPS_PACRF_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRF_WP0_SHIFT                     (29U)
+#define AIPS_PACRF_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_WP0_SHIFT)) & AIPS_PACRF_WP0_MASK)
+#define AIPS_PACRF_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRF_SP0_SHIFT                     (30U)
+#define AIPS_PACRF_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRF_SP0_SHIFT)) & AIPS_PACRF_SP0_MASK)
+
+/*! @name PACRG - Peripheral Access Control Register */
+#define AIPS_PACRG_TP7_MASK                      (0x1U)
+#define AIPS_PACRG_TP7_SHIFT                     (0U)
+#define AIPS_PACRG_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP7_SHIFT)) & AIPS_PACRG_TP7_MASK)
+#define AIPS_PACRG_WP7_MASK                      (0x2U)
+#define AIPS_PACRG_WP7_SHIFT                     (1U)
+#define AIPS_PACRG_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP7_SHIFT)) & AIPS_PACRG_WP7_MASK)
+#define AIPS_PACRG_SP7_MASK                      (0x4U)
+#define AIPS_PACRG_SP7_SHIFT                     (2U)
+#define AIPS_PACRG_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP7_SHIFT)) & AIPS_PACRG_SP7_MASK)
+#define AIPS_PACRG_TP6_MASK                      (0x10U)
+#define AIPS_PACRG_TP6_SHIFT                     (4U)
+#define AIPS_PACRG_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP6_SHIFT)) & AIPS_PACRG_TP6_MASK)
+#define AIPS_PACRG_WP6_MASK                      (0x20U)
+#define AIPS_PACRG_WP6_SHIFT                     (5U)
+#define AIPS_PACRG_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP6_SHIFT)) & AIPS_PACRG_WP6_MASK)
+#define AIPS_PACRG_SP6_MASK                      (0x40U)
+#define AIPS_PACRG_SP6_SHIFT                     (6U)
+#define AIPS_PACRG_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP6_SHIFT)) & AIPS_PACRG_SP6_MASK)
+#define AIPS_PACRG_TP5_MASK                      (0x100U)
+#define AIPS_PACRG_TP5_SHIFT                     (8U)
+#define AIPS_PACRG_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP5_SHIFT)) & AIPS_PACRG_TP5_MASK)
+#define AIPS_PACRG_WP5_MASK                      (0x200U)
+#define AIPS_PACRG_WP5_SHIFT                     (9U)
+#define AIPS_PACRG_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP5_SHIFT)) & AIPS_PACRG_WP5_MASK)
+#define AIPS_PACRG_SP5_MASK                      (0x400U)
+#define AIPS_PACRG_SP5_SHIFT                     (10U)
+#define AIPS_PACRG_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP5_SHIFT)) & AIPS_PACRG_SP5_MASK)
+#define AIPS_PACRG_TP4_MASK                      (0x1000U)
+#define AIPS_PACRG_TP4_SHIFT                     (12U)
+#define AIPS_PACRG_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP4_SHIFT)) & AIPS_PACRG_TP4_MASK)
+#define AIPS_PACRG_WP4_MASK                      (0x2000U)
+#define AIPS_PACRG_WP4_SHIFT                     (13U)
+#define AIPS_PACRG_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP4_SHIFT)) & AIPS_PACRG_WP4_MASK)
+#define AIPS_PACRG_SP4_MASK                      (0x4000U)
+#define AIPS_PACRG_SP4_SHIFT                     (14U)
+#define AIPS_PACRG_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP4_SHIFT)) & AIPS_PACRG_SP4_MASK)
+#define AIPS_PACRG_TP3_MASK                      (0x10000U)
+#define AIPS_PACRG_TP3_SHIFT                     (16U)
+#define AIPS_PACRG_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP3_SHIFT)) & AIPS_PACRG_TP3_MASK)
+#define AIPS_PACRG_WP3_MASK                      (0x20000U)
+#define AIPS_PACRG_WP3_SHIFT                     (17U)
+#define AIPS_PACRG_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP3_SHIFT)) & AIPS_PACRG_WP3_MASK)
+#define AIPS_PACRG_SP3_MASK                      (0x40000U)
+#define AIPS_PACRG_SP3_SHIFT                     (18U)
+#define AIPS_PACRG_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP3_SHIFT)) & AIPS_PACRG_SP3_MASK)
+#define AIPS_PACRG_TP2_MASK                      (0x100000U)
+#define AIPS_PACRG_TP2_SHIFT                     (20U)
+#define AIPS_PACRG_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP2_SHIFT)) & AIPS_PACRG_TP2_MASK)
+#define AIPS_PACRG_WP2_MASK                      (0x200000U)
+#define AIPS_PACRG_WP2_SHIFT                     (21U)
+#define AIPS_PACRG_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP2_SHIFT)) & AIPS_PACRG_WP2_MASK)
+#define AIPS_PACRG_SP2_MASK                      (0x400000U)
+#define AIPS_PACRG_SP2_SHIFT                     (22U)
+#define AIPS_PACRG_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP2_SHIFT)) & AIPS_PACRG_SP2_MASK)
+#define AIPS_PACRG_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRG_TP1_SHIFT                     (24U)
+#define AIPS_PACRG_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP1_SHIFT)) & AIPS_PACRG_TP1_MASK)
+#define AIPS_PACRG_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRG_WP1_SHIFT                     (25U)
+#define AIPS_PACRG_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP1_SHIFT)) & AIPS_PACRG_WP1_MASK)
+#define AIPS_PACRG_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRG_SP1_SHIFT                     (26U)
+#define AIPS_PACRG_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP1_SHIFT)) & AIPS_PACRG_SP1_MASK)
+#define AIPS_PACRG_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRG_TP0_SHIFT                     (28U)
+#define AIPS_PACRG_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_TP0_SHIFT)) & AIPS_PACRG_TP0_MASK)
+#define AIPS_PACRG_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRG_WP0_SHIFT                     (29U)
+#define AIPS_PACRG_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_WP0_SHIFT)) & AIPS_PACRG_WP0_MASK)
+#define AIPS_PACRG_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRG_SP0_SHIFT                     (30U)
+#define AIPS_PACRG_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRG_SP0_SHIFT)) & AIPS_PACRG_SP0_MASK)
+
+/*! @name PACRH - Peripheral Access Control Register */
+#define AIPS_PACRH_TP7_MASK                      (0x1U)
+#define AIPS_PACRH_TP7_SHIFT                     (0U)
+#define AIPS_PACRH_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP7_SHIFT)) & AIPS_PACRH_TP7_MASK)
+#define AIPS_PACRH_WP7_MASK                      (0x2U)
+#define AIPS_PACRH_WP7_SHIFT                     (1U)
+#define AIPS_PACRH_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP7_SHIFT)) & AIPS_PACRH_WP7_MASK)
+#define AIPS_PACRH_SP7_MASK                      (0x4U)
+#define AIPS_PACRH_SP7_SHIFT                     (2U)
+#define AIPS_PACRH_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP7_SHIFT)) & AIPS_PACRH_SP7_MASK)
+#define AIPS_PACRH_TP6_MASK                      (0x10U)
+#define AIPS_PACRH_TP6_SHIFT                     (4U)
+#define AIPS_PACRH_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP6_SHIFT)) & AIPS_PACRH_TP6_MASK)
+#define AIPS_PACRH_WP6_MASK                      (0x20U)
+#define AIPS_PACRH_WP6_SHIFT                     (5U)
+#define AIPS_PACRH_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP6_SHIFT)) & AIPS_PACRH_WP6_MASK)
+#define AIPS_PACRH_SP6_MASK                      (0x40U)
+#define AIPS_PACRH_SP6_SHIFT                     (6U)
+#define AIPS_PACRH_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP6_SHIFT)) & AIPS_PACRH_SP6_MASK)
+#define AIPS_PACRH_TP5_MASK                      (0x100U)
+#define AIPS_PACRH_TP5_SHIFT                     (8U)
+#define AIPS_PACRH_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP5_SHIFT)) & AIPS_PACRH_TP5_MASK)
+#define AIPS_PACRH_WP5_MASK                      (0x200U)
+#define AIPS_PACRH_WP5_SHIFT                     (9U)
+#define AIPS_PACRH_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP5_SHIFT)) & AIPS_PACRH_WP5_MASK)
+#define AIPS_PACRH_SP5_MASK                      (0x400U)
+#define AIPS_PACRH_SP5_SHIFT                     (10U)
+#define AIPS_PACRH_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP5_SHIFT)) & AIPS_PACRH_SP5_MASK)
+#define AIPS_PACRH_TP4_MASK                      (0x1000U)
+#define AIPS_PACRH_TP4_SHIFT                     (12U)
+#define AIPS_PACRH_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP4_SHIFT)) & AIPS_PACRH_TP4_MASK)
+#define AIPS_PACRH_WP4_MASK                      (0x2000U)
+#define AIPS_PACRH_WP4_SHIFT                     (13U)
+#define AIPS_PACRH_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP4_SHIFT)) & AIPS_PACRH_WP4_MASK)
+#define AIPS_PACRH_SP4_MASK                      (0x4000U)
+#define AIPS_PACRH_SP4_SHIFT                     (14U)
+#define AIPS_PACRH_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP4_SHIFT)) & AIPS_PACRH_SP4_MASK)
+#define AIPS_PACRH_TP3_MASK                      (0x10000U)
+#define AIPS_PACRH_TP3_SHIFT                     (16U)
+#define AIPS_PACRH_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP3_SHIFT)) & AIPS_PACRH_TP3_MASK)
+#define AIPS_PACRH_WP3_MASK                      (0x20000U)
+#define AIPS_PACRH_WP3_SHIFT                     (17U)
+#define AIPS_PACRH_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP3_SHIFT)) & AIPS_PACRH_WP3_MASK)
+#define AIPS_PACRH_SP3_MASK                      (0x40000U)
+#define AIPS_PACRH_SP3_SHIFT                     (18U)
+#define AIPS_PACRH_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP3_SHIFT)) & AIPS_PACRH_SP3_MASK)
+#define AIPS_PACRH_TP2_MASK                      (0x100000U)
+#define AIPS_PACRH_TP2_SHIFT                     (20U)
+#define AIPS_PACRH_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP2_SHIFT)) & AIPS_PACRH_TP2_MASK)
+#define AIPS_PACRH_WP2_MASK                      (0x200000U)
+#define AIPS_PACRH_WP2_SHIFT                     (21U)
+#define AIPS_PACRH_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP2_SHIFT)) & AIPS_PACRH_WP2_MASK)
+#define AIPS_PACRH_SP2_MASK                      (0x400000U)
+#define AIPS_PACRH_SP2_SHIFT                     (22U)
+#define AIPS_PACRH_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP2_SHIFT)) & AIPS_PACRH_SP2_MASK)
+#define AIPS_PACRH_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRH_TP1_SHIFT                     (24U)
+#define AIPS_PACRH_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP1_SHIFT)) & AIPS_PACRH_TP1_MASK)
+#define AIPS_PACRH_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRH_WP1_SHIFT                     (25U)
+#define AIPS_PACRH_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP1_SHIFT)) & AIPS_PACRH_WP1_MASK)
+#define AIPS_PACRH_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRH_SP1_SHIFT                     (26U)
+#define AIPS_PACRH_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP1_SHIFT)) & AIPS_PACRH_SP1_MASK)
+#define AIPS_PACRH_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRH_TP0_SHIFT                     (28U)
+#define AIPS_PACRH_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_TP0_SHIFT)) & AIPS_PACRH_TP0_MASK)
+#define AIPS_PACRH_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRH_WP0_SHIFT                     (29U)
+#define AIPS_PACRH_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_WP0_SHIFT)) & AIPS_PACRH_WP0_MASK)
+#define AIPS_PACRH_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRH_SP0_SHIFT                     (30U)
+#define AIPS_PACRH_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRH_SP0_SHIFT)) & AIPS_PACRH_SP0_MASK)
+
+/*! @name PACRI - Peripheral Access Control Register */
+#define AIPS_PACRI_TP7_MASK                      (0x1U)
+#define AIPS_PACRI_TP7_SHIFT                     (0U)
+#define AIPS_PACRI_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP7_SHIFT)) & AIPS_PACRI_TP7_MASK)
+#define AIPS_PACRI_WP7_MASK                      (0x2U)
+#define AIPS_PACRI_WP7_SHIFT                     (1U)
+#define AIPS_PACRI_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP7_SHIFT)) & AIPS_PACRI_WP7_MASK)
+#define AIPS_PACRI_SP7_MASK                      (0x4U)
+#define AIPS_PACRI_SP7_SHIFT                     (2U)
+#define AIPS_PACRI_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP7_SHIFT)) & AIPS_PACRI_SP7_MASK)
+#define AIPS_PACRI_TP6_MASK                      (0x10U)
+#define AIPS_PACRI_TP6_SHIFT                     (4U)
+#define AIPS_PACRI_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP6_SHIFT)) & AIPS_PACRI_TP6_MASK)
+#define AIPS_PACRI_WP6_MASK                      (0x20U)
+#define AIPS_PACRI_WP6_SHIFT                     (5U)
+#define AIPS_PACRI_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP6_SHIFT)) & AIPS_PACRI_WP6_MASK)
+#define AIPS_PACRI_SP6_MASK                      (0x40U)
+#define AIPS_PACRI_SP6_SHIFT                     (6U)
+#define AIPS_PACRI_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP6_SHIFT)) & AIPS_PACRI_SP6_MASK)
+#define AIPS_PACRI_TP5_MASK                      (0x100U)
+#define AIPS_PACRI_TP5_SHIFT                     (8U)
+#define AIPS_PACRI_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP5_SHIFT)) & AIPS_PACRI_TP5_MASK)
+#define AIPS_PACRI_WP5_MASK                      (0x200U)
+#define AIPS_PACRI_WP5_SHIFT                     (9U)
+#define AIPS_PACRI_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP5_SHIFT)) & AIPS_PACRI_WP5_MASK)
+#define AIPS_PACRI_SP5_MASK                      (0x400U)
+#define AIPS_PACRI_SP5_SHIFT                     (10U)
+#define AIPS_PACRI_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP5_SHIFT)) & AIPS_PACRI_SP5_MASK)
+#define AIPS_PACRI_TP4_MASK                      (0x1000U)
+#define AIPS_PACRI_TP4_SHIFT                     (12U)
+#define AIPS_PACRI_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP4_SHIFT)) & AIPS_PACRI_TP4_MASK)
+#define AIPS_PACRI_WP4_MASK                      (0x2000U)
+#define AIPS_PACRI_WP4_SHIFT                     (13U)
+#define AIPS_PACRI_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP4_SHIFT)) & AIPS_PACRI_WP4_MASK)
+#define AIPS_PACRI_SP4_MASK                      (0x4000U)
+#define AIPS_PACRI_SP4_SHIFT                     (14U)
+#define AIPS_PACRI_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP4_SHIFT)) & AIPS_PACRI_SP4_MASK)
+#define AIPS_PACRI_TP3_MASK                      (0x10000U)
+#define AIPS_PACRI_TP3_SHIFT                     (16U)
+#define AIPS_PACRI_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP3_SHIFT)) & AIPS_PACRI_TP3_MASK)
+#define AIPS_PACRI_WP3_MASK                      (0x20000U)
+#define AIPS_PACRI_WP3_SHIFT                     (17U)
+#define AIPS_PACRI_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP3_SHIFT)) & AIPS_PACRI_WP3_MASK)
+#define AIPS_PACRI_SP3_MASK                      (0x40000U)
+#define AIPS_PACRI_SP3_SHIFT                     (18U)
+#define AIPS_PACRI_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP3_SHIFT)) & AIPS_PACRI_SP3_MASK)
+#define AIPS_PACRI_TP2_MASK                      (0x100000U)
+#define AIPS_PACRI_TP2_SHIFT                     (20U)
+#define AIPS_PACRI_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP2_SHIFT)) & AIPS_PACRI_TP2_MASK)
+#define AIPS_PACRI_WP2_MASK                      (0x200000U)
+#define AIPS_PACRI_WP2_SHIFT                     (21U)
+#define AIPS_PACRI_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP2_SHIFT)) & AIPS_PACRI_WP2_MASK)
+#define AIPS_PACRI_SP2_MASK                      (0x400000U)
+#define AIPS_PACRI_SP2_SHIFT                     (22U)
+#define AIPS_PACRI_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP2_SHIFT)) & AIPS_PACRI_SP2_MASK)
+#define AIPS_PACRI_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRI_TP1_SHIFT                     (24U)
+#define AIPS_PACRI_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP1_SHIFT)) & AIPS_PACRI_TP1_MASK)
+#define AIPS_PACRI_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRI_WP1_SHIFT                     (25U)
+#define AIPS_PACRI_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP1_SHIFT)) & AIPS_PACRI_WP1_MASK)
+#define AIPS_PACRI_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRI_SP1_SHIFT                     (26U)
+#define AIPS_PACRI_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP1_SHIFT)) & AIPS_PACRI_SP1_MASK)
+#define AIPS_PACRI_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRI_TP0_SHIFT                     (28U)
+#define AIPS_PACRI_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_TP0_SHIFT)) & AIPS_PACRI_TP0_MASK)
+#define AIPS_PACRI_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRI_WP0_SHIFT                     (29U)
+#define AIPS_PACRI_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_WP0_SHIFT)) & AIPS_PACRI_WP0_MASK)
+#define AIPS_PACRI_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRI_SP0_SHIFT                     (30U)
+#define AIPS_PACRI_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRI_SP0_SHIFT)) & AIPS_PACRI_SP0_MASK)
+
+/*! @name PACRJ - Peripheral Access Control Register */
+#define AIPS_PACRJ_TP7_MASK                      (0x1U)
+#define AIPS_PACRJ_TP7_SHIFT                     (0U)
+#define AIPS_PACRJ_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP7_SHIFT)) & AIPS_PACRJ_TP7_MASK)
+#define AIPS_PACRJ_WP7_MASK                      (0x2U)
+#define AIPS_PACRJ_WP7_SHIFT                     (1U)
+#define AIPS_PACRJ_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP7_SHIFT)) & AIPS_PACRJ_WP7_MASK)
+#define AIPS_PACRJ_SP7_MASK                      (0x4U)
+#define AIPS_PACRJ_SP7_SHIFT                     (2U)
+#define AIPS_PACRJ_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP7_SHIFT)) & AIPS_PACRJ_SP7_MASK)
+#define AIPS_PACRJ_TP6_MASK                      (0x10U)
+#define AIPS_PACRJ_TP6_SHIFT                     (4U)
+#define AIPS_PACRJ_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP6_SHIFT)) & AIPS_PACRJ_TP6_MASK)
+#define AIPS_PACRJ_WP6_MASK                      (0x20U)
+#define AIPS_PACRJ_WP6_SHIFT                     (5U)
+#define AIPS_PACRJ_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP6_SHIFT)) & AIPS_PACRJ_WP6_MASK)
+#define AIPS_PACRJ_SP6_MASK                      (0x40U)
+#define AIPS_PACRJ_SP6_SHIFT                     (6U)
+#define AIPS_PACRJ_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP6_SHIFT)) & AIPS_PACRJ_SP6_MASK)
+#define AIPS_PACRJ_TP5_MASK                      (0x100U)
+#define AIPS_PACRJ_TP5_SHIFT                     (8U)
+#define AIPS_PACRJ_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP5_SHIFT)) & AIPS_PACRJ_TP5_MASK)
+#define AIPS_PACRJ_WP5_MASK                      (0x200U)
+#define AIPS_PACRJ_WP5_SHIFT                     (9U)
+#define AIPS_PACRJ_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP5_SHIFT)) & AIPS_PACRJ_WP5_MASK)
+#define AIPS_PACRJ_SP5_MASK                      (0x400U)
+#define AIPS_PACRJ_SP5_SHIFT                     (10U)
+#define AIPS_PACRJ_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP5_SHIFT)) & AIPS_PACRJ_SP5_MASK)
+#define AIPS_PACRJ_TP4_MASK                      (0x1000U)
+#define AIPS_PACRJ_TP4_SHIFT                     (12U)
+#define AIPS_PACRJ_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP4_SHIFT)) & AIPS_PACRJ_TP4_MASK)
+#define AIPS_PACRJ_WP4_MASK                      (0x2000U)
+#define AIPS_PACRJ_WP4_SHIFT                     (13U)
+#define AIPS_PACRJ_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP4_SHIFT)) & AIPS_PACRJ_WP4_MASK)
+#define AIPS_PACRJ_SP4_MASK                      (0x4000U)
+#define AIPS_PACRJ_SP4_SHIFT                     (14U)
+#define AIPS_PACRJ_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP4_SHIFT)) & AIPS_PACRJ_SP4_MASK)
+#define AIPS_PACRJ_TP3_MASK                      (0x10000U)
+#define AIPS_PACRJ_TP3_SHIFT                     (16U)
+#define AIPS_PACRJ_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP3_SHIFT)) & AIPS_PACRJ_TP3_MASK)
+#define AIPS_PACRJ_WP3_MASK                      (0x20000U)
+#define AIPS_PACRJ_WP3_SHIFT                     (17U)
+#define AIPS_PACRJ_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP3_SHIFT)) & AIPS_PACRJ_WP3_MASK)
+#define AIPS_PACRJ_SP3_MASK                      (0x40000U)
+#define AIPS_PACRJ_SP3_SHIFT                     (18U)
+#define AIPS_PACRJ_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP3_SHIFT)) & AIPS_PACRJ_SP3_MASK)
+#define AIPS_PACRJ_TP2_MASK                      (0x100000U)
+#define AIPS_PACRJ_TP2_SHIFT                     (20U)
+#define AIPS_PACRJ_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP2_SHIFT)) & AIPS_PACRJ_TP2_MASK)
+#define AIPS_PACRJ_WP2_MASK                      (0x200000U)
+#define AIPS_PACRJ_WP2_SHIFT                     (21U)
+#define AIPS_PACRJ_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP2_SHIFT)) & AIPS_PACRJ_WP2_MASK)
+#define AIPS_PACRJ_SP2_MASK                      (0x400000U)
+#define AIPS_PACRJ_SP2_SHIFT                     (22U)
+#define AIPS_PACRJ_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP2_SHIFT)) & AIPS_PACRJ_SP2_MASK)
+#define AIPS_PACRJ_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRJ_TP1_SHIFT                     (24U)
+#define AIPS_PACRJ_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP1_SHIFT)) & AIPS_PACRJ_TP1_MASK)
+#define AIPS_PACRJ_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRJ_WP1_SHIFT                     (25U)
+#define AIPS_PACRJ_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP1_SHIFT)) & AIPS_PACRJ_WP1_MASK)
+#define AIPS_PACRJ_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRJ_SP1_SHIFT                     (26U)
+#define AIPS_PACRJ_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP1_SHIFT)) & AIPS_PACRJ_SP1_MASK)
+#define AIPS_PACRJ_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRJ_TP0_SHIFT                     (28U)
+#define AIPS_PACRJ_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_TP0_SHIFT)) & AIPS_PACRJ_TP0_MASK)
+#define AIPS_PACRJ_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRJ_WP0_SHIFT                     (29U)
+#define AIPS_PACRJ_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_WP0_SHIFT)) & AIPS_PACRJ_WP0_MASK)
+#define AIPS_PACRJ_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRJ_SP0_SHIFT                     (30U)
+#define AIPS_PACRJ_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRJ_SP0_SHIFT)) & AIPS_PACRJ_SP0_MASK)
+
+/*! @name PACRK - Peripheral Access Control Register */
+#define AIPS_PACRK_TP7_MASK                      (0x1U)
+#define AIPS_PACRK_TP7_SHIFT                     (0U)
+#define AIPS_PACRK_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP7_SHIFT)) & AIPS_PACRK_TP7_MASK)
+#define AIPS_PACRK_WP7_MASK                      (0x2U)
+#define AIPS_PACRK_WP7_SHIFT                     (1U)
+#define AIPS_PACRK_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP7_SHIFT)) & AIPS_PACRK_WP7_MASK)
+#define AIPS_PACRK_SP7_MASK                      (0x4U)
+#define AIPS_PACRK_SP7_SHIFT                     (2U)
+#define AIPS_PACRK_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP7_SHIFT)) & AIPS_PACRK_SP7_MASK)
+#define AIPS_PACRK_TP6_MASK                      (0x10U)
+#define AIPS_PACRK_TP6_SHIFT                     (4U)
+#define AIPS_PACRK_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP6_SHIFT)) & AIPS_PACRK_TP6_MASK)
+#define AIPS_PACRK_WP6_MASK                      (0x20U)
+#define AIPS_PACRK_WP6_SHIFT                     (5U)
+#define AIPS_PACRK_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP6_SHIFT)) & AIPS_PACRK_WP6_MASK)
+#define AIPS_PACRK_SP6_MASK                      (0x40U)
+#define AIPS_PACRK_SP6_SHIFT                     (6U)
+#define AIPS_PACRK_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP6_SHIFT)) & AIPS_PACRK_SP6_MASK)
+#define AIPS_PACRK_TP5_MASK                      (0x100U)
+#define AIPS_PACRK_TP5_SHIFT                     (8U)
+#define AIPS_PACRK_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP5_SHIFT)) & AIPS_PACRK_TP5_MASK)
+#define AIPS_PACRK_WP5_MASK                      (0x200U)
+#define AIPS_PACRK_WP5_SHIFT                     (9U)
+#define AIPS_PACRK_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP5_SHIFT)) & AIPS_PACRK_WP5_MASK)
+#define AIPS_PACRK_SP5_MASK                      (0x400U)
+#define AIPS_PACRK_SP5_SHIFT                     (10U)
+#define AIPS_PACRK_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP5_SHIFT)) & AIPS_PACRK_SP5_MASK)
+#define AIPS_PACRK_TP4_MASK                      (0x1000U)
+#define AIPS_PACRK_TP4_SHIFT                     (12U)
+#define AIPS_PACRK_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP4_SHIFT)) & AIPS_PACRK_TP4_MASK)
+#define AIPS_PACRK_WP4_MASK                      (0x2000U)
+#define AIPS_PACRK_WP4_SHIFT                     (13U)
+#define AIPS_PACRK_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP4_SHIFT)) & AIPS_PACRK_WP4_MASK)
+#define AIPS_PACRK_SP4_MASK                      (0x4000U)
+#define AIPS_PACRK_SP4_SHIFT                     (14U)
+#define AIPS_PACRK_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP4_SHIFT)) & AIPS_PACRK_SP4_MASK)
+#define AIPS_PACRK_TP3_MASK                      (0x10000U)
+#define AIPS_PACRK_TP3_SHIFT                     (16U)
+#define AIPS_PACRK_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP3_SHIFT)) & AIPS_PACRK_TP3_MASK)
+#define AIPS_PACRK_WP3_MASK                      (0x20000U)
+#define AIPS_PACRK_WP3_SHIFT                     (17U)
+#define AIPS_PACRK_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP3_SHIFT)) & AIPS_PACRK_WP3_MASK)
+#define AIPS_PACRK_SP3_MASK                      (0x40000U)
+#define AIPS_PACRK_SP3_SHIFT                     (18U)
+#define AIPS_PACRK_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP3_SHIFT)) & AIPS_PACRK_SP3_MASK)
+#define AIPS_PACRK_TP2_MASK                      (0x100000U)
+#define AIPS_PACRK_TP2_SHIFT                     (20U)
+#define AIPS_PACRK_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP2_SHIFT)) & AIPS_PACRK_TP2_MASK)
+#define AIPS_PACRK_WP2_MASK                      (0x200000U)
+#define AIPS_PACRK_WP2_SHIFT                     (21U)
+#define AIPS_PACRK_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP2_SHIFT)) & AIPS_PACRK_WP2_MASK)
+#define AIPS_PACRK_SP2_MASK                      (0x400000U)
+#define AIPS_PACRK_SP2_SHIFT                     (22U)
+#define AIPS_PACRK_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP2_SHIFT)) & AIPS_PACRK_SP2_MASK)
+#define AIPS_PACRK_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRK_TP1_SHIFT                     (24U)
+#define AIPS_PACRK_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP1_SHIFT)) & AIPS_PACRK_TP1_MASK)
+#define AIPS_PACRK_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRK_WP1_SHIFT                     (25U)
+#define AIPS_PACRK_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP1_SHIFT)) & AIPS_PACRK_WP1_MASK)
+#define AIPS_PACRK_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRK_SP1_SHIFT                     (26U)
+#define AIPS_PACRK_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP1_SHIFT)) & AIPS_PACRK_SP1_MASK)
+#define AIPS_PACRK_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRK_TP0_SHIFT                     (28U)
+#define AIPS_PACRK_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_TP0_SHIFT)) & AIPS_PACRK_TP0_MASK)
+#define AIPS_PACRK_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRK_WP0_SHIFT                     (29U)
+#define AIPS_PACRK_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_WP0_SHIFT)) & AIPS_PACRK_WP0_MASK)
+#define AIPS_PACRK_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRK_SP0_SHIFT                     (30U)
+#define AIPS_PACRK_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRK_SP0_SHIFT)) & AIPS_PACRK_SP0_MASK)
+
+/*! @name PACRL - Peripheral Access Control Register */
+#define AIPS_PACRL_TP7_MASK                      (0x1U)
+#define AIPS_PACRL_TP7_SHIFT                     (0U)
+#define AIPS_PACRL_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP7_SHIFT)) & AIPS_PACRL_TP7_MASK)
+#define AIPS_PACRL_WP7_MASK                      (0x2U)
+#define AIPS_PACRL_WP7_SHIFT                     (1U)
+#define AIPS_PACRL_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP7_SHIFT)) & AIPS_PACRL_WP7_MASK)
+#define AIPS_PACRL_SP7_MASK                      (0x4U)
+#define AIPS_PACRL_SP7_SHIFT                     (2U)
+#define AIPS_PACRL_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP7_SHIFT)) & AIPS_PACRL_SP7_MASK)
+#define AIPS_PACRL_TP6_MASK                      (0x10U)
+#define AIPS_PACRL_TP6_SHIFT                     (4U)
+#define AIPS_PACRL_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP6_SHIFT)) & AIPS_PACRL_TP6_MASK)
+#define AIPS_PACRL_WP6_MASK                      (0x20U)
+#define AIPS_PACRL_WP6_SHIFT                     (5U)
+#define AIPS_PACRL_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP6_SHIFT)) & AIPS_PACRL_WP6_MASK)
+#define AIPS_PACRL_SP6_MASK                      (0x40U)
+#define AIPS_PACRL_SP6_SHIFT                     (6U)
+#define AIPS_PACRL_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP6_SHIFT)) & AIPS_PACRL_SP6_MASK)
+#define AIPS_PACRL_TP5_MASK                      (0x100U)
+#define AIPS_PACRL_TP5_SHIFT                     (8U)
+#define AIPS_PACRL_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP5_SHIFT)) & AIPS_PACRL_TP5_MASK)
+#define AIPS_PACRL_WP5_MASK                      (0x200U)
+#define AIPS_PACRL_WP5_SHIFT                     (9U)
+#define AIPS_PACRL_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP5_SHIFT)) & AIPS_PACRL_WP5_MASK)
+#define AIPS_PACRL_SP5_MASK                      (0x400U)
+#define AIPS_PACRL_SP5_SHIFT                     (10U)
+#define AIPS_PACRL_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP5_SHIFT)) & AIPS_PACRL_SP5_MASK)
+#define AIPS_PACRL_TP4_MASK                      (0x1000U)
+#define AIPS_PACRL_TP4_SHIFT                     (12U)
+#define AIPS_PACRL_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP4_SHIFT)) & AIPS_PACRL_TP4_MASK)
+#define AIPS_PACRL_WP4_MASK                      (0x2000U)
+#define AIPS_PACRL_WP4_SHIFT                     (13U)
+#define AIPS_PACRL_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP4_SHIFT)) & AIPS_PACRL_WP4_MASK)
+#define AIPS_PACRL_SP4_MASK                      (0x4000U)
+#define AIPS_PACRL_SP4_SHIFT                     (14U)
+#define AIPS_PACRL_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP4_SHIFT)) & AIPS_PACRL_SP4_MASK)
+#define AIPS_PACRL_TP3_MASK                      (0x10000U)
+#define AIPS_PACRL_TP3_SHIFT                     (16U)
+#define AIPS_PACRL_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP3_SHIFT)) & AIPS_PACRL_TP3_MASK)
+#define AIPS_PACRL_WP3_MASK                      (0x20000U)
+#define AIPS_PACRL_WP3_SHIFT                     (17U)
+#define AIPS_PACRL_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP3_SHIFT)) & AIPS_PACRL_WP3_MASK)
+#define AIPS_PACRL_SP3_MASK                      (0x40000U)
+#define AIPS_PACRL_SP3_SHIFT                     (18U)
+#define AIPS_PACRL_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP3_SHIFT)) & AIPS_PACRL_SP3_MASK)
+#define AIPS_PACRL_TP2_MASK                      (0x100000U)
+#define AIPS_PACRL_TP2_SHIFT                     (20U)
+#define AIPS_PACRL_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP2_SHIFT)) & AIPS_PACRL_TP2_MASK)
+#define AIPS_PACRL_WP2_MASK                      (0x200000U)
+#define AIPS_PACRL_WP2_SHIFT                     (21U)
+#define AIPS_PACRL_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP2_SHIFT)) & AIPS_PACRL_WP2_MASK)
+#define AIPS_PACRL_SP2_MASK                      (0x400000U)
+#define AIPS_PACRL_SP2_SHIFT                     (22U)
+#define AIPS_PACRL_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP2_SHIFT)) & AIPS_PACRL_SP2_MASK)
+#define AIPS_PACRL_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRL_TP1_SHIFT                     (24U)
+#define AIPS_PACRL_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP1_SHIFT)) & AIPS_PACRL_TP1_MASK)
+#define AIPS_PACRL_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRL_WP1_SHIFT                     (25U)
+#define AIPS_PACRL_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP1_SHIFT)) & AIPS_PACRL_WP1_MASK)
+#define AIPS_PACRL_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRL_SP1_SHIFT                     (26U)
+#define AIPS_PACRL_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP1_SHIFT)) & AIPS_PACRL_SP1_MASK)
+#define AIPS_PACRL_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRL_TP0_SHIFT                     (28U)
+#define AIPS_PACRL_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_TP0_SHIFT)) & AIPS_PACRL_TP0_MASK)
+#define AIPS_PACRL_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRL_WP0_SHIFT                     (29U)
+#define AIPS_PACRL_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_WP0_SHIFT)) & AIPS_PACRL_WP0_MASK)
+#define AIPS_PACRL_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRL_SP0_SHIFT                     (30U)
+#define AIPS_PACRL_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRL_SP0_SHIFT)) & AIPS_PACRL_SP0_MASK)
+
+/*! @name PACRM - Peripheral Access Control Register */
+#define AIPS_PACRM_TP7_MASK                      (0x1U)
+#define AIPS_PACRM_TP7_SHIFT                     (0U)
+#define AIPS_PACRM_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP7_SHIFT)) & AIPS_PACRM_TP7_MASK)
+#define AIPS_PACRM_WP7_MASK                      (0x2U)
+#define AIPS_PACRM_WP7_SHIFT                     (1U)
+#define AIPS_PACRM_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP7_SHIFT)) & AIPS_PACRM_WP7_MASK)
+#define AIPS_PACRM_SP7_MASK                      (0x4U)
+#define AIPS_PACRM_SP7_SHIFT                     (2U)
+#define AIPS_PACRM_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP7_SHIFT)) & AIPS_PACRM_SP7_MASK)
+#define AIPS_PACRM_TP6_MASK                      (0x10U)
+#define AIPS_PACRM_TP6_SHIFT                     (4U)
+#define AIPS_PACRM_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP6_SHIFT)) & AIPS_PACRM_TP6_MASK)
+#define AIPS_PACRM_WP6_MASK                      (0x20U)
+#define AIPS_PACRM_WP6_SHIFT                     (5U)
+#define AIPS_PACRM_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP6_SHIFT)) & AIPS_PACRM_WP6_MASK)
+#define AIPS_PACRM_SP6_MASK                      (0x40U)
+#define AIPS_PACRM_SP6_SHIFT                     (6U)
+#define AIPS_PACRM_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP6_SHIFT)) & AIPS_PACRM_SP6_MASK)
+#define AIPS_PACRM_TP5_MASK                      (0x100U)
+#define AIPS_PACRM_TP5_SHIFT                     (8U)
+#define AIPS_PACRM_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP5_SHIFT)) & AIPS_PACRM_TP5_MASK)
+#define AIPS_PACRM_WP5_MASK                      (0x200U)
+#define AIPS_PACRM_WP5_SHIFT                     (9U)
+#define AIPS_PACRM_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP5_SHIFT)) & AIPS_PACRM_WP5_MASK)
+#define AIPS_PACRM_SP5_MASK                      (0x400U)
+#define AIPS_PACRM_SP5_SHIFT                     (10U)
+#define AIPS_PACRM_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP5_SHIFT)) & AIPS_PACRM_SP5_MASK)
+#define AIPS_PACRM_TP4_MASK                      (0x1000U)
+#define AIPS_PACRM_TP4_SHIFT                     (12U)
+#define AIPS_PACRM_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP4_SHIFT)) & AIPS_PACRM_TP4_MASK)
+#define AIPS_PACRM_WP4_MASK                      (0x2000U)
+#define AIPS_PACRM_WP4_SHIFT                     (13U)
+#define AIPS_PACRM_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP4_SHIFT)) & AIPS_PACRM_WP4_MASK)
+#define AIPS_PACRM_SP4_MASK                      (0x4000U)
+#define AIPS_PACRM_SP4_SHIFT                     (14U)
+#define AIPS_PACRM_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP4_SHIFT)) & AIPS_PACRM_SP4_MASK)
+#define AIPS_PACRM_TP3_MASK                      (0x10000U)
+#define AIPS_PACRM_TP3_SHIFT                     (16U)
+#define AIPS_PACRM_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP3_SHIFT)) & AIPS_PACRM_TP3_MASK)
+#define AIPS_PACRM_WP3_MASK                      (0x20000U)
+#define AIPS_PACRM_WP3_SHIFT                     (17U)
+#define AIPS_PACRM_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP3_SHIFT)) & AIPS_PACRM_WP3_MASK)
+#define AIPS_PACRM_SP3_MASK                      (0x40000U)
+#define AIPS_PACRM_SP3_SHIFT                     (18U)
+#define AIPS_PACRM_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP3_SHIFT)) & AIPS_PACRM_SP3_MASK)
+#define AIPS_PACRM_TP2_MASK                      (0x100000U)
+#define AIPS_PACRM_TP2_SHIFT                     (20U)
+#define AIPS_PACRM_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP2_SHIFT)) & AIPS_PACRM_TP2_MASK)
+#define AIPS_PACRM_WP2_MASK                      (0x200000U)
+#define AIPS_PACRM_WP2_SHIFT                     (21U)
+#define AIPS_PACRM_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP2_SHIFT)) & AIPS_PACRM_WP2_MASK)
+#define AIPS_PACRM_SP2_MASK                      (0x400000U)
+#define AIPS_PACRM_SP2_SHIFT                     (22U)
+#define AIPS_PACRM_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP2_SHIFT)) & AIPS_PACRM_SP2_MASK)
+#define AIPS_PACRM_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRM_TP1_SHIFT                     (24U)
+#define AIPS_PACRM_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP1_SHIFT)) & AIPS_PACRM_TP1_MASK)
+#define AIPS_PACRM_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRM_WP1_SHIFT                     (25U)
+#define AIPS_PACRM_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP1_SHIFT)) & AIPS_PACRM_WP1_MASK)
+#define AIPS_PACRM_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRM_SP1_SHIFT                     (26U)
+#define AIPS_PACRM_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP1_SHIFT)) & AIPS_PACRM_SP1_MASK)
+#define AIPS_PACRM_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRM_TP0_SHIFT                     (28U)
+#define AIPS_PACRM_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_TP0_SHIFT)) & AIPS_PACRM_TP0_MASK)
+#define AIPS_PACRM_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRM_WP0_SHIFT                     (29U)
+#define AIPS_PACRM_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_WP0_SHIFT)) & AIPS_PACRM_WP0_MASK)
+#define AIPS_PACRM_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRM_SP0_SHIFT                     (30U)
+#define AIPS_PACRM_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRM_SP0_SHIFT)) & AIPS_PACRM_SP0_MASK)
+
+/*! @name PACRN - Peripheral Access Control Register */
+#define AIPS_PACRN_TP7_MASK                      (0x1U)
+#define AIPS_PACRN_TP7_SHIFT                     (0U)
+#define AIPS_PACRN_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP7_SHIFT)) & AIPS_PACRN_TP7_MASK)
+#define AIPS_PACRN_WP7_MASK                      (0x2U)
+#define AIPS_PACRN_WP7_SHIFT                     (1U)
+#define AIPS_PACRN_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP7_SHIFT)) & AIPS_PACRN_WP7_MASK)
+#define AIPS_PACRN_SP7_MASK                      (0x4U)
+#define AIPS_PACRN_SP7_SHIFT                     (2U)
+#define AIPS_PACRN_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP7_SHIFT)) & AIPS_PACRN_SP7_MASK)
+#define AIPS_PACRN_TP6_MASK                      (0x10U)
+#define AIPS_PACRN_TP6_SHIFT                     (4U)
+#define AIPS_PACRN_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP6_SHIFT)) & AIPS_PACRN_TP6_MASK)
+#define AIPS_PACRN_WP6_MASK                      (0x20U)
+#define AIPS_PACRN_WP6_SHIFT                     (5U)
+#define AIPS_PACRN_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP6_SHIFT)) & AIPS_PACRN_WP6_MASK)
+#define AIPS_PACRN_SP6_MASK                      (0x40U)
+#define AIPS_PACRN_SP6_SHIFT                     (6U)
+#define AIPS_PACRN_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP6_SHIFT)) & AIPS_PACRN_SP6_MASK)
+#define AIPS_PACRN_TP5_MASK                      (0x100U)
+#define AIPS_PACRN_TP5_SHIFT                     (8U)
+#define AIPS_PACRN_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP5_SHIFT)) & AIPS_PACRN_TP5_MASK)
+#define AIPS_PACRN_WP5_MASK                      (0x200U)
+#define AIPS_PACRN_WP5_SHIFT                     (9U)
+#define AIPS_PACRN_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP5_SHIFT)) & AIPS_PACRN_WP5_MASK)
+#define AIPS_PACRN_SP5_MASK                      (0x400U)
+#define AIPS_PACRN_SP5_SHIFT                     (10U)
+#define AIPS_PACRN_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP5_SHIFT)) & AIPS_PACRN_SP5_MASK)
+#define AIPS_PACRN_TP4_MASK                      (0x1000U)
+#define AIPS_PACRN_TP4_SHIFT                     (12U)
+#define AIPS_PACRN_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP4_SHIFT)) & AIPS_PACRN_TP4_MASK)
+#define AIPS_PACRN_WP4_MASK                      (0x2000U)
+#define AIPS_PACRN_WP4_SHIFT                     (13U)
+#define AIPS_PACRN_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP4_SHIFT)) & AIPS_PACRN_WP4_MASK)
+#define AIPS_PACRN_SP4_MASK                      (0x4000U)
+#define AIPS_PACRN_SP4_SHIFT                     (14U)
+#define AIPS_PACRN_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP4_SHIFT)) & AIPS_PACRN_SP4_MASK)
+#define AIPS_PACRN_TP3_MASK                      (0x10000U)
+#define AIPS_PACRN_TP3_SHIFT                     (16U)
+#define AIPS_PACRN_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP3_SHIFT)) & AIPS_PACRN_TP3_MASK)
+#define AIPS_PACRN_WP3_MASK                      (0x20000U)
+#define AIPS_PACRN_WP3_SHIFT                     (17U)
+#define AIPS_PACRN_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP3_SHIFT)) & AIPS_PACRN_WP3_MASK)
+#define AIPS_PACRN_SP3_MASK                      (0x40000U)
+#define AIPS_PACRN_SP3_SHIFT                     (18U)
+#define AIPS_PACRN_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP3_SHIFT)) & AIPS_PACRN_SP3_MASK)
+#define AIPS_PACRN_TP2_MASK                      (0x100000U)
+#define AIPS_PACRN_TP2_SHIFT                     (20U)
+#define AIPS_PACRN_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP2_SHIFT)) & AIPS_PACRN_TP2_MASK)
+#define AIPS_PACRN_WP2_MASK                      (0x200000U)
+#define AIPS_PACRN_WP2_SHIFT                     (21U)
+#define AIPS_PACRN_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP2_SHIFT)) & AIPS_PACRN_WP2_MASK)
+#define AIPS_PACRN_SP2_MASK                      (0x400000U)
+#define AIPS_PACRN_SP2_SHIFT                     (22U)
+#define AIPS_PACRN_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP2_SHIFT)) & AIPS_PACRN_SP2_MASK)
+#define AIPS_PACRN_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRN_TP1_SHIFT                     (24U)
+#define AIPS_PACRN_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP1_SHIFT)) & AIPS_PACRN_TP1_MASK)
+#define AIPS_PACRN_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRN_WP1_SHIFT                     (25U)
+#define AIPS_PACRN_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP1_SHIFT)) & AIPS_PACRN_WP1_MASK)
+#define AIPS_PACRN_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRN_SP1_SHIFT                     (26U)
+#define AIPS_PACRN_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP1_SHIFT)) & AIPS_PACRN_SP1_MASK)
+#define AIPS_PACRN_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRN_TP0_SHIFT                     (28U)
+#define AIPS_PACRN_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_TP0_SHIFT)) & AIPS_PACRN_TP0_MASK)
+#define AIPS_PACRN_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRN_WP0_SHIFT                     (29U)
+#define AIPS_PACRN_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_WP0_SHIFT)) & AIPS_PACRN_WP0_MASK)
+#define AIPS_PACRN_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRN_SP0_SHIFT                     (30U)
+#define AIPS_PACRN_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRN_SP0_SHIFT)) & AIPS_PACRN_SP0_MASK)
+
+/*! @name PACRO - Peripheral Access Control Register */
+#define AIPS_PACRO_TP7_MASK                      (0x1U)
+#define AIPS_PACRO_TP7_SHIFT                     (0U)
+#define AIPS_PACRO_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP7_SHIFT)) & AIPS_PACRO_TP7_MASK)
+#define AIPS_PACRO_WP7_MASK                      (0x2U)
+#define AIPS_PACRO_WP7_SHIFT                     (1U)
+#define AIPS_PACRO_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP7_SHIFT)) & AIPS_PACRO_WP7_MASK)
+#define AIPS_PACRO_SP7_MASK                      (0x4U)
+#define AIPS_PACRO_SP7_SHIFT                     (2U)
+#define AIPS_PACRO_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP7_SHIFT)) & AIPS_PACRO_SP7_MASK)
+#define AIPS_PACRO_TP6_MASK                      (0x10U)
+#define AIPS_PACRO_TP6_SHIFT                     (4U)
+#define AIPS_PACRO_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP6_SHIFT)) & AIPS_PACRO_TP6_MASK)
+#define AIPS_PACRO_WP6_MASK                      (0x20U)
+#define AIPS_PACRO_WP6_SHIFT                     (5U)
+#define AIPS_PACRO_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP6_SHIFT)) & AIPS_PACRO_WP6_MASK)
+#define AIPS_PACRO_SP6_MASK                      (0x40U)
+#define AIPS_PACRO_SP6_SHIFT                     (6U)
+#define AIPS_PACRO_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP6_SHIFT)) & AIPS_PACRO_SP6_MASK)
+#define AIPS_PACRO_TP5_MASK                      (0x100U)
+#define AIPS_PACRO_TP5_SHIFT                     (8U)
+#define AIPS_PACRO_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP5_SHIFT)) & AIPS_PACRO_TP5_MASK)
+#define AIPS_PACRO_WP5_MASK                      (0x200U)
+#define AIPS_PACRO_WP5_SHIFT                     (9U)
+#define AIPS_PACRO_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP5_SHIFT)) & AIPS_PACRO_WP5_MASK)
+#define AIPS_PACRO_SP5_MASK                      (0x400U)
+#define AIPS_PACRO_SP5_SHIFT                     (10U)
+#define AIPS_PACRO_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP5_SHIFT)) & AIPS_PACRO_SP5_MASK)
+#define AIPS_PACRO_TP4_MASK                      (0x1000U)
+#define AIPS_PACRO_TP4_SHIFT                     (12U)
+#define AIPS_PACRO_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP4_SHIFT)) & AIPS_PACRO_TP4_MASK)
+#define AIPS_PACRO_WP4_MASK                      (0x2000U)
+#define AIPS_PACRO_WP4_SHIFT                     (13U)
+#define AIPS_PACRO_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP4_SHIFT)) & AIPS_PACRO_WP4_MASK)
+#define AIPS_PACRO_SP4_MASK                      (0x4000U)
+#define AIPS_PACRO_SP4_SHIFT                     (14U)
+#define AIPS_PACRO_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP4_SHIFT)) & AIPS_PACRO_SP4_MASK)
+#define AIPS_PACRO_TP3_MASK                      (0x10000U)
+#define AIPS_PACRO_TP3_SHIFT                     (16U)
+#define AIPS_PACRO_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP3_SHIFT)) & AIPS_PACRO_TP3_MASK)
+#define AIPS_PACRO_WP3_MASK                      (0x20000U)
+#define AIPS_PACRO_WP3_SHIFT                     (17U)
+#define AIPS_PACRO_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP3_SHIFT)) & AIPS_PACRO_WP3_MASK)
+#define AIPS_PACRO_SP3_MASK                      (0x40000U)
+#define AIPS_PACRO_SP3_SHIFT                     (18U)
+#define AIPS_PACRO_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP3_SHIFT)) & AIPS_PACRO_SP3_MASK)
+#define AIPS_PACRO_TP2_MASK                      (0x100000U)
+#define AIPS_PACRO_TP2_SHIFT                     (20U)
+#define AIPS_PACRO_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP2_SHIFT)) & AIPS_PACRO_TP2_MASK)
+#define AIPS_PACRO_WP2_MASK                      (0x200000U)
+#define AIPS_PACRO_WP2_SHIFT                     (21U)
+#define AIPS_PACRO_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP2_SHIFT)) & AIPS_PACRO_WP2_MASK)
+#define AIPS_PACRO_SP2_MASK                      (0x400000U)
+#define AIPS_PACRO_SP2_SHIFT                     (22U)
+#define AIPS_PACRO_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP2_SHIFT)) & AIPS_PACRO_SP2_MASK)
+#define AIPS_PACRO_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRO_TP1_SHIFT                     (24U)
+#define AIPS_PACRO_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP1_SHIFT)) & AIPS_PACRO_TP1_MASK)
+#define AIPS_PACRO_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRO_WP1_SHIFT                     (25U)
+#define AIPS_PACRO_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP1_SHIFT)) & AIPS_PACRO_WP1_MASK)
+#define AIPS_PACRO_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRO_SP1_SHIFT                     (26U)
+#define AIPS_PACRO_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP1_SHIFT)) & AIPS_PACRO_SP1_MASK)
+#define AIPS_PACRO_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRO_TP0_SHIFT                     (28U)
+#define AIPS_PACRO_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_TP0_SHIFT)) & AIPS_PACRO_TP0_MASK)
+#define AIPS_PACRO_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRO_WP0_SHIFT                     (29U)
+#define AIPS_PACRO_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_WP0_SHIFT)) & AIPS_PACRO_WP0_MASK)
+#define AIPS_PACRO_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRO_SP0_SHIFT                     (30U)
+#define AIPS_PACRO_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRO_SP0_SHIFT)) & AIPS_PACRO_SP0_MASK)
+
+/*! @name PACRP - Peripheral Access Control Register */
+#define AIPS_PACRP_TP7_MASK                      (0x1U)
+#define AIPS_PACRP_TP7_SHIFT                     (0U)
+#define AIPS_PACRP_TP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP7_SHIFT)) & AIPS_PACRP_TP7_MASK)
+#define AIPS_PACRP_WP7_MASK                      (0x2U)
+#define AIPS_PACRP_WP7_SHIFT                     (1U)
+#define AIPS_PACRP_WP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP7_SHIFT)) & AIPS_PACRP_WP7_MASK)
+#define AIPS_PACRP_SP7_MASK                      (0x4U)
+#define AIPS_PACRP_SP7_SHIFT                     (2U)
+#define AIPS_PACRP_SP7(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP7_SHIFT)) & AIPS_PACRP_SP7_MASK)
+#define AIPS_PACRP_TP6_MASK                      (0x10U)
+#define AIPS_PACRP_TP6_SHIFT                     (4U)
+#define AIPS_PACRP_TP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP6_SHIFT)) & AIPS_PACRP_TP6_MASK)
+#define AIPS_PACRP_WP6_MASK                      (0x20U)
+#define AIPS_PACRP_WP6_SHIFT                     (5U)
+#define AIPS_PACRP_WP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP6_SHIFT)) & AIPS_PACRP_WP6_MASK)
+#define AIPS_PACRP_SP6_MASK                      (0x40U)
+#define AIPS_PACRP_SP6_SHIFT                     (6U)
+#define AIPS_PACRP_SP6(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP6_SHIFT)) & AIPS_PACRP_SP6_MASK)
+#define AIPS_PACRP_TP5_MASK                      (0x100U)
+#define AIPS_PACRP_TP5_SHIFT                     (8U)
+#define AIPS_PACRP_TP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP5_SHIFT)) & AIPS_PACRP_TP5_MASK)
+#define AIPS_PACRP_WP5_MASK                      (0x200U)
+#define AIPS_PACRP_WP5_SHIFT                     (9U)
+#define AIPS_PACRP_WP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP5_SHIFT)) & AIPS_PACRP_WP5_MASK)
+#define AIPS_PACRP_SP5_MASK                      (0x400U)
+#define AIPS_PACRP_SP5_SHIFT                     (10U)
+#define AIPS_PACRP_SP5(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP5_SHIFT)) & AIPS_PACRP_SP5_MASK)
+#define AIPS_PACRP_TP4_MASK                      (0x1000U)
+#define AIPS_PACRP_TP4_SHIFT                     (12U)
+#define AIPS_PACRP_TP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP4_SHIFT)) & AIPS_PACRP_TP4_MASK)
+#define AIPS_PACRP_WP4_MASK                      (0x2000U)
+#define AIPS_PACRP_WP4_SHIFT                     (13U)
+#define AIPS_PACRP_WP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP4_SHIFT)) & AIPS_PACRP_WP4_MASK)
+#define AIPS_PACRP_SP4_MASK                      (0x4000U)
+#define AIPS_PACRP_SP4_SHIFT                     (14U)
+#define AIPS_PACRP_SP4(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP4_SHIFT)) & AIPS_PACRP_SP4_MASK)
+#define AIPS_PACRP_TP3_MASK                      (0x10000U)
+#define AIPS_PACRP_TP3_SHIFT                     (16U)
+#define AIPS_PACRP_TP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP3_SHIFT)) & AIPS_PACRP_TP3_MASK)
+#define AIPS_PACRP_WP3_MASK                      (0x20000U)
+#define AIPS_PACRP_WP3_SHIFT                     (17U)
+#define AIPS_PACRP_WP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP3_SHIFT)) & AIPS_PACRP_WP3_MASK)
+#define AIPS_PACRP_SP3_MASK                      (0x40000U)
+#define AIPS_PACRP_SP3_SHIFT                     (18U)
+#define AIPS_PACRP_SP3(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP3_SHIFT)) & AIPS_PACRP_SP3_MASK)
+#define AIPS_PACRP_TP2_MASK                      (0x100000U)
+#define AIPS_PACRP_TP2_SHIFT                     (20U)
+#define AIPS_PACRP_TP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP2_SHIFT)) & AIPS_PACRP_TP2_MASK)
+#define AIPS_PACRP_WP2_MASK                      (0x200000U)
+#define AIPS_PACRP_WP2_SHIFT                     (21U)
+#define AIPS_PACRP_WP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP2_SHIFT)) & AIPS_PACRP_WP2_MASK)
+#define AIPS_PACRP_SP2_MASK                      (0x400000U)
+#define AIPS_PACRP_SP2_SHIFT                     (22U)
+#define AIPS_PACRP_SP2(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP2_SHIFT)) & AIPS_PACRP_SP2_MASK)
+#define AIPS_PACRP_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRP_TP1_SHIFT                     (24U)
+#define AIPS_PACRP_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP1_SHIFT)) & AIPS_PACRP_TP1_MASK)
+#define AIPS_PACRP_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRP_WP1_SHIFT                     (25U)
+#define AIPS_PACRP_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP1_SHIFT)) & AIPS_PACRP_WP1_MASK)
+#define AIPS_PACRP_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRP_SP1_SHIFT                     (26U)
+#define AIPS_PACRP_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP1_SHIFT)) & AIPS_PACRP_SP1_MASK)
+#define AIPS_PACRP_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRP_TP0_SHIFT                     (28U)
+#define AIPS_PACRP_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_TP0_SHIFT)) & AIPS_PACRP_TP0_MASK)
+#define AIPS_PACRP_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRP_WP0_SHIFT                     (29U)
+#define AIPS_PACRP_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_WP0_SHIFT)) & AIPS_PACRP_WP0_MASK)
+#define AIPS_PACRP_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRP_SP0_SHIFT                     (30U)
+#define AIPS_PACRP_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRP_SP0_SHIFT)) & AIPS_PACRP_SP0_MASK)
+
+/*! @name PACRU - Peripheral Access Control Register */
+#define AIPS_PACRU_TP1_MASK                      (0x1000000U)
+#define AIPS_PACRU_TP1_SHIFT                     (24U)
+#define AIPS_PACRU_TP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRU_TP1_SHIFT)) & AIPS_PACRU_TP1_MASK)
+#define AIPS_PACRU_WP1_MASK                      (0x2000000U)
+#define AIPS_PACRU_WP1_SHIFT                     (25U)
+#define AIPS_PACRU_WP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRU_WP1_SHIFT)) & AIPS_PACRU_WP1_MASK)
+#define AIPS_PACRU_SP1_MASK                      (0x4000000U)
+#define AIPS_PACRU_SP1_SHIFT                     (26U)
+#define AIPS_PACRU_SP1(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRU_SP1_SHIFT)) & AIPS_PACRU_SP1_MASK)
+#define AIPS_PACRU_TP0_MASK                      (0x10000000U)
+#define AIPS_PACRU_TP0_SHIFT                     (28U)
+#define AIPS_PACRU_TP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRU_TP0_SHIFT)) & AIPS_PACRU_TP0_MASK)
+#define AIPS_PACRU_WP0_MASK                      (0x20000000U)
+#define AIPS_PACRU_WP0_SHIFT                     (29U)
+#define AIPS_PACRU_WP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRU_WP0_SHIFT)) & AIPS_PACRU_WP0_MASK)
+#define AIPS_PACRU_SP0_MASK                      (0x40000000U)
+#define AIPS_PACRU_SP0_SHIFT                     (30U)
+#define AIPS_PACRU_SP0(x)                        (((uint32_t)(((uint32_t)(x)) << AIPS_PACRU_SP0_SHIFT)) & AIPS_PACRU_SP0_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group AIPS_Register_Masks */
+
+
+/* AIPS - Peripheral instance base addresses */
+/** Peripheral AIPS0 base address */
+#define AIPS0_BASE                               (0x40000000u)
+/** Peripheral AIPS0 base pointer */
+#define AIPS0                                    ((AIPS_Type *)AIPS0_BASE)
+/** Peripheral AIPS1 base address */
+#define AIPS1_BASE                               (0x40080000u)
+/** Peripheral AIPS1 base pointer */
+#define AIPS1                                    ((AIPS_Type *)AIPS1_BASE)
+/** Array initializer of AIPS peripheral base addresses */
+#define AIPS_BASE_ADDRS                          { AIPS0_BASE, AIPS1_BASE }
+/** Array initializer of AIPS peripheral base pointers */
+#define AIPS_BASE_PTRS                           { AIPS0, AIPS1 }
+
+/*!
+ * @}
+ */ /* end of group AIPS_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- AXBS Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AXBS_Peripheral_Access_Layer AXBS Peripheral Access Layer
+ * @{
+ */
+
+/** AXBS - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0x100 */
+    __IO uint32_t PRS;                               /**< Priority Registers Slave, array offset: 0x0, array step: 0x100 */
+         uint8_t RESERVED_0[12];
+    __IO uint32_t CRS;                               /**< Control Register, array offset: 0x10, array step: 0x100 */
+         uint8_t RESERVED_1[236];
+  } SLAVE[5];
+       uint8_t RESERVED_0[768];
+  __IO uint32_t MGPCR0;                            /**< Master General Purpose Control Register, offset: 0x800 */
+       uint8_t RESERVED_1[252];
+  __IO uint32_t MGPCR1;                            /**< Master General Purpose Control Register, offset: 0x900 */
+       uint8_t RESERVED_2[252];
+  __IO uint32_t MGPCR2;                            /**< Master General Purpose Control Register, offset: 0xA00 */
+       uint8_t RESERVED_3[252];
+  __IO uint32_t MGPCR3;                            /**< Master General Purpose Control Register, offset: 0xB00 */
+       uint8_t RESERVED_4[252];
+  __IO uint32_t MGPCR4;                            /**< Master General Purpose Control Register, offset: 0xC00 */
+       uint8_t RESERVED_5[252];
+  __IO uint32_t MGPCR5;                            /**< Master General Purpose Control Register, offset: 0xD00 */
+} AXBS_Type;
+
+/* ----------------------------------------------------------------------------
+   -- AXBS Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AXBS_Register_Masks AXBS Register Masks
+ * @{
+ */
+
+/*! @name PRS - Priority Registers Slave */
+#define AXBS_PRS_M0_MASK                         (0x7U)
+#define AXBS_PRS_M0_SHIFT                        (0U)
+#define AXBS_PRS_M0(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_PRS_M0_SHIFT)) & AXBS_PRS_M0_MASK)
+#define AXBS_PRS_M1_MASK                         (0x70U)
+#define AXBS_PRS_M1_SHIFT                        (4U)
+#define AXBS_PRS_M1(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_PRS_M1_SHIFT)) & AXBS_PRS_M1_MASK)
+#define AXBS_PRS_M2_MASK                         (0x700U)
+#define AXBS_PRS_M2_SHIFT                        (8U)
+#define AXBS_PRS_M2(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_PRS_M2_SHIFT)) & AXBS_PRS_M2_MASK)
+#define AXBS_PRS_M3_MASK                         (0x7000U)
+#define AXBS_PRS_M3_SHIFT                        (12U)
+#define AXBS_PRS_M3(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_PRS_M3_SHIFT)) & AXBS_PRS_M3_MASK)
+#define AXBS_PRS_M4_MASK                         (0x70000U)
+#define AXBS_PRS_M4_SHIFT                        (16U)
+#define AXBS_PRS_M4(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_PRS_M4_SHIFT)) & AXBS_PRS_M4_MASK)
+#define AXBS_PRS_M5_MASK                         (0x700000U)
+#define AXBS_PRS_M5_SHIFT                        (20U)
+#define AXBS_PRS_M5(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_PRS_M5_SHIFT)) & AXBS_PRS_M5_MASK)
+
+/* The count of AXBS_PRS */
+#define AXBS_PRS_COUNT                           (5U)
+
+/*! @name CRS - Control Register */
+#define AXBS_CRS_PARK_MASK                       (0x7U)
+#define AXBS_CRS_PARK_SHIFT                      (0U)
+#define AXBS_CRS_PARK(x)                         (((uint32_t)(((uint32_t)(x)) << AXBS_CRS_PARK_SHIFT)) & AXBS_CRS_PARK_MASK)
+#define AXBS_CRS_PCTL_MASK                       (0x30U)
+#define AXBS_CRS_PCTL_SHIFT                      (4U)
+#define AXBS_CRS_PCTL(x)                         (((uint32_t)(((uint32_t)(x)) << AXBS_CRS_PCTL_SHIFT)) & AXBS_CRS_PCTL_MASK)
+#define AXBS_CRS_ARB_MASK                        (0x300U)
+#define AXBS_CRS_ARB_SHIFT                       (8U)
+#define AXBS_CRS_ARB(x)                          (((uint32_t)(((uint32_t)(x)) << AXBS_CRS_ARB_SHIFT)) & AXBS_CRS_ARB_MASK)
+#define AXBS_CRS_HLP_MASK                        (0x40000000U)
+#define AXBS_CRS_HLP_SHIFT                       (30U)
+#define AXBS_CRS_HLP(x)                          (((uint32_t)(((uint32_t)(x)) << AXBS_CRS_HLP_SHIFT)) & AXBS_CRS_HLP_MASK)
+#define AXBS_CRS_RO_MASK                         (0x80000000U)
+#define AXBS_CRS_RO_SHIFT                        (31U)
+#define AXBS_CRS_RO(x)                           (((uint32_t)(((uint32_t)(x)) << AXBS_CRS_RO_SHIFT)) & AXBS_CRS_RO_MASK)
+
+/* The count of AXBS_CRS */
+#define AXBS_CRS_COUNT                           (5U)
+
+/*! @name MGPCR0 - Master General Purpose Control Register */
+#define AXBS_MGPCR0_AULB_MASK                    (0x7U)
+#define AXBS_MGPCR0_AULB_SHIFT                   (0U)
+#define AXBS_MGPCR0_AULB(x)                      (((uint32_t)(((uint32_t)(x)) << AXBS_MGPCR0_AULB_SHIFT)) & AXBS_MGPCR0_AULB_MASK)
+
+/*! @name MGPCR1 - Master General Purpose Control Register */
+#define AXBS_MGPCR1_AULB_MASK                    (0x7U)
+#define AXBS_MGPCR1_AULB_SHIFT                   (0U)
+#define AXBS_MGPCR1_AULB(x)                      (((uint32_t)(((uint32_t)(x)) << AXBS_MGPCR1_AULB_SHIFT)) & AXBS_MGPCR1_AULB_MASK)
+
+/*! @name MGPCR2 - Master General Purpose Control Register */
+#define AXBS_MGPCR2_AULB_MASK                    (0x7U)
+#define AXBS_MGPCR2_AULB_SHIFT                   (0U)
+#define AXBS_MGPCR2_AULB(x)                      (((uint32_t)(((uint32_t)(x)) << AXBS_MGPCR2_AULB_SHIFT)) & AXBS_MGPCR2_AULB_MASK)
+
+/*! @name MGPCR3 - Master General Purpose Control Register */
+#define AXBS_MGPCR3_AULB_MASK                    (0x7U)
+#define AXBS_MGPCR3_AULB_SHIFT                   (0U)
+#define AXBS_MGPCR3_AULB(x)                      (((uint32_t)(((uint32_t)(x)) << AXBS_MGPCR3_AULB_SHIFT)) & AXBS_MGPCR3_AULB_MASK)
+
+/*! @name MGPCR4 - Master General Purpose Control Register */
+#define AXBS_MGPCR4_AULB_MASK                    (0x7U)
+#define AXBS_MGPCR4_AULB_SHIFT                   (0U)
+#define AXBS_MGPCR4_AULB(x)                      (((uint32_t)(((uint32_t)(x)) << AXBS_MGPCR4_AULB_SHIFT)) & AXBS_MGPCR4_AULB_MASK)
+
+/*! @name MGPCR5 - Master General Purpose Control Register */
+#define AXBS_MGPCR5_AULB_MASK                    (0x7U)
+#define AXBS_MGPCR5_AULB_SHIFT                   (0U)
+#define AXBS_MGPCR5_AULB(x)                      (((uint32_t)(((uint32_t)(x)) << AXBS_MGPCR5_AULB_SHIFT)) & AXBS_MGPCR5_AULB_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group AXBS_Register_Masks */
+
+
+/* AXBS - Peripheral instance base addresses */
+/** Peripheral AXBS base address */
+#define AXBS_BASE                                (0x40004000u)
+/** Peripheral AXBS base pointer */
+#define AXBS                                     ((AXBS_Type *)AXBS_BASE)
+/** Array initializer of AXBS peripheral base addresses */
+#define AXBS_BASE_ADDRS                          { AXBS_BASE }
+/** Array initializer of AXBS peripheral base pointers */
+#define AXBS_BASE_PTRS                           { AXBS }
+
+/*!
+ * @}
+ */ /* end of group AXBS_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CAN Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAN_Peripheral_Access_Layer CAN Peripheral Access Layer
+ * @{
+ */
+
+/** CAN - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< Module Configuration Register, offset: 0x0 */
+  __IO uint32_t CTRL1;                             /**< Control 1 register, offset: 0x4 */
+  __IO uint32_t TIMER;                             /**< Free Running Timer, offset: 0x8 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t RXMGMASK;                          /**< Rx Mailboxes Global Mask Register, offset: 0x10 */
+  __IO uint32_t RX14MASK;                          /**< Rx 14 Mask register, offset: 0x14 */
+  __IO uint32_t RX15MASK;                          /**< Rx 15 Mask register, offset: 0x18 */
+  __IO uint32_t ECR;                               /**< Error Counter, offset: 0x1C */
+  __IO uint32_t ESR1;                              /**< Error and Status 1 register, offset: 0x20 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t IMASK1;                            /**< Interrupt Masks 1 register, offset: 0x28 */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t IFLAG1;                            /**< Interrupt Flags 1 register, offset: 0x30 */
+  __IO uint32_t CTRL2;                             /**< Control 2 register, offset: 0x34 */
+  __I  uint32_t ESR2;                              /**< Error and Status 2 register, offset: 0x38 */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t CRCR;                              /**< CRC Register, offset: 0x44 */
+  __IO uint32_t RXFGMASK;                          /**< Rx FIFO Global Mask register, offset: 0x48 */
+  __I  uint32_t RXFIR;                             /**< Rx FIFO Information Register, offset: 0x4C */
+       uint8_t RESERVED_4[48];
+  struct {                                         /* offset: 0x80, array step: 0x10 */
+    __IO uint32_t CS;                                /**< Message Buffer 0 CS Register..Message Buffer 15 CS Register, array offset: 0x80, array step: 0x10 */
+    __IO uint32_t ID;                                /**< Message Buffer 0 ID Register..Message Buffer 15 ID Register, array offset: 0x84, array step: 0x10 */
+    __IO uint32_t WORD0;                             /**< Message Buffer 0 WORD0 Register..Message Buffer 15 WORD0 Register, array offset: 0x88, array step: 0x10 */
+    __IO uint32_t WORD1;                             /**< Message Buffer 0 WORD1 Register..Message Buffer 15 WORD1 Register, array offset: 0x8C, array step: 0x10 */
+  } MB[16];
+       uint8_t RESERVED_5[1792];
+  __IO uint32_t RXIMR[16];                         /**< Rx Individual Mask Registers, array offset: 0x880, array step: 0x4 */
+} CAN_Type;
+
+/* ----------------------------------------------------------------------------
+   -- CAN Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAN_Register_Masks CAN Register Masks
+ * @{
+ */
+
+/*! @name MCR - Module Configuration Register */
+#define CAN_MCR_MAXMB_MASK                       (0x7FU)
+#define CAN_MCR_MAXMB_SHIFT                      (0U)
+#define CAN_MCR_MAXMB(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_MCR_MAXMB_SHIFT)) & CAN_MCR_MAXMB_MASK)
+#define CAN_MCR_IDAM_MASK                        (0x300U)
+#define CAN_MCR_IDAM_SHIFT                       (8U)
+#define CAN_MCR_IDAM(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_MCR_IDAM_SHIFT)) & CAN_MCR_IDAM_MASK)
+#define CAN_MCR_AEN_MASK                         (0x1000U)
+#define CAN_MCR_AEN_SHIFT                        (12U)
+#define CAN_MCR_AEN(x)                           (((uint32_t)(((uint32_t)(x)) << CAN_MCR_AEN_SHIFT)) & CAN_MCR_AEN_MASK)
+#define CAN_MCR_LPRIOEN_MASK                     (0x2000U)
+#define CAN_MCR_LPRIOEN_SHIFT                    (13U)
+#define CAN_MCR_LPRIOEN(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_MCR_LPRIOEN_SHIFT)) & CAN_MCR_LPRIOEN_MASK)
+#define CAN_MCR_IRMQ_MASK                        (0x10000U)
+#define CAN_MCR_IRMQ_SHIFT                       (16U)
+#define CAN_MCR_IRMQ(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_MCR_IRMQ_SHIFT)) & CAN_MCR_IRMQ_MASK)
+#define CAN_MCR_SRXDIS_MASK                      (0x20000U)
+#define CAN_MCR_SRXDIS_SHIFT                     (17U)
+#define CAN_MCR_SRXDIS(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_SRXDIS_SHIFT)) & CAN_MCR_SRXDIS_MASK)
+#define CAN_MCR_WAKSRC_MASK                      (0x80000U)
+#define CAN_MCR_WAKSRC_SHIFT                     (19U)
+#define CAN_MCR_WAKSRC(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_WAKSRC_SHIFT)) & CAN_MCR_WAKSRC_MASK)
+#define CAN_MCR_LPMACK_MASK                      (0x100000U)
+#define CAN_MCR_LPMACK_SHIFT                     (20U)
+#define CAN_MCR_LPMACK(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_LPMACK_SHIFT)) & CAN_MCR_LPMACK_MASK)
+#define CAN_MCR_WRNEN_MASK                       (0x200000U)
+#define CAN_MCR_WRNEN_SHIFT                      (21U)
+#define CAN_MCR_WRNEN(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_MCR_WRNEN_SHIFT)) & CAN_MCR_WRNEN_MASK)
+#define CAN_MCR_SLFWAK_MASK                      (0x400000U)
+#define CAN_MCR_SLFWAK_SHIFT                     (22U)
+#define CAN_MCR_SLFWAK(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_SLFWAK_SHIFT)) & CAN_MCR_SLFWAK_MASK)
+#define CAN_MCR_SUPV_MASK                        (0x800000U)
+#define CAN_MCR_SUPV_SHIFT                       (23U)
+#define CAN_MCR_SUPV(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_MCR_SUPV_SHIFT)) & CAN_MCR_SUPV_MASK)
+#define CAN_MCR_FRZACK_MASK                      (0x1000000U)
+#define CAN_MCR_FRZACK_SHIFT                     (24U)
+#define CAN_MCR_FRZACK(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_FRZACK_SHIFT)) & CAN_MCR_FRZACK_MASK)
+#define CAN_MCR_SOFTRST_MASK                     (0x2000000U)
+#define CAN_MCR_SOFTRST_SHIFT                    (25U)
+#define CAN_MCR_SOFTRST(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_MCR_SOFTRST_SHIFT)) & CAN_MCR_SOFTRST_MASK)
+#define CAN_MCR_WAKMSK_MASK                      (0x4000000U)
+#define CAN_MCR_WAKMSK_SHIFT                     (26U)
+#define CAN_MCR_WAKMSK(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_WAKMSK_SHIFT)) & CAN_MCR_WAKMSK_MASK)
+#define CAN_MCR_NOTRDY_MASK                      (0x8000000U)
+#define CAN_MCR_NOTRDY_SHIFT                     (27U)
+#define CAN_MCR_NOTRDY(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_MCR_NOTRDY_SHIFT)) & CAN_MCR_NOTRDY_MASK)
+#define CAN_MCR_HALT_MASK                        (0x10000000U)
+#define CAN_MCR_HALT_SHIFT                       (28U)
+#define CAN_MCR_HALT(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_MCR_HALT_SHIFT)) & CAN_MCR_HALT_MASK)
+#define CAN_MCR_RFEN_MASK                        (0x20000000U)
+#define CAN_MCR_RFEN_SHIFT                       (29U)
+#define CAN_MCR_RFEN(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_MCR_RFEN_SHIFT)) & CAN_MCR_RFEN_MASK)
+#define CAN_MCR_FRZ_MASK                         (0x40000000U)
+#define CAN_MCR_FRZ_SHIFT                        (30U)
+#define CAN_MCR_FRZ(x)                           (((uint32_t)(((uint32_t)(x)) << CAN_MCR_FRZ_SHIFT)) & CAN_MCR_FRZ_MASK)
+#define CAN_MCR_MDIS_MASK                        (0x80000000U)
+#define CAN_MCR_MDIS_SHIFT                       (31U)
+#define CAN_MCR_MDIS(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_MCR_MDIS_SHIFT)) & CAN_MCR_MDIS_MASK)
+
+/*! @name CTRL1 - Control 1 register */
+#define CAN_CTRL1_PROPSEG_MASK                   (0x7U)
+#define CAN_CTRL1_PROPSEG_SHIFT                  (0U)
+#define CAN_CTRL1_PROPSEG(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_PROPSEG_SHIFT)) & CAN_CTRL1_PROPSEG_MASK)
+#define CAN_CTRL1_LOM_MASK                       (0x8U)
+#define CAN_CTRL1_LOM_SHIFT                      (3U)
+#define CAN_CTRL1_LOM(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_LOM_SHIFT)) & CAN_CTRL1_LOM_MASK)
+#define CAN_CTRL1_LBUF_MASK                      (0x10U)
+#define CAN_CTRL1_LBUF_SHIFT                     (4U)
+#define CAN_CTRL1_LBUF(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_LBUF_SHIFT)) & CAN_CTRL1_LBUF_MASK)
+#define CAN_CTRL1_TSYN_MASK                      (0x20U)
+#define CAN_CTRL1_TSYN_SHIFT                     (5U)
+#define CAN_CTRL1_TSYN(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_TSYN_SHIFT)) & CAN_CTRL1_TSYN_MASK)
+#define CAN_CTRL1_BOFFREC_MASK                   (0x40U)
+#define CAN_CTRL1_BOFFREC_SHIFT                  (6U)
+#define CAN_CTRL1_BOFFREC(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_BOFFREC_SHIFT)) & CAN_CTRL1_BOFFREC_MASK)
+#define CAN_CTRL1_SMP_MASK                       (0x80U)
+#define CAN_CTRL1_SMP_SHIFT                      (7U)
+#define CAN_CTRL1_SMP(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_SMP_SHIFT)) & CAN_CTRL1_SMP_MASK)
+#define CAN_CTRL1_RWRNMSK_MASK                   (0x400U)
+#define CAN_CTRL1_RWRNMSK_SHIFT                  (10U)
+#define CAN_CTRL1_RWRNMSK(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_RWRNMSK_SHIFT)) & CAN_CTRL1_RWRNMSK_MASK)
+#define CAN_CTRL1_TWRNMSK_MASK                   (0x800U)
+#define CAN_CTRL1_TWRNMSK_SHIFT                  (11U)
+#define CAN_CTRL1_TWRNMSK(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_TWRNMSK_SHIFT)) & CAN_CTRL1_TWRNMSK_MASK)
+#define CAN_CTRL1_LPB_MASK                       (0x1000U)
+#define CAN_CTRL1_LPB_SHIFT                      (12U)
+#define CAN_CTRL1_LPB(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_LPB_SHIFT)) & CAN_CTRL1_LPB_MASK)
+#define CAN_CTRL1_CLKSRC_MASK                    (0x2000U)
+#define CAN_CTRL1_CLKSRC_SHIFT                   (13U)
+#define CAN_CTRL1_CLKSRC(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_CLKSRC_SHIFT)) & CAN_CTRL1_CLKSRC_MASK)
+#define CAN_CTRL1_ERRMSK_MASK                    (0x4000U)
+#define CAN_CTRL1_ERRMSK_SHIFT                   (14U)
+#define CAN_CTRL1_ERRMSK(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_ERRMSK_SHIFT)) & CAN_CTRL1_ERRMSK_MASK)
+#define CAN_CTRL1_BOFFMSK_MASK                   (0x8000U)
+#define CAN_CTRL1_BOFFMSK_SHIFT                  (15U)
+#define CAN_CTRL1_BOFFMSK(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_BOFFMSK_SHIFT)) & CAN_CTRL1_BOFFMSK_MASK)
+#define CAN_CTRL1_PSEG2_MASK                     (0x70000U)
+#define CAN_CTRL1_PSEG2_SHIFT                    (16U)
+#define CAN_CTRL1_PSEG2(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_PSEG2_SHIFT)) & CAN_CTRL1_PSEG2_MASK)
+#define CAN_CTRL1_PSEG1_MASK                     (0x380000U)
+#define CAN_CTRL1_PSEG1_SHIFT                    (19U)
+#define CAN_CTRL1_PSEG1(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_PSEG1_SHIFT)) & CAN_CTRL1_PSEG1_MASK)
+#define CAN_CTRL1_RJW_MASK                       (0xC00000U)
+#define CAN_CTRL1_RJW_SHIFT                      (22U)
+#define CAN_CTRL1_RJW(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_RJW_SHIFT)) & CAN_CTRL1_RJW_MASK)
+#define CAN_CTRL1_PRESDIV_MASK                   (0xFF000000U)
+#define CAN_CTRL1_PRESDIV_SHIFT                  (24U)
+#define CAN_CTRL1_PRESDIV(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_PRESDIV_SHIFT)) & CAN_CTRL1_PRESDIV_MASK)
+
+/*! @name TIMER - Free Running Timer */
+#define CAN_TIMER_TIMER_MASK                     (0xFFFFU)
+#define CAN_TIMER_TIMER_SHIFT                    (0U)
+#define CAN_TIMER_TIMER(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_TIMER_TIMER_SHIFT)) & CAN_TIMER_TIMER_MASK)
+
+/*! @name RXMGMASK - Rx Mailboxes Global Mask Register */
+#define CAN_RXMGMASK_MG_MASK                     (0xFFFFFFFFU)
+#define CAN_RXMGMASK_MG_SHIFT                    (0U)
+#define CAN_RXMGMASK_MG(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_RXMGMASK_MG_SHIFT)) & CAN_RXMGMASK_MG_MASK)
+
+/*! @name RX14MASK - Rx 14 Mask register */
+#define CAN_RX14MASK_RX14M_MASK                  (0xFFFFFFFFU)
+#define CAN_RX14MASK_RX14M_SHIFT                 (0U)
+#define CAN_RX14MASK_RX14M(x)                    (((uint32_t)(((uint32_t)(x)) << CAN_RX14MASK_RX14M_SHIFT)) & CAN_RX14MASK_RX14M_MASK)
+
+/*! @name RX15MASK - Rx 15 Mask register */
+#define CAN_RX15MASK_RX15M_MASK                  (0xFFFFFFFFU)
+#define CAN_RX15MASK_RX15M_SHIFT                 (0U)
+#define CAN_RX15MASK_RX15M(x)                    (((uint32_t)(((uint32_t)(x)) << CAN_RX15MASK_RX15M_SHIFT)) & CAN_RX15MASK_RX15M_MASK)
+
+/*! @name ECR - Error Counter */
+#define CAN_ECR_TXERRCNT_MASK                    (0xFFU)
+#define CAN_ECR_TXERRCNT_SHIFT                   (0U)
+#define CAN_ECR_TXERRCNT(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ECR_TXERRCNT_SHIFT)) & CAN_ECR_TXERRCNT_MASK)
+#define CAN_ECR_RXERRCNT_MASK                    (0xFF00U)
+#define CAN_ECR_RXERRCNT_SHIFT                   (8U)
+#define CAN_ECR_RXERRCNT(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ECR_RXERRCNT_SHIFT)) & CAN_ECR_RXERRCNT_MASK)
+
+/*! @name ESR1 - Error and Status 1 register */
+#define CAN_ESR1_WAKINT_MASK                     (0x1U)
+#define CAN_ESR1_WAKINT_SHIFT                    (0U)
+#define CAN_ESR1_WAKINT(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_WAKINT_SHIFT)) & CAN_ESR1_WAKINT_MASK)
+#define CAN_ESR1_ERRINT_MASK                     (0x2U)
+#define CAN_ESR1_ERRINT_SHIFT                    (1U)
+#define CAN_ESR1_ERRINT(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_ERRINT_SHIFT)) & CAN_ESR1_ERRINT_MASK)
+#define CAN_ESR1_BOFFINT_MASK                    (0x4U)
+#define CAN_ESR1_BOFFINT_SHIFT                   (2U)
+#define CAN_ESR1_BOFFINT(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_BOFFINT_SHIFT)) & CAN_ESR1_BOFFINT_MASK)
+#define CAN_ESR1_RX_MASK                         (0x8U)
+#define CAN_ESR1_RX_SHIFT                        (3U)
+#define CAN_ESR1_RX(x)                           (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_RX_SHIFT)) & CAN_ESR1_RX_MASK)
+#define CAN_ESR1_FLTCONF_MASK                    (0x30U)
+#define CAN_ESR1_FLTCONF_SHIFT                   (4U)
+#define CAN_ESR1_FLTCONF(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_FLTCONF_SHIFT)) & CAN_ESR1_FLTCONF_MASK)
+#define CAN_ESR1_TX_MASK                         (0x40U)
+#define CAN_ESR1_TX_SHIFT                        (6U)
+#define CAN_ESR1_TX(x)                           (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_TX_SHIFT)) & CAN_ESR1_TX_MASK)
+#define CAN_ESR1_IDLE_MASK                       (0x80U)
+#define CAN_ESR1_IDLE_SHIFT                      (7U)
+#define CAN_ESR1_IDLE(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_IDLE_SHIFT)) & CAN_ESR1_IDLE_MASK)
+#define CAN_ESR1_RXWRN_MASK                      (0x100U)
+#define CAN_ESR1_RXWRN_SHIFT                     (8U)
+#define CAN_ESR1_RXWRN(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_RXWRN_SHIFT)) & CAN_ESR1_RXWRN_MASK)
+#define CAN_ESR1_TXWRN_MASK                      (0x200U)
+#define CAN_ESR1_TXWRN_SHIFT                     (9U)
+#define CAN_ESR1_TXWRN(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_TXWRN_SHIFT)) & CAN_ESR1_TXWRN_MASK)
+#define CAN_ESR1_STFERR_MASK                     (0x400U)
+#define CAN_ESR1_STFERR_SHIFT                    (10U)
+#define CAN_ESR1_STFERR(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_STFERR_SHIFT)) & CAN_ESR1_STFERR_MASK)
+#define CAN_ESR1_FRMERR_MASK                     (0x800U)
+#define CAN_ESR1_FRMERR_SHIFT                    (11U)
+#define CAN_ESR1_FRMERR(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_FRMERR_SHIFT)) & CAN_ESR1_FRMERR_MASK)
+#define CAN_ESR1_CRCERR_MASK                     (0x1000U)
+#define CAN_ESR1_CRCERR_SHIFT                    (12U)
+#define CAN_ESR1_CRCERR(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_CRCERR_SHIFT)) & CAN_ESR1_CRCERR_MASK)
+#define CAN_ESR1_ACKERR_MASK                     (0x2000U)
+#define CAN_ESR1_ACKERR_SHIFT                    (13U)
+#define CAN_ESR1_ACKERR(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_ACKERR_SHIFT)) & CAN_ESR1_ACKERR_MASK)
+#define CAN_ESR1_BIT0ERR_MASK                    (0x4000U)
+#define CAN_ESR1_BIT0ERR_SHIFT                   (14U)
+#define CAN_ESR1_BIT0ERR(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_BIT0ERR_SHIFT)) & CAN_ESR1_BIT0ERR_MASK)
+#define CAN_ESR1_BIT1ERR_MASK                    (0x8000U)
+#define CAN_ESR1_BIT1ERR_SHIFT                   (15U)
+#define CAN_ESR1_BIT1ERR(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_BIT1ERR_SHIFT)) & CAN_ESR1_BIT1ERR_MASK)
+#define CAN_ESR1_RWRNINT_MASK                    (0x10000U)
+#define CAN_ESR1_RWRNINT_SHIFT                   (16U)
+#define CAN_ESR1_RWRNINT(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_RWRNINT_SHIFT)) & CAN_ESR1_RWRNINT_MASK)
+#define CAN_ESR1_TWRNINT_MASK                    (0x20000U)
+#define CAN_ESR1_TWRNINT_SHIFT                   (17U)
+#define CAN_ESR1_TWRNINT(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_TWRNINT_SHIFT)) & CAN_ESR1_TWRNINT_MASK)
+#define CAN_ESR1_SYNCH_MASK                      (0x40000U)
+#define CAN_ESR1_SYNCH_SHIFT                     (18U)
+#define CAN_ESR1_SYNCH(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_ESR1_SYNCH_SHIFT)) & CAN_ESR1_SYNCH_MASK)
+
+/*! @name IMASK1 - Interrupt Masks 1 register */
+#define CAN_IMASK1_BUFLM_MASK                    (0xFFFFFFFFU)
+#define CAN_IMASK1_BUFLM_SHIFT                   (0U)
+#define CAN_IMASK1_BUFLM(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_IMASK1_BUFLM_SHIFT)) & CAN_IMASK1_BUFLM_MASK)
+
+/*! @name IFLAG1 - Interrupt Flags 1 register */
+#define CAN_IFLAG1_BUF0I_MASK                    (0x1U)
+#define CAN_IFLAG1_BUF0I_SHIFT                   (0U)
+#define CAN_IFLAG1_BUF0I(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_IFLAG1_BUF0I_SHIFT)) & CAN_IFLAG1_BUF0I_MASK)
+#define CAN_IFLAG1_BUF4TO1I_MASK                 (0x1EU)
+#define CAN_IFLAG1_BUF4TO1I_SHIFT                (1U)
+#define CAN_IFLAG1_BUF4TO1I(x)                   (((uint32_t)(((uint32_t)(x)) << CAN_IFLAG1_BUF4TO1I_SHIFT)) & CAN_IFLAG1_BUF4TO1I_MASK)
+#define CAN_IFLAG1_BUF5I_MASK                    (0x20U)
+#define CAN_IFLAG1_BUF5I_SHIFT                   (5U)
+#define CAN_IFLAG1_BUF5I(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_IFLAG1_BUF5I_SHIFT)) & CAN_IFLAG1_BUF5I_MASK)
+#define CAN_IFLAG1_BUF6I_MASK                    (0x40U)
+#define CAN_IFLAG1_BUF6I_SHIFT                   (6U)
+#define CAN_IFLAG1_BUF6I(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_IFLAG1_BUF6I_SHIFT)) & CAN_IFLAG1_BUF6I_MASK)
+#define CAN_IFLAG1_BUF7I_MASK                    (0x80U)
+#define CAN_IFLAG1_BUF7I_SHIFT                   (7U)
+#define CAN_IFLAG1_BUF7I(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_IFLAG1_BUF7I_SHIFT)) & CAN_IFLAG1_BUF7I_MASK)
+#define CAN_IFLAG1_BUF31TO8I_MASK                (0xFFFFFF00U)
+#define CAN_IFLAG1_BUF31TO8I_SHIFT               (8U)
+#define CAN_IFLAG1_BUF31TO8I(x)                  (((uint32_t)(((uint32_t)(x)) << CAN_IFLAG1_BUF31TO8I_SHIFT)) & CAN_IFLAG1_BUF31TO8I_MASK)
+
+/*! @name CTRL2 - Control 2 register */
+#define CAN_CTRL2_EACEN_MASK                     (0x10000U)
+#define CAN_CTRL2_EACEN_SHIFT                    (16U)
+#define CAN_CTRL2_EACEN(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_CTRL2_EACEN_SHIFT)) & CAN_CTRL2_EACEN_MASK)
+#define CAN_CTRL2_RRS_MASK                       (0x20000U)
+#define CAN_CTRL2_RRS_SHIFT                      (17U)
+#define CAN_CTRL2_RRS(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_CTRL2_RRS_SHIFT)) & CAN_CTRL2_RRS_MASK)
+#define CAN_CTRL2_MRP_MASK                       (0x40000U)
+#define CAN_CTRL2_MRP_SHIFT                      (18U)
+#define CAN_CTRL2_MRP(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_CTRL2_MRP_SHIFT)) & CAN_CTRL2_MRP_MASK)
+#define CAN_CTRL2_TASD_MASK                      (0xF80000U)
+#define CAN_CTRL2_TASD_SHIFT                     (19U)
+#define CAN_CTRL2_TASD(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_CTRL2_TASD_SHIFT)) & CAN_CTRL2_TASD_MASK)
+#define CAN_CTRL2_RFFN_MASK                      (0xF000000U)
+#define CAN_CTRL2_RFFN_SHIFT                     (24U)
+#define CAN_CTRL2_RFFN(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_CTRL2_RFFN_SHIFT)) & CAN_CTRL2_RFFN_MASK)
+#define CAN_CTRL2_WRMFRZ_MASK                    (0x10000000U)
+#define CAN_CTRL2_WRMFRZ_SHIFT                   (28U)
+#define CAN_CTRL2_WRMFRZ(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_CTRL2_WRMFRZ_SHIFT)) & CAN_CTRL2_WRMFRZ_MASK)
+
+/*! @name ESR2 - Error and Status 2 register */
+#define CAN_ESR2_IMB_MASK                        (0x2000U)
+#define CAN_ESR2_IMB_SHIFT                       (13U)
+#define CAN_ESR2_IMB(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_ESR2_IMB_SHIFT)) & CAN_ESR2_IMB_MASK)
+#define CAN_ESR2_VPS_MASK                        (0x4000U)
+#define CAN_ESR2_VPS_SHIFT                       (14U)
+#define CAN_ESR2_VPS(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_ESR2_VPS_SHIFT)) & CAN_ESR2_VPS_MASK)
+#define CAN_ESR2_LPTM_MASK                       (0x7F0000U)
+#define CAN_ESR2_LPTM_SHIFT                      (16U)
+#define CAN_ESR2_LPTM(x)                         (((uint32_t)(((uint32_t)(x)) << CAN_ESR2_LPTM_SHIFT)) & CAN_ESR2_LPTM_MASK)
+
+/*! @name CRCR - CRC Register */
+#define CAN_CRCR_TXCRC_MASK                      (0x7FFFU)
+#define CAN_CRCR_TXCRC_SHIFT                     (0U)
+#define CAN_CRCR_TXCRC(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_CRCR_TXCRC_SHIFT)) & CAN_CRCR_TXCRC_MASK)
+#define CAN_CRCR_MBCRC_MASK                      (0x7F0000U)
+#define CAN_CRCR_MBCRC_SHIFT                     (16U)
+#define CAN_CRCR_MBCRC(x)                        (((uint32_t)(((uint32_t)(x)) << CAN_CRCR_MBCRC_SHIFT)) & CAN_CRCR_MBCRC_MASK)
+
+/*! @name RXFGMASK - Rx FIFO Global Mask register */
+#define CAN_RXFGMASK_FGM_MASK                    (0xFFFFFFFFU)
+#define CAN_RXFGMASK_FGM_SHIFT                   (0U)
+#define CAN_RXFGMASK_FGM(x)                      (((uint32_t)(((uint32_t)(x)) << CAN_RXFGMASK_FGM_SHIFT)) & CAN_RXFGMASK_FGM_MASK)
+
+/*! @name RXFIR - Rx FIFO Information Register */
+#define CAN_RXFIR_IDHIT_MASK                     (0x1FFU)
+#define CAN_RXFIR_IDHIT_SHIFT                    (0U)
+#define CAN_RXFIR_IDHIT(x)                       (((uint32_t)(((uint32_t)(x)) << CAN_RXFIR_IDHIT_SHIFT)) & CAN_RXFIR_IDHIT_MASK)
+
+/*! @name CS - Message Buffer 0 CS Register..Message Buffer 15 CS Register */
+#define CAN_CS_TIME_STAMP_MASK                   (0xFFFFU)
+#define CAN_CS_TIME_STAMP_SHIFT                  (0U)
+#define CAN_CS_TIME_STAMP(x)                     (((uint32_t)(((uint32_t)(x)) << CAN_CS_TIME_STAMP_SHIFT)) & CAN_CS_TIME_STAMP_MASK)
+#define CAN_CS_DLC_MASK                          (0xF0000U)
+#define CAN_CS_DLC_SHIFT                         (16U)
+#define CAN_CS_DLC(x)                            (((uint32_t)(((uint32_t)(x)) << CAN_CS_DLC_SHIFT)) & CAN_CS_DLC_MASK)
+#define CAN_CS_RTR_MASK                          (0x100000U)
+#define CAN_CS_RTR_SHIFT                         (20U)
+#define CAN_CS_RTR(x)                            (((uint32_t)(((uint32_t)(x)) << CAN_CS_RTR_SHIFT)) & CAN_CS_RTR_MASK)
+#define CAN_CS_IDE_MASK                          (0x200000U)
+#define CAN_CS_IDE_SHIFT                         (21U)
+#define CAN_CS_IDE(x)                            (((uint32_t)(((uint32_t)(x)) << CAN_CS_IDE_SHIFT)) & CAN_CS_IDE_MASK)
+#define CAN_CS_SRR_MASK                          (0x400000U)
+#define CAN_CS_SRR_SHIFT                         (22U)
+#define CAN_CS_SRR(x)                            (((uint32_t)(((uint32_t)(x)) << CAN_CS_SRR_SHIFT)) & CAN_CS_SRR_MASK)
+#define CAN_CS_CODE_MASK                         (0xF000000U)
+#define CAN_CS_CODE_SHIFT                        (24U)
+#define CAN_CS_CODE(x)                           (((uint32_t)(((uint32_t)(x)) << CAN_CS_CODE_SHIFT)) & CAN_CS_CODE_MASK)
+
+/* The count of CAN_CS */
+#define CAN_CS_COUNT                             (16U)
+
+/*! @name ID - Message Buffer 0 ID Register..Message Buffer 15 ID Register */
+#define CAN_ID_EXT_MASK                          (0x3FFFFU)
+#define CAN_ID_EXT_SHIFT                         (0U)
+#define CAN_ID_EXT(x)                            (((uint32_t)(((uint32_t)(x)) << CAN_ID_EXT_SHIFT)) & CAN_ID_EXT_MASK)
+#define CAN_ID_STD_MASK                          (0x1FFC0000U)
+#define CAN_ID_STD_SHIFT                         (18U)
+#define CAN_ID_STD(x)                            (((uint32_t)(((uint32_t)(x)) << CAN_ID_STD_SHIFT)) & CAN_ID_STD_MASK)
+#define CAN_ID_PRIO_MASK                         (0xE0000000U)
+#define CAN_ID_PRIO_SHIFT                        (29U)
+#define CAN_ID_PRIO(x)                           (((uint32_t)(((uint32_t)(x)) << CAN_ID_PRIO_SHIFT)) & CAN_ID_PRIO_MASK)
+
+/* The count of CAN_ID */
+#define CAN_ID_COUNT                             (16U)
+
+/*! @name WORD0 - Message Buffer 0 WORD0 Register..Message Buffer 15 WORD0 Register */
+#define CAN_WORD0_DATA_BYTE_3_MASK               (0xFFU)
+#define CAN_WORD0_DATA_BYTE_3_SHIFT              (0U)
+#define CAN_WORD0_DATA_BYTE_3(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD0_DATA_BYTE_3_SHIFT)) & CAN_WORD0_DATA_BYTE_3_MASK)
+#define CAN_WORD0_DATA_BYTE_2_MASK               (0xFF00U)
+#define CAN_WORD0_DATA_BYTE_2_SHIFT              (8U)
+#define CAN_WORD0_DATA_BYTE_2(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD0_DATA_BYTE_2_SHIFT)) & CAN_WORD0_DATA_BYTE_2_MASK)
+#define CAN_WORD0_DATA_BYTE_1_MASK               (0xFF0000U)
+#define CAN_WORD0_DATA_BYTE_1_SHIFT              (16U)
+#define CAN_WORD0_DATA_BYTE_1(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD0_DATA_BYTE_1_SHIFT)) & CAN_WORD0_DATA_BYTE_1_MASK)
+#define CAN_WORD0_DATA_BYTE_0_MASK               (0xFF000000U)
+#define CAN_WORD0_DATA_BYTE_0_SHIFT              (24U)
+#define CAN_WORD0_DATA_BYTE_0(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD0_DATA_BYTE_0_SHIFT)) & CAN_WORD0_DATA_BYTE_0_MASK)
+
+/* The count of CAN_WORD0 */
+#define CAN_WORD0_COUNT                          (16U)
+
+/*! @name WORD1 - Message Buffer 0 WORD1 Register..Message Buffer 15 WORD1 Register */
+#define CAN_WORD1_DATA_BYTE_7_MASK               (0xFFU)
+#define CAN_WORD1_DATA_BYTE_7_SHIFT              (0U)
+#define CAN_WORD1_DATA_BYTE_7(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD1_DATA_BYTE_7_SHIFT)) & CAN_WORD1_DATA_BYTE_7_MASK)
+#define CAN_WORD1_DATA_BYTE_6_MASK               (0xFF00U)
+#define CAN_WORD1_DATA_BYTE_6_SHIFT              (8U)
+#define CAN_WORD1_DATA_BYTE_6(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD1_DATA_BYTE_6_SHIFT)) & CAN_WORD1_DATA_BYTE_6_MASK)
+#define CAN_WORD1_DATA_BYTE_5_MASK               (0xFF0000U)
+#define CAN_WORD1_DATA_BYTE_5_SHIFT              (16U)
+#define CAN_WORD1_DATA_BYTE_5(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD1_DATA_BYTE_5_SHIFT)) & CAN_WORD1_DATA_BYTE_5_MASK)
+#define CAN_WORD1_DATA_BYTE_4_MASK               (0xFF000000U)
+#define CAN_WORD1_DATA_BYTE_4_SHIFT              (24U)
+#define CAN_WORD1_DATA_BYTE_4(x)                 (((uint32_t)(((uint32_t)(x)) << CAN_WORD1_DATA_BYTE_4_SHIFT)) & CAN_WORD1_DATA_BYTE_4_MASK)
+
+/* The count of CAN_WORD1 */
+#define CAN_WORD1_COUNT                          (16U)
+
+/*! @name RXIMR - Rx Individual Mask Registers */
+#define CAN_RXIMR_MI_MASK                        (0xFFFFFFFFU)
+#define CAN_RXIMR_MI_SHIFT                       (0U)
+#define CAN_RXIMR_MI(x)                          (((uint32_t)(((uint32_t)(x)) << CAN_RXIMR_MI_SHIFT)) & CAN_RXIMR_MI_MASK)
+
+/* The count of CAN_RXIMR */
+#define CAN_RXIMR_COUNT                          (16U)
+
+
+/*!
+ * @}
+ */ /* end of group CAN_Register_Masks */
+
+
+/* CAN - Peripheral instance base addresses */
+/** Peripheral CAN0 base address */
+#define CAN0_BASE                                (0x40024000u)
+/** Peripheral CAN0 base pointer */
+#define CAN0                                     ((CAN_Type *)CAN0_BASE)
+/** Array initializer of CAN peripheral base addresses */
+#define CAN_BASE_ADDRS                           { CAN0_BASE }
+/** Array initializer of CAN peripheral base pointers */
+#define CAN_BASE_PTRS                            { CAN0 }
+/** Interrupt vectors for the CAN peripheral type */
+#define CAN_Rx_Warning_IRQS                      { CAN0_Rx_Warning_IRQn }
+#define CAN_Tx_Warning_IRQS                      { CAN0_Tx_Warning_IRQn }
+#define CAN_Wake_Up_IRQS                         { CAN0_Wake_Up_IRQn }
+#define CAN_Error_IRQS                           { CAN0_Error_IRQn }
+#define CAN_Bus_Off_IRQS                         { CAN0_Bus_Off_IRQn }
+#define CAN_ORed_Message_buffer_IRQS             { CAN0_ORed_Message_buffer_IRQn }
+
+/*!
+ * @}
+ */ /* end of group CAN_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CAU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAU_Peripheral_Access_Layer CAU Peripheral Access Layer
+ * @{
+ */
+
+/** CAU - Register Layout Typedef */
+typedef struct {
+  __O  uint32_t DIRECT[16];                        /**< Direct access register 0..Direct access register 15, array offset: 0x0, array step: 0x4 */
+       uint8_t RESERVED_0[2048];
+  __O  uint32_t LDR_CASR;                          /**< Status register - Load Register command, offset: 0x840 */
+  __O  uint32_t LDR_CAA;                           /**< Accumulator register - Load Register command, offset: 0x844 */
+  __O  uint32_t LDR_CA[9];                         /**< General Purpose Register 0 - Load Register command..General Purpose Register 8 - Load Register command, array offset: 0x848, array step: 0x4 */
+       uint8_t RESERVED_1[20];
+  __I  uint32_t STR_CASR;                          /**< Status register - Store Register command, offset: 0x880 */
+  __I  uint32_t STR_CAA;                           /**< Accumulator register - Store Register command, offset: 0x884 */
+  __I  uint32_t STR_CA[9];                         /**< General Purpose Register 0 - Store Register command..General Purpose Register 8 - Store Register command, array offset: 0x888, array step: 0x4 */
+       uint8_t RESERVED_2[20];
+  __O  uint32_t ADR_CASR;                          /**< Status register - Add Register command, offset: 0x8C0 */
+  __O  uint32_t ADR_CAA;                           /**< Accumulator register - Add to register command, offset: 0x8C4 */
+  __O  uint32_t ADR_CA[9];                         /**< General Purpose Register 0 - Add to register command..General Purpose Register 8 - Add to register command, array offset: 0x8C8, array step: 0x4 */
+       uint8_t RESERVED_3[20];
+  __O  uint32_t RADR_CASR;                         /**< Status register - Reverse and Add to Register command, offset: 0x900 */
+  __O  uint32_t RADR_CAA;                          /**< Accumulator register - Reverse and Add to Register command, offset: 0x904 */
+  __O  uint32_t RADR_CA[9];                        /**< General Purpose Register 0 - Reverse and Add to Register command..General Purpose Register 8 - Reverse and Add to Register command, array offset: 0x908, array step: 0x4 */
+       uint8_t RESERVED_4[84];
+  __O  uint32_t XOR_CASR;                          /**< Status register - Exclusive Or command, offset: 0x980 */
+  __O  uint32_t XOR_CAA;                           /**< Accumulator register - Exclusive Or command, offset: 0x984 */
+  __O  uint32_t XOR_CA[9];                         /**< General Purpose Register 0 - Exclusive Or command..General Purpose Register 8 - Exclusive Or command, array offset: 0x988, array step: 0x4 */
+       uint8_t RESERVED_5[20];
+  __O  uint32_t ROTL_CASR;                         /**< Status register - Rotate Left command, offset: 0x9C0 */
+  __O  uint32_t ROTL_CAA;                          /**< Accumulator register - Rotate Left command, offset: 0x9C4 */
+  __O  uint32_t ROTL_CA[9];                        /**< General Purpose Register 0 - Rotate Left command..General Purpose Register 8 - Rotate Left command, array offset: 0x9C8, array step: 0x4 */
+       uint8_t RESERVED_6[276];
+  __O  uint32_t AESC_CASR;                         /**< Status register - AES Column Operation command, offset: 0xB00 */
+  __O  uint32_t AESC_CAA;                          /**< Accumulator register - AES Column Operation command, offset: 0xB04 */
+  __O  uint32_t AESC_CA[9];                        /**< General Purpose Register 0 - AES Column Operation command..General Purpose Register 8 - AES Column Operation command, array offset: 0xB08, array step: 0x4 */
+       uint8_t RESERVED_7[20];
+  __O  uint32_t AESIC_CASR;                        /**< Status register - AES Inverse Column Operation command, offset: 0xB40 */
+  __O  uint32_t AESIC_CAA;                         /**< Accumulator register - AES Inverse Column Operation command, offset: 0xB44 */
+  __O  uint32_t AESIC_CA[9];                       /**< General Purpose Register 0 - AES Inverse Column Operation command..General Purpose Register 8 - AES Inverse Column Operation command, array offset: 0xB48, array step: 0x4 */
+} CAU_Type;
+
+/* ----------------------------------------------------------------------------
+   -- CAU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAU_Register_Masks CAU Register Masks
+ * @{
+ */
+
+/*! @name DIRECT - Direct access register 0..Direct access register 15 */
+#define CAU_DIRECT_CAU_DIRECT0_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT0_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT0(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT0_SHIFT)) & CAU_DIRECT_CAU_DIRECT0_MASK)
+#define CAU_DIRECT_CAU_DIRECT1_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT1_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT1(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT1_SHIFT)) & CAU_DIRECT_CAU_DIRECT1_MASK)
+#define CAU_DIRECT_CAU_DIRECT2_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT2_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT2(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT2_SHIFT)) & CAU_DIRECT_CAU_DIRECT2_MASK)
+#define CAU_DIRECT_CAU_DIRECT3_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT3_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT3(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT3_SHIFT)) & CAU_DIRECT_CAU_DIRECT3_MASK)
+#define CAU_DIRECT_CAU_DIRECT4_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT4_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT4(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT4_SHIFT)) & CAU_DIRECT_CAU_DIRECT4_MASK)
+#define CAU_DIRECT_CAU_DIRECT5_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT5_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT5(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT5_SHIFT)) & CAU_DIRECT_CAU_DIRECT5_MASK)
+#define CAU_DIRECT_CAU_DIRECT6_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT6_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT6(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT6_SHIFT)) & CAU_DIRECT_CAU_DIRECT6_MASK)
+#define CAU_DIRECT_CAU_DIRECT7_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT7_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT7(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT7_SHIFT)) & CAU_DIRECT_CAU_DIRECT7_MASK)
+#define CAU_DIRECT_CAU_DIRECT8_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT8_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT8(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT8_SHIFT)) & CAU_DIRECT_CAU_DIRECT8_MASK)
+#define CAU_DIRECT_CAU_DIRECT9_MASK              (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT9_SHIFT             (0U)
+#define CAU_DIRECT_CAU_DIRECT9(x)                (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT9_SHIFT)) & CAU_DIRECT_CAU_DIRECT9_MASK)
+#define CAU_DIRECT_CAU_DIRECT10_MASK             (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT10_SHIFT            (0U)
+#define CAU_DIRECT_CAU_DIRECT10(x)               (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT10_SHIFT)) & CAU_DIRECT_CAU_DIRECT10_MASK)
+#define CAU_DIRECT_CAU_DIRECT11_MASK             (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT11_SHIFT            (0U)
+#define CAU_DIRECT_CAU_DIRECT11(x)               (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT11_SHIFT)) & CAU_DIRECT_CAU_DIRECT11_MASK)
+#define CAU_DIRECT_CAU_DIRECT12_MASK             (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT12_SHIFT            (0U)
+#define CAU_DIRECT_CAU_DIRECT12(x)               (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT12_SHIFT)) & CAU_DIRECT_CAU_DIRECT12_MASK)
+#define CAU_DIRECT_CAU_DIRECT13_MASK             (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT13_SHIFT            (0U)
+#define CAU_DIRECT_CAU_DIRECT13(x)               (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT13_SHIFT)) & CAU_DIRECT_CAU_DIRECT13_MASK)
+#define CAU_DIRECT_CAU_DIRECT14_MASK             (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT14_SHIFT            (0U)
+#define CAU_DIRECT_CAU_DIRECT14(x)               (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT14_SHIFT)) & CAU_DIRECT_CAU_DIRECT14_MASK)
+#define CAU_DIRECT_CAU_DIRECT15_MASK             (0xFFFFFFFFU)
+#define CAU_DIRECT_CAU_DIRECT15_SHIFT            (0U)
+#define CAU_DIRECT_CAU_DIRECT15(x)               (((uint32_t)(((uint32_t)(x)) << CAU_DIRECT_CAU_DIRECT15_SHIFT)) & CAU_DIRECT_CAU_DIRECT15_MASK)
+
+/* The count of CAU_DIRECT */
+#define CAU_DIRECT_COUNT                         (16U)
+
+/*! @name LDR_CASR - Status register - Load Register command */
+#define CAU_LDR_CASR_IC_MASK                     (0x1U)
+#define CAU_LDR_CASR_IC_SHIFT                    (0U)
+#define CAU_LDR_CASR_IC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CASR_IC_SHIFT)) & CAU_LDR_CASR_IC_MASK)
+#define CAU_LDR_CASR_DPE_MASK                    (0x2U)
+#define CAU_LDR_CASR_DPE_SHIFT                   (1U)
+#define CAU_LDR_CASR_DPE(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CASR_DPE_SHIFT)) & CAU_LDR_CASR_DPE_MASK)
+#define CAU_LDR_CASR_VER_MASK                    (0xF0000000U)
+#define CAU_LDR_CASR_VER_SHIFT                   (28U)
+#define CAU_LDR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CASR_VER_SHIFT)) & CAU_LDR_CASR_VER_MASK)
+
+/*! @name LDR_CAA - Accumulator register - Load Register command */
+#define CAU_LDR_CAA_ACC_MASK                     (0xFFFFFFFFU)
+#define CAU_LDR_CAA_ACC_SHIFT                    (0U)
+#define CAU_LDR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CAA_ACC_SHIFT)) & CAU_LDR_CAA_ACC_MASK)
+
+/*! @name LDR_CA - General Purpose Register 0 - Load Register command..General Purpose Register 8 - Load Register command */
+#define CAU_LDR_CA_CA0_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA0_SHIFT                     (0U)
+#define CAU_LDR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA0_SHIFT)) & CAU_LDR_CA_CA0_MASK)
+#define CAU_LDR_CA_CA1_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA1_SHIFT                     (0U)
+#define CAU_LDR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA1_SHIFT)) & CAU_LDR_CA_CA1_MASK)
+#define CAU_LDR_CA_CA2_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA2_SHIFT                     (0U)
+#define CAU_LDR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA2_SHIFT)) & CAU_LDR_CA_CA2_MASK)
+#define CAU_LDR_CA_CA3_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA3_SHIFT                     (0U)
+#define CAU_LDR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA3_SHIFT)) & CAU_LDR_CA_CA3_MASK)
+#define CAU_LDR_CA_CA4_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA4_SHIFT                     (0U)
+#define CAU_LDR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA4_SHIFT)) & CAU_LDR_CA_CA4_MASK)
+#define CAU_LDR_CA_CA5_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA5_SHIFT                     (0U)
+#define CAU_LDR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA5_SHIFT)) & CAU_LDR_CA_CA5_MASK)
+#define CAU_LDR_CA_CA6_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA6_SHIFT                     (0U)
+#define CAU_LDR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA6_SHIFT)) & CAU_LDR_CA_CA6_MASK)
+#define CAU_LDR_CA_CA7_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA7_SHIFT                     (0U)
+#define CAU_LDR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA7_SHIFT)) & CAU_LDR_CA_CA7_MASK)
+#define CAU_LDR_CA_CA8_MASK                      (0xFFFFFFFFU)
+#define CAU_LDR_CA_CA8_SHIFT                     (0U)
+#define CAU_LDR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_LDR_CA_CA8_SHIFT)) & CAU_LDR_CA_CA8_MASK)
+
+/* The count of CAU_LDR_CA */
+#define CAU_LDR_CA_COUNT                         (9U)
+
+/*! @name STR_CASR - Status register - Store Register command */
+#define CAU_STR_CASR_IC_MASK                     (0x1U)
+#define CAU_STR_CASR_IC_SHIFT                    (0U)
+#define CAU_STR_CASR_IC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_STR_CASR_IC_SHIFT)) & CAU_STR_CASR_IC_MASK)
+#define CAU_STR_CASR_DPE_MASK                    (0x2U)
+#define CAU_STR_CASR_DPE_SHIFT                   (1U)
+#define CAU_STR_CASR_DPE(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_STR_CASR_DPE_SHIFT)) & CAU_STR_CASR_DPE_MASK)
+#define CAU_STR_CASR_VER_MASK                    (0xF0000000U)
+#define CAU_STR_CASR_VER_SHIFT                   (28U)
+#define CAU_STR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_STR_CASR_VER_SHIFT)) & CAU_STR_CASR_VER_MASK)
+
+/*! @name STR_CAA - Accumulator register - Store Register command */
+#define CAU_STR_CAA_ACC_MASK                     (0xFFFFFFFFU)
+#define CAU_STR_CAA_ACC_SHIFT                    (0U)
+#define CAU_STR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_STR_CAA_ACC_SHIFT)) & CAU_STR_CAA_ACC_MASK)
+
+/*! @name STR_CA - General Purpose Register 0 - Store Register command..General Purpose Register 8 - Store Register command */
+#define CAU_STR_CA_CA0_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA0_SHIFT                     (0U)
+#define CAU_STR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA0_SHIFT)) & CAU_STR_CA_CA0_MASK)
+#define CAU_STR_CA_CA1_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA1_SHIFT                     (0U)
+#define CAU_STR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA1_SHIFT)) & CAU_STR_CA_CA1_MASK)
+#define CAU_STR_CA_CA2_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA2_SHIFT                     (0U)
+#define CAU_STR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA2_SHIFT)) & CAU_STR_CA_CA2_MASK)
+#define CAU_STR_CA_CA3_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA3_SHIFT                     (0U)
+#define CAU_STR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA3_SHIFT)) & CAU_STR_CA_CA3_MASK)
+#define CAU_STR_CA_CA4_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA4_SHIFT                     (0U)
+#define CAU_STR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA4_SHIFT)) & CAU_STR_CA_CA4_MASK)
+#define CAU_STR_CA_CA5_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA5_SHIFT                     (0U)
+#define CAU_STR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA5_SHIFT)) & CAU_STR_CA_CA5_MASK)
+#define CAU_STR_CA_CA6_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA6_SHIFT                     (0U)
+#define CAU_STR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA6_SHIFT)) & CAU_STR_CA_CA6_MASK)
+#define CAU_STR_CA_CA7_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA7_SHIFT                     (0U)
+#define CAU_STR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA7_SHIFT)) & CAU_STR_CA_CA7_MASK)
+#define CAU_STR_CA_CA8_MASK                      (0xFFFFFFFFU)
+#define CAU_STR_CA_CA8_SHIFT                     (0U)
+#define CAU_STR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_STR_CA_CA8_SHIFT)) & CAU_STR_CA_CA8_MASK)
+
+/* The count of CAU_STR_CA */
+#define CAU_STR_CA_COUNT                         (9U)
+
+/*! @name ADR_CASR - Status register - Add Register command */
+#define CAU_ADR_CASR_IC_MASK                     (0x1U)
+#define CAU_ADR_CASR_IC_SHIFT                    (0U)
+#define CAU_ADR_CASR_IC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CASR_IC_SHIFT)) & CAU_ADR_CASR_IC_MASK)
+#define CAU_ADR_CASR_DPE_MASK                    (0x2U)
+#define CAU_ADR_CASR_DPE_SHIFT                   (1U)
+#define CAU_ADR_CASR_DPE(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CASR_DPE_SHIFT)) & CAU_ADR_CASR_DPE_MASK)
+#define CAU_ADR_CASR_VER_MASK                    (0xF0000000U)
+#define CAU_ADR_CASR_VER_SHIFT                   (28U)
+#define CAU_ADR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CASR_VER_SHIFT)) & CAU_ADR_CASR_VER_MASK)
+
+/*! @name ADR_CAA - Accumulator register - Add to register command */
+#define CAU_ADR_CAA_ACC_MASK                     (0xFFFFFFFFU)
+#define CAU_ADR_CAA_ACC_SHIFT                    (0U)
+#define CAU_ADR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CAA_ACC_SHIFT)) & CAU_ADR_CAA_ACC_MASK)
+
+/*! @name ADR_CA - General Purpose Register 0 - Add to register command..General Purpose Register 8 - Add to register command */
+#define CAU_ADR_CA_CA0_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA0_SHIFT                     (0U)
+#define CAU_ADR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA0_SHIFT)) & CAU_ADR_CA_CA0_MASK)
+#define CAU_ADR_CA_CA1_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA1_SHIFT                     (0U)
+#define CAU_ADR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA1_SHIFT)) & CAU_ADR_CA_CA1_MASK)
+#define CAU_ADR_CA_CA2_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA2_SHIFT                     (0U)
+#define CAU_ADR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA2_SHIFT)) & CAU_ADR_CA_CA2_MASK)
+#define CAU_ADR_CA_CA3_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA3_SHIFT                     (0U)
+#define CAU_ADR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA3_SHIFT)) & CAU_ADR_CA_CA3_MASK)
+#define CAU_ADR_CA_CA4_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA4_SHIFT                     (0U)
+#define CAU_ADR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA4_SHIFT)) & CAU_ADR_CA_CA4_MASK)
+#define CAU_ADR_CA_CA5_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA5_SHIFT                     (0U)
+#define CAU_ADR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA5_SHIFT)) & CAU_ADR_CA_CA5_MASK)
+#define CAU_ADR_CA_CA6_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA6_SHIFT                     (0U)
+#define CAU_ADR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA6_SHIFT)) & CAU_ADR_CA_CA6_MASK)
+#define CAU_ADR_CA_CA7_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA7_SHIFT                     (0U)
+#define CAU_ADR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA7_SHIFT)) & CAU_ADR_CA_CA7_MASK)
+#define CAU_ADR_CA_CA8_MASK                      (0xFFFFFFFFU)
+#define CAU_ADR_CA_CA8_SHIFT                     (0U)
+#define CAU_ADR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_ADR_CA_CA8_SHIFT)) & CAU_ADR_CA_CA8_MASK)
+
+/* The count of CAU_ADR_CA */
+#define CAU_ADR_CA_COUNT                         (9U)
+
+/*! @name RADR_CASR - Status register - Reverse and Add to Register command */
+#define CAU_RADR_CASR_IC_MASK                    (0x1U)
+#define CAU_RADR_CASR_IC_SHIFT                   (0U)
+#define CAU_RADR_CASR_IC(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CASR_IC_SHIFT)) & CAU_RADR_CASR_IC_MASK)
+#define CAU_RADR_CASR_DPE_MASK                   (0x2U)
+#define CAU_RADR_CASR_DPE_SHIFT                  (1U)
+#define CAU_RADR_CASR_DPE(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CASR_DPE_SHIFT)) & CAU_RADR_CASR_DPE_MASK)
+#define CAU_RADR_CASR_VER_MASK                   (0xF0000000U)
+#define CAU_RADR_CASR_VER_SHIFT                  (28U)
+#define CAU_RADR_CASR_VER(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CASR_VER_SHIFT)) & CAU_RADR_CASR_VER_MASK)
+
+/*! @name RADR_CAA - Accumulator register - Reverse and Add to Register command */
+#define CAU_RADR_CAA_ACC_MASK                    (0xFFFFFFFFU)
+#define CAU_RADR_CAA_ACC_SHIFT                   (0U)
+#define CAU_RADR_CAA_ACC(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CAA_ACC_SHIFT)) & CAU_RADR_CAA_ACC_MASK)
+
+/*! @name RADR_CA - General Purpose Register 0 - Reverse and Add to Register command..General Purpose Register 8 - Reverse and Add to Register command */
+#define CAU_RADR_CA_CA0_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA0_SHIFT                    (0U)
+#define CAU_RADR_CA_CA0(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA0_SHIFT)) & CAU_RADR_CA_CA0_MASK)
+#define CAU_RADR_CA_CA1_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA1_SHIFT                    (0U)
+#define CAU_RADR_CA_CA1(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA1_SHIFT)) & CAU_RADR_CA_CA1_MASK)
+#define CAU_RADR_CA_CA2_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA2_SHIFT                    (0U)
+#define CAU_RADR_CA_CA2(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA2_SHIFT)) & CAU_RADR_CA_CA2_MASK)
+#define CAU_RADR_CA_CA3_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA3_SHIFT                    (0U)
+#define CAU_RADR_CA_CA3(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA3_SHIFT)) & CAU_RADR_CA_CA3_MASK)
+#define CAU_RADR_CA_CA4_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA4_SHIFT                    (0U)
+#define CAU_RADR_CA_CA4(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA4_SHIFT)) & CAU_RADR_CA_CA4_MASK)
+#define CAU_RADR_CA_CA5_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA5_SHIFT                    (0U)
+#define CAU_RADR_CA_CA5(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA5_SHIFT)) & CAU_RADR_CA_CA5_MASK)
+#define CAU_RADR_CA_CA6_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA6_SHIFT                    (0U)
+#define CAU_RADR_CA_CA6(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA6_SHIFT)) & CAU_RADR_CA_CA6_MASK)
+#define CAU_RADR_CA_CA7_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA7_SHIFT                    (0U)
+#define CAU_RADR_CA_CA7(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA7_SHIFT)) & CAU_RADR_CA_CA7_MASK)
+#define CAU_RADR_CA_CA8_MASK                     (0xFFFFFFFFU)
+#define CAU_RADR_CA_CA8_SHIFT                    (0U)
+#define CAU_RADR_CA_CA8(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_RADR_CA_CA8_SHIFT)) & CAU_RADR_CA_CA8_MASK)
+
+/* The count of CAU_RADR_CA */
+#define CAU_RADR_CA_COUNT                        (9U)
+
+/*! @name XOR_CASR - Status register - Exclusive Or command */
+#define CAU_XOR_CASR_IC_MASK                     (0x1U)
+#define CAU_XOR_CASR_IC_SHIFT                    (0U)
+#define CAU_XOR_CASR_IC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CASR_IC_SHIFT)) & CAU_XOR_CASR_IC_MASK)
+#define CAU_XOR_CASR_DPE_MASK                    (0x2U)
+#define CAU_XOR_CASR_DPE_SHIFT                   (1U)
+#define CAU_XOR_CASR_DPE(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CASR_DPE_SHIFT)) & CAU_XOR_CASR_DPE_MASK)
+#define CAU_XOR_CASR_VER_MASK                    (0xF0000000U)
+#define CAU_XOR_CASR_VER_SHIFT                   (28U)
+#define CAU_XOR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CASR_VER_SHIFT)) & CAU_XOR_CASR_VER_MASK)
+
+/*! @name XOR_CAA - Accumulator register - Exclusive Or command */
+#define CAU_XOR_CAA_ACC_MASK                     (0xFFFFFFFFU)
+#define CAU_XOR_CAA_ACC_SHIFT                    (0U)
+#define CAU_XOR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CAA_ACC_SHIFT)) & CAU_XOR_CAA_ACC_MASK)
+
+/*! @name XOR_CA - General Purpose Register 0 - Exclusive Or command..General Purpose Register 8 - Exclusive Or command */
+#define CAU_XOR_CA_CA0_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA0_SHIFT                     (0U)
+#define CAU_XOR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA0_SHIFT)) & CAU_XOR_CA_CA0_MASK)
+#define CAU_XOR_CA_CA1_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA1_SHIFT                     (0U)
+#define CAU_XOR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA1_SHIFT)) & CAU_XOR_CA_CA1_MASK)
+#define CAU_XOR_CA_CA2_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA2_SHIFT                     (0U)
+#define CAU_XOR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA2_SHIFT)) & CAU_XOR_CA_CA2_MASK)
+#define CAU_XOR_CA_CA3_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA3_SHIFT                     (0U)
+#define CAU_XOR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA3_SHIFT)) & CAU_XOR_CA_CA3_MASK)
+#define CAU_XOR_CA_CA4_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA4_SHIFT                     (0U)
+#define CAU_XOR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA4_SHIFT)) & CAU_XOR_CA_CA4_MASK)
+#define CAU_XOR_CA_CA5_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA5_SHIFT                     (0U)
+#define CAU_XOR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA5_SHIFT)) & CAU_XOR_CA_CA5_MASK)
+#define CAU_XOR_CA_CA6_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA6_SHIFT                     (0U)
+#define CAU_XOR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA6_SHIFT)) & CAU_XOR_CA_CA6_MASK)
+#define CAU_XOR_CA_CA7_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA7_SHIFT                     (0U)
+#define CAU_XOR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA7_SHIFT)) & CAU_XOR_CA_CA7_MASK)
+#define CAU_XOR_CA_CA8_MASK                      (0xFFFFFFFFU)
+#define CAU_XOR_CA_CA8_SHIFT                     (0U)
+#define CAU_XOR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x)) << CAU_XOR_CA_CA8_SHIFT)) & CAU_XOR_CA_CA8_MASK)
+
+/* The count of CAU_XOR_CA */
+#define CAU_XOR_CA_COUNT                         (9U)
+
+/*! @name ROTL_CASR - Status register - Rotate Left command */
+#define CAU_ROTL_CASR_IC_MASK                    (0x1U)
+#define CAU_ROTL_CASR_IC_SHIFT                   (0U)
+#define CAU_ROTL_CASR_IC(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CASR_IC_SHIFT)) & CAU_ROTL_CASR_IC_MASK)
+#define CAU_ROTL_CASR_DPE_MASK                   (0x2U)
+#define CAU_ROTL_CASR_DPE_SHIFT                  (1U)
+#define CAU_ROTL_CASR_DPE(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CASR_DPE_SHIFT)) & CAU_ROTL_CASR_DPE_MASK)
+#define CAU_ROTL_CASR_VER_MASK                   (0xF0000000U)
+#define CAU_ROTL_CASR_VER_SHIFT                  (28U)
+#define CAU_ROTL_CASR_VER(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CASR_VER_SHIFT)) & CAU_ROTL_CASR_VER_MASK)
+
+/*! @name ROTL_CAA - Accumulator register - Rotate Left command */
+#define CAU_ROTL_CAA_ACC_MASK                    (0xFFFFFFFFU)
+#define CAU_ROTL_CAA_ACC_SHIFT                   (0U)
+#define CAU_ROTL_CAA_ACC(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CAA_ACC_SHIFT)) & CAU_ROTL_CAA_ACC_MASK)
+
+/*! @name ROTL_CA - General Purpose Register 0 - Rotate Left command..General Purpose Register 8 - Rotate Left command */
+#define CAU_ROTL_CA_CA0_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA0_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA0(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA0_SHIFT)) & CAU_ROTL_CA_CA0_MASK)
+#define CAU_ROTL_CA_CA1_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA1_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA1(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA1_SHIFT)) & CAU_ROTL_CA_CA1_MASK)
+#define CAU_ROTL_CA_CA2_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA2_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA2(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA2_SHIFT)) & CAU_ROTL_CA_CA2_MASK)
+#define CAU_ROTL_CA_CA3_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA3_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA3(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA3_SHIFT)) & CAU_ROTL_CA_CA3_MASK)
+#define CAU_ROTL_CA_CA4_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA4_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA4(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA4_SHIFT)) & CAU_ROTL_CA_CA4_MASK)
+#define CAU_ROTL_CA_CA5_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA5_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA5(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA5_SHIFT)) & CAU_ROTL_CA_CA5_MASK)
+#define CAU_ROTL_CA_CA6_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA6_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA6(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA6_SHIFT)) & CAU_ROTL_CA_CA6_MASK)
+#define CAU_ROTL_CA_CA7_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA7_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA7(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA7_SHIFT)) & CAU_ROTL_CA_CA7_MASK)
+#define CAU_ROTL_CA_CA8_MASK                     (0xFFFFFFFFU)
+#define CAU_ROTL_CA_CA8_SHIFT                    (0U)
+#define CAU_ROTL_CA_CA8(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_ROTL_CA_CA8_SHIFT)) & CAU_ROTL_CA_CA8_MASK)
+
+/* The count of CAU_ROTL_CA */
+#define CAU_ROTL_CA_COUNT                        (9U)
+
+/*! @name AESC_CASR - Status register - AES Column Operation command */
+#define CAU_AESC_CASR_IC_MASK                    (0x1U)
+#define CAU_AESC_CASR_IC_SHIFT                   (0U)
+#define CAU_AESC_CASR_IC(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CASR_IC_SHIFT)) & CAU_AESC_CASR_IC_MASK)
+#define CAU_AESC_CASR_DPE_MASK                   (0x2U)
+#define CAU_AESC_CASR_DPE_SHIFT                  (1U)
+#define CAU_AESC_CASR_DPE(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CASR_DPE_SHIFT)) & CAU_AESC_CASR_DPE_MASK)
+#define CAU_AESC_CASR_VER_MASK                   (0xF0000000U)
+#define CAU_AESC_CASR_VER_SHIFT                  (28U)
+#define CAU_AESC_CASR_VER(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CASR_VER_SHIFT)) & CAU_AESC_CASR_VER_MASK)
+
+/*! @name AESC_CAA - Accumulator register - AES Column Operation command */
+#define CAU_AESC_CAA_ACC_MASK                    (0xFFFFFFFFU)
+#define CAU_AESC_CAA_ACC_SHIFT                   (0U)
+#define CAU_AESC_CAA_ACC(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CAA_ACC_SHIFT)) & CAU_AESC_CAA_ACC_MASK)
+
+/*! @name AESC_CA - General Purpose Register 0 - AES Column Operation command..General Purpose Register 8 - AES Column Operation command */
+#define CAU_AESC_CA_CA0_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA0_SHIFT                    (0U)
+#define CAU_AESC_CA_CA0(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA0_SHIFT)) & CAU_AESC_CA_CA0_MASK)
+#define CAU_AESC_CA_CA1_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA1_SHIFT                    (0U)
+#define CAU_AESC_CA_CA1(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA1_SHIFT)) & CAU_AESC_CA_CA1_MASK)
+#define CAU_AESC_CA_CA2_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA2_SHIFT                    (0U)
+#define CAU_AESC_CA_CA2(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA2_SHIFT)) & CAU_AESC_CA_CA2_MASK)
+#define CAU_AESC_CA_CA3_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA3_SHIFT                    (0U)
+#define CAU_AESC_CA_CA3(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA3_SHIFT)) & CAU_AESC_CA_CA3_MASK)
+#define CAU_AESC_CA_CA4_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA4_SHIFT                    (0U)
+#define CAU_AESC_CA_CA4(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA4_SHIFT)) & CAU_AESC_CA_CA4_MASK)
+#define CAU_AESC_CA_CA5_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA5_SHIFT                    (0U)
+#define CAU_AESC_CA_CA5(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA5_SHIFT)) & CAU_AESC_CA_CA5_MASK)
+#define CAU_AESC_CA_CA6_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA6_SHIFT                    (0U)
+#define CAU_AESC_CA_CA6(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA6_SHIFT)) & CAU_AESC_CA_CA6_MASK)
+#define CAU_AESC_CA_CA7_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA7_SHIFT                    (0U)
+#define CAU_AESC_CA_CA7(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA7_SHIFT)) & CAU_AESC_CA_CA7_MASK)
+#define CAU_AESC_CA_CA8_MASK                     (0xFFFFFFFFU)
+#define CAU_AESC_CA_CA8_SHIFT                    (0U)
+#define CAU_AESC_CA_CA8(x)                       (((uint32_t)(((uint32_t)(x)) << CAU_AESC_CA_CA8_SHIFT)) & CAU_AESC_CA_CA8_MASK)
+
+/* The count of CAU_AESC_CA */
+#define CAU_AESC_CA_COUNT                        (9U)
+
+/*! @name AESIC_CASR - Status register - AES Inverse Column Operation command */
+#define CAU_AESIC_CASR_IC_MASK                   (0x1U)
+#define CAU_AESIC_CASR_IC_SHIFT                  (0U)
+#define CAU_AESIC_CASR_IC(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CASR_IC_SHIFT)) & CAU_AESIC_CASR_IC_MASK)
+#define CAU_AESIC_CASR_DPE_MASK                  (0x2U)
+#define CAU_AESIC_CASR_DPE_SHIFT                 (1U)
+#define CAU_AESIC_CASR_DPE(x)                    (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CASR_DPE_SHIFT)) & CAU_AESIC_CASR_DPE_MASK)
+#define CAU_AESIC_CASR_VER_MASK                  (0xF0000000U)
+#define CAU_AESIC_CASR_VER_SHIFT                 (28U)
+#define CAU_AESIC_CASR_VER(x)                    (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CASR_VER_SHIFT)) & CAU_AESIC_CASR_VER_MASK)
+
+/*! @name AESIC_CAA - Accumulator register - AES Inverse Column Operation command */
+#define CAU_AESIC_CAA_ACC_MASK                   (0xFFFFFFFFU)
+#define CAU_AESIC_CAA_ACC_SHIFT                  (0U)
+#define CAU_AESIC_CAA_ACC(x)                     (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CAA_ACC_SHIFT)) & CAU_AESIC_CAA_ACC_MASK)
+
+/*! @name AESIC_CA - General Purpose Register 0 - AES Inverse Column Operation command..General Purpose Register 8 - AES Inverse Column Operation command */
+#define CAU_AESIC_CA_CA0_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA0_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA0(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA0_SHIFT)) & CAU_AESIC_CA_CA0_MASK)
+#define CAU_AESIC_CA_CA1_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA1_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA1(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA1_SHIFT)) & CAU_AESIC_CA_CA1_MASK)
+#define CAU_AESIC_CA_CA2_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA2_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA2(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA2_SHIFT)) & CAU_AESIC_CA_CA2_MASK)
+#define CAU_AESIC_CA_CA3_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA3_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA3(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA3_SHIFT)) & CAU_AESIC_CA_CA3_MASK)
+#define CAU_AESIC_CA_CA4_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA4_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA4(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA4_SHIFT)) & CAU_AESIC_CA_CA4_MASK)
+#define CAU_AESIC_CA_CA5_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA5_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA5(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA5_SHIFT)) & CAU_AESIC_CA_CA5_MASK)
+#define CAU_AESIC_CA_CA6_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA6_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA6(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA6_SHIFT)) & CAU_AESIC_CA_CA6_MASK)
+#define CAU_AESIC_CA_CA7_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA7_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA7(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA7_SHIFT)) & CAU_AESIC_CA_CA7_MASK)
+#define CAU_AESIC_CA_CA8_MASK                    (0xFFFFFFFFU)
+#define CAU_AESIC_CA_CA8_SHIFT                   (0U)
+#define CAU_AESIC_CA_CA8(x)                      (((uint32_t)(((uint32_t)(x)) << CAU_AESIC_CA_CA8_SHIFT)) & CAU_AESIC_CA_CA8_MASK)
+
+/* The count of CAU_AESIC_CA */
+#define CAU_AESIC_CA_COUNT                       (9U)
+
+
+/*!
+ * @}
+ */ /* end of group CAU_Register_Masks */
+
+
+/* CAU - Peripheral instance base addresses */
+/** Peripheral CAU base address */
+#define CAU_BASE                                 (0xE0081000u)
+/** Peripheral CAU base pointer */
+#define CAU                                      ((CAU_Type *)CAU_BASE)
+/** Array initializer of CAU peripheral base addresses */
+#define CAU_BASE_ADDRS                           { CAU_BASE }
+/** Array initializer of CAU peripheral base pointers */
+#define CAU_BASE_PTRS                            { CAU }
+
+/*!
+ * @}
+ */ /* end of group CAU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMP Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Peripheral_Access_Layer CMP Peripheral Access Layer
+ * @{
+ */
+
+/** CMP - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR0;                                /**< CMP Control Register 0, offset: 0x0 */
+  __IO uint8_t CR1;                                /**< CMP Control Register 1, offset: 0x1 */
+  __IO uint8_t FPR;                                /**< CMP Filter Period Register, offset: 0x2 */
+  __IO uint8_t SCR;                                /**< CMP Status and Control Register, offset: 0x3 */
+  __IO uint8_t DACCR;                              /**< DAC Control Register, offset: 0x4 */
+  __IO uint8_t MUXCR;                              /**< MUX Control Register, offset: 0x5 */
+} CMP_Type;
+
+/* ----------------------------------------------------------------------------
+   -- CMP Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Masks CMP Register Masks
+ * @{
+ */
+
+/*! @name CR0 - CMP Control Register 0 */
+#define CMP_CR0_HYSTCTR_MASK                     (0x3U)
+#define CMP_CR0_HYSTCTR_SHIFT                    (0U)
+#define CMP_CR0_HYSTCTR(x)                       (((uint8_t)(((uint8_t)(x)) << CMP_CR0_HYSTCTR_SHIFT)) & CMP_CR0_HYSTCTR_MASK)
+#define CMP_CR0_FILTER_CNT_MASK                  (0x70U)
+#define CMP_CR0_FILTER_CNT_SHIFT                 (4U)
+#define CMP_CR0_FILTER_CNT(x)                    (((uint8_t)(((uint8_t)(x)) << CMP_CR0_FILTER_CNT_SHIFT)) & CMP_CR0_FILTER_CNT_MASK)
+
+/*! @name CR1 - CMP Control Register 1 */
+#define CMP_CR1_EN_MASK                          (0x1U)
+#define CMP_CR1_EN_SHIFT                         (0U)
+#define CMP_CR1_EN(x)                            (((uint8_t)(((uint8_t)(x)) << CMP_CR1_EN_SHIFT)) & CMP_CR1_EN_MASK)
+#define CMP_CR1_OPE_MASK                         (0x2U)
+#define CMP_CR1_OPE_SHIFT                        (1U)
+#define CMP_CR1_OPE(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_CR1_OPE_SHIFT)) & CMP_CR1_OPE_MASK)
+#define CMP_CR1_COS_MASK                         (0x4U)
+#define CMP_CR1_COS_SHIFT                        (2U)
+#define CMP_CR1_COS(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_CR1_COS_SHIFT)) & CMP_CR1_COS_MASK)
+#define CMP_CR1_INV_MASK                         (0x8U)
+#define CMP_CR1_INV_SHIFT                        (3U)
+#define CMP_CR1_INV(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_CR1_INV_SHIFT)) & CMP_CR1_INV_MASK)
+#define CMP_CR1_PMODE_MASK                       (0x10U)
+#define CMP_CR1_PMODE_SHIFT                      (4U)
+#define CMP_CR1_PMODE(x)                         (((uint8_t)(((uint8_t)(x)) << CMP_CR1_PMODE_SHIFT)) & CMP_CR1_PMODE_MASK)
+#define CMP_CR1_WE_MASK                          (0x40U)
+#define CMP_CR1_WE_SHIFT                         (6U)
+#define CMP_CR1_WE(x)                            (((uint8_t)(((uint8_t)(x)) << CMP_CR1_WE_SHIFT)) & CMP_CR1_WE_MASK)
+#define CMP_CR1_SE_MASK                          (0x80U)
+#define CMP_CR1_SE_SHIFT                         (7U)
+#define CMP_CR1_SE(x)                            (((uint8_t)(((uint8_t)(x)) << CMP_CR1_SE_SHIFT)) & CMP_CR1_SE_MASK)
+
+/*! @name FPR - CMP Filter Period Register */
+#define CMP_FPR_FILT_PER_MASK                    (0xFFU)
+#define CMP_FPR_FILT_PER_SHIFT                   (0U)
+#define CMP_FPR_FILT_PER(x)                      (((uint8_t)(((uint8_t)(x)) << CMP_FPR_FILT_PER_SHIFT)) & CMP_FPR_FILT_PER_MASK)
+
+/*! @name SCR - CMP Status and Control Register */
+#define CMP_SCR_COUT_MASK                        (0x1U)
+#define CMP_SCR_COUT_SHIFT                       (0U)
+#define CMP_SCR_COUT(x)                          (((uint8_t)(((uint8_t)(x)) << CMP_SCR_COUT_SHIFT)) & CMP_SCR_COUT_MASK)
+#define CMP_SCR_CFF_MASK                         (0x2U)
+#define CMP_SCR_CFF_SHIFT                        (1U)
+#define CMP_SCR_CFF(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_SCR_CFF_SHIFT)) & CMP_SCR_CFF_MASK)
+#define CMP_SCR_CFR_MASK                         (0x4U)
+#define CMP_SCR_CFR_SHIFT                        (2U)
+#define CMP_SCR_CFR(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_SCR_CFR_SHIFT)) & CMP_SCR_CFR_MASK)
+#define CMP_SCR_IEF_MASK                         (0x8U)
+#define CMP_SCR_IEF_SHIFT                        (3U)
+#define CMP_SCR_IEF(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_SCR_IEF_SHIFT)) & CMP_SCR_IEF_MASK)
+#define CMP_SCR_IER_MASK                         (0x10U)
+#define CMP_SCR_IER_SHIFT                        (4U)
+#define CMP_SCR_IER(x)                           (((uint8_t)(((uint8_t)(x)) << CMP_SCR_IER_SHIFT)) & CMP_SCR_IER_MASK)
+#define CMP_SCR_DMAEN_MASK                       (0x40U)
+#define CMP_SCR_DMAEN_SHIFT                      (6U)
+#define CMP_SCR_DMAEN(x)                         (((uint8_t)(((uint8_t)(x)) << CMP_SCR_DMAEN_SHIFT)) & CMP_SCR_DMAEN_MASK)
+
+/*! @name DACCR - DAC Control Register */
+#define CMP_DACCR_VOSEL_MASK                     (0x3FU)
+#define CMP_DACCR_VOSEL_SHIFT                    (0U)
+#define CMP_DACCR_VOSEL(x)                       (((uint8_t)(((uint8_t)(x)) << CMP_DACCR_VOSEL_SHIFT)) & CMP_DACCR_VOSEL_MASK)
+#define CMP_DACCR_VRSEL_MASK                     (0x40U)
+#define CMP_DACCR_VRSEL_SHIFT                    (6U)
+#define CMP_DACCR_VRSEL(x)                       (((uint8_t)(((uint8_t)(x)) << CMP_DACCR_VRSEL_SHIFT)) & CMP_DACCR_VRSEL_MASK)
+#define CMP_DACCR_DACEN_MASK                     (0x80U)
+#define CMP_DACCR_DACEN_SHIFT                    (7U)
+#define CMP_DACCR_DACEN(x)                       (((uint8_t)(((uint8_t)(x)) << CMP_DACCR_DACEN_SHIFT)) & CMP_DACCR_DACEN_MASK)
+
+/*! @name MUXCR - MUX Control Register */
+#define CMP_MUXCR_MSEL_MASK                      (0x7U)
+#define CMP_MUXCR_MSEL_SHIFT                     (0U)
+#define CMP_MUXCR_MSEL(x)                        (((uint8_t)(((uint8_t)(x)) << CMP_MUXCR_MSEL_SHIFT)) & CMP_MUXCR_MSEL_MASK)
+#define CMP_MUXCR_PSEL_MASK                      (0x38U)
+#define CMP_MUXCR_PSEL_SHIFT                     (3U)
+#define CMP_MUXCR_PSEL(x)                        (((uint8_t)(((uint8_t)(x)) << CMP_MUXCR_PSEL_SHIFT)) & CMP_MUXCR_PSEL_MASK)
+#define CMP_MUXCR_PSTM_MASK                      (0x80U)
+#define CMP_MUXCR_PSTM_SHIFT                     (7U)
+#define CMP_MUXCR_PSTM(x)                        (((uint8_t)(((uint8_t)(x)) << CMP_MUXCR_PSTM_SHIFT)) & CMP_MUXCR_PSTM_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Masks */
+
+
+/* CMP - Peripheral instance base addresses */
+/** Peripheral CMP0 base address */
+#define CMP0_BASE                                (0x40073000u)
+/** Peripheral CMP0 base pointer */
+#define CMP0                                     ((CMP_Type *)CMP0_BASE)
+/** Peripheral CMP1 base address */
+#define CMP1_BASE                                (0x40073008u)
+/** Peripheral CMP1 base pointer */
+#define CMP1                                     ((CMP_Type *)CMP1_BASE)
+/** Peripheral CMP2 base address */
+#define CMP2_BASE                                (0x40073010u)
+/** Peripheral CMP2 base pointer */
+#define CMP2                                     ((CMP_Type *)CMP2_BASE)
+/** Array initializer of CMP peripheral base addresses */
+#define CMP_BASE_ADDRS                           { CMP0_BASE, CMP1_BASE, CMP2_BASE }
+/** Array initializer of CMP peripheral base pointers */
+#define CMP_BASE_PTRS                            { CMP0, CMP1, CMP2 }
+/** Interrupt vectors for the CMP peripheral type */
+#define CMP_IRQS                                 { CMP0_IRQn, CMP1_IRQn, CMP2_IRQn }
+
+/*!
+ * @}
+ */ /* end of group CMP_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMT_Peripheral_Access_Layer CMT Peripheral Access Layer
+ * @{
+ */
+
+/** CMT - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CGH1;                               /**< CMT Carrier Generator High Data Register 1, offset: 0x0 */
+  __IO uint8_t CGL1;                               /**< CMT Carrier Generator Low Data Register 1, offset: 0x1 */
+  __IO uint8_t CGH2;                               /**< CMT Carrier Generator High Data Register 2, offset: 0x2 */
+  __IO uint8_t CGL2;                               /**< CMT Carrier Generator Low Data Register 2, offset: 0x3 */
+  __IO uint8_t OC;                                 /**< CMT Output Control Register, offset: 0x4 */
+  __IO uint8_t MSC;                                /**< CMT Modulator Status and Control Register, offset: 0x5 */
+  __IO uint8_t CMD1;                               /**< CMT Modulator Data Register Mark High, offset: 0x6 */
+  __IO uint8_t CMD2;                               /**< CMT Modulator Data Register Mark Low, offset: 0x7 */
+  __IO uint8_t CMD3;                               /**< CMT Modulator Data Register Space High, offset: 0x8 */
+  __IO uint8_t CMD4;                               /**< CMT Modulator Data Register Space Low, offset: 0x9 */
+  __IO uint8_t PPS;                                /**< CMT Primary Prescaler Register, offset: 0xA */
+  __IO uint8_t DMA;                                /**< CMT Direct Memory Access Register, offset: 0xB */
+} CMT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- CMT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMT_Register_Masks CMT Register Masks
+ * @{
+ */
+
+/*! @name CGH1 - CMT Carrier Generator High Data Register 1 */
+#define CMT_CGH1_PH_MASK                         (0xFFU)
+#define CMT_CGH1_PH_SHIFT                        (0U)
+#define CMT_CGH1_PH(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CGH1_PH_SHIFT)) & CMT_CGH1_PH_MASK)
+
+/*! @name CGL1 - CMT Carrier Generator Low Data Register 1 */
+#define CMT_CGL1_PL_MASK                         (0xFFU)
+#define CMT_CGL1_PL_SHIFT                        (0U)
+#define CMT_CGL1_PL(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CGL1_PL_SHIFT)) & CMT_CGL1_PL_MASK)
+
+/*! @name CGH2 - CMT Carrier Generator High Data Register 2 */
+#define CMT_CGH2_SH_MASK                         (0xFFU)
+#define CMT_CGH2_SH_SHIFT                        (0U)
+#define CMT_CGH2_SH(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CGH2_SH_SHIFT)) & CMT_CGH2_SH_MASK)
+
+/*! @name CGL2 - CMT Carrier Generator Low Data Register 2 */
+#define CMT_CGL2_SL_MASK                         (0xFFU)
+#define CMT_CGL2_SL_SHIFT                        (0U)
+#define CMT_CGL2_SL(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CGL2_SL_SHIFT)) & CMT_CGL2_SL_MASK)
+
+/*! @name OC - CMT Output Control Register */
+#define CMT_OC_IROPEN_MASK                       (0x20U)
+#define CMT_OC_IROPEN_SHIFT                      (5U)
+#define CMT_OC_IROPEN(x)                         (((uint8_t)(((uint8_t)(x)) << CMT_OC_IROPEN_SHIFT)) & CMT_OC_IROPEN_MASK)
+#define CMT_OC_CMTPOL_MASK                       (0x40U)
+#define CMT_OC_CMTPOL_SHIFT                      (6U)
+#define CMT_OC_CMTPOL(x)                         (((uint8_t)(((uint8_t)(x)) << CMT_OC_CMTPOL_SHIFT)) & CMT_OC_CMTPOL_MASK)
+#define CMT_OC_IROL_MASK                         (0x80U)
+#define CMT_OC_IROL_SHIFT                        (7U)
+#define CMT_OC_IROL(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_OC_IROL_SHIFT)) & CMT_OC_IROL_MASK)
+
+/*! @name MSC - CMT Modulator Status and Control Register */
+#define CMT_MSC_MCGEN_MASK                       (0x1U)
+#define CMT_MSC_MCGEN_SHIFT                      (0U)
+#define CMT_MSC_MCGEN(x)                         (((uint8_t)(((uint8_t)(x)) << CMT_MSC_MCGEN_SHIFT)) & CMT_MSC_MCGEN_MASK)
+#define CMT_MSC_EOCIE_MASK                       (0x2U)
+#define CMT_MSC_EOCIE_SHIFT                      (1U)
+#define CMT_MSC_EOCIE(x)                         (((uint8_t)(((uint8_t)(x)) << CMT_MSC_EOCIE_SHIFT)) & CMT_MSC_EOCIE_MASK)
+#define CMT_MSC_FSK_MASK                         (0x4U)
+#define CMT_MSC_FSK_SHIFT                        (2U)
+#define CMT_MSC_FSK(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_MSC_FSK_SHIFT)) & CMT_MSC_FSK_MASK)
+#define CMT_MSC_BASE_MASK                        (0x8U)
+#define CMT_MSC_BASE_SHIFT                       (3U)
+#define CMT_MSC_BASE(x)                          (((uint8_t)(((uint8_t)(x)) << CMT_MSC_BASE_SHIFT)) & CMT_MSC_BASE_MASK)
+#define CMT_MSC_EXSPC_MASK                       (0x10U)
+#define CMT_MSC_EXSPC_SHIFT                      (4U)
+#define CMT_MSC_EXSPC(x)                         (((uint8_t)(((uint8_t)(x)) << CMT_MSC_EXSPC_SHIFT)) & CMT_MSC_EXSPC_MASK)
+#define CMT_MSC_CMTDIV_MASK                      (0x60U)
+#define CMT_MSC_CMTDIV_SHIFT                     (5U)
+#define CMT_MSC_CMTDIV(x)                        (((uint8_t)(((uint8_t)(x)) << CMT_MSC_CMTDIV_SHIFT)) & CMT_MSC_CMTDIV_MASK)
+#define CMT_MSC_EOCF_MASK                        (0x80U)
+#define CMT_MSC_EOCF_SHIFT                       (7U)
+#define CMT_MSC_EOCF(x)                          (((uint8_t)(((uint8_t)(x)) << CMT_MSC_EOCF_SHIFT)) & CMT_MSC_EOCF_MASK)
+
+/*! @name CMD1 - CMT Modulator Data Register Mark High */
+#define CMT_CMD1_MB_MASK                         (0xFFU)
+#define CMT_CMD1_MB_SHIFT                        (0U)
+#define CMT_CMD1_MB(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CMD1_MB_SHIFT)) & CMT_CMD1_MB_MASK)
+
+/*! @name CMD2 - CMT Modulator Data Register Mark Low */
+#define CMT_CMD2_MB_MASK                         (0xFFU)
+#define CMT_CMD2_MB_SHIFT                        (0U)
+#define CMT_CMD2_MB(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CMD2_MB_SHIFT)) & CMT_CMD2_MB_MASK)
+
+/*! @name CMD3 - CMT Modulator Data Register Space High */
+#define CMT_CMD3_SB_MASK                         (0xFFU)
+#define CMT_CMD3_SB_SHIFT                        (0U)
+#define CMT_CMD3_SB(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CMD3_SB_SHIFT)) & CMT_CMD3_SB_MASK)
+
+/*! @name CMD4 - CMT Modulator Data Register Space Low */
+#define CMT_CMD4_SB_MASK                         (0xFFU)
+#define CMT_CMD4_SB_SHIFT                        (0U)
+#define CMT_CMD4_SB(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_CMD4_SB_SHIFT)) & CMT_CMD4_SB_MASK)
+
+/*! @name PPS - CMT Primary Prescaler Register */
+#define CMT_PPS_PPSDIV_MASK                      (0xFU)
+#define CMT_PPS_PPSDIV_SHIFT                     (0U)
+#define CMT_PPS_PPSDIV(x)                        (((uint8_t)(((uint8_t)(x)) << CMT_PPS_PPSDIV_SHIFT)) & CMT_PPS_PPSDIV_MASK)
+
+/*! @name DMA - CMT Direct Memory Access Register */
+#define CMT_DMA_DMA_MASK                         (0x1U)
+#define CMT_DMA_DMA_SHIFT                        (0U)
+#define CMT_DMA_DMA(x)                           (((uint8_t)(((uint8_t)(x)) << CMT_DMA_DMA_SHIFT)) & CMT_DMA_DMA_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group CMT_Register_Masks */
+
+
+/* CMT - Peripheral instance base addresses */
+/** Peripheral CMT base address */
+#define CMT_BASE                                 (0x40062000u)
+/** Peripheral CMT base pointer */
+#define CMT                                      ((CMT_Type *)CMT_BASE)
+/** Array initializer of CMT peripheral base addresses */
+#define CMT_BASE_ADDRS                           { CMT_BASE }
+/** Array initializer of CMT peripheral base pointers */
+#define CMT_BASE_PTRS                            { CMT }
+/** Interrupt vectors for the CMT peripheral type */
+#define CMT_IRQS                                 { CMT_IRQn }
+
+/*!
+ * @}
+ */ /* end of group CMT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CRC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CRC_Peripheral_Access_Layer CRC Peripheral Access Layer
+ * @{
+ */
+
+/** CRC - Register Layout Typedef */
+typedef struct {
+  union {                                          /* offset: 0x0 */
+    struct {                                         /* offset: 0x0 */
+      __IO uint16_t DATAL;                             /**< CRC_DATAL register., offset: 0x0 */
+      __IO uint16_t DATAH;                             /**< CRC_DATAH register., offset: 0x2 */
+    } ACCESS16BIT;
+    __IO uint32_t DATA;                              /**< CRC Data register, offset: 0x0 */
+    struct {                                         /* offset: 0x0 */
+      __IO uint8_t DATALL;                             /**< CRC_DATALL register., offset: 0x0 */
+      __IO uint8_t DATALU;                             /**< CRC_DATALU register., offset: 0x1 */
+      __IO uint8_t DATAHL;                             /**< CRC_DATAHL register., offset: 0x2 */
+      __IO uint8_t DATAHU;                             /**< CRC_DATAHU register., offset: 0x3 */
+    } ACCESS8BIT;
+  };
+  union {                                          /* offset: 0x4 */
+    struct {                                         /* offset: 0x4 */
+      __IO uint16_t GPOLYL;                            /**< CRC_GPOLYL register., offset: 0x4 */
+      __IO uint16_t GPOLYH;                            /**< CRC_GPOLYH register., offset: 0x6 */
+    } GPOLY_ACCESS16BIT;
+    __IO uint32_t GPOLY;                             /**< CRC Polynomial register, offset: 0x4 */
+    struct {                                         /* offset: 0x4 */
+      __IO uint8_t GPOLYLL;                            /**< CRC_GPOLYLL register., offset: 0x4 */
+      __IO uint8_t GPOLYLU;                            /**< CRC_GPOLYLU register., offset: 0x5 */
+      __IO uint8_t GPOLYHL;                            /**< CRC_GPOLYHL register., offset: 0x6 */
+      __IO uint8_t GPOLYHU;                            /**< CRC_GPOLYHU register., offset: 0x7 */
+    } GPOLY_ACCESS8BIT;
+  };
+  union {                                          /* offset: 0x8 */
+    __IO uint32_t CTRL;                              /**< CRC Control register, offset: 0x8 */
+    struct {                                         /* offset: 0x8 */
+           uint8_t RESERVED_0[3];
+      __IO uint8_t CTRLHU;                             /**< CRC_CTRLHU register., offset: 0xB */
+    } CTRL_ACCESS8BIT;
+  };
+} CRC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- CRC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CRC_Register_Masks CRC Register Masks
+ * @{
+ */
+
+/*! @name DATAL - CRC_DATAL register. */
+#define CRC_DATAL_DATAL_MASK                     (0xFFFFU)
+#define CRC_DATAL_DATAL_SHIFT                    (0U)
+#define CRC_DATAL_DATAL(x)                       (((uint16_t)(((uint16_t)(x)) << CRC_DATAL_DATAL_SHIFT)) & CRC_DATAL_DATAL_MASK)
+
+/*! @name DATAH - CRC_DATAH register. */
+#define CRC_DATAH_DATAH_MASK                     (0xFFFFU)
+#define CRC_DATAH_DATAH_SHIFT                    (0U)
+#define CRC_DATAH_DATAH(x)                       (((uint16_t)(((uint16_t)(x)) << CRC_DATAH_DATAH_SHIFT)) & CRC_DATAH_DATAH_MASK)
+
+/*! @name DATA - CRC Data register */
+#define CRC_DATA_LL_MASK                         (0xFFU)
+#define CRC_DATA_LL_SHIFT                        (0U)
+#define CRC_DATA_LL(x)                           (((uint32_t)(((uint32_t)(x)) << CRC_DATA_LL_SHIFT)) & CRC_DATA_LL_MASK)
+#define CRC_DATA_LU_MASK                         (0xFF00U)
+#define CRC_DATA_LU_SHIFT                        (8U)
+#define CRC_DATA_LU(x)                           (((uint32_t)(((uint32_t)(x)) << CRC_DATA_LU_SHIFT)) & CRC_DATA_LU_MASK)
+#define CRC_DATA_HL_MASK                         (0xFF0000U)
+#define CRC_DATA_HL_SHIFT                        (16U)
+#define CRC_DATA_HL(x)                           (((uint32_t)(((uint32_t)(x)) << CRC_DATA_HL_SHIFT)) & CRC_DATA_HL_MASK)
+#define CRC_DATA_HU_MASK                         (0xFF000000U)
+#define CRC_DATA_HU_SHIFT                        (24U)
+#define CRC_DATA_HU(x)                           (((uint32_t)(((uint32_t)(x)) << CRC_DATA_HU_SHIFT)) & CRC_DATA_HU_MASK)
+
+/*! @name DATALL - CRC_DATALL register. */
+#define CRC_DATALL_DATALL_MASK                   (0xFFU)
+#define CRC_DATALL_DATALL_SHIFT                  (0U)
+#define CRC_DATALL_DATALL(x)                     (((uint8_t)(((uint8_t)(x)) << CRC_DATALL_DATALL_SHIFT)) & CRC_DATALL_DATALL_MASK)
+
+/*! @name DATALU - CRC_DATALU register. */
+#define CRC_DATALU_DATALU_MASK                   (0xFFU)
+#define CRC_DATALU_DATALU_SHIFT                  (0U)
+#define CRC_DATALU_DATALU(x)                     (((uint8_t)(((uint8_t)(x)) << CRC_DATALU_DATALU_SHIFT)) & CRC_DATALU_DATALU_MASK)
+
+/*! @name DATAHL - CRC_DATAHL register. */
+#define CRC_DATAHL_DATAHL_MASK                   (0xFFU)
+#define CRC_DATAHL_DATAHL_SHIFT                  (0U)
+#define CRC_DATAHL_DATAHL(x)                     (((uint8_t)(((uint8_t)(x)) << CRC_DATAHL_DATAHL_SHIFT)) & CRC_DATAHL_DATAHL_MASK)
+
+/*! @name DATAHU - CRC_DATAHU register. */
+#define CRC_DATAHU_DATAHU_MASK                   (0xFFU)
+#define CRC_DATAHU_DATAHU_SHIFT                  (0U)
+#define CRC_DATAHU_DATAHU(x)                     (((uint8_t)(((uint8_t)(x)) << CRC_DATAHU_DATAHU_SHIFT)) & CRC_DATAHU_DATAHU_MASK)
+
+/*! @name GPOLYL - CRC_GPOLYL register. */
+#define CRC_GPOLYL_GPOLYL_MASK                   (0xFFFFU)
+#define CRC_GPOLYL_GPOLYL_SHIFT                  (0U)
+#define CRC_GPOLYL_GPOLYL(x)                     (((uint16_t)(((uint16_t)(x)) << CRC_GPOLYL_GPOLYL_SHIFT)) & CRC_GPOLYL_GPOLYL_MASK)
+
+/*! @name GPOLYH - CRC_GPOLYH register. */
+#define CRC_GPOLYH_GPOLYH_MASK                   (0xFFFFU)
+#define CRC_GPOLYH_GPOLYH_SHIFT                  (0U)
+#define CRC_GPOLYH_GPOLYH(x)                     (((uint16_t)(((uint16_t)(x)) << CRC_GPOLYH_GPOLYH_SHIFT)) & CRC_GPOLYH_GPOLYH_MASK)
+
+/*! @name GPOLY - CRC Polynomial register */
+#define CRC_GPOLY_LOW_MASK                       (0xFFFFU)
+#define CRC_GPOLY_LOW_SHIFT                      (0U)
+#define CRC_GPOLY_LOW(x)                         (((uint32_t)(((uint32_t)(x)) << CRC_GPOLY_LOW_SHIFT)) & CRC_GPOLY_LOW_MASK)
+#define CRC_GPOLY_HIGH_MASK                      (0xFFFF0000U)
+#define CRC_GPOLY_HIGH_SHIFT                     (16U)
+#define CRC_GPOLY_HIGH(x)                        (((uint32_t)(((uint32_t)(x)) << CRC_GPOLY_HIGH_SHIFT)) & CRC_GPOLY_HIGH_MASK)
+
+/*! @name GPOLYLL - CRC_GPOLYLL register. */
+#define CRC_GPOLYLL_GPOLYLL_MASK                 (0xFFU)
+#define CRC_GPOLYLL_GPOLYLL_SHIFT                (0U)
+#define CRC_GPOLYLL_GPOLYLL(x)                   (((uint8_t)(((uint8_t)(x)) << CRC_GPOLYLL_GPOLYLL_SHIFT)) & CRC_GPOLYLL_GPOLYLL_MASK)
+
+/*! @name GPOLYLU - CRC_GPOLYLU register. */
+#define CRC_GPOLYLU_GPOLYLU_MASK                 (0xFFU)
+#define CRC_GPOLYLU_GPOLYLU_SHIFT                (0U)
+#define CRC_GPOLYLU_GPOLYLU(x)                   (((uint8_t)(((uint8_t)(x)) << CRC_GPOLYLU_GPOLYLU_SHIFT)) & CRC_GPOLYLU_GPOLYLU_MASK)
+
+/*! @name GPOLYHL - CRC_GPOLYHL register. */
+#define CRC_GPOLYHL_GPOLYHL_MASK                 (0xFFU)
+#define CRC_GPOLYHL_GPOLYHL_SHIFT                (0U)
+#define CRC_GPOLYHL_GPOLYHL(x)                   (((uint8_t)(((uint8_t)(x)) << CRC_GPOLYHL_GPOLYHL_SHIFT)) & CRC_GPOLYHL_GPOLYHL_MASK)
+
+/*! @name GPOLYHU - CRC_GPOLYHU register. */
+#define CRC_GPOLYHU_GPOLYHU_MASK                 (0xFFU)
+#define CRC_GPOLYHU_GPOLYHU_SHIFT                (0U)
+#define CRC_GPOLYHU_GPOLYHU(x)                   (((uint8_t)(((uint8_t)(x)) << CRC_GPOLYHU_GPOLYHU_SHIFT)) & CRC_GPOLYHU_GPOLYHU_MASK)
+
+/*! @name CTRL - CRC Control register */
+#define CRC_CTRL_TCRC_MASK                       (0x1000000U)
+#define CRC_CTRL_TCRC_SHIFT                      (24U)
+#define CRC_CTRL_TCRC(x)                         (((uint32_t)(((uint32_t)(x)) << CRC_CTRL_TCRC_SHIFT)) & CRC_CTRL_TCRC_MASK)
+#define CRC_CTRL_WAS_MASK                        (0x2000000U)
+#define CRC_CTRL_WAS_SHIFT                       (25U)
+#define CRC_CTRL_WAS(x)                          (((uint32_t)(((uint32_t)(x)) << CRC_CTRL_WAS_SHIFT)) & CRC_CTRL_WAS_MASK)
+#define CRC_CTRL_FXOR_MASK                       (0x4000000U)
+#define CRC_CTRL_FXOR_SHIFT                      (26U)
+#define CRC_CTRL_FXOR(x)                         (((uint32_t)(((uint32_t)(x)) << CRC_CTRL_FXOR_SHIFT)) & CRC_CTRL_FXOR_MASK)
+#define CRC_CTRL_TOTR_MASK                       (0x30000000U)
+#define CRC_CTRL_TOTR_SHIFT                      (28U)
+#define CRC_CTRL_TOTR(x)                         (((uint32_t)(((uint32_t)(x)) << CRC_CTRL_TOTR_SHIFT)) & CRC_CTRL_TOTR_MASK)
+#define CRC_CTRL_TOT_MASK                        (0xC0000000U)
+#define CRC_CTRL_TOT_SHIFT                       (30U)
+#define CRC_CTRL_TOT(x)                          (((uint32_t)(((uint32_t)(x)) << CRC_CTRL_TOT_SHIFT)) & CRC_CTRL_TOT_MASK)
+
+/*! @name CTRLHU - CRC_CTRLHU register. */
+#define CRC_CTRLHU_TCRC_MASK                     (0x1U)
+#define CRC_CTRLHU_TCRC_SHIFT                    (0U)
+#define CRC_CTRLHU_TCRC(x)                       (((uint8_t)(((uint8_t)(x)) << CRC_CTRLHU_TCRC_SHIFT)) & CRC_CTRLHU_TCRC_MASK)
+#define CRC_CTRLHU_WAS_MASK                      (0x2U)
+#define CRC_CTRLHU_WAS_SHIFT                     (1U)
+#define CRC_CTRLHU_WAS(x)                        (((uint8_t)(((uint8_t)(x)) << CRC_CTRLHU_WAS_SHIFT)) & CRC_CTRLHU_WAS_MASK)
+#define CRC_CTRLHU_FXOR_MASK                     (0x4U)
+#define CRC_CTRLHU_FXOR_SHIFT                    (2U)
+#define CRC_CTRLHU_FXOR(x)                       (((uint8_t)(((uint8_t)(x)) << CRC_CTRLHU_FXOR_SHIFT)) & CRC_CTRLHU_FXOR_MASK)
+#define CRC_CTRLHU_TOTR_MASK                     (0x30U)
+#define CRC_CTRLHU_TOTR_SHIFT                    (4U)
+#define CRC_CTRLHU_TOTR(x)                       (((uint8_t)(((uint8_t)(x)) << CRC_CTRLHU_TOTR_SHIFT)) & CRC_CTRLHU_TOTR_MASK)
+#define CRC_CTRLHU_TOT_MASK                      (0xC0U)
+#define CRC_CTRLHU_TOT_SHIFT                     (6U)
+#define CRC_CTRLHU_TOT(x)                        (((uint8_t)(((uint8_t)(x)) << CRC_CTRLHU_TOT_SHIFT)) & CRC_CTRLHU_TOT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group CRC_Register_Masks */
+
+
+/* CRC - Peripheral instance base addresses */
+/** Peripheral CRC base address */
+#define CRC_BASE                                 (0x40032000u)
+/** Peripheral CRC base pointer */
+#define CRC0                                     ((CRC_Type *)CRC_BASE)
+/** Array initializer of CRC peripheral base addresses */
+#define CRC_BASE_ADDRS                           { CRC_BASE }
+/** Array initializer of CRC peripheral base pointers */
+#define CRC_BASE_PTRS                            { CRC0 }
+
+/*!
+ * @}
+ */ /* end of group CRC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DAC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Peripheral_Access_Layer DAC Peripheral Access Layer
+ * @{
+ */
+
+/** DAC - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATL;                               /**< DAC Data Low Register, array offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATH;                               /**< DAC Data High Register, array offset: 0x1, array step: 0x2 */
+  } DAT[16];
+  __IO uint8_t SR;                                 /**< DAC Status Register, offset: 0x20 */
+  __IO uint8_t C0;                                 /**< DAC Control Register, offset: 0x21 */
+  __IO uint8_t C1;                                 /**< DAC Control Register 1, offset: 0x22 */
+  __IO uint8_t C2;                                 /**< DAC Control Register 2, offset: 0x23 */
+} DAC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- DAC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Masks DAC Register Masks
+ * @{
+ */
+
+/*! @name DATL - DAC Data Low Register */
+#define DAC_DATL_DATA0_MASK                      (0xFFU)
+#define DAC_DATL_DATA0_SHIFT                     (0U)
+#define DAC_DATL_DATA0(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_DATL_DATA0_SHIFT)) & DAC_DATL_DATA0_MASK)
+
+/* The count of DAC_DATL */
+#define DAC_DATL_COUNT                           (16U)
+
+/*! @name DATH - DAC Data High Register */
+#define DAC_DATH_DATA1_MASK                      (0xFU)
+#define DAC_DATH_DATA1_SHIFT                     (0U)
+#define DAC_DATH_DATA1(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_DATH_DATA1_SHIFT)) & DAC_DATH_DATA1_MASK)
+
+/* The count of DAC_DATH */
+#define DAC_DATH_COUNT                           (16U)
+
+/*! @name SR - DAC Status Register */
+#define DAC_SR_DACBFRPBF_MASK                    (0x1U)
+#define DAC_SR_DACBFRPBF_SHIFT                   (0U)
+#define DAC_SR_DACBFRPBF(x)                      (((uint8_t)(((uint8_t)(x)) << DAC_SR_DACBFRPBF_SHIFT)) & DAC_SR_DACBFRPBF_MASK)
+#define DAC_SR_DACBFRPTF_MASK                    (0x2U)
+#define DAC_SR_DACBFRPTF_SHIFT                   (1U)
+#define DAC_SR_DACBFRPTF(x)                      (((uint8_t)(((uint8_t)(x)) << DAC_SR_DACBFRPTF_SHIFT)) & DAC_SR_DACBFRPTF_MASK)
+#define DAC_SR_DACBFWMF_MASK                     (0x4U)
+#define DAC_SR_DACBFWMF_SHIFT                    (2U)
+#define DAC_SR_DACBFWMF(x)                       (((uint8_t)(((uint8_t)(x)) << DAC_SR_DACBFWMF_SHIFT)) & DAC_SR_DACBFWMF_MASK)
+
+/*! @name C0 - DAC Control Register */
+#define DAC_C0_DACBBIEN_MASK                     (0x1U)
+#define DAC_C0_DACBBIEN_SHIFT                    (0U)
+#define DAC_C0_DACBBIEN(x)                       (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACBBIEN_SHIFT)) & DAC_C0_DACBBIEN_MASK)
+#define DAC_C0_DACBTIEN_MASK                     (0x2U)
+#define DAC_C0_DACBTIEN_SHIFT                    (1U)
+#define DAC_C0_DACBTIEN(x)                       (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACBTIEN_SHIFT)) & DAC_C0_DACBTIEN_MASK)
+#define DAC_C0_DACBWIEN_MASK                     (0x4U)
+#define DAC_C0_DACBWIEN_SHIFT                    (2U)
+#define DAC_C0_DACBWIEN(x)                       (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACBWIEN_SHIFT)) & DAC_C0_DACBWIEN_MASK)
+#define DAC_C0_LPEN_MASK                         (0x8U)
+#define DAC_C0_LPEN_SHIFT                        (3U)
+#define DAC_C0_LPEN(x)                           (((uint8_t)(((uint8_t)(x)) << DAC_C0_LPEN_SHIFT)) & DAC_C0_LPEN_MASK)
+#define DAC_C0_DACSWTRG_MASK                     (0x10U)
+#define DAC_C0_DACSWTRG_SHIFT                    (4U)
+#define DAC_C0_DACSWTRG(x)                       (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACSWTRG_SHIFT)) & DAC_C0_DACSWTRG_MASK)
+#define DAC_C0_DACTRGSEL_MASK                    (0x20U)
+#define DAC_C0_DACTRGSEL_SHIFT                   (5U)
+#define DAC_C0_DACTRGSEL(x)                      (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACTRGSEL_SHIFT)) & DAC_C0_DACTRGSEL_MASK)
+#define DAC_C0_DACRFS_MASK                       (0x40U)
+#define DAC_C0_DACRFS_SHIFT                      (6U)
+#define DAC_C0_DACRFS(x)                         (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACRFS_SHIFT)) & DAC_C0_DACRFS_MASK)
+#define DAC_C0_DACEN_MASK                        (0x80U)
+#define DAC_C0_DACEN_SHIFT                       (7U)
+#define DAC_C0_DACEN(x)                          (((uint8_t)(((uint8_t)(x)) << DAC_C0_DACEN_SHIFT)) & DAC_C0_DACEN_MASK)
+
+/*! @name C1 - DAC Control Register 1 */
+#define DAC_C1_DACBFEN_MASK                      (0x1U)
+#define DAC_C1_DACBFEN_SHIFT                     (0U)
+#define DAC_C1_DACBFEN(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_C1_DACBFEN_SHIFT)) & DAC_C1_DACBFEN_MASK)
+#define DAC_C1_DACBFMD_MASK                      (0x6U)
+#define DAC_C1_DACBFMD_SHIFT                     (1U)
+#define DAC_C1_DACBFMD(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_C1_DACBFMD_SHIFT)) & DAC_C1_DACBFMD_MASK)
+#define DAC_C1_DACBFWM_MASK                      (0x18U)
+#define DAC_C1_DACBFWM_SHIFT                     (3U)
+#define DAC_C1_DACBFWM(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_C1_DACBFWM_SHIFT)) & DAC_C1_DACBFWM_MASK)
+#define DAC_C1_DMAEN_MASK                        (0x80U)
+#define DAC_C1_DMAEN_SHIFT                       (7U)
+#define DAC_C1_DMAEN(x)                          (((uint8_t)(((uint8_t)(x)) << DAC_C1_DMAEN_SHIFT)) & DAC_C1_DMAEN_MASK)
+
+/*! @name C2 - DAC Control Register 2 */
+#define DAC_C2_DACBFUP_MASK                      (0xFU)
+#define DAC_C2_DACBFUP_SHIFT                     (0U)
+#define DAC_C2_DACBFUP(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_C2_DACBFUP_SHIFT)) & DAC_C2_DACBFUP_MASK)
+#define DAC_C2_DACBFRP_MASK                      (0xF0U)
+#define DAC_C2_DACBFRP_SHIFT                     (4U)
+#define DAC_C2_DACBFRP(x)                        (((uint8_t)(((uint8_t)(x)) << DAC_C2_DACBFRP_SHIFT)) & DAC_C2_DACBFRP_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Masks */
+
+
+/* DAC - Peripheral instance base addresses */
+/** Peripheral DAC0 base address */
+#define DAC0_BASE                                (0x400CC000u)
+/** Peripheral DAC0 base pointer */
+#define DAC0                                     ((DAC_Type *)DAC0_BASE)
+/** Peripheral DAC1 base address */
+#define DAC1_BASE                                (0x400CD000u)
+/** Peripheral DAC1 base pointer */
+#define DAC1                                     ((DAC_Type *)DAC1_BASE)
+/** Array initializer of DAC peripheral base addresses */
+#define DAC_BASE_ADDRS                           { DAC0_BASE, DAC1_BASE }
+/** Array initializer of DAC peripheral base pointers */
+#define DAC_BASE_PTRS                            { DAC0, DAC1 }
+/** Interrupt vectors for the DAC peripheral type */
+#define DAC_IRQS                                 { DAC0_IRQn, DAC1_IRQn }
+
+/*!
+ * @}
+ */ /* end of group DAC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Peripheral_Access_Layer DMA Peripheral Access Layer
+ * @{
+ */
+
+/** DMA - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CR;                                /**< Control Register, offset: 0x0 */
+  __I  uint32_t ES;                                /**< Error Status Register, offset: 0x4 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t ERQ;                               /**< Enable Request Register, offset: 0xC */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t EEI;                               /**< Enable Error Interrupt Register, offset: 0x14 */
+  __O  uint8_t CEEI;                               /**< Clear Enable Error Interrupt Register, offset: 0x18 */
+  __O  uint8_t SEEI;                               /**< Set Enable Error Interrupt Register, offset: 0x19 */
+  __O  uint8_t CERQ;                               /**< Clear Enable Request Register, offset: 0x1A */
+  __O  uint8_t SERQ;                               /**< Set Enable Request Register, offset: 0x1B */
+  __O  uint8_t CDNE;                               /**< Clear DONE Status Bit Register, offset: 0x1C */
+  __O  uint8_t SSRT;                               /**< Set START Bit Register, offset: 0x1D */
+  __O  uint8_t CERR;                               /**< Clear Error Register, offset: 0x1E */
+  __O  uint8_t CINT;                               /**< Clear Interrupt Request Register, offset: 0x1F */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t INT;                               /**< Interrupt Request Register, offset: 0x24 */
+       uint8_t RESERVED_3[4];
+  __IO uint32_t ERR;                               /**< Error Register, offset: 0x2C */
+       uint8_t RESERVED_4[4];
+  __I  uint32_t HRS;                               /**< Hardware Request Status Register, offset: 0x34 */
+       uint8_t RESERVED_5[200];
+  __IO uint8_t DCHPRI3;                            /**< Channel n Priority Register, offset: 0x100 */
+  __IO uint8_t DCHPRI2;                            /**< Channel n Priority Register, offset: 0x101 */
+  __IO uint8_t DCHPRI1;                            /**< Channel n Priority Register, offset: 0x102 */
+  __IO uint8_t DCHPRI0;                            /**< Channel n Priority Register, offset: 0x103 */
+  __IO uint8_t DCHPRI7;                            /**< Channel n Priority Register, offset: 0x104 */
+  __IO uint8_t DCHPRI6;                            /**< Channel n Priority Register, offset: 0x105 */
+  __IO uint8_t DCHPRI5;                            /**< Channel n Priority Register, offset: 0x106 */
+  __IO uint8_t DCHPRI4;                            /**< Channel n Priority Register, offset: 0x107 */
+  __IO uint8_t DCHPRI11;                           /**< Channel n Priority Register, offset: 0x108 */
+  __IO uint8_t DCHPRI10;                           /**< Channel n Priority Register, offset: 0x109 */
+  __IO uint8_t DCHPRI9;                            /**< Channel n Priority Register, offset: 0x10A */
+  __IO uint8_t DCHPRI8;                            /**< Channel n Priority Register, offset: 0x10B */
+  __IO uint8_t DCHPRI15;                           /**< Channel n Priority Register, offset: 0x10C */
+  __IO uint8_t DCHPRI14;                           /**< Channel n Priority Register, offset: 0x10D */
+  __IO uint8_t DCHPRI13;                           /**< Channel n Priority Register, offset: 0x10E */
+  __IO uint8_t DCHPRI12;                           /**< Channel n Priority Register, offset: 0x10F */
+       uint8_t RESERVED_6[3824];
+  struct {                                         /* offset: 0x1000, array step: 0x20 */
+    __IO uint32_t SADDR;                             /**< TCD Source Address, array offset: 0x1000, array step: 0x20 */
+    __IO uint16_t SOFF;                              /**< TCD Signed Source Address Offset, array offset: 0x1004, array step: 0x20 */
+    __IO uint16_t ATTR;                              /**< TCD Transfer Attributes, array offset: 0x1006, array step: 0x20 */
+    union {                                          /* offset: 0x1008, array step: 0x20 */
+      __IO uint32_t NBYTES_MLNO;                       /**< TCD Minor Byte Count (Minor Loop Disabled), array offset: 0x1008, array step: 0x20 */
+      __IO uint32_t NBYTES_MLOFFNO;                    /**< TCD Signed Minor Loop Offset (Minor Loop Enabled and Offset Disabled), array offset: 0x1008, array step: 0x20 */
+      __IO uint32_t NBYTES_MLOFFYES;                   /**< TCD Signed Minor Loop Offset (Minor Loop and Offset Enabled), array offset: 0x1008, array step: 0x20 */
+    };
+    __IO uint32_t SLAST;                             /**< TCD Last Source Address Adjustment, array offset: 0x100C, array step: 0x20 */
+    __IO uint32_t DADDR;                             /**< TCD Destination Address, array offset: 0x1010, array step: 0x20 */
+    __IO uint16_t DOFF;                              /**< TCD Signed Destination Address Offset, array offset: 0x1014, array step: 0x20 */
+    union {                                          /* offset: 0x1016, array step: 0x20 */
+      __IO uint16_t CITER_ELINKNO;                     /**< TCD Current Minor Loop Link, Major Loop Count (Channel Linking Disabled), array offset: 0x1016, array step: 0x20 */
+      __IO uint16_t CITER_ELINKYES;                    /**< TCD Current Minor Loop Link, Major Loop Count (Channel Linking Enabled), array offset: 0x1016, array step: 0x20 */
+    };
+    __IO uint32_t DLAST_SGA;                         /**< TCD Last Destination Address Adjustment/Scatter Gather Address, array offset: 0x1018, array step: 0x20 */
+    __IO uint16_t CSR;                               /**< TCD Control and Status, array offset: 0x101C, array step: 0x20 */
+    union {                                          /* offset: 0x101E, array step: 0x20 */
+      __IO uint16_t BITER_ELINKNO;                     /**< TCD Beginning Minor Loop Link, Major Loop Count (Channel Linking Disabled), array offset: 0x101E, array step: 0x20 */
+      __IO uint16_t BITER_ELINKYES;                    /**< TCD Beginning Minor Loop Link, Major Loop Count (Channel Linking Enabled), array offset: 0x101E, array step: 0x20 */
+    };
+  } TCD[16];
+} DMA_Type;
+
+/* ----------------------------------------------------------------------------
+   -- DMA Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Masks DMA Register Masks
+ * @{
+ */
+
+/*! @name CR - Control Register */
+#define DMA_CR_EDBG_MASK                         (0x2U)
+#define DMA_CR_EDBG_SHIFT                        (1U)
+#define DMA_CR_EDBG(x)                           (((uint32_t)(((uint32_t)(x)) << DMA_CR_EDBG_SHIFT)) & DMA_CR_EDBG_MASK)
+#define DMA_CR_ERCA_MASK                         (0x4U)
+#define DMA_CR_ERCA_SHIFT                        (2U)
+#define DMA_CR_ERCA(x)                           (((uint32_t)(((uint32_t)(x)) << DMA_CR_ERCA_SHIFT)) & DMA_CR_ERCA_MASK)
+#define DMA_CR_HOE_MASK                          (0x10U)
+#define DMA_CR_HOE_SHIFT                         (4U)
+#define DMA_CR_HOE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_CR_HOE_SHIFT)) & DMA_CR_HOE_MASK)
+#define DMA_CR_HALT_MASK                         (0x20U)
+#define DMA_CR_HALT_SHIFT                        (5U)
+#define DMA_CR_HALT(x)                           (((uint32_t)(((uint32_t)(x)) << DMA_CR_HALT_SHIFT)) & DMA_CR_HALT_MASK)
+#define DMA_CR_CLM_MASK                          (0x40U)
+#define DMA_CR_CLM_SHIFT                         (6U)
+#define DMA_CR_CLM(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_CR_CLM_SHIFT)) & DMA_CR_CLM_MASK)
+#define DMA_CR_EMLM_MASK                         (0x80U)
+#define DMA_CR_EMLM_SHIFT                        (7U)
+#define DMA_CR_EMLM(x)                           (((uint32_t)(((uint32_t)(x)) << DMA_CR_EMLM_SHIFT)) & DMA_CR_EMLM_MASK)
+#define DMA_CR_ECX_MASK                          (0x10000U)
+#define DMA_CR_ECX_SHIFT                         (16U)
+#define DMA_CR_ECX(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_CR_ECX_SHIFT)) & DMA_CR_ECX_MASK)
+#define DMA_CR_CX_MASK                           (0x20000U)
+#define DMA_CR_CX_SHIFT                          (17U)
+#define DMA_CR_CX(x)                             (((uint32_t)(((uint32_t)(x)) << DMA_CR_CX_SHIFT)) & DMA_CR_CX_MASK)
+
+/*! @name ES - Error Status Register */
+#define DMA_ES_DBE_MASK                          (0x1U)
+#define DMA_ES_DBE_SHIFT                         (0U)
+#define DMA_ES_DBE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_DBE_SHIFT)) & DMA_ES_DBE_MASK)
+#define DMA_ES_SBE_MASK                          (0x2U)
+#define DMA_ES_SBE_SHIFT                         (1U)
+#define DMA_ES_SBE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_SBE_SHIFT)) & DMA_ES_SBE_MASK)
+#define DMA_ES_SGE_MASK                          (0x4U)
+#define DMA_ES_SGE_SHIFT                         (2U)
+#define DMA_ES_SGE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_SGE_SHIFT)) & DMA_ES_SGE_MASK)
+#define DMA_ES_NCE_MASK                          (0x8U)
+#define DMA_ES_NCE_SHIFT                         (3U)
+#define DMA_ES_NCE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_NCE_SHIFT)) & DMA_ES_NCE_MASK)
+#define DMA_ES_DOE_MASK                          (0x10U)
+#define DMA_ES_DOE_SHIFT                         (4U)
+#define DMA_ES_DOE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_DOE_SHIFT)) & DMA_ES_DOE_MASK)
+#define DMA_ES_DAE_MASK                          (0x20U)
+#define DMA_ES_DAE_SHIFT                         (5U)
+#define DMA_ES_DAE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_DAE_SHIFT)) & DMA_ES_DAE_MASK)
+#define DMA_ES_SOE_MASK                          (0x40U)
+#define DMA_ES_SOE_SHIFT                         (6U)
+#define DMA_ES_SOE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_SOE_SHIFT)) & DMA_ES_SOE_MASK)
+#define DMA_ES_SAE_MASK                          (0x80U)
+#define DMA_ES_SAE_SHIFT                         (7U)
+#define DMA_ES_SAE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_SAE_SHIFT)) & DMA_ES_SAE_MASK)
+#define DMA_ES_ERRCHN_MASK                       (0xF00U)
+#define DMA_ES_ERRCHN_SHIFT                      (8U)
+#define DMA_ES_ERRCHN(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ES_ERRCHN_SHIFT)) & DMA_ES_ERRCHN_MASK)
+#define DMA_ES_CPE_MASK                          (0x4000U)
+#define DMA_ES_CPE_SHIFT                         (14U)
+#define DMA_ES_CPE(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_CPE_SHIFT)) & DMA_ES_CPE_MASK)
+#define DMA_ES_ECX_MASK                          (0x10000U)
+#define DMA_ES_ECX_SHIFT                         (16U)
+#define DMA_ES_ECX(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_ECX_SHIFT)) & DMA_ES_ECX_MASK)
+#define DMA_ES_VLD_MASK                          (0x80000000U)
+#define DMA_ES_VLD_SHIFT                         (31U)
+#define DMA_ES_VLD(x)                            (((uint32_t)(((uint32_t)(x)) << DMA_ES_VLD_SHIFT)) & DMA_ES_VLD_MASK)
+
+/*! @name ERQ - Enable Request Register */
+#define DMA_ERQ_ERQ0_MASK                        (0x1U)
+#define DMA_ERQ_ERQ0_SHIFT                       (0U)
+#define DMA_ERQ_ERQ0(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ0_SHIFT)) & DMA_ERQ_ERQ0_MASK)
+#define DMA_ERQ_ERQ1_MASK                        (0x2U)
+#define DMA_ERQ_ERQ1_SHIFT                       (1U)
+#define DMA_ERQ_ERQ1(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ1_SHIFT)) & DMA_ERQ_ERQ1_MASK)
+#define DMA_ERQ_ERQ2_MASK                        (0x4U)
+#define DMA_ERQ_ERQ2_SHIFT                       (2U)
+#define DMA_ERQ_ERQ2(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ2_SHIFT)) & DMA_ERQ_ERQ2_MASK)
+#define DMA_ERQ_ERQ3_MASK                        (0x8U)
+#define DMA_ERQ_ERQ3_SHIFT                       (3U)
+#define DMA_ERQ_ERQ3(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ3_SHIFT)) & DMA_ERQ_ERQ3_MASK)
+#define DMA_ERQ_ERQ4_MASK                        (0x10U)
+#define DMA_ERQ_ERQ4_SHIFT                       (4U)
+#define DMA_ERQ_ERQ4(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ4_SHIFT)) & DMA_ERQ_ERQ4_MASK)
+#define DMA_ERQ_ERQ5_MASK                        (0x20U)
+#define DMA_ERQ_ERQ5_SHIFT                       (5U)
+#define DMA_ERQ_ERQ5(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ5_SHIFT)) & DMA_ERQ_ERQ5_MASK)
+#define DMA_ERQ_ERQ6_MASK                        (0x40U)
+#define DMA_ERQ_ERQ6_SHIFT                       (6U)
+#define DMA_ERQ_ERQ6(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ6_SHIFT)) & DMA_ERQ_ERQ6_MASK)
+#define DMA_ERQ_ERQ7_MASK                        (0x80U)
+#define DMA_ERQ_ERQ7_SHIFT                       (7U)
+#define DMA_ERQ_ERQ7(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ7_SHIFT)) & DMA_ERQ_ERQ7_MASK)
+#define DMA_ERQ_ERQ8_MASK                        (0x100U)
+#define DMA_ERQ_ERQ8_SHIFT                       (8U)
+#define DMA_ERQ_ERQ8(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ8_SHIFT)) & DMA_ERQ_ERQ8_MASK)
+#define DMA_ERQ_ERQ9_MASK                        (0x200U)
+#define DMA_ERQ_ERQ9_SHIFT                       (9U)
+#define DMA_ERQ_ERQ9(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ9_SHIFT)) & DMA_ERQ_ERQ9_MASK)
+#define DMA_ERQ_ERQ10_MASK                       (0x400U)
+#define DMA_ERQ_ERQ10_SHIFT                      (10U)
+#define DMA_ERQ_ERQ10(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ10_SHIFT)) & DMA_ERQ_ERQ10_MASK)
+#define DMA_ERQ_ERQ11_MASK                       (0x800U)
+#define DMA_ERQ_ERQ11_SHIFT                      (11U)
+#define DMA_ERQ_ERQ11(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ11_SHIFT)) & DMA_ERQ_ERQ11_MASK)
+#define DMA_ERQ_ERQ12_MASK                       (0x1000U)
+#define DMA_ERQ_ERQ12_SHIFT                      (12U)
+#define DMA_ERQ_ERQ12(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ12_SHIFT)) & DMA_ERQ_ERQ12_MASK)
+#define DMA_ERQ_ERQ13_MASK                       (0x2000U)
+#define DMA_ERQ_ERQ13_SHIFT                      (13U)
+#define DMA_ERQ_ERQ13(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ13_SHIFT)) & DMA_ERQ_ERQ13_MASK)
+#define DMA_ERQ_ERQ14_MASK                       (0x4000U)
+#define DMA_ERQ_ERQ14_SHIFT                      (14U)
+#define DMA_ERQ_ERQ14(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ14_SHIFT)) & DMA_ERQ_ERQ14_MASK)
+#define DMA_ERQ_ERQ15_MASK                       (0x8000U)
+#define DMA_ERQ_ERQ15_SHIFT                      (15U)
+#define DMA_ERQ_ERQ15(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERQ_ERQ15_SHIFT)) & DMA_ERQ_ERQ15_MASK)
+
+/*! @name EEI - Enable Error Interrupt Register */
+#define DMA_EEI_EEI0_MASK                        (0x1U)
+#define DMA_EEI_EEI0_SHIFT                       (0U)
+#define DMA_EEI_EEI0(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI0_SHIFT)) & DMA_EEI_EEI0_MASK)
+#define DMA_EEI_EEI1_MASK                        (0x2U)
+#define DMA_EEI_EEI1_SHIFT                       (1U)
+#define DMA_EEI_EEI1(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI1_SHIFT)) & DMA_EEI_EEI1_MASK)
+#define DMA_EEI_EEI2_MASK                        (0x4U)
+#define DMA_EEI_EEI2_SHIFT                       (2U)
+#define DMA_EEI_EEI2(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI2_SHIFT)) & DMA_EEI_EEI2_MASK)
+#define DMA_EEI_EEI3_MASK                        (0x8U)
+#define DMA_EEI_EEI3_SHIFT                       (3U)
+#define DMA_EEI_EEI3(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI3_SHIFT)) & DMA_EEI_EEI3_MASK)
+#define DMA_EEI_EEI4_MASK                        (0x10U)
+#define DMA_EEI_EEI4_SHIFT                       (4U)
+#define DMA_EEI_EEI4(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI4_SHIFT)) & DMA_EEI_EEI4_MASK)
+#define DMA_EEI_EEI5_MASK                        (0x20U)
+#define DMA_EEI_EEI5_SHIFT                       (5U)
+#define DMA_EEI_EEI5(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI5_SHIFT)) & DMA_EEI_EEI5_MASK)
+#define DMA_EEI_EEI6_MASK                        (0x40U)
+#define DMA_EEI_EEI6_SHIFT                       (6U)
+#define DMA_EEI_EEI6(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI6_SHIFT)) & DMA_EEI_EEI6_MASK)
+#define DMA_EEI_EEI7_MASK                        (0x80U)
+#define DMA_EEI_EEI7_SHIFT                       (7U)
+#define DMA_EEI_EEI7(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI7_SHIFT)) & DMA_EEI_EEI7_MASK)
+#define DMA_EEI_EEI8_MASK                        (0x100U)
+#define DMA_EEI_EEI8_SHIFT                       (8U)
+#define DMA_EEI_EEI8(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI8_SHIFT)) & DMA_EEI_EEI8_MASK)
+#define DMA_EEI_EEI9_MASK                        (0x200U)
+#define DMA_EEI_EEI9_SHIFT                       (9U)
+#define DMA_EEI_EEI9(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI9_SHIFT)) & DMA_EEI_EEI9_MASK)
+#define DMA_EEI_EEI10_MASK                       (0x400U)
+#define DMA_EEI_EEI10_SHIFT                      (10U)
+#define DMA_EEI_EEI10(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI10_SHIFT)) & DMA_EEI_EEI10_MASK)
+#define DMA_EEI_EEI11_MASK                       (0x800U)
+#define DMA_EEI_EEI11_SHIFT                      (11U)
+#define DMA_EEI_EEI11(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI11_SHIFT)) & DMA_EEI_EEI11_MASK)
+#define DMA_EEI_EEI12_MASK                       (0x1000U)
+#define DMA_EEI_EEI12_SHIFT                      (12U)
+#define DMA_EEI_EEI12(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI12_SHIFT)) & DMA_EEI_EEI12_MASK)
+#define DMA_EEI_EEI13_MASK                       (0x2000U)
+#define DMA_EEI_EEI13_SHIFT                      (13U)
+#define DMA_EEI_EEI13(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI13_SHIFT)) & DMA_EEI_EEI13_MASK)
+#define DMA_EEI_EEI14_MASK                       (0x4000U)
+#define DMA_EEI_EEI14_SHIFT                      (14U)
+#define DMA_EEI_EEI14(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI14_SHIFT)) & DMA_EEI_EEI14_MASK)
+#define DMA_EEI_EEI15_MASK                       (0x8000U)
+#define DMA_EEI_EEI15_SHIFT                      (15U)
+#define DMA_EEI_EEI15(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_EEI_EEI15_SHIFT)) & DMA_EEI_EEI15_MASK)
+
+/*! @name CEEI - Clear Enable Error Interrupt Register */
+#define DMA_CEEI_CEEI_MASK                       (0xFU)
+#define DMA_CEEI_CEEI_SHIFT                      (0U)
+#define DMA_CEEI_CEEI(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CEEI_CEEI_SHIFT)) & DMA_CEEI_CEEI_MASK)
+#define DMA_CEEI_CAEE_MASK                       (0x40U)
+#define DMA_CEEI_CAEE_SHIFT                      (6U)
+#define DMA_CEEI_CAEE(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CEEI_CAEE_SHIFT)) & DMA_CEEI_CAEE_MASK)
+#define DMA_CEEI_NOP_MASK                        (0x80U)
+#define DMA_CEEI_NOP_SHIFT                       (7U)
+#define DMA_CEEI_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_CEEI_NOP_SHIFT)) & DMA_CEEI_NOP_MASK)
+
+/*! @name SEEI - Set Enable Error Interrupt Register */
+#define DMA_SEEI_SEEI_MASK                       (0xFU)
+#define DMA_SEEI_SEEI_SHIFT                      (0U)
+#define DMA_SEEI_SEEI(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_SEEI_SEEI_SHIFT)) & DMA_SEEI_SEEI_MASK)
+#define DMA_SEEI_SAEE_MASK                       (0x40U)
+#define DMA_SEEI_SAEE_SHIFT                      (6U)
+#define DMA_SEEI_SAEE(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_SEEI_SAEE_SHIFT)) & DMA_SEEI_SAEE_MASK)
+#define DMA_SEEI_NOP_MASK                        (0x80U)
+#define DMA_SEEI_NOP_SHIFT                       (7U)
+#define DMA_SEEI_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_SEEI_NOP_SHIFT)) & DMA_SEEI_NOP_MASK)
+
+/*! @name CERQ - Clear Enable Request Register */
+#define DMA_CERQ_CERQ_MASK                       (0xFU)
+#define DMA_CERQ_CERQ_SHIFT                      (0U)
+#define DMA_CERQ_CERQ(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CERQ_CERQ_SHIFT)) & DMA_CERQ_CERQ_MASK)
+#define DMA_CERQ_CAER_MASK                       (0x40U)
+#define DMA_CERQ_CAER_SHIFT                      (6U)
+#define DMA_CERQ_CAER(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CERQ_CAER_SHIFT)) & DMA_CERQ_CAER_MASK)
+#define DMA_CERQ_NOP_MASK                        (0x80U)
+#define DMA_CERQ_NOP_SHIFT                       (7U)
+#define DMA_CERQ_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_CERQ_NOP_SHIFT)) & DMA_CERQ_NOP_MASK)
+
+/*! @name SERQ - Set Enable Request Register */
+#define DMA_SERQ_SERQ_MASK                       (0xFU)
+#define DMA_SERQ_SERQ_SHIFT                      (0U)
+#define DMA_SERQ_SERQ(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_SERQ_SERQ_SHIFT)) & DMA_SERQ_SERQ_MASK)
+#define DMA_SERQ_SAER_MASK                       (0x40U)
+#define DMA_SERQ_SAER_SHIFT                      (6U)
+#define DMA_SERQ_SAER(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_SERQ_SAER_SHIFT)) & DMA_SERQ_SAER_MASK)
+#define DMA_SERQ_NOP_MASK                        (0x80U)
+#define DMA_SERQ_NOP_SHIFT                       (7U)
+#define DMA_SERQ_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_SERQ_NOP_SHIFT)) & DMA_SERQ_NOP_MASK)
+
+/*! @name CDNE - Clear DONE Status Bit Register */
+#define DMA_CDNE_CDNE_MASK                       (0xFU)
+#define DMA_CDNE_CDNE_SHIFT                      (0U)
+#define DMA_CDNE_CDNE(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CDNE_CDNE_SHIFT)) & DMA_CDNE_CDNE_MASK)
+#define DMA_CDNE_CADN_MASK                       (0x40U)
+#define DMA_CDNE_CADN_SHIFT                      (6U)
+#define DMA_CDNE_CADN(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CDNE_CADN_SHIFT)) & DMA_CDNE_CADN_MASK)
+#define DMA_CDNE_NOP_MASK                        (0x80U)
+#define DMA_CDNE_NOP_SHIFT                       (7U)
+#define DMA_CDNE_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_CDNE_NOP_SHIFT)) & DMA_CDNE_NOP_MASK)
+
+/*! @name SSRT - Set START Bit Register */
+#define DMA_SSRT_SSRT_MASK                       (0xFU)
+#define DMA_SSRT_SSRT_SHIFT                      (0U)
+#define DMA_SSRT_SSRT(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_SSRT_SSRT_SHIFT)) & DMA_SSRT_SSRT_MASK)
+#define DMA_SSRT_SAST_MASK                       (0x40U)
+#define DMA_SSRT_SAST_SHIFT                      (6U)
+#define DMA_SSRT_SAST(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_SSRT_SAST_SHIFT)) & DMA_SSRT_SAST_MASK)
+#define DMA_SSRT_NOP_MASK                        (0x80U)
+#define DMA_SSRT_NOP_SHIFT                       (7U)
+#define DMA_SSRT_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_SSRT_NOP_SHIFT)) & DMA_SSRT_NOP_MASK)
+
+/*! @name CERR - Clear Error Register */
+#define DMA_CERR_CERR_MASK                       (0xFU)
+#define DMA_CERR_CERR_SHIFT                      (0U)
+#define DMA_CERR_CERR(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CERR_CERR_SHIFT)) & DMA_CERR_CERR_MASK)
+#define DMA_CERR_CAEI_MASK                       (0x40U)
+#define DMA_CERR_CAEI_SHIFT                      (6U)
+#define DMA_CERR_CAEI(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CERR_CAEI_SHIFT)) & DMA_CERR_CAEI_MASK)
+#define DMA_CERR_NOP_MASK                        (0x80U)
+#define DMA_CERR_NOP_SHIFT                       (7U)
+#define DMA_CERR_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_CERR_NOP_SHIFT)) & DMA_CERR_NOP_MASK)
+
+/*! @name CINT - Clear Interrupt Request Register */
+#define DMA_CINT_CINT_MASK                       (0xFU)
+#define DMA_CINT_CINT_SHIFT                      (0U)
+#define DMA_CINT_CINT(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CINT_CINT_SHIFT)) & DMA_CINT_CINT_MASK)
+#define DMA_CINT_CAIR_MASK                       (0x40U)
+#define DMA_CINT_CAIR_SHIFT                      (6U)
+#define DMA_CINT_CAIR(x)                         (((uint8_t)(((uint8_t)(x)) << DMA_CINT_CAIR_SHIFT)) & DMA_CINT_CAIR_MASK)
+#define DMA_CINT_NOP_MASK                        (0x80U)
+#define DMA_CINT_NOP_SHIFT                       (7U)
+#define DMA_CINT_NOP(x)                          (((uint8_t)(((uint8_t)(x)) << DMA_CINT_NOP_SHIFT)) & DMA_CINT_NOP_MASK)
+
+/*! @name INT - Interrupt Request Register */
+#define DMA_INT_INT0_MASK                        (0x1U)
+#define DMA_INT_INT0_SHIFT                       (0U)
+#define DMA_INT_INT0(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT0_SHIFT)) & DMA_INT_INT0_MASK)
+#define DMA_INT_INT1_MASK                        (0x2U)
+#define DMA_INT_INT1_SHIFT                       (1U)
+#define DMA_INT_INT1(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT1_SHIFT)) & DMA_INT_INT1_MASK)
+#define DMA_INT_INT2_MASK                        (0x4U)
+#define DMA_INT_INT2_SHIFT                       (2U)
+#define DMA_INT_INT2(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT2_SHIFT)) & DMA_INT_INT2_MASK)
+#define DMA_INT_INT3_MASK                        (0x8U)
+#define DMA_INT_INT3_SHIFT                       (3U)
+#define DMA_INT_INT3(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT3_SHIFT)) & DMA_INT_INT3_MASK)
+#define DMA_INT_INT4_MASK                        (0x10U)
+#define DMA_INT_INT4_SHIFT                       (4U)
+#define DMA_INT_INT4(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT4_SHIFT)) & DMA_INT_INT4_MASK)
+#define DMA_INT_INT5_MASK                        (0x20U)
+#define DMA_INT_INT5_SHIFT                       (5U)
+#define DMA_INT_INT5(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT5_SHIFT)) & DMA_INT_INT5_MASK)
+#define DMA_INT_INT6_MASK                        (0x40U)
+#define DMA_INT_INT6_SHIFT                       (6U)
+#define DMA_INT_INT6(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT6_SHIFT)) & DMA_INT_INT6_MASK)
+#define DMA_INT_INT7_MASK                        (0x80U)
+#define DMA_INT_INT7_SHIFT                       (7U)
+#define DMA_INT_INT7(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT7_SHIFT)) & DMA_INT_INT7_MASK)
+#define DMA_INT_INT8_MASK                        (0x100U)
+#define DMA_INT_INT8_SHIFT                       (8U)
+#define DMA_INT_INT8(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT8_SHIFT)) & DMA_INT_INT8_MASK)
+#define DMA_INT_INT9_MASK                        (0x200U)
+#define DMA_INT_INT9_SHIFT                       (9U)
+#define DMA_INT_INT9(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT9_SHIFT)) & DMA_INT_INT9_MASK)
+#define DMA_INT_INT10_MASK                       (0x400U)
+#define DMA_INT_INT10_SHIFT                      (10U)
+#define DMA_INT_INT10(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT10_SHIFT)) & DMA_INT_INT10_MASK)
+#define DMA_INT_INT11_MASK                       (0x800U)
+#define DMA_INT_INT11_SHIFT                      (11U)
+#define DMA_INT_INT11(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT11_SHIFT)) & DMA_INT_INT11_MASK)
+#define DMA_INT_INT12_MASK                       (0x1000U)
+#define DMA_INT_INT12_SHIFT                      (12U)
+#define DMA_INT_INT12(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT12_SHIFT)) & DMA_INT_INT12_MASK)
+#define DMA_INT_INT13_MASK                       (0x2000U)
+#define DMA_INT_INT13_SHIFT                      (13U)
+#define DMA_INT_INT13(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT13_SHIFT)) & DMA_INT_INT13_MASK)
+#define DMA_INT_INT14_MASK                       (0x4000U)
+#define DMA_INT_INT14_SHIFT                      (14U)
+#define DMA_INT_INT14(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT14_SHIFT)) & DMA_INT_INT14_MASK)
+#define DMA_INT_INT15_MASK                       (0x8000U)
+#define DMA_INT_INT15_SHIFT                      (15U)
+#define DMA_INT_INT15(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_INT_INT15_SHIFT)) & DMA_INT_INT15_MASK)
+
+/*! @name ERR - Error Register */
+#define DMA_ERR_ERR0_MASK                        (0x1U)
+#define DMA_ERR_ERR0_SHIFT                       (0U)
+#define DMA_ERR_ERR0(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR0_SHIFT)) & DMA_ERR_ERR0_MASK)
+#define DMA_ERR_ERR1_MASK                        (0x2U)
+#define DMA_ERR_ERR1_SHIFT                       (1U)
+#define DMA_ERR_ERR1(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR1_SHIFT)) & DMA_ERR_ERR1_MASK)
+#define DMA_ERR_ERR2_MASK                        (0x4U)
+#define DMA_ERR_ERR2_SHIFT                       (2U)
+#define DMA_ERR_ERR2(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR2_SHIFT)) & DMA_ERR_ERR2_MASK)
+#define DMA_ERR_ERR3_MASK                        (0x8U)
+#define DMA_ERR_ERR3_SHIFT                       (3U)
+#define DMA_ERR_ERR3(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR3_SHIFT)) & DMA_ERR_ERR3_MASK)
+#define DMA_ERR_ERR4_MASK                        (0x10U)
+#define DMA_ERR_ERR4_SHIFT                       (4U)
+#define DMA_ERR_ERR4(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR4_SHIFT)) & DMA_ERR_ERR4_MASK)
+#define DMA_ERR_ERR5_MASK                        (0x20U)
+#define DMA_ERR_ERR5_SHIFT                       (5U)
+#define DMA_ERR_ERR5(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR5_SHIFT)) & DMA_ERR_ERR5_MASK)
+#define DMA_ERR_ERR6_MASK                        (0x40U)
+#define DMA_ERR_ERR6_SHIFT                       (6U)
+#define DMA_ERR_ERR6(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR6_SHIFT)) & DMA_ERR_ERR6_MASK)
+#define DMA_ERR_ERR7_MASK                        (0x80U)
+#define DMA_ERR_ERR7_SHIFT                       (7U)
+#define DMA_ERR_ERR7(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR7_SHIFT)) & DMA_ERR_ERR7_MASK)
+#define DMA_ERR_ERR8_MASK                        (0x100U)
+#define DMA_ERR_ERR8_SHIFT                       (8U)
+#define DMA_ERR_ERR8(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR8_SHIFT)) & DMA_ERR_ERR8_MASK)
+#define DMA_ERR_ERR9_MASK                        (0x200U)
+#define DMA_ERR_ERR9_SHIFT                       (9U)
+#define DMA_ERR_ERR9(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR9_SHIFT)) & DMA_ERR_ERR9_MASK)
+#define DMA_ERR_ERR10_MASK                       (0x400U)
+#define DMA_ERR_ERR10_SHIFT                      (10U)
+#define DMA_ERR_ERR10(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR10_SHIFT)) & DMA_ERR_ERR10_MASK)
+#define DMA_ERR_ERR11_MASK                       (0x800U)
+#define DMA_ERR_ERR11_SHIFT                      (11U)
+#define DMA_ERR_ERR11(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR11_SHIFT)) & DMA_ERR_ERR11_MASK)
+#define DMA_ERR_ERR12_MASK                       (0x1000U)
+#define DMA_ERR_ERR12_SHIFT                      (12U)
+#define DMA_ERR_ERR12(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR12_SHIFT)) & DMA_ERR_ERR12_MASK)
+#define DMA_ERR_ERR13_MASK                       (0x2000U)
+#define DMA_ERR_ERR13_SHIFT                      (13U)
+#define DMA_ERR_ERR13(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR13_SHIFT)) & DMA_ERR_ERR13_MASK)
+#define DMA_ERR_ERR14_MASK                       (0x4000U)
+#define DMA_ERR_ERR14_SHIFT                      (14U)
+#define DMA_ERR_ERR14(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR14_SHIFT)) & DMA_ERR_ERR14_MASK)
+#define DMA_ERR_ERR15_MASK                       (0x8000U)
+#define DMA_ERR_ERR15_SHIFT                      (15U)
+#define DMA_ERR_ERR15(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_ERR_ERR15_SHIFT)) & DMA_ERR_ERR15_MASK)
+
+/*! @name HRS - Hardware Request Status Register */
+#define DMA_HRS_HRS0_MASK                        (0x1U)
+#define DMA_HRS_HRS0_SHIFT                       (0U)
+#define DMA_HRS_HRS0(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS0_SHIFT)) & DMA_HRS_HRS0_MASK)
+#define DMA_HRS_HRS1_MASK                        (0x2U)
+#define DMA_HRS_HRS1_SHIFT                       (1U)
+#define DMA_HRS_HRS1(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS1_SHIFT)) & DMA_HRS_HRS1_MASK)
+#define DMA_HRS_HRS2_MASK                        (0x4U)
+#define DMA_HRS_HRS2_SHIFT                       (2U)
+#define DMA_HRS_HRS2(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS2_SHIFT)) & DMA_HRS_HRS2_MASK)
+#define DMA_HRS_HRS3_MASK                        (0x8U)
+#define DMA_HRS_HRS3_SHIFT                       (3U)
+#define DMA_HRS_HRS3(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS3_SHIFT)) & DMA_HRS_HRS3_MASK)
+#define DMA_HRS_HRS4_MASK                        (0x10U)
+#define DMA_HRS_HRS4_SHIFT                       (4U)
+#define DMA_HRS_HRS4(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS4_SHIFT)) & DMA_HRS_HRS4_MASK)
+#define DMA_HRS_HRS5_MASK                        (0x20U)
+#define DMA_HRS_HRS5_SHIFT                       (5U)
+#define DMA_HRS_HRS5(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS5_SHIFT)) & DMA_HRS_HRS5_MASK)
+#define DMA_HRS_HRS6_MASK                        (0x40U)
+#define DMA_HRS_HRS6_SHIFT                       (6U)
+#define DMA_HRS_HRS6(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS6_SHIFT)) & DMA_HRS_HRS6_MASK)
+#define DMA_HRS_HRS7_MASK                        (0x80U)
+#define DMA_HRS_HRS7_SHIFT                       (7U)
+#define DMA_HRS_HRS7(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS7_SHIFT)) & DMA_HRS_HRS7_MASK)
+#define DMA_HRS_HRS8_MASK                        (0x100U)
+#define DMA_HRS_HRS8_SHIFT                       (8U)
+#define DMA_HRS_HRS8(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS8_SHIFT)) & DMA_HRS_HRS8_MASK)
+#define DMA_HRS_HRS9_MASK                        (0x200U)
+#define DMA_HRS_HRS9_SHIFT                       (9U)
+#define DMA_HRS_HRS9(x)                          (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS9_SHIFT)) & DMA_HRS_HRS9_MASK)
+#define DMA_HRS_HRS10_MASK                       (0x400U)
+#define DMA_HRS_HRS10_SHIFT                      (10U)
+#define DMA_HRS_HRS10(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS10_SHIFT)) & DMA_HRS_HRS10_MASK)
+#define DMA_HRS_HRS11_MASK                       (0x800U)
+#define DMA_HRS_HRS11_SHIFT                      (11U)
+#define DMA_HRS_HRS11(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS11_SHIFT)) & DMA_HRS_HRS11_MASK)
+#define DMA_HRS_HRS12_MASK                       (0x1000U)
+#define DMA_HRS_HRS12_SHIFT                      (12U)
+#define DMA_HRS_HRS12(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS12_SHIFT)) & DMA_HRS_HRS12_MASK)
+#define DMA_HRS_HRS13_MASK                       (0x2000U)
+#define DMA_HRS_HRS13_SHIFT                      (13U)
+#define DMA_HRS_HRS13(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS13_SHIFT)) & DMA_HRS_HRS13_MASK)
+#define DMA_HRS_HRS14_MASK                       (0x4000U)
+#define DMA_HRS_HRS14_SHIFT                      (14U)
+#define DMA_HRS_HRS14(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS14_SHIFT)) & DMA_HRS_HRS14_MASK)
+#define DMA_HRS_HRS15_MASK                       (0x8000U)
+#define DMA_HRS_HRS15_SHIFT                      (15U)
+#define DMA_HRS_HRS15(x)                         (((uint32_t)(((uint32_t)(x)) << DMA_HRS_HRS15_SHIFT)) & DMA_HRS_HRS15_MASK)
+
+/*! @name DCHPRI3 - Channel n Priority Register */
+#define DMA_DCHPRI3_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI3_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI3_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI3_CHPRI_SHIFT)) & DMA_DCHPRI3_CHPRI_MASK)
+#define DMA_DCHPRI3_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI3_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI3_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI3_DPA_SHIFT)) & DMA_DCHPRI3_DPA_MASK)
+#define DMA_DCHPRI3_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI3_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI3_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI3_ECP_SHIFT)) & DMA_DCHPRI3_ECP_MASK)
+
+/*! @name DCHPRI2 - Channel n Priority Register */
+#define DMA_DCHPRI2_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI2_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI2_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI2_CHPRI_SHIFT)) & DMA_DCHPRI2_CHPRI_MASK)
+#define DMA_DCHPRI2_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI2_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI2_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI2_DPA_SHIFT)) & DMA_DCHPRI2_DPA_MASK)
+#define DMA_DCHPRI2_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI2_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI2_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI2_ECP_SHIFT)) & DMA_DCHPRI2_ECP_MASK)
+
+/*! @name DCHPRI1 - Channel n Priority Register */
+#define DMA_DCHPRI1_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI1_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI1_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI1_CHPRI_SHIFT)) & DMA_DCHPRI1_CHPRI_MASK)
+#define DMA_DCHPRI1_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI1_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI1_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI1_DPA_SHIFT)) & DMA_DCHPRI1_DPA_MASK)
+#define DMA_DCHPRI1_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI1_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI1_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI1_ECP_SHIFT)) & DMA_DCHPRI1_ECP_MASK)
+
+/*! @name DCHPRI0 - Channel n Priority Register */
+#define DMA_DCHPRI0_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI0_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI0_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI0_CHPRI_SHIFT)) & DMA_DCHPRI0_CHPRI_MASK)
+#define DMA_DCHPRI0_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI0_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI0_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI0_DPA_SHIFT)) & DMA_DCHPRI0_DPA_MASK)
+#define DMA_DCHPRI0_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI0_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI0_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI0_ECP_SHIFT)) & DMA_DCHPRI0_ECP_MASK)
+
+/*! @name DCHPRI7 - Channel n Priority Register */
+#define DMA_DCHPRI7_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI7_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI7_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI7_CHPRI_SHIFT)) & DMA_DCHPRI7_CHPRI_MASK)
+#define DMA_DCHPRI7_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI7_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI7_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI7_DPA_SHIFT)) & DMA_DCHPRI7_DPA_MASK)
+#define DMA_DCHPRI7_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI7_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI7_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI7_ECP_SHIFT)) & DMA_DCHPRI7_ECP_MASK)
+
+/*! @name DCHPRI6 - Channel n Priority Register */
+#define DMA_DCHPRI6_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI6_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI6_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI6_CHPRI_SHIFT)) & DMA_DCHPRI6_CHPRI_MASK)
+#define DMA_DCHPRI6_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI6_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI6_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI6_DPA_SHIFT)) & DMA_DCHPRI6_DPA_MASK)
+#define DMA_DCHPRI6_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI6_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI6_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI6_ECP_SHIFT)) & DMA_DCHPRI6_ECP_MASK)
+
+/*! @name DCHPRI5 - Channel n Priority Register */
+#define DMA_DCHPRI5_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI5_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI5_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI5_CHPRI_SHIFT)) & DMA_DCHPRI5_CHPRI_MASK)
+#define DMA_DCHPRI5_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI5_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI5_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI5_DPA_SHIFT)) & DMA_DCHPRI5_DPA_MASK)
+#define DMA_DCHPRI5_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI5_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI5_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI5_ECP_SHIFT)) & DMA_DCHPRI5_ECP_MASK)
+
+/*! @name DCHPRI4 - Channel n Priority Register */
+#define DMA_DCHPRI4_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI4_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI4_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI4_CHPRI_SHIFT)) & DMA_DCHPRI4_CHPRI_MASK)
+#define DMA_DCHPRI4_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI4_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI4_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI4_DPA_SHIFT)) & DMA_DCHPRI4_DPA_MASK)
+#define DMA_DCHPRI4_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI4_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI4_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI4_ECP_SHIFT)) & DMA_DCHPRI4_ECP_MASK)
+
+/*! @name DCHPRI11 - Channel n Priority Register */
+#define DMA_DCHPRI11_CHPRI_MASK                  (0xFU)
+#define DMA_DCHPRI11_CHPRI_SHIFT                 (0U)
+#define DMA_DCHPRI11_CHPRI(x)                    (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI11_CHPRI_SHIFT)) & DMA_DCHPRI11_CHPRI_MASK)
+#define DMA_DCHPRI11_DPA_MASK                    (0x40U)
+#define DMA_DCHPRI11_DPA_SHIFT                   (6U)
+#define DMA_DCHPRI11_DPA(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI11_DPA_SHIFT)) & DMA_DCHPRI11_DPA_MASK)
+#define DMA_DCHPRI11_ECP_MASK                    (0x80U)
+#define DMA_DCHPRI11_ECP_SHIFT                   (7U)
+#define DMA_DCHPRI11_ECP(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI11_ECP_SHIFT)) & DMA_DCHPRI11_ECP_MASK)
+
+/*! @name DCHPRI10 - Channel n Priority Register */
+#define DMA_DCHPRI10_CHPRI_MASK                  (0xFU)
+#define DMA_DCHPRI10_CHPRI_SHIFT                 (0U)
+#define DMA_DCHPRI10_CHPRI(x)                    (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI10_CHPRI_SHIFT)) & DMA_DCHPRI10_CHPRI_MASK)
+#define DMA_DCHPRI10_DPA_MASK                    (0x40U)
+#define DMA_DCHPRI10_DPA_SHIFT                   (6U)
+#define DMA_DCHPRI10_DPA(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI10_DPA_SHIFT)) & DMA_DCHPRI10_DPA_MASK)
+#define DMA_DCHPRI10_ECP_MASK                    (0x80U)
+#define DMA_DCHPRI10_ECP_SHIFT                   (7U)
+#define DMA_DCHPRI10_ECP(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI10_ECP_SHIFT)) & DMA_DCHPRI10_ECP_MASK)
+
+/*! @name DCHPRI9 - Channel n Priority Register */
+#define DMA_DCHPRI9_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI9_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI9_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI9_CHPRI_SHIFT)) & DMA_DCHPRI9_CHPRI_MASK)
+#define DMA_DCHPRI9_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI9_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI9_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI9_DPA_SHIFT)) & DMA_DCHPRI9_DPA_MASK)
+#define DMA_DCHPRI9_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI9_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI9_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI9_ECP_SHIFT)) & DMA_DCHPRI9_ECP_MASK)
+
+/*! @name DCHPRI8 - Channel n Priority Register */
+#define DMA_DCHPRI8_CHPRI_MASK                   (0xFU)
+#define DMA_DCHPRI8_CHPRI_SHIFT                  (0U)
+#define DMA_DCHPRI8_CHPRI(x)                     (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI8_CHPRI_SHIFT)) & DMA_DCHPRI8_CHPRI_MASK)
+#define DMA_DCHPRI8_DPA_MASK                     (0x40U)
+#define DMA_DCHPRI8_DPA_SHIFT                    (6U)
+#define DMA_DCHPRI8_DPA(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI8_DPA_SHIFT)) & DMA_DCHPRI8_DPA_MASK)
+#define DMA_DCHPRI8_ECP_MASK                     (0x80U)
+#define DMA_DCHPRI8_ECP_SHIFT                    (7U)
+#define DMA_DCHPRI8_ECP(x)                       (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI8_ECP_SHIFT)) & DMA_DCHPRI8_ECP_MASK)
+
+/*! @name DCHPRI15 - Channel n Priority Register */
+#define DMA_DCHPRI15_CHPRI_MASK                  (0xFU)
+#define DMA_DCHPRI15_CHPRI_SHIFT                 (0U)
+#define DMA_DCHPRI15_CHPRI(x)                    (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI15_CHPRI_SHIFT)) & DMA_DCHPRI15_CHPRI_MASK)
+#define DMA_DCHPRI15_DPA_MASK                    (0x40U)
+#define DMA_DCHPRI15_DPA_SHIFT                   (6U)
+#define DMA_DCHPRI15_DPA(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI15_DPA_SHIFT)) & DMA_DCHPRI15_DPA_MASK)
+#define DMA_DCHPRI15_ECP_MASK                    (0x80U)
+#define DMA_DCHPRI15_ECP_SHIFT                   (7U)
+#define DMA_DCHPRI15_ECP(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI15_ECP_SHIFT)) & DMA_DCHPRI15_ECP_MASK)
+
+/*! @name DCHPRI14 - Channel n Priority Register */
+#define DMA_DCHPRI14_CHPRI_MASK                  (0xFU)
+#define DMA_DCHPRI14_CHPRI_SHIFT                 (0U)
+#define DMA_DCHPRI14_CHPRI(x)                    (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI14_CHPRI_SHIFT)) & DMA_DCHPRI14_CHPRI_MASK)
+#define DMA_DCHPRI14_DPA_MASK                    (0x40U)
+#define DMA_DCHPRI14_DPA_SHIFT                   (6U)
+#define DMA_DCHPRI14_DPA(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI14_DPA_SHIFT)) & DMA_DCHPRI14_DPA_MASK)
+#define DMA_DCHPRI14_ECP_MASK                    (0x80U)
+#define DMA_DCHPRI14_ECP_SHIFT                   (7U)
+#define DMA_DCHPRI14_ECP(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI14_ECP_SHIFT)) & DMA_DCHPRI14_ECP_MASK)
+
+/*! @name DCHPRI13 - Channel n Priority Register */
+#define DMA_DCHPRI13_CHPRI_MASK                  (0xFU)
+#define DMA_DCHPRI13_CHPRI_SHIFT                 (0U)
+#define DMA_DCHPRI13_CHPRI(x)                    (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI13_CHPRI_SHIFT)) & DMA_DCHPRI13_CHPRI_MASK)
+#define DMA_DCHPRI13_DPA_MASK                    (0x40U)
+#define DMA_DCHPRI13_DPA_SHIFT                   (6U)
+#define DMA_DCHPRI13_DPA(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI13_DPA_SHIFT)) & DMA_DCHPRI13_DPA_MASK)
+#define DMA_DCHPRI13_ECP_MASK                    (0x80U)
+#define DMA_DCHPRI13_ECP_SHIFT                   (7U)
+#define DMA_DCHPRI13_ECP(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI13_ECP_SHIFT)) & DMA_DCHPRI13_ECP_MASK)
+
+/*! @name DCHPRI12 - Channel n Priority Register */
+#define DMA_DCHPRI12_CHPRI_MASK                  (0xFU)
+#define DMA_DCHPRI12_CHPRI_SHIFT                 (0U)
+#define DMA_DCHPRI12_CHPRI(x)                    (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI12_CHPRI_SHIFT)) & DMA_DCHPRI12_CHPRI_MASK)
+#define DMA_DCHPRI12_DPA_MASK                    (0x40U)
+#define DMA_DCHPRI12_DPA_SHIFT                   (6U)
+#define DMA_DCHPRI12_DPA(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI12_DPA_SHIFT)) & DMA_DCHPRI12_DPA_MASK)
+#define DMA_DCHPRI12_ECP_MASK                    (0x80U)
+#define DMA_DCHPRI12_ECP_SHIFT                   (7U)
+#define DMA_DCHPRI12_ECP(x)                      (((uint8_t)(((uint8_t)(x)) << DMA_DCHPRI12_ECP_SHIFT)) & DMA_DCHPRI12_ECP_MASK)
+
+/*! @name SADDR - TCD Source Address */
+#define DMA_SADDR_SADDR_MASK                     (0xFFFFFFFFU)
+#define DMA_SADDR_SADDR_SHIFT                    (0U)
+#define DMA_SADDR_SADDR(x)                       (((uint32_t)(((uint32_t)(x)) << DMA_SADDR_SADDR_SHIFT)) & DMA_SADDR_SADDR_MASK)
+
+/* The count of DMA_SADDR */
+#define DMA_SADDR_COUNT                          (16U)
+
+/*! @name SOFF - TCD Signed Source Address Offset */
+#define DMA_SOFF_SOFF_MASK                       (0xFFFFU)
+#define DMA_SOFF_SOFF_SHIFT                      (0U)
+#define DMA_SOFF_SOFF(x)                         (((uint16_t)(((uint16_t)(x)) << DMA_SOFF_SOFF_SHIFT)) & DMA_SOFF_SOFF_MASK)
+
+/* The count of DMA_SOFF */
+#define DMA_SOFF_COUNT                           (16U)
+
+/*! @name ATTR - TCD Transfer Attributes */
+#define DMA_ATTR_DSIZE_MASK                      (0x7U)
+#define DMA_ATTR_DSIZE_SHIFT                     (0U)
+#define DMA_ATTR_DSIZE(x)                        (((uint16_t)(((uint16_t)(x)) << DMA_ATTR_DSIZE_SHIFT)) & DMA_ATTR_DSIZE_MASK)
+#define DMA_ATTR_DMOD_MASK                       (0xF8U)
+#define DMA_ATTR_DMOD_SHIFT                      (3U)
+#define DMA_ATTR_DMOD(x)                         (((uint16_t)(((uint16_t)(x)) << DMA_ATTR_DMOD_SHIFT)) & DMA_ATTR_DMOD_MASK)
+#define DMA_ATTR_SSIZE_MASK                      (0x700U)
+#define DMA_ATTR_SSIZE_SHIFT                     (8U)
+#define DMA_ATTR_SSIZE(x)                        (((uint16_t)(((uint16_t)(x)) << DMA_ATTR_SSIZE_SHIFT)) & DMA_ATTR_SSIZE_MASK)
+#define DMA_ATTR_SMOD_MASK                       (0xF800U)
+#define DMA_ATTR_SMOD_SHIFT                      (11U)
+#define DMA_ATTR_SMOD(x)                         (((uint16_t)(((uint16_t)(x)) << DMA_ATTR_SMOD_SHIFT)) & DMA_ATTR_SMOD_MASK)
+
+/* The count of DMA_ATTR */
+#define DMA_ATTR_COUNT                           (16U)
+
+/*! @name NBYTES_MLNO - TCD Minor Byte Count (Minor Loop Disabled) */
+#define DMA_NBYTES_MLNO_NBYTES_MASK              (0xFFFFFFFFU)
+#define DMA_NBYTES_MLNO_NBYTES_SHIFT             (0U)
+#define DMA_NBYTES_MLNO_NBYTES(x)                (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLNO_NBYTES_SHIFT)) & DMA_NBYTES_MLNO_NBYTES_MASK)
+
+/* The count of DMA_NBYTES_MLNO */
+#define DMA_NBYTES_MLNO_COUNT                    (16U)
+
+/*! @name NBYTES_MLOFFNO - TCD Signed Minor Loop Offset (Minor Loop Enabled and Offset Disabled) */
+#define DMA_NBYTES_MLOFFNO_NBYTES_MASK           (0x3FFFFFFFU)
+#define DMA_NBYTES_MLOFFNO_NBYTES_SHIFT          (0U)
+#define DMA_NBYTES_MLOFFNO_NBYTES(x)             (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFNO_NBYTES_SHIFT)) & DMA_NBYTES_MLOFFNO_NBYTES_MASK)
+#define DMA_NBYTES_MLOFFNO_DMLOE_MASK            (0x40000000U)
+#define DMA_NBYTES_MLOFFNO_DMLOE_SHIFT           (30U)
+#define DMA_NBYTES_MLOFFNO_DMLOE(x)              (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFNO_DMLOE_SHIFT)) & DMA_NBYTES_MLOFFNO_DMLOE_MASK)
+#define DMA_NBYTES_MLOFFNO_SMLOE_MASK            (0x80000000U)
+#define DMA_NBYTES_MLOFFNO_SMLOE_SHIFT           (31U)
+#define DMA_NBYTES_MLOFFNO_SMLOE(x)              (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFNO_SMLOE_SHIFT)) & DMA_NBYTES_MLOFFNO_SMLOE_MASK)
+
+/* The count of DMA_NBYTES_MLOFFNO */
+#define DMA_NBYTES_MLOFFNO_COUNT                 (16U)
+
+/*! @name NBYTES_MLOFFYES - TCD Signed Minor Loop Offset (Minor Loop and Offset Enabled) */
+#define DMA_NBYTES_MLOFFYES_NBYTES_MASK          (0x3FFU)
+#define DMA_NBYTES_MLOFFYES_NBYTES_SHIFT         (0U)
+#define DMA_NBYTES_MLOFFYES_NBYTES(x)            (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFYES_NBYTES_SHIFT)) & DMA_NBYTES_MLOFFYES_NBYTES_MASK)
+#define DMA_NBYTES_MLOFFYES_MLOFF_MASK           (0x3FFFFC00U)
+#define DMA_NBYTES_MLOFFYES_MLOFF_SHIFT          (10U)
+#define DMA_NBYTES_MLOFFYES_MLOFF(x)             (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFYES_MLOFF_SHIFT)) & DMA_NBYTES_MLOFFYES_MLOFF_MASK)
+#define DMA_NBYTES_MLOFFYES_DMLOE_MASK           (0x40000000U)
+#define DMA_NBYTES_MLOFFYES_DMLOE_SHIFT          (30U)
+#define DMA_NBYTES_MLOFFYES_DMLOE(x)             (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFYES_DMLOE_SHIFT)) & DMA_NBYTES_MLOFFYES_DMLOE_MASK)
+#define DMA_NBYTES_MLOFFYES_SMLOE_MASK           (0x80000000U)
+#define DMA_NBYTES_MLOFFYES_SMLOE_SHIFT          (31U)
+#define DMA_NBYTES_MLOFFYES_SMLOE(x)             (((uint32_t)(((uint32_t)(x)) << DMA_NBYTES_MLOFFYES_SMLOE_SHIFT)) & DMA_NBYTES_MLOFFYES_SMLOE_MASK)
+
+/* The count of DMA_NBYTES_MLOFFYES */
+#define DMA_NBYTES_MLOFFYES_COUNT                (16U)
+
+/*! @name SLAST - TCD Last Source Address Adjustment */
+#define DMA_SLAST_SLAST_MASK                     (0xFFFFFFFFU)
+#define DMA_SLAST_SLAST_SHIFT                    (0U)
+#define DMA_SLAST_SLAST(x)                       (((uint32_t)(((uint32_t)(x)) << DMA_SLAST_SLAST_SHIFT)) & DMA_SLAST_SLAST_MASK)
+
+/* The count of DMA_SLAST */
+#define DMA_SLAST_COUNT                          (16U)
+
+/*! @name DADDR - TCD Destination Address */
+#define DMA_DADDR_DADDR_MASK                     (0xFFFFFFFFU)
+#define DMA_DADDR_DADDR_SHIFT                    (0U)
+#define DMA_DADDR_DADDR(x)                       (((uint32_t)(((uint32_t)(x)) << DMA_DADDR_DADDR_SHIFT)) & DMA_DADDR_DADDR_MASK)
+
+/* The count of DMA_DADDR */
+#define DMA_DADDR_COUNT                          (16U)
+
+/*! @name DOFF - TCD Signed Destination Address Offset */
+#define DMA_DOFF_DOFF_MASK                       (0xFFFFU)
+#define DMA_DOFF_DOFF_SHIFT                      (0U)
+#define DMA_DOFF_DOFF(x)                         (((uint16_t)(((uint16_t)(x)) << DMA_DOFF_DOFF_SHIFT)) & DMA_DOFF_DOFF_MASK)
+
+/* The count of DMA_DOFF */
+#define DMA_DOFF_COUNT                           (16U)
+
+/*! @name CITER_ELINKNO - TCD Current Minor Loop Link, Major Loop Count (Channel Linking Disabled) */
+#define DMA_CITER_ELINKNO_CITER_MASK             (0x7FFFU)
+#define DMA_CITER_ELINKNO_CITER_SHIFT            (0U)
+#define DMA_CITER_ELINKNO_CITER(x)               (((uint16_t)(((uint16_t)(x)) << DMA_CITER_ELINKNO_CITER_SHIFT)) & DMA_CITER_ELINKNO_CITER_MASK)
+#define DMA_CITER_ELINKNO_ELINK_MASK             (0x8000U)
+#define DMA_CITER_ELINKNO_ELINK_SHIFT            (15U)
+#define DMA_CITER_ELINKNO_ELINK(x)               (((uint16_t)(((uint16_t)(x)) << DMA_CITER_ELINKNO_ELINK_SHIFT)) & DMA_CITER_ELINKNO_ELINK_MASK)
+
+/* The count of DMA_CITER_ELINKNO */
+#define DMA_CITER_ELINKNO_COUNT                  (16U)
+
+/*! @name CITER_ELINKYES - TCD Current Minor Loop Link, Major Loop Count (Channel Linking Enabled) */
+#define DMA_CITER_ELINKYES_CITER_MASK            (0x1FFU)
+#define DMA_CITER_ELINKYES_CITER_SHIFT           (0U)
+#define DMA_CITER_ELINKYES_CITER(x)              (((uint16_t)(((uint16_t)(x)) << DMA_CITER_ELINKYES_CITER_SHIFT)) & DMA_CITER_ELINKYES_CITER_MASK)
+#define DMA_CITER_ELINKYES_LINKCH_MASK           (0x1E00U)
+#define DMA_CITER_ELINKYES_LINKCH_SHIFT          (9U)
+#define DMA_CITER_ELINKYES_LINKCH(x)             (((uint16_t)(((uint16_t)(x)) << DMA_CITER_ELINKYES_LINKCH_SHIFT)) & DMA_CITER_ELINKYES_LINKCH_MASK)
+#define DMA_CITER_ELINKYES_ELINK_MASK            (0x8000U)
+#define DMA_CITER_ELINKYES_ELINK_SHIFT           (15U)
+#define DMA_CITER_ELINKYES_ELINK(x)              (((uint16_t)(((uint16_t)(x)) << DMA_CITER_ELINKYES_ELINK_SHIFT)) & DMA_CITER_ELINKYES_ELINK_MASK)
+
+/* The count of DMA_CITER_ELINKYES */
+#define DMA_CITER_ELINKYES_COUNT                 (16U)
+
+/*! @name DLAST_SGA - TCD Last Destination Address Adjustment/Scatter Gather Address */
+#define DMA_DLAST_SGA_DLASTSGA_MASK              (0xFFFFFFFFU)
+#define DMA_DLAST_SGA_DLASTSGA_SHIFT             (0U)
+#define DMA_DLAST_SGA_DLASTSGA(x)                (((uint32_t)(((uint32_t)(x)) << DMA_DLAST_SGA_DLASTSGA_SHIFT)) & DMA_DLAST_SGA_DLASTSGA_MASK)
+
+/* The count of DMA_DLAST_SGA */
+#define DMA_DLAST_SGA_COUNT                      (16U)
+
+/*! @name CSR - TCD Control and Status */
+#define DMA_CSR_START_MASK                       (0x1U)
+#define DMA_CSR_START_SHIFT                      (0U)
+#define DMA_CSR_START(x)                         (((uint16_t)(((uint16_t)(x)) << DMA_CSR_START_SHIFT)) & DMA_CSR_START_MASK)
+#define DMA_CSR_INTMAJOR_MASK                    (0x2U)
+#define DMA_CSR_INTMAJOR_SHIFT                   (1U)
+#define DMA_CSR_INTMAJOR(x)                      (((uint16_t)(((uint16_t)(x)) << DMA_CSR_INTMAJOR_SHIFT)) & DMA_CSR_INTMAJOR_MASK)
+#define DMA_CSR_INTHALF_MASK                     (0x4U)
+#define DMA_CSR_INTHALF_SHIFT                    (2U)
+#define DMA_CSR_INTHALF(x)                       (((uint16_t)(((uint16_t)(x)) << DMA_CSR_INTHALF_SHIFT)) & DMA_CSR_INTHALF_MASK)
+#define DMA_CSR_DREQ_MASK                        (0x8U)
+#define DMA_CSR_DREQ_SHIFT                       (3U)
+#define DMA_CSR_DREQ(x)                          (((uint16_t)(((uint16_t)(x)) << DMA_CSR_DREQ_SHIFT)) & DMA_CSR_DREQ_MASK)
+#define DMA_CSR_ESG_MASK                         (0x10U)
+#define DMA_CSR_ESG_SHIFT                        (4U)
+#define DMA_CSR_ESG(x)                           (((uint16_t)(((uint16_t)(x)) << DMA_CSR_ESG_SHIFT)) & DMA_CSR_ESG_MASK)
+#define DMA_CSR_MAJORELINK_MASK                  (0x20U)
+#define DMA_CSR_MAJORELINK_SHIFT                 (5U)
+#define DMA_CSR_MAJORELINK(x)                    (((uint16_t)(((uint16_t)(x)) << DMA_CSR_MAJORELINK_SHIFT)) & DMA_CSR_MAJORELINK_MASK)
+#define DMA_CSR_ACTIVE_MASK                      (0x40U)
+#define DMA_CSR_ACTIVE_SHIFT                     (6U)
+#define DMA_CSR_ACTIVE(x)                        (((uint16_t)(((uint16_t)(x)) << DMA_CSR_ACTIVE_SHIFT)) & DMA_CSR_ACTIVE_MASK)
+#define DMA_CSR_DONE_MASK                        (0x80U)
+#define DMA_CSR_DONE_SHIFT                       (7U)
+#define DMA_CSR_DONE(x)                          (((uint16_t)(((uint16_t)(x)) << DMA_CSR_DONE_SHIFT)) & DMA_CSR_DONE_MASK)
+#define DMA_CSR_MAJORLINKCH_MASK                 (0xF00U)
+#define DMA_CSR_MAJORLINKCH_SHIFT                (8U)
+#define DMA_CSR_MAJORLINKCH(x)                   (((uint16_t)(((uint16_t)(x)) << DMA_CSR_MAJORLINKCH_SHIFT)) & DMA_CSR_MAJORLINKCH_MASK)
+#define DMA_CSR_BWC_MASK                         (0xC000U)
+#define DMA_CSR_BWC_SHIFT                        (14U)
+#define DMA_CSR_BWC(x)                           (((uint16_t)(((uint16_t)(x)) << DMA_CSR_BWC_SHIFT)) & DMA_CSR_BWC_MASK)
+
+/* The count of DMA_CSR */
+#define DMA_CSR_COUNT                            (16U)
+
+/*! @name BITER_ELINKNO - TCD Beginning Minor Loop Link, Major Loop Count (Channel Linking Disabled) */
+#define DMA_BITER_ELINKNO_BITER_MASK             (0x7FFFU)
+#define DMA_BITER_ELINKNO_BITER_SHIFT            (0U)
+#define DMA_BITER_ELINKNO_BITER(x)               (((uint16_t)(((uint16_t)(x)) << DMA_BITER_ELINKNO_BITER_SHIFT)) & DMA_BITER_ELINKNO_BITER_MASK)
+#define DMA_BITER_ELINKNO_ELINK_MASK             (0x8000U)
+#define DMA_BITER_ELINKNO_ELINK_SHIFT            (15U)
+#define DMA_BITER_ELINKNO_ELINK(x)               (((uint16_t)(((uint16_t)(x)) << DMA_BITER_ELINKNO_ELINK_SHIFT)) & DMA_BITER_ELINKNO_ELINK_MASK)
+
+/* The count of DMA_BITER_ELINKNO */
+#define DMA_BITER_ELINKNO_COUNT                  (16U)
+
+/*! @name BITER_ELINKYES - TCD Beginning Minor Loop Link, Major Loop Count (Channel Linking Enabled) */
+#define DMA_BITER_ELINKYES_BITER_MASK            (0x1FFU)
+#define DMA_BITER_ELINKYES_BITER_SHIFT           (0U)
+#define DMA_BITER_ELINKYES_BITER(x)              (((uint16_t)(((uint16_t)(x)) << DMA_BITER_ELINKYES_BITER_SHIFT)) & DMA_BITER_ELINKYES_BITER_MASK)
+#define DMA_BITER_ELINKYES_LINKCH_MASK           (0x1E00U)
+#define DMA_BITER_ELINKYES_LINKCH_SHIFT          (9U)
+#define DMA_BITER_ELINKYES_LINKCH(x)             (((uint16_t)(((uint16_t)(x)) << DMA_BITER_ELINKYES_LINKCH_SHIFT)) & DMA_BITER_ELINKYES_LINKCH_MASK)
+#define DMA_BITER_ELINKYES_ELINK_MASK            (0x8000U)
+#define DMA_BITER_ELINKYES_ELINK_SHIFT           (15U)
+#define DMA_BITER_ELINKYES_ELINK(x)              (((uint16_t)(((uint16_t)(x)) << DMA_BITER_ELINKYES_ELINK_SHIFT)) & DMA_BITER_ELINKYES_ELINK_MASK)
+
+/* The count of DMA_BITER_ELINKYES */
+#define DMA_BITER_ELINKYES_COUNT                 (16U)
+
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Masks */
+
+
+/* DMA - Peripheral instance base addresses */
+/** Peripheral DMA base address */
+#define DMA_BASE                                 (0x40008000u)
+/** Peripheral DMA base pointer */
+#define DMA0                                     ((DMA_Type *)DMA_BASE)
+/** Array initializer of DMA peripheral base addresses */
+#define DMA_BASE_ADDRS                           { DMA_BASE }
+/** Array initializer of DMA peripheral base pointers */
+#define DMA_BASE_PTRS                            { DMA0 }
+/** Interrupt vectors for the DMA peripheral type */
+#define DMA_CHN_IRQS                             { DMA0_IRQn, DMA1_IRQn, DMA2_IRQn, DMA3_IRQn, DMA4_IRQn, DMA5_IRQn, DMA6_IRQn, DMA7_IRQn, DMA8_IRQn, DMA9_IRQn, DMA10_IRQn, DMA11_IRQn, DMA12_IRQn, DMA13_IRQn, DMA14_IRQn, DMA15_IRQn }
+#define DMA_ERROR_IRQS                           { DMA_Error_IRQn }
+
+/*!
+ * @}
+ */ /* end of group DMA_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Peripheral_Access_Layer DMAMUX Peripheral Access Layer
+ * @{
+ */
+
+/** DMAMUX - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CHCFG[16];                          /**< Channel Configuration register, array offset: 0x0, array step: 0x1 */
+} DMAMUX_Type;
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Masks DMAMUX Register Masks
+ * @{
+ */
+
+/*! @name CHCFG - Channel Configuration register */
+#define DMAMUX_CHCFG_SOURCE_MASK                 (0x3FU)
+#define DMAMUX_CHCFG_SOURCE_SHIFT                (0U)
+#define DMAMUX_CHCFG_SOURCE(x)                   (((uint8_t)(((uint8_t)(x)) << DMAMUX_CHCFG_SOURCE_SHIFT)) & DMAMUX_CHCFG_SOURCE_MASK)
+#define DMAMUX_CHCFG_TRIG_MASK                   (0x40U)
+#define DMAMUX_CHCFG_TRIG_SHIFT                  (6U)
+#define DMAMUX_CHCFG_TRIG(x)                     (((uint8_t)(((uint8_t)(x)) << DMAMUX_CHCFG_TRIG_SHIFT)) & DMAMUX_CHCFG_TRIG_MASK)
+#define DMAMUX_CHCFG_ENBL_MASK                   (0x80U)
+#define DMAMUX_CHCFG_ENBL_SHIFT                  (7U)
+#define DMAMUX_CHCFG_ENBL(x)                     (((uint8_t)(((uint8_t)(x)) << DMAMUX_CHCFG_ENBL_SHIFT)) & DMAMUX_CHCFG_ENBL_MASK)
+
+/* The count of DMAMUX_CHCFG */
+#define DMAMUX_CHCFG_COUNT                       (16U)
+
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Masks */
+
+
+/* DMAMUX - Peripheral instance base addresses */
+/** Peripheral DMAMUX base address */
+#define DMAMUX_BASE                              (0x40021000u)
+/** Peripheral DMAMUX base pointer */
+#define DMAMUX                                   ((DMAMUX_Type *)DMAMUX_BASE)
+/** Array initializer of DMAMUX peripheral base addresses */
+#define DMAMUX_BASE_ADDRS                        { DMAMUX_BASE }
+/** Array initializer of DMAMUX peripheral base pointers */
+#define DMAMUX_BASE_PTRS                         { DMAMUX }
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- ENET Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ENET_Peripheral_Access_Layer ENET Peripheral Access Layer
+ * @{
+ */
+
+/** ENET - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[4];
+  __IO uint32_t EIR;                               /**< Interrupt Event Register, offset: 0x4 */
+  __IO uint32_t EIMR;                              /**< Interrupt Mask Register, offset: 0x8 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t RDAR;                              /**< Receive Descriptor Active Register, offset: 0x10 */
+  __IO uint32_t TDAR;                              /**< Transmit Descriptor Active Register, offset: 0x14 */
+       uint8_t RESERVED_2[12];
+  __IO uint32_t ECR;                               /**< Ethernet Control Register, offset: 0x24 */
+       uint8_t RESERVED_3[24];
+  __IO uint32_t MMFR;                              /**< MII Management Frame Register, offset: 0x40 */
+  __IO uint32_t MSCR;                              /**< MII Speed Control Register, offset: 0x44 */
+       uint8_t RESERVED_4[28];
+  __IO uint32_t MIBC;                              /**< MIB Control Register, offset: 0x64 */
+       uint8_t RESERVED_5[28];
+  __IO uint32_t RCR;                               /**< Receive Control Register, offset: 0x84 */
+       uint8_t RESERVED_6[60];
+  __IO uint32_t TCR;                               /**< Transmit Control Register, offset: 0xC4 */
+       uint8_t RESERVED_7[28];
+  __IO uint32_t PALR;                              /**< Physical Address Lower Register, offset: 0xE4 */
+  __IO uint32_t PAUR;                              /**< Physical Address Upper Register, offset: 0xE8 */
+  __IO uint32_t OPD;                               /**< Opcode/Pause Duration Register, offset: 0xEC */
+       uint8_t RESERVED_8[40];
+  __IO uint32_t IAUR;                              /**< Descriptor Individual Upper Address Register, offset: 0x118 */
+  __IO uint32_t IALR;                              /**< Descriptor Individual Lower Address Register, offset: 0x11C */
+  __IO uint32_t GAUR;                              /**< Descriptor Group Upper Address Register, offset: 0x120 */
+  __IO uint32_t GALR;                              /**< Descriptor Group Lower Address Register, offset: 0x124 */
+       uint8_t RESERVED_9[28];
+  __IO uint32_t TFWR;                              /**< Transmit FIFO Watermark Register, offset: 0x144 */
+       uint8_t RESERVED_10[56];
+  __IO uint32_t RDSR;                              /**< Receive Descriptor Ring Start Register, offset: 0x180 */
+  __IO uint32_t TDSR;                              /**< Transmit Buffer Descriptor Ring Start Register, offset: 0x184 */
+  __IO uint32_t MRBR;                              /**< Maximum Receive Buffer Size Register, offset: 0x188 */
+       uint8_t RESERVED_11[4];
+  __IO uint32_t RSFL;                              /**< Receive FIFO Section Full Threshold, offset: 0x190 */
+  __IO uint32_t RSEM;                              /**< Receive FIFO Section Empty Threshold, offset: 0x194 */
+  __IO uint32_t RAEM;                              /**< Receive FIFO Almost Empty Threshold, offset: 0x198 */
+  __IO uint32_t RAFL;                              /**< Receive FIFO Almost Full Threshold, offset: 0x19C */
+  __IO uint32_t TSEM;                              /**< Transmit FIFO Section Empty Threshold, offset: 0x1A0 */
+  __IO uint32_t TAEM;                              /**< Transmit FIFO Almost Empty Threshold, offset: 0x1A4 */
+  __IO uint32_t TAFL;                              /**< Transmit FIFO Almost Full Threshold, offset: 0x1A8 */
+  __IO uint32_t TIPG;                              /**< Transmit Inter-Packet Gap, offset: 0x1AC */
+  __IO uint32_t FTRL;                              /**< Frame Truncation Length, offset: 0x1B0 */
+       uint8_t RESERVED_12[12];
+  __IO uint32_t TACC;                              /**< Transmit Accelerator Function Configuration, offset: 0x1C0 */
+  __IO uint32_t RACC;                              /**< Receive Accelerator Function Configuration, offset: 0x1C4 */
+       uint8_t RESERVED_13[60];
+  __I  uint32_t RMON_T_PACKETS;                    /**< Tx Packet Count Statistic Register, offset: 0x204 */
+  __I  uint32_t RMON_T_BC_PKT;                     /**< Tx Broadcast Packets Statistic Register, offset: 0x208 */
+  __I  uint32_t RMON_T_MC_PKT;                     /**< Tx Multicast Packets Statistic Register, offset: 0x20C */
+  __I  uint32_t RMON_T_CRC_ALIGN;                  /**< Tx Packets with CRC/Align Error Statistic Register, offset: 0x210 */
+  __I  uint32_t RMON_T_UNDERSIZE;                  /**< Tx Packets Less Than Bytes and Good CRC Statistic Register, offset: 0x214 */
+  __I  uint32_t RMON_T_OVERSIZE;                   /**< Tx Packets GT MAX_FL bytes and Good CRC Statistic Register, offset: 0x218 */
+  __I  uint32_t RMON_T_FRAG;                       /**< Tx Packets Less Than 64 Bytes and Bad CRC Statistic Register, offset: 0x21C */
+  __I  uint32_t RMON_T_JAB;                        /**< Tx Packets Greater Than MAX_FL bytes and Bad CRC Statistic Register, offset: 0x220 */
+  __I  uint32_t RMON_T_COL;                        /**< Tx Collision Count Statistic Register, offset: 0x224 */
+  __I  uint32_t RMON_T_P64;                        /**< Tx 64-Byte Packets Statistic Register, offset: 0x228 */
+  __I  uint32_t RMON_T_P65TO127;                   /**< Tx 65- to 127-byte Packets Statistic Register, offset: 0x22C */
+  __I  uint32_t RMON_T_P128TO255;                  /**< Tx 128- to 255-byte Packets Statistic Register, offset: 0x230 */
+  __I  uint32_t RMON_T_P256TO511;                  /**< Tx 256- to 511-byte Packets Statistic Register, offset: 0x234 */
+  __I  uint32_t RMON_T_P512TO1023;                 /**< Tx 512- to 1023-byte Packets Statistic Register, offset: 0x238 */
+  __I  uint32_t RMON_T_P1024TO2047;                /**< Tx 1024- to 2047-byte Packets Statistic Register, offset: 0x23C */
+  __I  uint32_t RMON_T_P_GTE2048;                  /**< Tx Packets Greater Than 2048 Bytes Statistic Register, offset: 0x240 */
+  __I  uint32_t RMON_T_OCTETS;                     /**< Tx Octets Statistic Register, offset: 0x244 */
+       uint8_t RESERVED_14[4];
+  __I  uint32_t IEEE_T_FRAME_OK;                   /**< Frames Transmitted OK Statistic Register, offset: 0x24C */
+  __I  uint32_t IEEE_T_1COL;                       /**< Frames Transmitted with Single Collision Statistic Register, offset: 0x250 */
+  __I  uint32_t IEEE_T_MCOL;                       /**< Frames Transmitted with Multiple Collisions Statistic Register, offset: 0x254 */
+  __I  uint32_t IEEE_T_DEF;                        /**< Frames Transmitted after Deferral Delay Statistic Register, offset: 0x258 */
+  __I  uint32_t IEEE_T_LCOL;                       /**< Frames Transmitted with Late Collision Statistic Register, offset: 0x25C */
+  __I  uint32_t IEEE_T_EXCOL;                      /**< Frames Transmitted with Excessive Collisions Statistic Register, offset: 0x260 */
+  __I  uint32_t IEEE_T_MACERR;                     /**< Frames Transmitted with Tx FIFO Underrun Statistic Register, offset: 0x264 */
+  __I  uint32_t IEEE_T_CSERR;                      /**< Frames Transmitted with Carrier Sense Error Statistic Register, offset: 0x268 */
+       uint8_t RESERVED_15[4];
+  __I  uint32_t IEEE_T_FDXFC;                      /**< Flow Control Pause Frames Transmitted Statistic Register, offset: 0x270 */
+  __I  uint32_t IEEE_T_OCTETS_OK;                  /**< Octet Count for Frames Transmitted w/o Error Statistic Register, offset: 0x274 */
+       uint8_t RESERVED_16[12];
+  __I  uint32_t RMON_R_PACKETS;                    /**< Rx Packet Count Statistic Register, offset: 0x284 */
+  __I  uint32_t RMON_R_BC_PKT;                     /**< Rx Broadcast Packets Statistic Register, offset: 0x288 */
+  __I  uint32_t RMON_R_MC_PKT;                     /**< Rx Multicast Packets Statistic Register, offset: 0x28C */
+  __I  uint32_t RMON_R_CRC_ALIGN;                  /**< Rx Packets with CRC/Align Error Statistic Register, offset: 0x290 */
+  __I  uint32_t RMON_R_UNDERSIZE;                  /**< Rx Packets with Less Than 64 Bytes and Good CRC Statistic Register, offset: 0x294 */
+  __I  uint32_t RMON_R_OVERSIZE;                   /**< Rx Packets Greater Than MAX_FL and Good CRC Statistic Register, offset: 0x298 */
+  __I  uint32_t RMON_R_FRAG;                       /**< Rx Packets Less Than 64 Bytes and Bad CRC Statistic Register, offset: 0x29C */
+  __I  uint32_t RMON_R_JAB;                        /**< Rx Packets Greater Than MAX_FL Bytes and Bad CRC Statistic Register, offset: 0x2A0 */
+       uint8_t RESERVED_17[4];
+  __I  uint32_t RMON_R_P64;                        /**< Rx 64-Byte Packets Statistic Register, offset: 0x2A8 */
+  __I  uint32_t RMON_R_P65TO127;                   /**< Rx 65- to 127-Byte Packets Statistic Register, offset: 0x2AC */
+  __I  uint32_t RMON_R_P128TO255;                  /**< Rx 128- to 255-Byte Packets Statistic Register, offset: 0x2B0 */
+  __I  uint32_t RMON_R_P256TO511;                  /**< Rx 256- to 511-Byte Packets Statistic Register, offset: 0x2B4 */
+  __I  uint32_t RMON_R_P512TO1023;                 /**< Rx 512- to 1023-Byte Packets Statistic Register, offset: 0x2B8 */
+  __I  uint32_t RMON_R_P1024TO2047;                /**< Rx 1024- to 2047-Byte Packets Statistic Register, offset: 0x2BC */
+  __I  uint32_t RMON_R_P_GTE2048;                  /**< Rx Packets Greater than 2048 Bytes Statistic Register, offset: 0x2C0 */
+  __I  uint32_t RMON_R_OCTETS;                     /**< Rx Octets Statistic Register, offset: 0x2C4 */
+  __I  uint32_t IEEE_R_DROP;                       /**< Frames not Counted Correctly Statistic Register, offset: 0x2C8 */
+  __I  uint32_t IEEE_R_FRAME_OK;                   /**< Frames Received OK Statistic Register, offset: 0x2CC */
+  __I  uint32_t IEEE_R_CRC;                        /**< Frames Received with CRC Error Statistic Register, offset: 0x2D0 */
+  __I  uint32_t IEEE_R_ALIGN;                      /**< Frames Received with Alignment Error Statistic Register, offset: 0x2D4 */
+  __I  uint32_t IEEE_R_MACERR;                     /**< Receive FIFO Overflow Count Statistic Register, offset: 0x2D8 */
+  __I  uint32_t IEEE_R_FDXFC;                      /**< Flow Control Pause Frames Received Statistic Register, offset: 0x2DC */
+  __I  uint32_t IEEE_R_OCTETS_OK;                  /**< Octet Count for Frames Received without Error Statistic Register, offset: 0x2E0 */
+       uint8_t RESERVED_18[284];
+  __IO uint32_t ATCR;                              /**< Adjustable Timer Control Register, offset: 0x400 */
+  __IO uint32_t ATVR;                              /**< Timer Value Register, offset: 0x404 */
+  __IO uint32_t ATOFF;                             /**< Timer Offset Register, offset: 0x408 */
+  __IO uint32_t ATPER;                             /**< Timer Period Register, offset: 0x40C */
+  __IO uint32_t ATCOR;                             /**< Timer Correction Register, offset: 0x410 */
+  __IO uint32_t ATINC;                             /**< Time-Stamping Clock Period Register, offset: 0x414 */
+  __I  uint32_t ATSTMP;                            /**< Timestamp of Last Transmitted Frame, offset: 0x418 */
+       uint8_t RESERVED_19[488];
+  __IO uint32_t TGSR;                              /**< Timer Global Status Register, offset: 0x604 */
+  struct {                                         /* offset: 0x608, array step: 0x8 */
+    __IO uint32_t TCSR;                              /**< Timer Control Status Register, array offset: 0x608, array step: 0x8 */
+    __IO uint32_t TCCR;                              /**< Timer Compare Capture Register, array offset: 0x60C, array step: 0x8 */
+  } CHANNEL[4];
+} ENET_Type;
+
+/* ----------------------------------------------------------------------------
+   -- ENET Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ENET_Register_Masks ENET Register Masks
+ * @{
+ */
+
+/*! @name EIR - Interrupt Event Register */
+#define ENET_EIR_TS_TIMER_MASK                   (0x8000U)
+#define ENET_EIR_TS_TIMER_SHIFT                  (15U)
+#define ENET_EIR_TS_TIMER(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_EIR_TS_TIMER_SHIFT)) & ENET_EIR_TS_TIMER_MASK)
+#define ENET_EIR_TS_AVAIL_MASK                   (0x10000U)
+#define ENET_EIR_TS_AVAIL_SHIFT                  (16U)
+#define ENET_EIR_TS_AVAIL(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_EIR_TS_AVAIL_SHIFT)) & ENET_EIR_TS_AVAIL_MASK)
+#define ENET_EIR_WAKEUP_MASK                     (0x20000U)
+#define ENET_EIR_WAKEUP_SHIFT                    (17U)
+#define ENET_EIR_WAKEUP(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_EIR_WAKEUP_SHIFT)) & ENET_EIR_WAKEUP_MASK)
+#define ENET_EIR_PLR_MASK                        (0x40000U)
+#define ENET_EIR_PLR_SHIFT                       (18U)
+#define ENET_EIR_PLR(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_PLR_SHIFT)) & ENET_EIR_PLR_MASK)
+#define ENET_EIR_UN_MASK                         (0x80000U)
+#define ENET_EIR_UN_SHIFT                        (19U)
+#define ENET_EIR_UN(x)                           (((uint32_t)(((uint32_t)(x)) << ENET_EIR_UN_SHIFT)) & ENET_EIR_UN_MASK)
+#define ENET_EIR_RL_MASK                         (0x100000U)
+#define ENET_EIR_RL_SHIFT                        (20U)
+#define ENET_EIR_RL(x)                           (((uint32_t)(((uint32_t)(x)) << ENET_EIR_RL_SHIFT)) & ENET_EIR_RL_MASK)
+#define ENET_EIR_LC_MASK                         (0x200000U)
+#define ENET_EIR_LC_SHIFT                        (21U)
+#define ENET_EIR_LC(x)                           (((uint32_t)(((uint32_t)(x)) << ENET_EIR_LC_SHIFT)) & ENET_EIR_LC_MASK)
+#define ENET_EIR_EBERR_MASK                      (0x400000U)
+#define ENET_EIR_EBERR_SHIFT                     (22U)
+#define ENET_EIR_EBERR(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_EIR_EBERR_SHIFT)) & ENET_EIR_EBERR_MASK)
+#define ENET_EIR_MII_MASK                        (0x800000U)
+#define ENET_EIR_MII_SHIFT                       (23U)
+#define ENET_EIR_MII(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_MII_SHIFT)) & ENET_EIR_MII_MASK)
+#define ENET_EIR_RXB_MASK                        (0x1000000U)
+#define ENET_EIR_RXB_SHIFT                       (24U)
+#define ENET_EIR_RXB(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_RXB_SHIFT)) & ENET_EIR_RXB_MASK)
+#define ENET_EIR_RXF_MASK                        (0x2000000U)
+#define ENET_EIR_RXF_SHIFT                       (25U)
+#define ENET_EIR_RXF(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_RXF_SHIFT)) & ENET_EIR_RXF_MASK)
+#define ENET_EIR_TXB_MASK                        (0x4000000U)
+#define ENET_EIR_TXB_SHIFT                       (26U)
+#define ENET_EIR_TXB(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_TXB_SHIFT)) & ENET_EIR_TXB_MASK)
+#define ENET_EIR_TXF_MASK                        (0x8000000U)
+#define ENET_EIR_TXF_SHIFT                       (27U)
+#define ENET_EIR_TXF(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_TXF_SHIFT)) & ENET_EIR_TXF_MASK)
+#define ENET_EIR_GRA_MASK                        (0x10000000U)
+#define ENET_EIR_GRA_SHIFT                       (28U)
+#define ENET_EIR_GRA(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIR_GRA_SHIFT)) & ENET_EIR_GRA_MASK)
+#define ENET_EIR_BABT_MASK                       (0x20000000U)
+#define ENET_EIR_BABT_SHIFT                      (29U)
+#define ENET_EIR_BABT(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIR_BABT_SHIFT)) & ENET_EIR_BABT_MASK)
+#define ENET_EIR_BABR_MASK                       (0x40000000U)
+#define ENET_EIR_BABR_SHIFT                      (30U)
+#define ENET_EIR_BABR(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIR_BABR_SHIFT)) & ENET_EIR_BABR_MASK)
+
+/*! @name EIMR - Interrupt Mask Register */
+#define ENET_EIMR_TS_TIMER_MASK                  (0x8000U)
+#define ENET_EIMR_TS_TIMER_SHIFT                 (15U)
+#define ENET_EIMR_TS_TIMER(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_TS_TIMER_SHIFT)) & ENET_EIMR_TS_TIMER_MASK)
+#define ENET_EIMR_TS_AVAIL_MASK                  (0x10000U)
+#define ENET_EIMR_TS_AVAIL_SHIFT                 (16U)
+#define ENET_EIMR_TS_AVAIL(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_TS_AVAIL_SHIFT)) & ENET_EIMR_TS_AVAIL_MASK)
+#define ENET_EIMR_WAKEUP_MASK                    (0x20000U)
+#define ENET_EIMR_WAKEUP_SHIFT                   (17U)
+#define ENET_EIMR_WAKEUP(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_WAKEUP_SHIFT)) & ENET_EIMR_WAKEUP_MASK)
+#define ENET_EIMR_PLR_MASK                       (0x40000U)
+#define ENET_EIMR_PLR_SHIFT                      (18U)
+#define ENET_EIMR_PLR(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_PLR_SHIFT)) & ENET_EIMR_PLR_MASK)
+#define ENET_EIMR_UN_MASK                        (0x80000U)
+#define ENET_EIMR_UN_SHIFT                       (19U)
+#define ENET_EIMR_UN(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_UN_SHIFT)) & ENET_EIMR_UN_MASK)
+#define ENET_EIMR_RL_MASK                        (0x100000U)
+#define ENET_EIMR_RL_SHIFT                       (20U)
+#define ENET_EIMR_RL(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_RL_SHIFT)) & ENET_EIMR_RL_MASK)
+#define ENET_EIMR_LC_MASK                        (0x200000U)
+#define ENET_EIMR_LC_SHIFT                       (21U)
+#define ENET_EIMR_LC(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_LC_SHIFT)) & ENET_EIMR_LC_MASK)
+#define ENET_EIMR_EBERR_MASK                     (0x400000U)
+#define ENET_EIMR_EBERR_SHIFT                    (22U)
+#define ENET_EIMR_EBERR(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_EBERR_SHIFT)) & ENET_EIMR_EBERR_MASK)
+#define ENET_EIMR_MII_MASK                       (0x800000U)
+#define ENET_EIMR_MII_SHIFT                      (23U)
+#define ENET_EIMR_MII(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_MII_SHIFT)) & ENET_EIMR_MII_MASK)
+#define ENET_EIMR_RXB_MASK                       (0x1000000U)
+#define ENET_EIMR_RXB_SHIFT                      (24U)
+#define ENET_EIMR_RXB(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_RXB_SHIFT)) & ENET_EIMR_RXB_MASK)
+#define ENET_EIMR_RXF_MASK                       (0x2000000U)
+#define ENET_EIMR_RXF_SHIFT                      (25U)
+#define ENET_EIMR_RXF(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_RXF_SHIFT)) & ENET_EIMR_RXF_MASK)
+#define ENET_EIMR_TXB_MASK                       (0x4000000U)
+#define ENET_EIMR_TXB_SHIFT                      (26U)
+#define ENET_EIMR_TXB(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_TXB_SHIFT)) & ENET_EIMR_TXB_MASK)
+#define ENET_EIMR_TXF_MASK                       (0x8000000U)
+#define ENET_EIMR_TXF_SHIFT                      (27U)
+#define ENET_EIMR_TXF(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_TXF_SHIFT)) & ENET_EIMR_TXF_MASK)
+#define ENET_EIMR_GRA_MASK                       (0x10000000U)
+#define ENET_EIMR_GRA_SHIFT                      (28U)
+#define ENET_EIMR_GRA(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_GRA_SHIFT)) & ENET_EIMR_GRA_MASK)
+#define ENET_EIMR_BABT_MASK                      (0x20000000U)
+#define ENET_EIMR_BABT_SHIFT                     (29U)
+#define ENET_EIMR_BABT(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_BABT_SHIFT)) & ENET_EIMR_BABT_MASK)
+#define ENET_EIMR_BABR_MASK                      (0x40000000U)
+#define ENET_EIMR_BABR_SHIFT                     (30U)
+#define ENET_EIMR_BABR(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_EIMR_BABR_SHIFT)) & ENET_EIMR_BABR_MASK)
+
+/*! @name RDAR - Receive Descriptor Active Register */
+#define ENET_RDAR_RDAR_MASK                      (0x1000000U)
+#define ENET_RDAR_RDAR_SHIFT                     (24U)
+#define ENET_RDAR_RDAR(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_RDAR_RDAR_SHIFT)) & ENET_RDAR_RDAR_MASK)
+
+/*! @name TDAR - Transmit Descriptor Active Register */
+#define ENET_TDAR_TDAR_MASK                      (0x1000000U)
+#define ENET_TDAR_TDAR_SHIFT                     (24U)
+#define ENET_TDAR_TDAR(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_TDAR_TDAR_SHIFT)) & ENET_TDAR_TDAR_MASK)
+
+/*! @name ECR - Ethernet Control Register */
+#define ENET_ECR_RESET_MASK                      (0x1U)
+#define ENET_ECR_RESET_SHIFT                     (0U)
+#define ENET_ECR_RESET(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_ECR_RESET_SHIFT)) & ENET_ECR_RESET_MASK)
+#define ENET_ECR_ETHEREN_MASK                    (0x2U)
+#define ENET_ECR_ETHEREN_SHIFT                   (1U)
+#define ENET_ECR_ETHEREN(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_ECR_ETHEREN_SHIFT)) & ENET_ECR_ETHEREN_MASK)
+#define ENET_ECR_MAGICEN_MASK                    (0x4U)
+#define ENET_ECR_MAGICEN_SHIFT                   (2U)
+#define ENET_ECR_MAGICEN(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_ECR_MAGICEN_SHIFT)) & ENET_ECR_MAGICEN_MASK)
+#define ENET_ECR_SLEEP_MASK                      (0x8U)
+#define ENET_ECR_SLEEP_SHIFT                     (3U)
+#define ENET_ECR_SLEEP(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_ECR_SLEEP_SHIFT)) & ENET_ECR_SLEEP_MASK)
+#define ENET_ECR_EN1588_MASK                     (0x10U)
+#define ENET_ECR_EN1588_SHIFT                    (4U)
+#define ENET_ECR_EN1588(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_ECR_EN1588_SHIFT)) & ENET_ECR_EN1588_MASK)
+#define ENET_ECR_DBGEN_MASK                      (0x40U)
+#define ENET_ECR_DBGEN_SHIFT                     (6U)
+#define ENET_ECR_DBGEN(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_ECR_DBGEN_SHIFT)) & ENET_ECR_DBGEN_MASK)
+#define ENET_ECR_STOPEN_MASK                     (0x80U)
+#define ENET_ECR_STOPEN_SHIFT                    (7U)
+#define ENET_ECR_STOPEN(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_ECR_STOPEN_SHIFT)) & ENET_ECR_STOPEN_MASK)
+#define ENET_ECR_DBSWP_MASK                      (0x100U)
+#define ENET_ECR_DBSWP_SHIFT                     (8U)
+#define ENET_ECR_DBSWP(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_ECR_DBSWP_SHIFT)) & ENET_ECR_DBSWP_MASK)
+
+/*! @name MMFR - MII Management Frame Register */
+#define ENET_MMFR_DATA_MASK                      (0xFFFFU)
+#define ENET_MMFR_DATA_SHIFT                     (0U)
+#define ENET_MMFR_DATA(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_MMFR_DATA_SHIFT)) & ENET_MMFR_DATA_MASK)
+#define ENET_MMFR_TA_MASK                        (0x30000U)
+#define ENET_MMFR_TA_SHIFT                       (16U)
+#define ENET_MMFR_TA(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_MMFR_TA_SHIFT)) & ENET_MMFR_TA_MASK)
+#define ENET_MMFR_RA_MASK                        (0x7C0000U)
+#define ENET_MMFR_RA_SHIFT                       (18U)
+#define ENET_MMFR_RA(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_MMFR_RA_SHIFT)) & ENET_MMFR_RA_MASK)
+#define ENET_MMFR_PA_MASK                        (0xF800000U)
+#define ENET_MMFR_PA_SHIFT                       (23U)
+#define ENET_MMFR_PA(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_MMFR_PA_SHIFT)) & ENET_MMFR_PA_MASK)
+#define ENET_MMFR_OP_MASK                        (0x30000000U)
+#define ENET_MMFR_OP_SHIFT                       (28U)
+#define ENET_MMFR_OP(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_MMFR_OP_SHIFT)) & ENET_MMFR_OP_MASK)
+#define ENET_MMFR_ST_MASK                        (0xC0000000U)
+#define ENET_MMFR_ST_SHIFT                       (30U)
+#define ENET_MMFR_ST(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_MMFR_ST_SHIFT)) & ENET_MMFR_ST_MASK)
+
+/*! @name MSCR - MII Speed Control Register */
+#define ENET_MSCR_MII_SPEED_MASK                 (0x7EU)
+#define ENET_MSCR_MII_SPEED_SHIFT                (1U)
+#define ENET_MSCR_MII_SPEED(x)                   (((uint32_t)(((uint32_t)(x)) << ENET_MSCR_MII_SPEED_SHIFT)) & ENET_MSCR_MII_SPEED_MASK)
+#define ENET_MSCR_DIS_PRE_MASK                   (0x80U)
+#define ENET_MSCR_DIS_PRE_SHIFT                  (7U)
+#define ENET_MSCR_DIS_PRE(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_MSCR_DIS_PRE_SHIFT)) & ENET_MSCR_DIS_PRE_MASK)
+#define ENET_MSCR_HOLDTIME_MASK                  (0x700U)
+#define ENET_MSCR_HOLDTIME_SHIFT                 (8U)
+#define ENET_MSCR_HOLDTIME(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_MSCR_HOLDTIME_SHIFT)) & ENET_MSCR_HOLDTIME_MASK)
+
+/*! @name MIBC - MIB Control Register */
+#define ENET_MIBC_MIB_CLEAR_MASK                 (0x20000000U)
+#define ENET_MIBC_MIB_CLEAR_SHIFT                (29U)
+#define ENET_MIBC_MIB_CLEAR(x)                   (((uint32_t)(((uint32_t)(x)) << ENET_MIBC_MIB_CLEAR_SHIFT)) & ENET_MIBC_MIB_CLEAR_MASK)
+#define ENET_MIBC_MIB_IDLE_MASK                  (0x40000000U)
+#define ENET_MIBC_MIB_IDLE_SHIFT                 (30U)
+#define ENET_MIBC_MIB_IDLE(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_MIBC_MIB_IDLE_SHIFT)) & ENET_MIBC_MIB_IDLE_MASK)
+#define ENET_MIBC_MIB_DIS_MASK                   (0x80000000U)
+#define ENET_MIBC_MIB_DIS_SHIFT                  (31U)
+#define ENET_MIBC_MIB_DIS(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_MIBC_MIB_DIS_SHIFT)) & ENET_MIBC_MIB_DIS_MASK)
+
+/*! @name RCR - Receive Control Register */
+#define ENET_RCR_LOOP_MASK                       (0x1U)
+#define ENET_RCR_LOOP_SHIFT                      (0U)
+#define ENET_RCR_LOOP(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_RCR_LOOP_SHIFT)) & ENET_RCR_LOOP_MASK)
+#define ENET_RCR_DRT_MASK                        (0x2U)
+#define ENET_RCR_DRT_SHIFT                       (1U)
+#define ENET_RCR_DRT(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_RCR_DRT_SHIFT)) & ENET_RCR_DRT_MASK)
+#define ENET_RCR_MII_MODE_MASK                   (0x4U)
+#define ENET_RCR_MII_MODE_SHIFT                  (2U)
+#define ENET_RCR_MII_MODE(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_RCR_MII_MODE_SHIFT)) & ENET_RCR_MII_MODE_MASK)
+#define ENET_RCR_PROM_MASK                       (0x8U)
+#define ENET_RCR_PROM_SHIFT                      (3U)
+#define ENET_RCR_PROM(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_RCR_PROM_SHIFT)) & ENET_RCR_PROM_MASK)
+#define ENET_RCR_BC_REJ_MASK                     (0x10U)
+#define ENET_RCR_BC_REJ_SHIFT                    (4U)
+#define ENET_RCR_BC_REJ(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_RCR_BC_REJ_SHIFT)) & ENET_RCR_BC_REJ_MASK)
+#define ENET_RCR_FCE_MASK                        (0x20U)
+#define ENET_RCR_FCE_SHIFT                       (5U)
+#define ENET_RCR_FCE(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_RCR_FCE_SHIFT)) & ENET_RCR_FCE_MASK)
+#define ENET_RCR_RMII_MODE_MASK                  (0x100U)
+#define ENET_RCR_RMII_MODE_SHIFT                 (8U)
+#define ENET_RCR_RMII_MODE(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_RCR_RMII_MODE_SHIFT)) & ENET_RCR_RMII_MODE_MASK)
+#define ENET_RCR_RMII_10T_MASK                   (0x200U)
+#define ENET_RCR_RMII_10T_SHIFT                  (9U)
+#define ENET_RCR_RMII_10T(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_RCR_RMII_10T_SHIFT)) & ENET_RCR_RMII_10T_MASK)
+#define ENET_RCR_PADEN_MASK                      (0x1000U)
+#define ENET_RCR_PADEN_SHIFT                     (12U)
+#define ENET_RCR_PADEN(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_RCR_PADEN_SHIFT)) & ENET_RCR_PADEN_MASK)
+#define ENET_RCR_PAUFWD_MASK                     (0x2000U)
+#define ENET_RCR_PAUFWD_SHIFT                    (13U)
+#define ENET_RCR_PAUFWD(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_RCR_PAUFWD_SHIFT)) & ENET_RCR_PAUFWD_MASK)
+#define ENET_RCR_CRCFWD_MASK                     (0x4000U)
+#define ENET_RCR_CRCFWD_SHIFT                    (14U)
+#define ENET_RCR_CRCFWD(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_RCR_CRCFWD_SHIFT)) & ENET_RCR_CRCFWD_MASK)
+#define ENET_RCR_CFEN_MASK                       (0x8000U)
+#define ENET_RCR_CFEN_SHIFT                      (15U)
+#define ENET_RCR_CFEN(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_RCR_CFEN_SHIFT)) & ENET_RCR_CFEN_MASK)
+#define ENET_RCR_MAX_FL_MASK                     (0x3FFF0000U)
+#define ENET_RCR_MAX_FL_SHIFT                    (16U)
+#define ENET_RCR_MAX_FL(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_RCR_MAX_FL_SHIFT)) & ENET_RCR_MAX_FL_MASK)
+#define ENET_RCR_NLC_MASK                        (0x40000000U)
+#define ENET_RCR_NLC_SHIFT                       (30U)
+#define ENET_RCR_NLC(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_RCR_NLC_SHIFT)) & ENET_RCR_NLC_MASK)
+#define ENET_RCR_GRS_MASK                        (0x80000000U)
+#define ENET_RCR_GRS_SHIFT                       (31U)
+#define ENET_RCR_GRS(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_RCR_GRS_SHIFT)) & ENET_RCR_GRS_MASK)
+
+/*! @name TCR - Transmit Control Register */
+#define ENET_TCR_GTS_MASK                        (0x1U)
+#define ENET_TCR_GTS_SHIFT                       (0U)
+#define ENET_TCR_GTS(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_TCR_GTS_SHIFT)) & ENET_TCR_GTS_MASK)
+#define ENET_TCR_FDEN_MASK                       (0x4U)
+#define ENET_TCR_FDEN_SHIFT                      (2U)
+#define ENET_TCR_FDEN(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TCR_FDEN_SHIFT)) & ENET_TCR_FDEN_MASK)
+#define ENET_TCR_TFC_PAUSE_MASK                  (0x8U)
+#define ENET_TCR_TFC_PAUSE_SHIFT                 (3U)
+#define ENET_TCR_TFC_PAUSE(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_TCR_TFC_PAUSE_SHIFT)) & ENET_TCR_TFC_PAUSE_MASK)
+#define ENET_TCR_RFC_PAUSE_MASK                  (0x10U)
+#define ENET_TCR_RFC_PAUSE_SHIFT                 (4U)
+#define ENET_TCR_RFC_PAUSE(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_TCR_RFC_PAUSE_SHIFT)) & ENET_TCR_RFC_PAUSE_MASK)
+#define ENET_TCR_ADDSEL_MASK                     (0xE0U)
+#define ENET_TCR_ADDSEL_SHIFT                    (5U)
+#define ENET_TCR_ADDSEL(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_TCR_ADDSEL_SHIFT)) & ENET_TCR_ADDSEL_MASK)
+#define ENET_TCR_ADDINS_MASK                     (0x100U)
+#define ENET_TCR_ADDINS_SHIFT                    (8U)
+#define ENET_TCR_ADDINS(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_TCR_ADDINS_SHIFT)) & ENET_TCR_ADDINS_MASK)
+#define ENET_TCR_CRCFWD_MASK                     (0x200U)
+#define ENET_TCR_CRCFWD_SHIFT                    (9U)
+#define ENET_TCR_CRCFWD(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_TCR_CRCFWD_SHIFT)) & ENET_TCR_CRCFWD_MASK)
+
+/*! @name PALR - Physical Address Lower Register */
+#define ENET_PALR_PADDR1_MASK                    (0xFFFFFFFFU)
+#define ENET_PALR_PADDR1_SHIFT                   (0U)
+#define ENET_PALR_PADDR1(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_PALR_PADDR1_SHIFT)) & ENET_PALR_PADDR1_MASK)
+
+/*! @name PAUR - Physical Address Upper Register */
+#define ENET_PAUR_TYPE_MASK                      (0xFFFFU)
+#define ENET_PAUR_TYPE_SHIFT                     (0U)
+#define ENET_PAUR_TYPE(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_PAUR_TYPE_SHIFT)) & ENET_PAUR_TYPE_MASK)
+#define ENET_PAUR_PADDR2_MASK                    (0xFFFF0000U)
+#define ENET_PAUR_PADDR2_SHIFT                   (16U)
+#define ENET_PAUR_PADDR2(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_PAUR_PADDR2_SHIFT)) & ENET_PAUR_PADDR2_MASK)
+
+/*! @name OPD - Opcode/Pause Duration Register */
+#define ENET_OPD_PAUSE_DUR_MASK                  (0xFFFFU)
+#define ENET_OPD_PAUSE_DUR_SHIFT                 (0U)
+#define ENET_OPD_PAUSE_DUR(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_OPD_PAUSE_DUR_SHIFT)) & ENET_OPD_PAUSE_DUR_MASK)
+#define ENET_OPD_OPCODE_MASK                     (0xFFFF0000U)
+#define ENET_OPD_OPCODE_SHIFT                    (16U)
+#define ENET_OPD_OPCODE(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_OPD_OPCODE_SHIFT)) & ENET_OPD_OPCODE_MASK)
+
+/*! @name IAUR - Descriptor Individual Upper Address Register */
+#define ENET_IAUR_IADDR1_MASK                    (0xFFFFFFFFU)
+#define ENET_IAUR_IADDR1_SHIFT                   (0U)
+#define ENET_IAUR_IADDR1(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_IAUR_IADDR1_SHIFT)) & ENET_IAUR_IADDR1_MASK)
+
+/*! @name IALR - Descriptor Individual Lower Address Register */
+#define ENET_IALR_IADDR2_MASK                    (0xFFFFFFFFU)
+#define ENET_IALR_IADDR2_SHIFT                   (0U)
+#define ENET_IALR_IADDR2(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_IALR_IADDR2_SHIFT)) & ENET_IALR_IADDR2_MASK)
+
+/*! @name GAUR - Descriptor Group Upper Address Register */
+#define ENET_GAUR_GADDR1_MASK                    (0xFFFFFFFFU)
+#define ENET_GAUR_GADDR1_SHIFT                   (0U)
+#define ENET_GAUR_GADDR1(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_GAUR_GADDR1_SHIFT)) & ENET_GAUR_GADDR1_MASK)
+
+/*! @name GALR - Descriptor Group Lower Address Register */
+#define ENET_GALR_GADDR2_MASK                    (0xFFFFFFFFU)
+#define ENET_GALR_GADDR2_SHIFT                   (0U)
+#define ENET_GALR_GADDR2(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_GALR_GADDR2_SHIFT)) & ENET_GALR_GADDR2_MASK)
+
+/*! @name TFWR - Transmit FIFO Watermark Register */
+#define ENET_TFWR_TFWR_MASK                      (0x3FU)
+#define ENET_TFWR_TFWR_SHIFT                     (0U)
+#define ENET_TFWR_TFWR(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_TFWR_TFWR_SHIFT)) & ENET_TFWR_TFWR_MASK)
+#define ENET_TFWR_STRFWD_MASK                    (0x100U)
+#define ENET_TFWR_STRFWD_SHIFT                   (8U)
+#define ENET_TFWR_STRFWD(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_TFWR_STRFWD_SHIFT)) & ENET_TFWR_STRFWD_MASK)
+
+/*! @name RDSR - Receive Descriptor Ring Start Register */
+#define ENET_RDSR_R_DES_START_MASK               (0xFFFFFFF8U)
+#define ENET_RDSR_R_DES_START_SHIFT              (3U)
+#define ENET_RDSR_R_DES_START(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_RDSR_R_DES_START_SHIFT)) & ENET_RDSR_R_DES_START_MASK)
+
+/*! @name TDSR - Transmit Buffer Descriptor Ring Start Register */
+#define ENET_TDSR_X_DES_START_MASK               (0xFFFFFFF8U)
+#define ENET_TDSR_X_DES_START_SHIFT              (3U)
+#define ENET_TDSR_X_DES_START(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_TDSR_X_DES_START_SHIFT)) & ENET_TDSR_X_DES_START_MASK)
+
+/*! @name MRBR - Maximum Receive Buffer Size Register */
+#define ENET_MRBR_R_BUF_SIZE_MASK                (0x3FF0U)
+#define ENET_MRBR_R_BUF_SIZE_SHIFT               (4U)
+#define ENET_MRBR_R_BUF_SIZE(x)                  (((uint32_t)(((uint32_t)(x)) << ENET_MRBR_R_BUF_SIZE_SHIFT)) & ENET_MRBR_R_BUF_SIZE_MASK)
+
+/*! @name RSFL - Receive FIFO Section Full Threshold */
+#define ENET_RSFL_RX_SECTION_FULL_MASK           (0xFFU)
+#define ENET_RSFL_RX_SECTION_FULL_SHIFT          (0U)
+#define ENET_RSFL_RX_SECTION_FULL(x)             (((uint32_t)(((uint32_t)(x)) << ENET_RSFL_RX_SECTION_FULL_SHIFT)) & ENET_RSFL_RX_SECTION_FULL_MASK)
+
+/*! @name RSEM - Receive FIFO Section Empty Threshold */
+#define ENET_RSEM_RX_SECTION_EMPTY_MASK          (0xFFU)
+#define ENET_RSEM_RX_SECTION_EMPTY_SHIFT         (0U)
+#define ENET_RSEM_RX_SECTION_EMPTY(x)            (((uint32_t)(((uint32_t)(x)) << ENET_RSEM_RX_SECTION_EMPTY_SHIFT)) & ENET_RSEM_RX_SECTION_EMPTY_MASK)
+#define ENET_RSEM_STAT_SECTION_EMPTY_MASK        (0x1F0000U)
+#define ENET_RSEM_STAT_SECTION_EMPTY_SHIFT       (16U)
+#define ENET_RSEM_STAT_SECTION_EMPTY(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RSEM_STAT_SECTION_EMPTY_SHIFT)) & ENET_RSEM_STAT_SECTION_EMPTY_MASK)
+
+/*! @name RAEM - Receive FIFO Almost Empty Threshold */
+#define ENET_RAEM_RX_ALMOST_EMPTY_MASK           (0xFFU)
+#define ENET_RAEM_RX_ALMOST_EMPTY_SHIFT          (0U)
+#define ENET_RAEM_RX_ALMOST_EMPTY(x)             (((uint32_t)(((uint32_t)(x)) << ENET_RAEM_RX_ALMOST_EMPTY_SHIFT)) & ENET_RAEM_RX_ALMOST_EMPTY_MASK)
+
+/*! @name RAFL - Receive FIFO Almost Full Threshold */
+#define ENET_RAFL_RX_ALMOST_FULL_MASK            (0xFFU)
+#define ENET_RAFL_RX_ALMOST_FULL_SHIFT           (0U)
+#define ENET_RAFL_RX_ALMOST_FULL(x)              (((uint32_t)(((uint32_t)(x)) << ENET_RAFL_RX_ALMOST_FULL_SHIFT)) & ENET_RAFL_RX_ALMOST_FULL_MASK)
+
+/*! @name TSEM - Transmit FIFO Section Empty Threshold */
+#define ENET_TSEM_TX_SECTION_EMPTY_MASK          (0xFFU)
+#define ENET_TSEM_TX_SECTION_EMPTY_SHIFT         (0U)
+#define ENET_TSEM_TX_SECTION_EMPTY(x)            (((uint32_t)(((uint32_t)(x)) << ENET_TSEM_TX_SECTION_EMPTY_SHIFT)) & ENET_TSEM_TX_SECTION_EMPTY_MASK)
+
+/*! @name TAEM - Transmit FIFO Almost Empty Threshold */
+#define ENET_TAEM_TX_ALMOST_EMPTY_MASK           (0xFFU)
+#define ENET_TAEM_TX_ALMOST_EMPTY_SHIFT          (0U)
+#define ENET_TAEM_TX_ALMOST_EMPTY(x)             (((uint32_t)(((uint32_t)(x)) << ENET_TAEM_TX_ALMOST_EMPTY_SHIFT)) & ENET_TAEM_TX_ALMOST_EMPTY_MASK)
+
+/*! @name TAFL - Transmit FIFO Almost Full Threshold */
+#define ENET_TAFL_TX_ALMOST_FULL_MASK            (0xFFU)
+#define ENET_TAFL_TX_ALMOST_FULL_SHIFT           (0U)
+#define ENET_TAFL_TX_ALMOST_FULL(x)              (((uint32_t)(((uint32_t)(x)) << ENET_TAFL_TX_ALMOST_FULL_SHIFT)) & ENET_TAFL_TX_ALMOST_FULL_MASK)
+
+/*! @name TIPG - Transmit Inter-Packet Gap */
+#define ENET_TIPG_IPG_MASK                       (0x1FU)
+#define ENET_TIPG_IPG_SHIFT                      (0U)
+#define ENET_TIPG_IPG(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TIPG_IPG_SHIFT)) & ENET_TIPG_IPG_MASK)
+
+/*! @name FTRL - Frame Truncation Length */
+#define ENET_FTRL_TRUNC_FL_MASK                  (0x3FFFU)
+#define ENET_FTRL_TRUNC_FL_SHIFT                 (0U)
+#define ENET_FTRL_TRUNC_FL(x)                    (((uint32_t)(((uint32_t)(x)) << ENET_FTRL_TRUNC_FL_SHIFT)) & ENET_FTRL_TRUNC_FL_MASK)
+
+/*! @name TACC - Transmit Accelerator Function Configuration */
+#define ENET_TACC_SHIFT16_MASK                   (0x1U)
+#define ENET_TACC_SHIFT16_SHIFT                  (0U)
+#define ENET_TACC_SHIFT16(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_TACC_SHIFT16_SHIFT)) & ENET_TACC_SHIFT16_MASK)
+#define ENET_TACC_IPCHK_MASK                     (0x8U)
+#define ENET_TACC_IPCHK_SHIFT                    (3U)
+#define ENET_TACC_IPCHK(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_TACC_IPCHK_SHIFT)) & ENET_TACC_IPCHK_MASK)
+#define ENET_TACC_PROCHK_MASK                    (0x10U)
+#define ENET_TACC_PROCHK_SHIFT                   (4U)
+#define ENET_TACC_PROCHK(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_TACC_PROCHK_SHIFT)) & ENET_TACC_PROCHK_MASK)
+
+/*! @name RACC - Receive Accelerator Function Configuration */
+#define ENET_RACC_PADREM_MASK                    (0x1U)
+#define ENET_RACC_PADREM_SHIFT                   (0U)
+#define ENET_RACC_PADREM(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_RACC_PADREM_SHIFT)) & ENET_RACC_PADREM_MASK)
+#define ENET_RACC_IPDIS_MASK                     (0x2U)
+#define ENET_RACC_IPDIS_SHIFT                    (1U)
+#define ENET_RACC_IPDIS(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_RACC_IPDIS_SHIFT)) & ENET_RACC_IPDIS_MASK)
+#define ENET_RACC_PRODIS_MASK                    (0x4U)
+#define ENET_RACC_PRODIS_SHIFT                   (2U)
+#define ENET_RACC_PRODIS(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_RACC_PRODIS_SHIFT)) & ENET_RACC_PRODIS_MASK)
+#define ENET_RACC_LINEDIS_MASK                   (0x40U)
+#define ENET_RACC_LINEDIS_SHIFT                  (6U)
+#define ENET_RACC_LINEDIS(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_RACC_LINEDIS_SHIFT)) & ENET_RACC_LINEDIS_MASK)
+#define ENET_RACC_SHIFT16_MASK                   (0x80U)
+#define ENET_RACC_SHIFT16_SHIFT                  (7U)
+#define ENET_RACC_SHIFT16(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_RACC_SHIFT16_SHIFT)) & ENET_RACC_SHIFT16_MASK)
+
+/*! @name RMON_T_PACKETS - Tx Packet Count Statistic Register */
+#define ENET_RMON_T_PACKETS_TXPKTS_MASK          (0xFFFFU)
+#define ENET_RMON_T_PACKETS_TXPKTS_SHIFT         (0U)
+#define ENET_RMON_T_PACKETS_TXPKTS(x)            (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_PACKETS_TXPKTS_SHIFT)) & ENET_RMON_T_PACKETS_TXPKTS_MASK)
+
+/*! @name RMON_T_BC_PKT - Tx Broadcast Packets Statistic Register */
+#define ENET_RMON_T_BC_PKT_TXPKTS_MASK           (0xFFFFU)
+#define ENET_RMON_T_BC_PKT_TXPKTS_SHIFT          (0U)
+#define ENET_RMON_T_BC_PKT_TXPKTS(x)             (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_BC_PKT_TXPKTS_SHIFT)) & ENET_RMON_T_BC_PKT_TXPKTS_MASK)
+
+/*! @name RMON_T_MC_PKT - Tx Multicast Packets Statistic Register */
+#define ENET_RMON_T_MC_PKT_TXPKTS_MASK           (0xFFFFU)
+#define ENET_RMON_T_MC_PKT_TXPKTS_SHIFT          (0U)
+#define ENET_RMON_T_MC_PKT_TXPKTS(x)             (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_MC_PKT_TXPKTS_SHIFT)) & ENET_RMON_T_MC_PKT_TXPKTS_MASK)
+
+/*! @name RMON_T_CRC_ALIGN - Tx Packets with CRC/Align Error Statistic Register */
+#define ENET_RMON_T_CRC_ALIGN_TXPKTS_MASK        (0xFFFFU)
+#define ENET_RMON_T_CRC_ALIGN_TXPKTS_SHIFT       (0U)
+#define ENET_RMON_T_CRC_ALIGN_TXPKTS(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_CRC_ALIGN_TXPKTS_SHIFT)) & ENET_RMON_T_CRC_ALIGN_TXPKTS_MASK)
+
+/*! @name RMON_T_UNDERSIZE - Tx Packets Less Than Bytes and Good CRC Statistic Register */
+#define ENET_RMON_T_UNDERSIZE_TXPKTS_MASK        (0xFFFFU)
+#define ENET_RMON_T_UNDERSIZE_TXPKTS_SHIFT       (0U)
+#define ENET_RMON_T_UNDERSIZE_TXPKTS(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_UNDERSIZE_TXPKTS_SHIFT)) & ENET_RMON_T_UNDERSIZE_TXPKTS_MASK)
+
+/*! @name RMON_T_OVERSIZE - Tx Packets GT MAX_FL bytes and Good CRC Statistic Register */
+#define ENET_RMON_T_OVERSIZE_TXPKTS_MASK         (0xFFFFU)
+#define ENET_RMON_T_OVERSIZE_TXPKTS_SHIFT        (0U)
+#define ENET_RMON_T_OVERSIZE_TXPKTS(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_OVERSIZE_TXPKTS_SHIFT)) & ENET_RMON_T_OVERSIZE_TXPKTS_MASK)
+
+/*! @name RMON_T_FRAG - Tx Packets Less Than 64 Bytes and Bad CRC Statistic Register */
+#define ENET_RMON_T_FRAG_TXPKTS_MASK             (0xFFFFU)
+#define ENET_RMON_T_FRAG_TXPKTS_SHIFT            (0U)
+#define ENET_RMON_T_FRAG_TXPKTS(x)               (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_FRAG_TXPKTS_SHIFT)) & ENET_RMON_T_FRAG_TXPKTS_MASK)
+
+/*! @name RMON_T_JAB - Tx Packets Greater Than MAX_FL bytes and Bad CRC Statistic Register */
+#define ENET_RMON_T_JAB_TXPKTS_MASK              (0xFFFFU)
+#define ENET_RMON_T_JAB_TXPKTS_SHIFT             (0U)
+#define ENET_RMON_T_JAB_TXPKTS(x)                (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_JAB_TXPKTS_SHIFT)) & ENET_RMON_T_JAB_TXPKTS_MASK)
+
+/*! @name RMON_T_COL - Tx Collision Count Statistic Register */
+#define ENET_RMON_T_COL_TXPKTS_MASK              (0xFFFFU)
+#define ENET_RMON_T_COL_TXPKTS_SHIFT             (0U)
+#define ENET_RMON_T_COL_TXPKTS(x)                (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_COL_TXPKTS_SHIFT)) & ENET_RMON_T_COL_TXPKTS_MASK)
+
+/*! @name RMON_T_P64 - Tx 64-Byte Packets Statistic Register */
+#define ENET_RMON_T_P64_TXPKTS_MASK              (0xFFFFU)
+#define ENET_RMON_T_P64_TXPKTS_SHIFT             (0U)
+#define ENET_RMON_T_P64_TXPKTS(x)                (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P64_TXPKTS_SHIFT)) & ENET_RMON_T_P64_TXPKTS_MASK)
+
+/*! @name RMON_T_P65TO127 - Tx 65- to 127-byte Packets Statistic Register */
+#define ENET_RMON_T_P65TO127_TXPKTS_MASK         (0xFFFFU)
+#define ENET_RMON_T_P65TO127_TXPKTS_SHIFT        (0U)
+#define ENET_RMON_T_P65TO127_TXPKTS(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P65TO127_TXPKTS_SHIFT)) & ENET_RMON_T_P65TO127_TXPKTS_MASK)
+
+/*! @name RMON_T_P128TO255 - Tx 128- to 255-byte Packets Statistic Register */
+#define ENET_RMON_T_P128TO255_TXPKTS_MASK        (0xFFFFU)
+#define ENET_RMON_T_P128TO255_TXPKTS_SHIFT       (0U)
+#define ENET_RMON_T_P128TO255_TXPKTS(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P128TO255_TXPKTS_SHIFT)) & ENET_RMON_T_P128TO255_TXPKTS_MASK)
+
+/*! @name RMON_T_P256TO511 - Tx 256- to 511-byte Packets Statistic Register */
+#define ENET_RMON_T_P256TO511_TXPKTS_MASK        (0xFFFFU)
+#define ENET_RMON_T_P256TO511_TXPKTS_SHIFT       (0U)
+#define ENET_RMON_T_P256TO511_TXPKTS(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P256TO511_TXPKTS_SHIFT)) & ENET_RMON_T_P256TO511_TXPKTS_MASK)
+
+/*! @name RMON_T_P512TO1023 - Tx 512- to 1023-byte Packets Statistic Register */
+#define ENET_RMON_T_P512TO1023_TXPKTS_MASK       (0xFFFFU)
+#define ENET_RMON_T_P512TO1023_TXPKTS_SHIFT      (0U)
+#define ENET_RMON_T_P512TO1023_TXPKTS(x)         (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P512TO1023_TXPKTS_SHIFT)) & ENET_RMON_T_P512TO1023_TXPKTS_MASK)
+
+/*! @name RMON_T_P1024TO2047 - Tx 1024- to 2047-byte Packets Statistic Register */
+#define ENET_RMON_T_P1024TO2047_TXPKTS_MASK      (0xFFFFU)
+#define ENET_RMON_T_P1024TO2047_TXPKTS_SHIFT     (0U)
+#define ENET_RMON_T_P1024TO2047_TXPKTS(x)        (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P1024TO2047_TXPKTS_SHIFT)) & ENET_RMON_T_P1024TO2047_TXPKTS_MASK)
+
+/*! @name RMON_T_P_GTE2048 - Tx Packets Greater Than 2048 Bytes Statistic Register */
+#define ENET_RMON_T_P_GTE2048_TXPKTS_MASK        (0xFFFFU)
+#define ENET_RMON_T_P_GTE2048_TXPKTS_SHIFT       (0U)
+#define ENET_RMON_T_P_GTE2048_TXPKTS(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_P_GTE2048_TXPKTS_SHIFT)) & ENET_RMON_T_P_GTE2048_TXPKTS_MASK)
+
+/*! @name RMON_T_OCTETS - Tx Octets Statistic Register */
+#define ENET_RMON_T_OCTETS_TXOCTS_MASK           (0xFFFFFFFFU)
+#define ENET_RMON_T_OCTETS_TXOCTS_SHIFT          (0U)
+#define ENET_RMON_T_OCTETS_TXOCTS(x)             (((uint32_t)(((uint32_t)(x)) << ENET_RMON_T_OCTETS_TXOCTS_SHIFT)) & ENET_RMON_T_OCTETS_TXOCTS_MASK)
+
+/*! @name IEEE_T_FRAME_OK - Frames Transmitted OK Statistic Register */
+#define ENET_IEEE_T_FRAME_OK_COUNT_MASK          (0xFFFFU)
+#define ENET_IEEE_T_FRAME_OK_COUNT_SHIFT         (0U)
+#define ENET_IEEE_T_FRAME_OK_COUNT(x)            (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_FRAME_OK_COUNT_SHIFT)) & ENET_IEEE_T_FRAME_OK_COUNT_MASK)
+
+/*! @name IEEE_T_1COL - Frames Transmitted with Single Collision Statistic Register */
+#define ENET_IEEE_T_1COL_COUNT_MASK              (0xFFFFU)
+#define ENET_IEEE_T_1COL_COUNT_SHIFT             (0U)
+#define ENET_IEEE_T_1COL_COUNT(x)                (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_1COL_COUNT_SHIFT)) & ENET_IEEE_T_1COL_COUNT_MASK)
+
+/*! @name IEEE_T_MCOL - Frames Transmitted with Multiple Collisions Statistic Register */
+#define ENET_IEEE_T_MCOL_COUNT_MASK              (0xFFFFU)
+#define ENET_IEEE_T_MCOL_COUNT_SHIFT             (0U)
+#define ENET_IEEE_T_MCOL_COUNT(x)                (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_MCOL_COUNT_SHIFT)) & ENET_IEEE_T_MCOL_COUNT_MASK)
+
+/*! @name IEEE_T_DEF - Frames Transmitted after Deferral Delay Statistic Register */
+#define ENET_IEEE_T_DEF_COUNT_MASK               (0xFFFFU)
+#define ENET_IEEE_T_DEF_COUNT_SHIFT              (0U)
+#define ENET_IEEE_T_DEF_COUNT(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_DEF_COUNT_SHIFT)) & ENET_IEEE_T_DEF_COUNT_MASK)
+
+/*! @name IEEE_T_LCOL - Frames Transmitted with Late Collision Statistic Register */
+#define ENET_IEEE_T_LCOL_COUNT_MASK              (0xFFFFU)
+#define ENET_IEEE_T_LCOL_COUNT_SHIFT             (0U)
+#define ENET_IEEE_T_LCOL_COUNT(x)                (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_LCOL_COUNT_SHIFT)) & ENET_IEEE_T_LCOL_COUNT_MASK)
+
+/*! @name IEEE_T_EXCOL - Frames Transmitted with Excessive Collisions Statistic Register */
+#define ENET_IEEE_T_EXCOL_COUNT_MASK             (0xFFFFU)
+#define ENET_IEEE_T_EXCOL_COUNT_SHIFT            (0U)
+#define ENET_IEEE_T_EXCOL_COUNT(x)               (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_EXCOL_COUNT_SHIFT)) & ENET_IEEE_T_EXCOL_COUNT_MASK)
+
+/*! @name IEEE_T_MACERR - Frames Transmitted with Tx FIFO Underrun Statistic Register */
+#define ENET_IEEE_T_MACERR_COUNT_MASK            (0xFFFFU)
+#define ENET_IEEE_T_MACERR_COUNT_SHIFT           (0U)
+#define ENET_IEEE_T_MACERR_COUNT(x)              (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_MACERR_COUNT_SHIFT)) & ENET_IEEE_T_MACERR_COUNT_MASK)
+
+/*! @name IEEE_T_CSERR - Frames Transmitted with Carrier Sense Error Statistic Register */
+#define ENET_IEEE_T_CSERR_COUNT_MASK             (0xFFFFU)
+#define ENET_IEEE_T_CSERR_COUNT_SHIFT            (0U)
+#define ENET_IEEE_T_CSERR_COUNT(x)               (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_CSERR_COUNT_SHIFT)) & ENET_IEEE_T_CSERR_COUNT_MASK)
+
+/*! @name IEEE_T_FDXFC - Flow Control Pause Frames Transmitted Statistic Register */
+#define ENET_IEEE_T_FDXFC_COUNT_MASK             (0xFFFFU)
+#define ENET_IEEE_T_FDXFC_COUNT_SHIFT            (0U)
+#define ENET_IEEE_T_FDXFC_COUNT(x)               (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_FDXFC_COUNT_SHIFT)) & ENET_IEEE_T_FDXFC_COUNT_MASK)
+
+/*! @name IEEE_T_OCTETS_OK - Octet Count for Frames Transmitted w/o Error Statistic Register */
+#define ENET_IEEE_T_OCTETS_OK_COUNT_MASK         (0xFFFFFFFFU)
+#define ENET_IEEE_T_OCTETS_OK_COUNT_SHIFT        (0U)
+#define ENET_IEEE_T_OCTETS_OK_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_T_OCTETS_OK_COUNT_SHIFT)) & ENET_IEEE_T_OCTETS_OK_COUNT_MASK)
+
+/*! @name RMON_R_PACKETS - Rx Packet Count Statistic Register */
+#define ENET_RMON_R_PACKETS_COUNT_MASK           (0xFFFFU)
+#define ENET_RMON_R_PACKETS_COUNT_SHIFT          (0U)
+#define ENET_RMON_R_PACKETS_COUNT(x)             (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_PACKETS_COUNT_SHIFT)) & ENET_RMON_R_PACKETS_COUNT_MASK)
+
+/*! @name RMON_R_BC_PKT - Rx Broadcast Packets Statistic Register */
+#define ENET_RMON_R_BC_PKT_COUNT_MASK            (0xFFFFU)
+#define ENET_RMON_R_BC_PKT_COUNT_SHIFT           (0U)
+#define ENET_RMON_R_BC_PKT_COUNT(x)              (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_BC_PKT_COUNT_SHIFT)) & ENET_RMON_R_BC_PKT_COUNT_MASK)
+
+/*! @name RMON_R_MC_PKT - Rx Multicast Packets Statistic Register */
+#define ENET_RMON_R_MC_PKT_COUNT_MASK            (0xFFFFU)
+#define ENET_RMON_R_MC_PKT_COUNT_SHIFT           (0U)
+#define ENET_RMON_R_MC_PKT_COUNT(x)              (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_MC_PKT_COUNT_SHIFT)) & ENET_RMON_R_MC_PKT_COUNT_MASK)
+
+/*! @name RMON_R_CRC_ALIGN - Rx Packets with CRC/Align Error Statistic Register */
+#define ENET_RMON_R_CRC_ALIGN_COUNT_MASK         (0xFFFFU)
+#define ENET_RMON_R_CRC_ALIGN_COUNT_SHIFT        (0U)
+#define ENET_RMON_R_CRC_ALIGN_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_CRC_ALIGN_COUNT_SHIFT)) & ENET_RMON_R_CRC_ALIGN_COUNT_MASK)
+
+/*! @name RMON_R_UNDERSIZE - Rx Packets with Less Than 64 Bytes and Good CRC Statistic Register */
+#define ENET_RMON_R_UNDERSIZE_COUNT_MASK         (0xFFFFU)
+#define ENET_RMON_R_UNDERSIZE_COUNT_SHIFT        (0U)
+#define ENET_RMON_R_UNDERSIZE_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_UNDERSIZE_COUNT_SHIFT)) & ENET_RMON_R_UNDERSIZE_COUNT_MASK)
+
+/*! @name RMON_R_OVERSIZE - Rx Packets Greater Than MAX_FL and Good CRC Statistic Register */
+#define ENET_RMON_R_OVERSIZE_COUNT_MASK          (0xFFFFU)
+#define ENET_RMON_R_OVERSIZE_COUNT_SHIFT         (0U)
+#define ENET_RMON_R_OVERSIZE_COUNT(x)            (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_OVERSIZE_COUNT_SHIFT)) & ENET_RMON_R_OVERSIZE_COUNT_MASK)
+
+/*! @name RMON_R_FRAG - Rx Packets Less Than 64 Bytes and Bad CRC Statistic Register */
+#define ENET_RMON_R_FRAG_COUNT_MASK              (0xFFFFU)
+#define ENET_RMON_R_FRAG_COUNT_SHIFT             (0U)
+#define ENET_RMON_R_FRAG_COUNT(x)                (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_FRAG_COUNT_SHIFT)) & ENET_RMON_R_FRAG_COUNT_MASK)
+
+/*! @name RMON_R_JAB - Rx Packets Greater Than MAX_FL Bytes and Bad CRC Statistic Register */
+#define ENET_RMON_R_JAB_COUNT_MASK               (0xFFFFU)
+#define ENET_RMON_R_JAB_COUNT_SHIFT              (0U)
+#define ENET_RMON_R_JAB_COUNT(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_JAB_COUNT_SHIFT)) & ENET_RMON_R_JAB_COUNT_MASK)
+
+/*! @name RMON_R_P64 - Rx 64-Byte Packets Statistic Register */
+#define ENET_RMON_R_P64_COUNT_MASK               (0xFFFFU)
+#define ENET_RMON_R_P64_COUNT_SHIFT              (0U)
+#define ENET_RMON_R_P64_COUNT(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P64_COUNT_SHIFT)) & ENET_RMON_R_P64_COUNT_MASK)
+
+/*! @name RMON_R_P65TO127 - Rx 65- to 127-Byte Packets Statistic Register */
+#define ENET_RMON_R_P65TO127_COUNT_MASK          (0xFFFFU)
+#define ENET_RMON_R_P65TO127_COUNT_SHIFT         (0U)
+#define ENET_RMON_R_P65TO127_COUNT(x)            (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P65TO127_COUNT_SHIFT)) & ENET_RMON_R_P65TO127_COUNT_MASK)
+
+/*! @name RMON_R_P128TO255 - Rx 128- to 255-Byte Packets Statistic Register */
+#define ENET_RMON_R_P128TO255_COUNT_MASK         (0xFFFFU)
+#define ENET_RMON_R_P128TO255_COUNT_SHIFT        (0U)
+#define ENET_RMON_R_P128TO255_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P128TO255_COUNT_SHIFT)) & ENET_RMON_R_P128TO255_COUNT_MASK)
+
+/*! @name RMON_R_P256TO511 - Rx 256- to 511-Byte Packets Statistic Register */
+#define ENET_RMON_R_P256TO511_COUNT_MASK         (0xFFFFU)
+#define ENET_RMON_R_P256TO511_COUNT_SHIFT        (0U)
+#define ENET_RMON_R_P256TO511_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P256TO511_COUNT_SHIFT)) & ENET_RMON_R_P256TO511_COUNT_MASK)
+
+/*! @name RMON_R_P512TO1023 - Rx 512- to 1023-Byte Packets Statistic Register */
+#define ENET_RMON_R_P512TO1023_COUNT_MASK        (0xFFFFU)
+#define ENET_RMON_R_P512TO1023_COUNT_SHIFT       (0U)
+#define ENET_RMON_R_P512TO1023_COUNT(x)          (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P512TO1023_COUNT_SHIFT)) & ENET_RMON_R_P512TO1023_COUNT_MASK)
+
+/*! @name RMON_R_P1024TO2047 - Rx 1024- to 2047-Byte Packets Statistic Register */
+#define ENET_RMON_R_P1024TO2047_COUNT_MASK       (0xFFFFU)
+#define ENET_RMON_R_P1024TO2047_COUNT_SHIFT      (0U)
+#define ENET_RMON_R_P1024TO2047_COUNT(x)         (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P1024TO2047_COUNT_SHIFT)) & ENET_RMON_R_P1024TO2047_COUNT_MASK)
+
+/*! @name RMON_R_P_GTE2048 - Rx Packets Greater than 2048 Bytes Statistic Register */
+#define ENET_RMON_R_P_GTE2048_COUNT_MASK         (0xFFFFU)
+#define ENET_RMON_R_P_GTE2048_COUNT_SHIFT        (0U)
+#define ENET_RMON_R_P_GTE2048_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_P_GTE2048_COUNT_SHIFT)) & ENET_RMON_R_P_GTE2048_COUNT_MASK)
+
+/*! @name RMON_R_OCTETS - Rx Octets Statistic Register */
+#define ENET_RMON_R_OCTETS_COUNT_MASK            (0xFFFFFFFFU)
+#define ENET_RMON_R_OCTETS_COUNT_SHIFT           (0U)
+#define ENET_RMON_R_OCTETS_COUNT(x)              (((uint32_t)(((uint32_t)(x)) << ENET_RMON_R_OCTETS_COUNT_SHIFT)) & ENET_RMON_R_OCTETS_COUNT_MASK)
+
+/*! @name IEEE_R_DROP - Frames not Counted Correctly Statistic Register */
+#define ENET_IEEE_R_DROP_COUNT_MASK              (0xFFFFU)
+#define ENET_IEEE_R_DROP_COUNT_SHIFT             (0U)
+#define ENET_IEEE_R_DROP_COUNT(x)                (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_DROP_COUNT_SHIFT)) & ENET_IEEE_R_DROP_COUNT_MASK)
+
+/*! @name IEEE_R_FRAME_OK - Frames Received OK Statistic Register */
+#define ENET_IEEE_R_FRAME_OK_COUNT_MASK          (0xFFFFU)
+#define ENET_IEEE_R_FRAME_OK_COUNT_SHIFT         (0U)
+#define ENET_IEEE_R_FRAME_OK_COUNT(x)            (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_FRAME_OK_COUNT_SHIFT)) & ENET_IEEE_R_FRAME_OK_COUNT_MASK)
+
+/*! @name IEEE_R_CRC - Frames Received with CRC Error Statistic Register */
+#define ENET_IEEE_R_CRC_COUNT_MASK               (0xFFFFU)
+#define ENET_IEEE_R_CRC_COUNT_SHIFT              (0U)
+#define ENET_IEEE_R_CRC_COUNT(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_CRC_COUNT_SHIFT)) & ENET_IEEE_R_CRC_COUNT_MASK)
+
+/*! @name IEEE_R_ALIGN - Frames Received with Alignment Error Statistic Register */
+#define ENET_IEEE_R_ALIGN_COUNT_MASK             (0xFFFFU)
+#define ENET_IEEE_R_ALIGN_COUNT_SHIFT            (0U)
+#define ENET_IEEE_R_ALIGN_COUNT(x)               (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_ALIGN_COUNT_SHIFT)) & ENET_IEEE_R_ALIGN_COUNT_MASK)
+
+/*! @name IEEE_R_MACERR - Receive FIFO Overflow Count Statistic Register */
+#define ENET_IEEE_R_MACERR_COUNT_MASK            (0xFFFFU)
+#define ENET_IEEE_R_MACERR_COUNT_SHIFT           (0U)
+#define ENET_IEEE_R_MACERR_COUNT(x)              (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_MACERR_COUNT_SHIFT)) & ENET_IEEE_R_MACERR_COUNT_MASK)
+
+/*! @name IEEE_R_FDXFC - Flow Control Pause Frames Received Statistic Register */
+#define ENET_IEEE_R_FDXFC_COUNT_MASK             (0xFFFFU)
+#define ENET_IEEE_R_FDXFC_COUNT_SHIFT            (0U)
+#define ENET_IEEE_R_FDXFC_COUNT(x)               (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_FDXFC_COUNT_SHIFT)) & ENET_IEEE_R_FDXFC_COUNT_MASK)
+
+/*! @name IEEE_R_OCTETS_OK - Octet Count for Frames Received without Error Statistic Register */
+#define ENET_IEEE_R_OCTETS_OK_COUNT_MASK         (0xFFFFFFFFU)
+#define ENET_IEEE_R_OCTETS_OK_COUNT_SHIFT        (0U)
+#define ENET_IEEE_R_OCTETS_OK_COUNT(x)           (((uint32_t)(((uint32_t)(x)) << ENET_IEEE_R_OCTETS_OK_COUNT_SHIFT)) & ENET_IEEE_R_OCTETS_OK_COUNT_MASK)
+
+/*! @name ATCR - Adjustable Timer Control Register */
+#define ENET_ATCR_EN_MASK                        (0x1U)
+#define ENET_ATCR_EN_SHIFT                       (0U)
+#define ENET_ATCR_EN(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_EN_SHIFT)) & ENET_ATCR_EN_MASK)
+#define ENET_ATCR_OFFEN_MASK                     (0x4U)
+#define ENET_ATCR_OFFEN_SHIFT                    (2U)
+#define ENET_ATCR_OFFEN(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_OFFEN_SHIFT)) & ENET_ATCR_OFFEN_MASK)
+#define ENET_ATCR_OFFRST_MASK                    (0x8U)
+#define ENET_ATCR_OFFRST_SHIFT                   (3U)
+#define ENET_ATCR_OFFRST(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_OFFRST_SHIFT)) & ENET_ATCR_OFFRST_MASK)
+#define ENET_ATCR_PEREN_MASK                     (0x10U)
+#define ENET_ATCR_PEREN_SHIFT                    (4U)
+#define ENET_ATCR_PEREN(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_PEREN_SHIFT)) & ENET_ATCR_PEREN_MASK)
+#define ENET_ATCR_PINPER_MASK                    (0x80U)
+#define ENET_ATCR_PINPER_SHIFT                   (7U)
+#define ENET_ATCR_PINPER(x)                      (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_PINPER_SHIFT)) & ENET_ATCR_PINPER_MASK)
+#define ENET_ATCR_RESTART_MASK                   (0x200U)
+#define ENET_ATCR_RESTART_SHIFT                  (9U)
+#define ENET_ATCR_RESTART(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_RESTART_SHIFT)) & ENET_ATCR_RESTART_MASK)
+#define ENET_ATCR_CAPTURE_MASK                   (0x800U)
+#define ENET_ATCR_CAPTURE_SHIFT                  (11U)
+#define ENET_ATCR_CAPTURE(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_CAPTURE_SHIFT)) & ENET_ATCR_CAPTURE_MASK)
+#define ENET_ATCR_SLAVE_MASK                     (0x2000U)
+#define ENET_ATCR_SLAVE_SHIFT                    (13U)
+#define ENET_ATCR_SLAVE(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_ATCR_SLAVE_SHIFT)) & ENET_ATCR_SLAVE_MASK)
+
+/*! @name ATVR - Timer Value Register */
+#define ENET_ATVR_ATIME_MASK                     (0xFFFFFFFFU)
+#define ENET_ATVR_ATIME_SHIFT                    (0U)
+#define ENET_ATVR_ATIME(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_ATVR_ATIME_SHIFT)) & ENET_ATVR_ATIME_MASK)
+
+/*! @name ATOFF - Timer Offset Register */
+#define ENET_ATOFF_OFFSET_MASK                   (0xFFFFFFFFU)
+#define ENET_ATOFF_OFFSET_SHIFT                  (0U)
+#define ENET_ATOFF_OFFSET(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_ATOFF_OFFSET_SHIFT)) & ENET_ATOFF_OFFSET_MASK)
+
+/*! @name ATPER - Timer Period Register */
+#define ENET_ATPER_PERIOD_MASK                   (0xFFFFFFFFU)
+#define ENET_ATPER_PERIOD_SHIFT                  (0U)
+#define ENET_ATPER_PERIOD(x)                     (((uint32_t)(((uint32_t)(x)) << ENET_ATPER_PERIOD_SHIFT)) & ENET_ATPER_PERIOD_MASK)
+
+/*! @name ATCOR - Timer Correction Register */
+#define ENET_ATCOR_COR_MASK                      (0x7FFFFFFFU)
+#define ENET_ATCOR_COR_SHIFT                     (0U)
+#define ENET_ATCOR_COR(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_ATCOR_COR_SHIFT)) & ENET_ATCOR_COR_MASK)
+
+/*! @name ATINC - Time-Stamping Clock Period Register */
+#define ENET_ATINC_INC_MASK                      (0x7FU)
+#define ENET_ATINC_INC_SHIFT                     (0U)
+#define ENET_ATINC_INC(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_ATINC_INC_SHIFT)) & ENET_ATINC_INC_MASK)
+#define ENET_ATINC_INC_CORR_MASK                 (0x7F00U)
+#define ENET_ATINC_INC_CORR_SHIFT                (8U)
+#define ENET_ATINC_INC_CORR(x)                   (((uint32_t)(((uint32_t)(x)) << ENET_ATINC_INC_CORR_SHIFT)) & ENET_ATINC_INC_CORR_MASK)
+
+/*! @name ATSTMP - Timestamp of Last Transmitted Frame */
+#define ENET_ATSTMP_TIMESTAMP_MASK               (0xFFFFFFFFU)
+#define ENET_ATSTMP_TIMESTAMP_SHIFT              (0U)
+#define ENET_ATSTMP_TIMESTAMP(x)                 (((uint32_t)(((uint32_t)(x)) << ENET_ATSTMP_TIMESTAMP_SHIFT)) & ENET_ATSTMP_TIMESTAMP_MASK)
+
+/*! @name TGSR - Timer Global Status Register */
+#define ENET_TGSR_TF0_MASK                       (0x1U)
+#define ENET_TGSR_TF0_SHIFT                      (0U)
+#define ENET_TGSR_TF0(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TGSR_TF0_SHIFT)) & ENET_TGSR_TF0_MASK)
+#define ENET_TGSR_TF1_MASK                       (0x2U)
+#define ENET_TGSR_TF1_SHIFT                      (1U)
+#define ENET_TGSR_TF1(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TGSR_TF1_SHIFT)) & ENET_TGSR_TF1_MASK)
+#define ENET_TGSR_TF2_MASK                       (0x4U)
+#define ENET_TGSR_TF2_SHIFT                      (2U)
+#define ENET_TGSR_TF2(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TGSR_TF2_SHIFT)) & ENET_TGSR_TF2_MASK)
+#define ENET_TGSR_TF3_MASK                       (0x8U)
+#define ENET_TGSR_TF3_SHIFT                      (3U)
+#define ENET_TGSR_TF3(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TGSR_TF3_SHIFT)) & ENET_TGSR_TF3_MASK)
+
+/*! @name TCSR - Timer Control Status Register */
+#define ENET_TCSR_TDRE_MASK                      (0x1U)
+#define ENET_TCSR_TDRE_SHIFT                     (0U)
+#define ENET_TCSR_TDRE(x)                        (((uint32_t)(((uint32_t)(x)) << ENET_TCSR_TDRE_SHIFT)) & ENET_TCSR_TDRE_MASK)
+#define ENET_TCSR_TMODE_MASK                     (0x3CU)
+#define ENET_TCSR_TMODE_SHIFT                    (2U)
+#define ENET_TCSR_TMODE(x)                       (((uint32_t)(((uint32_t)(x)) << ENET_TCSR_TMODE_SHIFT)) & ENET_TCSR_TMODE_MASK)
+#define ENET_TCSR_TIE_MASK                       (0x40U)
+#define ENET_TCSR_TIE_SHIFT                      (6U)
+#define ENET_TCSR_TIE(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TCSR_TIE_SHIFT)) & ENET_TCSR_TIE_MASK)
+#define ENET_TCSR_TF_MASK                        (0x80U)
+#define ENET_TCSR_TF_SHIFT                       (7U)
+#define ENET_TCSR_TF(x)                          (((uint32_t)(((uint32_t)(x)) << ENET_TCSR_TF_SHIFT)) & ENET_TCSR_TF_MASK)
+
+/* The count of ENET_TCSR */
+#define ENET_TCSR_COUNT                          (4U)
+
+/*! @name TCCR - Timer Compare Capture Register */
+#define ENET_TCCR_TCC_MASK                       (0xFFFFFFFFU)
+#define ENET_TCCR_TCC_SHIFT                      (0U)
+#define ENET_TCCR_TCC(x)                         (((uint32_t)(((uint32_t)(x)) << ENET_TCCR_TCC_SHIFT)) & ENET_TCCR_TCC_MASK)
+
+/* The count of ENET_TCCR */
+#define ENET_TCCR_COUNT                          (4U)
+
+
+/*!
+ * @}
+ */ /* end of group ENET_Register_Masks */
+
+
+/* ENET - Peripheral instance base addresses */
+/** Peripheral ENET base address */
+#define ENET_BASE                                (0x400C0000u)
+/** Peripheral ENET base pointer */
+#define ENET                                     ((ENET_Type *)ENET_BASE)
+/** Array initializer of ENET peripheral base addresses */
+#define ENET_BASE_ADDRS                          { ENET_BASE }
+/** Array initializer of ENET peripheral base pointers */
+#define ENET_BASE_PTRS                           { ENET }
+/** Interrupt vectors for the ENET peripheral type */
+#define ENET_Transmit_IRQS                       { ENET_Transmit_IRQn }
+#define ENET_Receive_IRQS                        { ENET_Receive_IRQn }
+#define ENET_Error_IRQS                          { ENET_Error_IRQn }
+#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn }
+
+/*!
+ * @}
+ */ /* end of group ENET_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- EWM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EWM_Peripheral_Access_Layer EWM Peripheral Access Layer
+ * @{
+ */
+
+/** EWM - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CTRL;                               /**< Control Register, offset: 0x0 */
+  __O  uint8_t SERV;                               /**< Service Register, offset: 0x1 */
+  __IO uint8_t CMPL;                               /**< Compare Low Register, offset: 0x2 */
+  __IO uint8_t CMPH;                               /**< Compare High Register, offset: 0x3 */
+} EWM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- EWM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EWM_Register_Masks EWM Register Masks
+ * @{
+ */
+
+/*! @name CTRL - Control Register */
+#define EWM_CTRL_EWMEN_MASK                      (0x1U)
+#define EWM_CTRL_EWMEN_SHIFT                     (0U)
+#define EWM_CTRL_EWMEN(x)                        (((uint8_t)(((uint8_t)(x)) << EWM_CTRL_EWMEN_SHIFT)) & EWM_CTRL_EWMEN_MASK)
+#define EWM_CTRL_ASSIN_MASK                      (0x2U)
+#define EWM_CTRL_ASSIN_SHIFT                     (1U)
+#define EWM_CTRL_ASSIN(x)                        (((uint8_t)(((uint8_t)(x)) << EWM_CTRL_ASSIN_SHIFT)) & EWM_CTRL_ASSIN_MASK)
+#define EWM_CTRL_INEN_MASK                       (0x4U)
+#define EWM_CTRL_INEN_SHIFT                      (2U)
+#define EWM_CTRL_INEN(x)                         (((uint8_t)(((uint8_t)(x)) << EWM_CTRL_INEN_SHIFT)) & EWM_CTRL_INEN_MASK)
+#define EWM_CTRL_INTEN_MASK                      (0x8U)
+#define EWM_CTRL_INTEN_SHIFT                     (3U)
+#define EWM_CTRL_INTEN(x)                        (((uint8_t)(((uint8_t)(x)) << EWM_CTRL_INTEN_SHIFT)) & EWM_CTRL_INTEN_MASK)
+
+/*! @name SERV - Service Register */
+#define EWM_SERV_SERVICE_MASK                    (0xFFU)
+#define EWM_SERV_SERVICE_SHIFT                   (0U)
+#define EWM_SERV_SERVICE(x)                      (((uint8_t)(((uint8_t)(x)) << EWM_SERV_SERVICE_SHIFT)) & EWM_SERV_SERVICE_MASK)
+
+/*! @name CMPL - Compare Low Register */
+#define EWM_CMPL_COMPAREL_MASK                   (0xFFU)
+#define EWM_CMPL_COMPAREL_SHIFT                  (0U)
+#define EWM_CMPL_COMPAREL(x)                     (((uint8_t)(((uint8_t)(x)) << EWM_CMPL_COMPAREL_SHIFT)) & EWM_CMPL_COMPAREL_MASK)
+
+/*! @name CMPH - Compare High Register */
+#define EWM_CMPH_COMPAREH_MASK                   (0xFFU)
+#define EWM_CMPH_COMPAREH_SHIFT                  (0U)
+#define EWM_CMPH_COMPAREH(x)                     (((uint8_t)(((uint8_t)(x)) << EWM_CMPH_COMPAREH_SHIFT)) & EWM_CMPH_COMPAREH_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group EWM_Register_Masks */
+
+
+/* EWM - Peripheral instance base addresses */
+/** Peripheral EWM base address */
+#define EWM_BASE                                 (0x40061000u)
+/** Peripheral EWM base pointer */
+#define EWM                                      ((EWM_Type *)EWM_BASE)
+/** Array initializer of EWM peripheral base addresses */
+#define EWM_BASE_ADDRS                           { EWM_BASE }
+/** Array initializer of EWM peripheral base pointers */
+#define EWM_BASE_PTRS                            { EWM }
+/** Interrupt vectors for the EWM peripheral type */
+#define EWM_IRQS                                 { WDOG_EWM_IRQn }
+
+/*!
+ * @}
+ */ /* end of group EWM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FB_Peripheral_Access_Layer FB Peripheral Access Layer
+ * @{
+ */
+
+/** FB - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0xC */
+    __IO uint32_t CSAR;                              /**< Chip Select Address Register, array offset: 0x0, array step: 0xC */
+    __IO uint32_t CSMR;                              /**< Chip Select Mask Register, array offset: 0x4, array step: 0xC */
+    __IO uint32_t CSCR;                              /**< Chip Select Control Register, array offset: 0x8, array step: 0xC */
+  } CS[6];
+       uint8_t RESERVED_0[24];
+  __IO uint32_t CSPMCR;                            /**< Chip Select port Multiplexing Control Register, offset: 0x60 */
+} FB_Type;
+
+/* ----------------------------------------------------------------------------
+   -- FB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FB_Register_Masks FB Register Masks
+ * @{
+ */
+
+/*! @name CSAR - Chip Select Address Register */
+#define FB_CSAR_BA_MASK                          (0xFFFF0000U)
+#define FB_CSAR_BA_SHIFT                         (16U)
+#define FB_CSAR_BA(x)                            (((uint32_t)(((uint32_t)(x)) << FB_CSAR_BA_SHIFT)) & FB_CSAR_BA_MASK)
+
+/* The count of FB_CSAR */
+#define FB_CSAR_COUNT                            (6U)
+
+/*! @name CSMR - Chip Select Mask Register */
+#define FB_CSMR_V_MASK                           (0x1U)
+#define FB_CSMR_V_SHIFT                          (0U)
+#define FB_CSMR_V(x)                             (((uint32_t)(((uint32_t)(x)) << FB_CSMR_V_SHIFT)) & FB_CSMR_V_MASK)
+#define FB_CSMR_WP_MASK                          (0x100U)
+#define FB_CSMR_WP_SHIFT                         (8U)
+#define FB_CSMR_WP(x)                            (((uint32_t)(((uint32_t)(x)) << FB_CSMR_WP_SHIFT)) & FB_CSMR_WP_MASK)
+#define FB_CSMR_BAM_MASK                         (0xFFFF0000U)
+#define FB_CSMR_BAM_SHIFT                        (16U)
+#define FB_CSMR_BAM(x)                           (((uint32_t)(((uint32_t)(x)) << FB_CSMR_BAM_SHIFT)) & FB_CSMR_BAM_MASK)
+
+/* The count of FB_CSMR */
+#define FB_CSMR_COUNT                            (6U)
+
+/*! @name CSCR - Chip Select Control Register */
+#define FB_CSCR_BSTW_MASK                        (0x8U)
+#define FB_CSCR_BSTW_SHIFT                       (3U)
+#define FB_CSCR_BSTW(x)                          (((uint32_t)(((uint32_t)(x)) << FB_CSCR_BSTW_SHIFT)) & FB_CSCR_BSTW_MASK)
+#define FB_CSCR_BSTR_MASK                        (0x10U)
+#define FB_CSCR_BSTR_SHIFT                       (4U)
+#define FB_CSCR_BSTR(x)                          (((uint32_t)(((uint32_t)(x)) << FB_CSCR_BSTR_SHIFT)) & FB_CSCR_BSTR_MASK)
+#define FB_CSCR_BEM_MASK                         (0x20U)
+#define FB_CSCR_BEM_SHIFT                        (5U)
+#define FB_CSCR_BEM(x)                           (((uint32_t)(((uint32_t)(x)) << FB_CSCR_BEM_SHIFT)) & FB_CSCR_BEM_MASK)
+#define FB_CSCR_PS_MASK                          (0xC0U)
+#define FB_CSCR_PS_SHIFT                         (6U)
+#define FB_CSCR_PS(x)                            (((uint32_t)(((uint32_t)(x)) << FB_CSCR_PS_SHIFT)) & FB_CSCR_PS_MASK)
+#define FB_CSCR_AA_MASK                          (0x100U)
+#define FB_CSCR_AA_SHIFT                         (8U)
+#define FB_CSCR_AA(x)                            (((uint32_t)(((uint32_t)(x)) << FB_CSCR_AA_SHIFT)) & FB_CSCR_AA_MASK)
+#define FB_CSCR_BLS_MASK                         (0x200U)
+#define FB_CSCR_BLS_SHIFT                        (9U)
+#define FB_CSCR_BLS(x)                           (((uint32_t)(((uint32_t)(x)) << FB_CSCR_BLS_SHIFT)) & FB_CSCR_BLS_MASK)
+#define FB_CSCR_WS_MASK                          (0xFC00U)
+#define FB_CSCR_WS_SHIFT                         (10U)
+#define FB_CSCR_WS(x)                            (((uint32_t)(((uint32_t)(x)) << FB_CSCR_WS_SHIFT)) & FB_CSCR_WS_MASK)
+#define FB_CSCR_WRAH_MASK                        (0x30000U)
+#define FB_CSCR_WRAH_SHIFT                       (16U)
+#define FB_CSCR_WRAH(x)                          (((uint32_t)(((uint32_t)(x)) << FB_CSCR_WRAH_SHIFT)) & FB_CSCR_WRAH_MASK)
+#define FB_CSCR_RDAH_MASK                        (0xC0000U)
+#define FB_CSCR_RDAH_SHIFT                       (18U)
+#define FB_CSCR_RDAH(x)                          (((uint32_t)(((uint32_t)(x)) << FB_CSCR_RDAH_SHIFT)) & FB_CSCR_RDAH_MASK)
+#define FB_CSCR_ASET_MASK                        (0x300000U)
+#define FB_CSCR_ASET_SHIFT                       (20U)
+#define FB_CSCR_ASET(x)                          (((uint32_t)(((uint32_t)(x)) << FB_CSCR_ASET_SHIFT)) & FB_CSCR_ASET_MASK)
+#define FB_CSCR_EXTS_MASK                        (0x400000U)
+#define FB_CSCR_EXTS_SHIFT                       (22U)
+#define FB_CSCR_EXTS(x)                          (((uint32_t)(((uint32_t)(x)) << FB_CSCR_EXTS_SHIFT)) & FB_CSCR_EXTS_MASK)
+#define FB_CSCR_SWSEN_MASK                       (0x800000U)
+#define FB_CSCR_SWSEN_SHIFT                      (23U)
+#define FB_CSCR_SWSEN(x)                         (((uint32_t)(((uint32_t)(x)) << FB_CSCR_SWSEN_SHIFT)) & FB_CSCR_SWSEN_MASK)
+#define FB_CSCR_SWS_MASK                         (0xFC000000U)
+#define FB_CSCR_SWS_SHIFT                        (26U)
+#define FB_CSCR_SWS(x)                           (((uint32_t)(((uint32_t)(x)) << FB_CSCR_SWS_SHIFT)) & FB_CSCR_SWS_MASK)
+
+/* The count of FB_CSCR */
+#define FB_CSCR_COUNT                            (6U)
+
+/*! @name CSPMCR - Chip Select port Multiplexing Control Register */
+#define FB_CSPMCR_GROUP5_MASK                    (0xF000U)
+#define FB_CSPMCR_GROUP5_SHIFT                   (12U)
+#define FB_CSPMCR_GROUP5(x)                      (((uint32_t)(((uint32_t)(x)) << FB_CSPMCR_GROUP5_SHIFT)) & FB_CSPMCR_GROUP5_MASK)
+#define FB_CSPMCR_GROUP4_MASK                    (0xF0000U)
+#define FB_CSPMCR_GROUP4_SHIFT                   (16U)
+#define FB_CSPMCR_GROUP4(x)                      (((uint32_t)(((uint32_t)(x)) << FB_CSPMCR_GROUP4_SHIFT)) & FB_CSPMCR_GROUP4_MASK)
+#define FB_CSPMCR_GROUP3_MASK                    (0xF00000U)
+#define FB_CSPMCR_GROUP3_SHIFT                   (20U)
+#define FB_CSPMCR_GROUP3(x)                      (((uint32_t)(((uint32_t)(x)) << FB_CSPMCR_GROUP3_SHIFT)) & FB_CSPMCR_GROUP3_MASK)
+#define FB_CSPMCR_GROUP2_MASK                    (0xF000000U)
+#define FB_CSPMCR_GROUP2_SHIFT                   (24U)
+#define FB_CSPMCR_GROUP2(x)                      (((uint32_t)(((uint32_t)(x)) << FB_CSPMCR_GROUP2_SHIFT)) & FB_CSPMCR_GROUP2_MASK)
+#define FB_CSPMCR_GROUP1_MASK                    (0xF0000000U)
+#define FB_CSPMCR_GROUP1_SHIFT                   (28U)
+#define FB_CSPMCR_GROUP1(x)                      (((uint32_t)(((uint32_t)(x)) << FB_CSPMCR_GROUP1_SHIFT)) & FB_CSPMCR_GROUP1_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group FB_Register_Masks */
+
+
+/* FB - Peripheral instance base addresses */
+/** Peripheral FB base address */
+#define FB_BASE                                  (0x4000C000u)
+/** Peripheral FB base pointer */
+#define FB                                       ((FB_Type *)FB_BASE)
+/** Array initializer of FB peripheral base addresses */
+#define FB_BASE_ADDRS                            { FB_BASE }
+/** Array initializer of FB peripheral base pointers */
+#define FB_BASE_PTRS                             { FB }
+
+/*!
+ * @}
+ */ /* end of group FB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FMC_Peripheral_Access_Layer FMC Peripheral Access Layer
+ * @{
+ */
+
+/** FMC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PFAPR;                             /**< Flash Access Protection Register, offset: 0x0 */
+  __IO uint32_t PFB0CR;                            /**< Flash Bank 0 Control Register, offset: 0x4 */
+  __IO uint32_t PFB1CR;                            /**< Flash Bank 1 Control Register, offset: 0x8 */
+       uint8_t RESERVED_0[244];
+  __IO uint32_t TAGVDW0S[4];                       /**< Cache Tag Storage, array offset: 0x100, array step: 0x4 */
+  __IO uint32_t TAGVDW1S[4];                       /**< Cache Tag Storage, array offset: 0x110, array step: 0x4 */
+  __IO uint32_t TAGVDW2S[4];                       /**< Cache Tag Storage, array offset: 0x120, array step: 0x4 */
+  __IO uint32_t TAGVDW3S[4];                       /**< Cache Tag Storage, array offset: 0x130, array step: 0x4 */
+       uint8_t RESERVED_1[192];
+  struct {                                         /* offset: 0x200, array step: index*0x20, index2*0x8 */
+    __IO uint32_t DATA_U;                            /**< Cache Data Storage (upper word), array offset: 0x200, array step: index*0x20, index2*0x8 */
+    __IO uint32_t DATA_L;                            /**< Cache Data Storage (lower word), array offset: 0x204, array step: index*0x20, index2*0x8 */
+  } SET[4][4];
+} FMC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- FMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FMC_Register_Masks FMC Register Masks
+ * @{
+ */
+
+/*! @name PFAPR - Flash Access Protection Register */
+#define FMC_PFAPR_M0AP_MASK                      (0x3U)
+#define FMC_PFAPR_M0AP_SHIFT                     (0U)
+#define FMC_PFAPR_M0AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M0AP_SHIFT)) & FMC_PFAPR_M0AP_MASK)
+#define FMC_PFAPR_M1AP_MASK                      (0xCU)
+#define FMC_PFAPR_M1AP_SHIFT                     (2U)
+#define FMC_PFAPR_M1AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M1AP_SHIFT)) & FMC_PFAPR_M1AP_MASK)
+#define FMC_PFAPR_M2AP_MASK                      (0x30U)
+#define FMC_PFAPR_M2AP_SHIFT                     (4U)
+#define FMC_PFAPR_M2AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M2AP_SHIFT)) & FMC_PFAPR_M2AP_MASK)
+#define FMC_PFAPR_M3AP_MASK                      (0xC0U)
+#define FMC_PFAPR_M3AP_SHIFT                     (6U)
+#define FMC_PFAPR_M3AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M3AP_SHIFT)) & FMC_PFAPR_M3AP_MASK)
+#define FMC_PFAPR_M4AP_MASK                      (0x300U)
+#define FMC_PFAPR_M4AP_SHIFT                     (8U)
+#define FMC_PFAPR_M4AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M4AP_SHIFT)) & FMC_PFAPR_M4AP_MASK)
+#define FMC_PFAPR_M5AP_MASK                      (0xC00U)
+#define FMC_PFAPR_M5AP_SHIFT                     (10U)
+#define FMC_PFAPR_M5AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M5AP_SHIFT)) & FMC_PFAPR_M5AP_MASK)
+#define FMC_PFAPR_M6AP_MASK                      (0x3000U)
+#define FMC_PFAPR_M6AP_SHIFT                     (12U)
+#define FMC_PFAPR_M6AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M6AP_SHIFT)) & FMC_PFAPR_M6AP_MASK)
+#define FMC_PFAPR_M7AP_MASK                      (0xC000U)
+#define FMC_PFAPR_M7AP_SHIFT                     (14U)
+#define FMC_PFAPR_M7AP(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M7AP_SHIFT)) & FMC_PFAPR_M7AP_MASK)
+#define FMC_PFAPR_M0PFD_MASK                     (0x10000U)
+#define FMC_PFAPR_M0PFD_SHIFT                    (16U)
+#define FMC_PFAPR_M0PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M0PFD_SHIFT)) & FMC_PFAPR_M0PFD_MASK)
+#define FMC_PFAPR_M1PFD_MASK                     (0x20000U)
+#define FMC_PFAPR_M1PFD_SHIFT                    (17U)
+#define FMC_PFAPR_M1PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M1PFD_SHIFT)) & FMC_PFAPR_M1PFD_MASK)
+#define FMC_PFAPR_M2PFD_MASK                     (0x40000U)
+#define FMC_PFAPR_M2PFD_SHIFT                    (18U)
+#define FMC_PFAPR_M2PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M2PFD_SHIFT)) & FMC_PFAPR_M2PFD_MASK)
+#define FMC_PFAPR_M3PFD_MASK                     (0x80000U)
+#define FMC_PFAPR_M3PFD_SHIFT                    (19U)
+#define FMC_PFAPR_M3PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M3PFD_SHIFT)) & FMC_PFAPR_M3PFD_MASK)
+#define FMC_PFAPR_M4PFD_MASK                     (0x100000U)
+#define FMC_PFAPR_M4PFD_SHIFT                    (20U)
+#define FMC_PFAPR_M4PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M4PFD_SHIFT)) & FMC_PFAPR_M4PFD_MASK)
+#define FMC_PFAPR_M5PFD_MASK                     (0x200000U)
+#define FMC_PFAPR_M5PFD_SHIFT                    (21U)
+#define FMC_PFAPR_M5PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M5PFD_SHIFT)) & FMC_PFAPR_M5PFD_MASK)
+#define FMC_PFAPR_M6PFD_MASK                     (0x400000U)
+#define FMC_PFAPR_M6PFD_SHIFT                    (22U)
+#define FMC_PFAPR_M6PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M6PFD_SHIFT)) & FMC_PFAPR_M6PFD_MASK)
+#define FMC_PFAPR_M7PFD_MASK                     (0x800000U)
+#define FMC_PFAPR_M7PFD_SHIFT                    (23U)
+#define FMC_PFAPR_M7PFD(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFAPR_M7PFD_SHIFT)) & FMC_PFAPR_M7PFD_MASK)
+
+/*! @name PFB0CR - Flash Bank 0 Control Register */
+#define FMC_PFB0CR_B0SEBE_MASK                   (0x1U)
+#define FMC_PFB0CR_B0SEBE_SHIFT                  (0U)
+#define FMC_PFB0CR_B0SEBE(x)                     (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0SEBE_SHIFT)) & FMC_PFB0CR_B0SEBE_MASK)
+#define FMC_PFB0CR_B0IPE_MASK                    (0x2U)
+#define FMC_PFB0CR_B0IPE_SHIFT                   (1U)
+#define FMC_PFB0CR_B0IPE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0IPE_SHIFT)) & FMC_PFB0CR_B0IPE_MASK)
+#define FMC_PFB0CR_B0DPE_MASK                    (0x4U)
+#define FMC_PFB0CR_B0DPE_SHIFT                   (2U)
+#define FMC_PFB0CR_B0DPE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0DPE_SHIFT)) & FMC_PFB0CR_B0DPE_MASK)
+#define FMC_PFB0CR_B0ICE_MASK                    (0x8U)
+#define FMC_PFB0CR_B0ICE_SHIFT                   (3U)
+#define FMC_PFB0CR_B0ICE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0ICE_SHIFT)) & FMC_PFB0CR_B0ICE_MASK)
+#define FMC_PFB0CR_B0DCE_MASK                    (0x10U)
+#define FMC_PFB0CR_B0DCE_SHIFT                   (4U)
+#define FMC_PFB0CR_B0DCE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0DCE_SHIFT)) & FMC_PFB0CR_B0DCE_MASK)
+#define FMC_PFB0CR_CRC_MASK                      (0xE0U)
+#define FMC_PFB0CR_CRC_SHIFT                     (5U)
+#define FMC_PFB0CR_CRC(x)                        (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_CRC_SHIFT)) & FMC_PFB0CR_CRC_MASK)
+#define FMC_PFB0CR_B0MW_MASK                     (0x60000U)
+#define FMC_PFB0CR_B0MW_SHIFT                    (17U)
+#define FMC_PFB0CR_B0MW(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0MW_SHIFT)) & FMC_PFB0CR_B0MW_MASK)
+#define FMC_PFB0CR_S_B_INV_MASK                  (0x80000U)
+#define FMC_PFB0CR_S_B_INV_SHIFT                 (19U)
+#define FMC_PFB0CR_S_B_INV(x)                    (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_S_B_INV_SHIFT)) & FMC_PFB0CR_S_B_INV_MASK)
+#define FMC_PFB0CR_CINV_WAY_MASK                 (0xF00000U)
+#define FMC_PFB0CR_CINV_WAY_SHIFT                (20U)
+#define FMC_PFB0CR_CINV_WAY(x)                   (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_CINV_WAY_SHIFT)) & FMC_PFB0CR_CINV_WAY_MASK)
+#define FMC_PFB0CR_CLCK_WAY_MASK                 (0xF000000U)
+#define FMC_PFB0CR_CLCK_WAY_SHIFT                (24U)
+#define FMC_PFB0CR_CLCK_WAY(x)                   (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_CLCK_WAY_SHIFT)) & FMC_PFB0CR_CLCK_WAY_MASK)
+#define FMC_PFB0CR_B0RWSC_MASK                   (0xF0000000U)
+#define FMC_PFB0CR_B0RWSC_SHIFT                  (28U)
+#define FMC_PFB0CR_B0RWSC(x)                     (((uint32_t)(((uint32_t)(x)) << FMC_PFB0CR_B0RWSC_SHIFT)) & FMC_PFB0CR_B0RWSC_MASK)
+
+/*! @name PFB1CR - Flash Bank 1 Control Register */
+#define FMC_PFB1CR_B1SEBE_MASK                   (0x1U)
+#define FMC_PFB1CR_B1SEBE_SHIFT                  (0U)
+#define FMC_PFB1CR_B1SEBE(x)                     (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1SEBE_SHIFT)) & FMC_PFB1CR_B1SEBE_MASK)
+#define FMC_PFB1CR_B1IPE_MASK                    (0x2U)
+#define FMC_PFB1CR_B1IPE_SHIFT                   (1U)
+#define FMC_PFB1CR_B1IPE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1IPE_SHIFT)) & FMC_PFB1CR_B1IPE_MASK)
+#define FMC_PFB1CR_B1DPE_MASK                    (0x4U)
+#define FMC_PFB1CR_B1DPE_SHIFT                   (2U)
+#define FMC_PFB1CR_B1DPE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1DPE_SHIFT)) & FMC_PFB1CR_B1DPE_MASK)
+#define FMC_PFB1CR_B1ICE_MASK                    (0x8U)
+#define FMC_PFB1CR_B1ICE_SHIFT                   (3U)
+#define FMC_PFB1CR_B1ICE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1ICE_SHIFT)) & FMC_PFB1CR_B1ICE_MASK)
+#define FMC_PFB1CR_B1DCE_MASK                    (0x10U)
+#define FMC_PFB1CR_B1DCE_SHIFT                   (4U)
+#define FMC_PFB1CR_B1DCE(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1DCE_SHIFT)) & FMC_PFB1CR_B1DCE_MASK)
+#define FMC_PFB1CR_B1MW_MASK                     (0x60000U)
+#define FMC_PFB1CR_B1MW_SHIFT                    (17U)
+#define FMC_PFB1CR_B1MW(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1MW_SHIFT)) & FMC_PFB1CR_B1MW_MASK)
+#define FMC_PFB1CR_B1RWSC_MASK                   (0xF0000000U)
+#define FMC_PFB1CR_B1RWSC_SHIFT                  (28U)
+#define FMC_PFB1CR_B1RWSC(x)                     (((uint32_t)(((uint32_t)(x)) << FMC_PFB1CR_B1RWSC_SHIFT)) & FMC_PFB1CR_B1RWSC_MASK)
+
+/*! @name TAGVDW0S - Cache Tag Storage */
+#define FMC_TAGVDW0S_valid_MASK                  (0x1U)
+#define FMC_TAGVDW0S_valid_SHIFT                 (0U)
+#define FMC_TAGVDW0S_valid(x)                    (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW0S_valid_SHIFT)) & FMC_TAGVDW0S_valid_MASK)
+#define FMC_TAGVDW0S_tag_MASK                    (0x7FFE0U)
+#define FMC_TAGVDW0S_tag_SHIFT                   (5U)
+#define FMC_TAGVDW0S_tag(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW0S_tag_SHIFT)) & FMC_TAGVDW0S_tag_MASK)
+
+/* The count of FMC_TAGVDW0S */
+#define FMC_TAGVDW0S_COUNT                       (4U)
+
+/*! @name TAGVDW1S - Cache Tag Storage */
+#define FMC_TAGVDW1S_valid_MASK                  (0x1U)
+#define FMC_TAGVDW1S_valid_SHIFT                 (0U)
+#define FMC_TAGVDW1S_valid(x)                    (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW1S_valid_SHIFT)) & FMC_TAGVDW1S_valid_MASK)
+#define FMC_TAGVDW1S_tag_MASK                    (0x7FFE0U)
+#define FMC_TAGVDW1S_tag_SHIFT                   (5U)
+#define FMC_TAGVDW1S_tag(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW1S_tag_SHIFT)) & FMC_TAGVDW1S_tag_MASK)
+
+/* The count of FMC_TAGVDW1S */
+#define FMC_TAGVDW1S_COUNT                       (4U)
+
+/*! @name TAGVDW2S - Cache Tag Storage */
+#define FMC_TAGVDW2S_valid_MASK                  (0x1U)
+#define FMC_TAGVDW2S_valid_SHIFT                 (0U)
+#define FMC_TAGVDW2S_valid(x)                    (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW2S_valid_SHIFT)) & FMC_TAGVDW2S_valid_MASK)
+#define FMC_TAGVDW2S_tag_MASK                    (0x7FFE0U)
+#define FMC_TAGVDW2S_tag_SHIFT                   (5U)
+#define FMC_TAGVDW2S_tag(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW2S_tag_SHIFT)) & FMC_TAGVDW2S_tag_MASK)
+
+/* The count of FMC_TAGVDW2S */
+#define FMC_TAGVDW2S_COUNT                       (4U)
+
+/*! @name TAGVDW3S - Cache Tag Storage */
+#define FMC_TAGVDW3S_valid_MASK                  (0x1U)
+#define FMC_TAGVDW3S_valid_SHIFT                 (0U)
+#define FMC_TAGVDW3S_valid(x)                    (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW3S_valid_SHIFT)) & FMC_TAGVDW3S_valid_MASK)
+#define FMC_TAGVDW3S_tag_MASK                    (0x7FFE0U)
+#define FMC_TAGVDW3S_tag_SHIFT                   (5U)
+#define FMC_TAGVDW3S_tag(x)                      (((uint32_t)(((uint32_t)(x)) << FMC_TAGVDW3S_tag_SHIFT)) & FMC_TAGVDW3S_tag_MASK)
+
+/* The count of FMC_TAGVDW3S */
+#define FMC_TAGVDW3S_COUNT                       (4U)
+
+/*! @name DATA_U - Cache Data Storage (upper word) */
+#define FMC_DATA_U_data_MASK                     (0xFFFFFFFFU)
+#define FMC_DATA_U_data_SHIFT                    (0U)
+#define FMC_DATA_U_data(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_DATA_U_data_SHIFT)) & FMC_DATA_U_data_MASK)
+
+/* The count of FMC_DATA_U */
+#define FMC_DATA_U_COUNT                         (4U)
+
+/* The count of FMC_DATA_U */
+#define FMC_DATA_U_COUNT2                        (4U)
+
+/*! @name DATA_L - Cache Data Storage (lower word) */
+#define FMC_DATA_L_data_MASK                     (0xFFFFFFFFU)
+#define FMC_DATA_L_data_SHIFT                    (0U)
+#define FMC_DATA_L_data(x)                       (((uint32_t)(((uint32_t)(x)) << FMC_DATA_L_data_SHIFT)) & FMC_DATA_L_data_MASK)
+
+/* The count of FMC_DATA_L */
+#define FMC_DATA_L_COUNT                         (4U)
+
+/* The count of FMC_DATA_L */
+#define FMC_DATA_L_COUNT2                        (4U)
+
+
+/*!
+ * @}
+ */ /* end of group FMC_Register_Masks */
+
+
+/* FMC - Peripheral instance base addresses */
+/** Peripheral FMC base address */
+#define FMC_BASE                                 (0x4001F000u)
+/** Peripheral FMC base pointer */
+#define FMC                                      ((FMC_Type *)FMC_BASE)
+/** Array initializer of FMC peripheral base addresses */
+#define FMC_BASE_ADDRS                           { FMC_BASE }
+/** Array initializer of FMC peripheral base pointers */
+#define FMC_BASE_PTRS                            { FMC }
+
+/*!
+ * @}
+ */ /* end of group FMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTFE Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFE_Peripheral_Access_Layer FTFE Peripheral Access Layer
+ * @{
+ */
+
+/** FTFE - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t FSTAT;                              /**< Flash Status Register, offset: 0x0 */
+  __IO uint8_t FCNFG;                              /**< Flash Configuration Register, offset: 0x1 */
+  __I  uint8_t FSEC;                               /**< Flash Security Register, offset: 0x2 */
+  __I  uint8_t FOPT;                               /**< Flash Option Register, offset: 0x3 */
+  __IO uint8_t FCCOB3;                             /**< Flash Common Command Object Registers, offset: 0x4 */
+  __IO uint8_t FCCOB2;                             /**< Flash Common Command Object Registers, offset: 0x5 */
+  __IO uint8_t FCCOB1;                             /**< Flash Common Command Object Registers, offset: 0x6 */
+  __IO uint8_t FCCOB0;                             /**< Flash Common Command Object Registers, offset: 0x7 */
+  __IO uint8_t FCCOB7;                             /**< Flash Common Command Object Registers, offset: 0x8 */
+  __IO uint8_t FCCOB6;                             /**< Flash Common Command Object Registers, offset: 0x9 */
+  __IO uint8_t FCCOB5;                             /**< Flash Common Command Object Registers, offset: 0xA */
+  __IO uint8_t FCCOB4;                             /**< Flash Common Command Object Registers, offset: 0xB */
+  __IO uint8_t FCCOBB;                             /**< Flash Common Command Object Registers, offset: 0xC */
+  __IO uint8_t FCCOBA;                             /**< Flash Common Command Object Registers, offset: 0xD */
+  __IO uint8_t FCCOB9;                             /**< Flash Common Command Object Registers, offset: 0xE */
+  __IO uint8_t FCCOB8;                             /**< Flash Common Command Object Registers, offset: 0xF */
+  __IO uint8_t FPROT3;                             /**< Program Flash Protection Registers, offset: 0x10 */
+  __IO uint8_t FPROT2;                             /**< Program Flash Protection Registers, offset: 0x11 */
+  __IO uint8_t FPROT1;                             /**< Program Flash Protection Registers, offset: 0x12 */
+  __IO uint8_t FPROT0;                             /**< Program Flash Protection Registers, offset: 0x13 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t FEPROT;                             /**< EEPROM Protection Register, offset: 0x16 */
+  __IO uint8_t FDPROT;                             /**< Data Flash Protection Register, offset: 0x17 */
+} FTFE_Type;
+
+/* ----------------------------------------------------------------------------
+   -- FTFE Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFE_Register_Masks FTFE Register Masks
+ * @{
+ */
+
+/*! @name FSTAT - Flash Status Register */
+#define FTFE_FSTAT_MGSTAT0_MASK                  (0x1U)
+#define FTFE_FSTAT_MGSTAT0_SHIFT                 (0U)
+#define FTFE_FSTAT_MGSTAT0(x)                    (((uint8_t)(((uint8_t)(x)) << FTFE_FSTAT_MGSTAT0_SHIFT)) & FTFE_FSTAT_MGSTAT0_MASK)
+#define FTFE_FSTAT_FPVIOL_MASK                   (0x10U)
+#define FTFE_FSTAT_FPVIOL_SHIFT                  (4U)
+#define FTFE_FSTAT_FPVIOL(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FSTAT_FPVIOL_SHIFT)) & FTFE_FSTAT_FPVIOL_MASK)
+#define FTFE_FSTAT_ACCERR_MASK                   (0x20U)
+#define FTFE_FSTAT_ACCERR_SHIFT                  (5U)
+#define FTFE_FSTAT_ACCERR(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FSTAT_ACCERR_SHIFT)) & FTFE_FSTAT_ACCERR_MASK)
+#define FTFE_FSTAT_RDCOLERR_MASK                 (0x40U)
+#define FTFE_FSTAT_RDCOLERR_SHIFT                (6U)
+#define FTFE_FSTAT_RDCOLERR(x)                   (((uint8_t)(((uint8_t)(x)) << FTFE_FSTAT_RDCOLERR_SHIFT)) & FTFE_FSTAT_RDCOLERR_MASK)
+#define FTFE_FSTAT_CCIF_MASK                     (0x80U)
+#define FTFE_FSTAT_CCIF_SHIFT                    (7U)
+#define FTFE_FSTAT_CCIF(x)                       (((uint8_t)(((uint8_t)(x)) << FTFE_FSTAT_CCIF_SHIFT)) & FTFE_FSTAT_CCIF_MASK)
+
+/*! @name FCNFG - Flash Configuration Register */
+#define FTFE_FCNFG_EEERDY_MASK                   (0x1U)
+#define FTFE_FCNFG_EEERDY_SHIFT                  (0U)
+#define FTFE_FCNFG_EEERDY(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_EEERDY_SHIFT)) & FTFE_FCNFG_EEERDY_MASK)
+#define FTFE_FCNFG_RAMRDY_MASK                   (0x2U)
+#define FTFE_FCNFG_RAMRDY_SHIFT                  (1U)
+#define FTFE_FCNFG_RAMRDY(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_RAMRDY_SHIFT)) & FTFE_FCNFG_RAMRDY_MASK)
+#define FTFE_FCNFG_PFLSH_MASK                    (0x4U)
+#define FTFE_FCNFG_PFLSH_SHIFT                   (2U)
+#define FTFE_FCNFG_PFLSH(x)                      (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_PFLSH_SHIFT)) & FTFE_FCNFG_PFLSH_MASK)
+#define FTFE_FCNFG_SWAP_MASK                     (0x8U)
+#define FTFE_FCNFG_SWAP_SHIFT                    (3U)
+#define FTFE_FCNFG_SWAP(x)                       (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_SWAP_SHIFT)) & FTFE_FCNFG_SWAP_MASK)
+#define FTFE_FCNFG_ERSSUSP_MASK                  (0x10U)
+#define FTFE_FCNFG_ERSSUSP_SHIFT                 (4U)
+#define FTFE_FCNFG_ERSSUSP(x)                    (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_ERSSUSP_SHIFT)) & FTFE_FCNFG_ERSSUSP_MASK)
+#define FTFE_FCNFG_ERSAREQ_MASK                  (0x20U)
+#define FTFE_FCNFG_ERSAREQ_SHIFT                 (5U)
+#define FTFE_FCNFG_ERSAREQ(x)                    (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_ERSAREQ_SHIFT)) & FTFE_FCNFG_ERSAREQ_MASK)
+#define FTFE_FCNFG_RDCOLLIE_MASK                 (0x40U)
+#define FTFE_FCNFG_RDCOLLIE_SHIFT                (6U)
+#define FTFE_FCNFG_RDCOLLIE(x)                   (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_RDCOLLIE_SHIFT)) & FTFE_FCNFG_RDCOLLIE_MASK)
+#define FTFE_FCNFG_CCIE_MASK                     (0x80U)
+#define FTFE_FCNFG_CCIE_SHIFT                    (7U)
+#define FTFE_FCNFG_CCIE(x)                       (((uint8_t)(((uint8_t)(x)) << FTFE_FCNFG_CCIE_SHIFT)) & FTFE_FCNFG_CCIE_MASK)
+
+/*! @name FSEC - Flash Security Register */
+#define FTFE_FSEC_SEC_MASK                       (0x3U)
+#define FTFE_FSEC_SEC_SHIFT                      (0U)
+#define FTFE_FSEC_SEC(x)                         (((uint8_t)(((uint8_t)(x)) << FTFE_FSEC_SEC_SHIFT)) & FTFE_FSEC_SEC_MASK)
+#define FTFE_FSEC_FSLACC_MASK                    (0xCU)
+#define FTFE_FSEC_FSLACC_SHIFT                   (2U)
+#define FTFE_FSEC_FSLACC(x)                      (((uint8_t)(((uint8_t)(x)) << FTFE_FSEC_FSLACC_SHIFT)) & FTFE_FSEC_FSLACC_MASK)
+#define FTFE_FSEC_MEEN_MASK                      (0x30U)
+#define FTFE_FSEC_MEEN_SHIFT                     (4U)
+#define FTFE_FSEC_MEEN(x)                        (((uint8_t)(((uint8_t)(x)) << FTFE_FSEC_MEEN_SHIFT)) & FTFE_FSEC_MEEN_MASK)
+#define FTFE_FSEC_KEYEN_MASK                     (0xC0U)
+#define FTFE_FSEC_KEYEN_SHIFT                    (6U)
+#define FTFE_FSEC_KEYEN(x)                       (((uint8_t)(((uint8_t)(x)) << FTFE_FSEC_KEYEN_SHIFT)) & FTFE_FSEC_KEYEN_MASK)
+
+/*! @name FOPT - Flash Option Register */
+#define FTFE_FOPT_OPT_MASK                       (0xFFU)
+#define FTFE_FOPT_OPT_SHIFT                      (0U)
+#define FTFE_FOPT_OPT(x)                         (((uint8_t)(((uint8_t)(x)) << FTFE_FOPT_OPT_SHIFT)) & FTFE_FOPT_OPT_MASK)
+
+/*! @name FCCOB3 - Flash Common Command Object Registers */
+#define FTFE_FCCOB3_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB3_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB3_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB3_CCOBn_SHIFT)) & FTFE_FCCOB3_CCOBn_MASK)
+
+/*! @name FCCOB2 - Flash Common Command Object Registers */
+#define FTFE_FCCOB2_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB2_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB2_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB2_CCOBn_SHIFT)) & FTFE_FCCOB2_CCOBn_MASK)
+
+/*! @name FCCOB1 - Flash Common Command Object Registers */
+#define FTFE_FCCOB1_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB1_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB1_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB1_CCOBn_SHIFT)) & FTFE_FCCOB1_CCOBn_MASK)
+
+/*! @name FCCOB0 - Flash Common Command Object Registers */
+#define FTFE_FCCOB0_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB0_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB0_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB0_CCOBn_SHIFT)) & FTFE_FCCOB0_CCOBn_MASK)
+
+/*! @name FCCOB7 - Flash Common Command Object Registers */
+#define FTFE_FCCOB7_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB7_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB7_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB7_CCOBn_SHIFT)) & FTFE_FCCOB7_CCOBn_MASK)
+
+/*! @name FCCOB6 - Flash Common Command Object Registers */
+#define FTFE_FCCOB6_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB6_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB6_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB6_CCOBn_SHIFT)) & FTFE_FCCOB6_CCOBn_MASK)
+
+/*! @name FCCOB5 - Flash Common Command Object Registers */
+#define FTFE_FCCOB5_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB5_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB5_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB5_CCOBn_SHIFT)) & FTFE_FCCOB5_CCOBn_MASK)
+
+/*! @name FCCOB4 - Flash Common Command Object Registers */
+#define FTFE_FCCOB4_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB4_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB4_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB4_CCOBn_SHIFT)) & FTFE_FCCOB4_CCOBn_MASK)
+
+/*! @name FCCOBB - Flash Common Command Object Registers */
+#define FTFE_FCCOBB_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOBB_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOBB_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOBB_CCOBn_SHIFT)) & FTFE_FCCOBB_CCOBn_MASK)
+
+/*! @name FCCOBA - Flash Common Command Object Registers */
+#define FTFE_FCCOBA_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOBA_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOBA_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOBA_CCOBn_SHIFT)) & FTFE_FCCOBA_CCOBn_MASK)
+
+/*! @name FCCOB9 - Flash Common Command Object Registers */
+#define FTFE_FCCOB9_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB9_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB9_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB9_CCOBn_SHIFT)) & FTFE_FCCOB9_CCOBn_MASK)
+
+/*! @name FCCOB8 - Flash Common Command Object Registers */
+#define FTFE_FCCOB8_CCOBn_MASK                   (0xFFU)
+#define FTFE_FCCOB8_CCOBn_SHIFT                  (0U)
+#define FTFE_FCCOB8_CCOBn(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FCCOB8_CCOBn_SHIFT)) & FTFE_FCCOB8_CCOBn_MASK)
+
+/*! @name FPROT3 - Program Flash Protection Registers */
+#define FTFE_FPROT3_PROT_MASK                    (0xFFU)
+#define FTFE_FPROT3_PROT_SHIFT                   (0U)
+#define FTFE_FPROT3_PROT(x)                      (((uint8_t)(((uint8_t)(x)) << FTFE_FPROT3_PROT_SHIFT)) & FTFE_FPROT3_PROT_MASK)
+
+/*! @name FPROT2 - Program Flash Protection Registers */
+#define FTFE_FPROT2_PROT_MASK                    (0xFFU)
+#define FTFE_FPROT2_PROT_SHIFT                   (0U)
+#define FTFE_FPROT2_PROT(x)                      (((uint8_t)(((uint8_t)(x)) << FTFE_FPROT2_PROT_SHIFT)) & FTFE_FPROT2_PROT_MASK)
+
+/*! @name FPROT1 - Program Flash Protection Registers */
+#define FTFE_FPROT1_PROT_MASK                    (0xFFU)
+#define FTFE_FPROT1_PROT_SHIFT                   (0U)
+#define FTFE_FPROT1_PROT(x)                      (((uint8_t)(((uint8_t)(x)) << FTFE_FPROT1_PROT_SHIFT)) & FTFE_FPROT1_PROT_MASK)
+
+/*! @name FPROT0 - Program Flash Protection Registers */
+#define FTFE_FPROT0_PROT_MASK                    (0xFFU)
+#define FTFE_FPROT0_PROT_SHIFT                   (0U)
+#define FTFE_FPROT0_PROT(x)                      (((uint8_t)(((uint8_t)(x)) << FTFE_FPROT0_PROT_SHIFT)) & FTFE_FPROT0_PROT_MASK)
+
+/*! @name FEPROT - EEPROM Protection Register */
+#define FTFE_FEPROT_EPROT_MASK                   (0xFFU)
+#define FTFE_FEPROT_EPROT_SHIFT                  (0U)
+#define FTFE_FEPROT_EPROT(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FEPROT_EPROT_SHIFT)) & FTFE_FEPROT_EPROT_MASK)
+
+/*! @name FDPROT - Data Flash Protection Register */
+#define FTFE_FDPROT_DPROT_MASK                   (0xFFU)
+#define FTFE_FDPROT_DPROT_SHIFT                  (0U)
+#define FTFE_FDPROT_DPROT(x)                     (((uint8_t)(((uint8_t)(x)) << FTFE_FDPROT_DPROT_SHIFT)) & FTFE_FDPROT_DPROT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group FTFE_Register_Masks */
+
+
+/* FTFE - Peripheral instance base addresses */
+/** Peripheral FTFE base address */
+#define FTFE_BASE                                (0x40020000u)
+/** Peripheral FTFE base pointer */
+#define FTFE                                     ((FTFE_Type *)FTFE_BASE)
+/** Array initializer of FTFE peripheral base addresses */
+#define FTFE_BASE_ADDRS                          { FTFE_BASE }
+/** Array initializer of FTFE peripheral base pointers */
+#define FTFE_BASE_PTRS                           { FTFE }
+/** Interrupt vectors for the FTFE peripheral type */
+#define FTFE_COMMAND_COMPLETE_IRQS               { FTFE_IRQn }
+#define FTFE_READ_COLLISION_IRQS                 { Read_Collision_IRQn }
+
+/*!
+ * @}
+ */ /* end of group FTFE_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTM_Peripheral_Access_Layer FTM Peripheral Access Layer
+ * @{
+ */
+
+/** FTM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC;                                /**< Status And Control, offset: 0x0 */
+  __IO uint32_t CNT;                               /**< Counter, offset: 0x4 */
+  __IO uint32_t MOD;                               /**< Modulo, offset: 0x8 */
+  struct {                                         /* offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnSC;                              /**< Channel (n) Status And Control, array offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnV;                               /**< Channel (n) Value, array offset: 0x10, array step: 0x8 */
+  } CONTROLS[8];
+  __IO uint32_t CNTIN;                             /**< Counter Initial Value, offset: 0x4C */
+  __IO uint32_t STATUS;                            /**< Capture And Compare Status, offset: 0x50 */
+  __IO uint32_t MODE;                              /**< Features Mode Selection, offset: 0x54 */
+  __IO uint32_t SYNC;                              /**< Synchronization, offset: 0x58 */
+  __IO uint32_t OUTINIT;                           /**< Initial State For Channels Output, offset: 0x5C */
+  __IO uint32_t OUTMASK;                           /**< Output Mask, offset: 0x60 */
+  __IO uint32_t COMBINE;                           /**< Function For Linked Channels, offset: 0x64 */
+  __IO uint32_t DEADTIME;                          /**< Deadtime Insertion Control, offset: 0x68 */
+  __IO uint32_t EXTTRIG;                           /**< FTM External Trigger, offset: 0x6C */
+  __IO uint32_t POL;                               /**< Channels Polarity, offset: 0x70 */
+  __IO uint32_t FMS;                               /**< Fault Mode Status, offset: 0x74 */
+  __IO uint32_t FILTER;                            /**< Input Capture Filter Control, offset: 0x78 */
+  __IO uint32_t FLTCTRL;                           /**< Fault Control, offset: 0x7C */
+  __IO uint32_t QDCTRL;                            /**< Quadrature Decoder Control And Status, offset: 0x80 */
+  __IO uint32_t CONF;                              /**< Configuration, offset: 0x84 */
+  __IO uint32_t FLTPOL;                            /**< FTM Fault Input Polarity, offset: 0x88 */
+  __IO uint32_t SYNCONF;                           /**< Synchronization Configuration, offset: 0x8C */
+  __IO uint32_t INVCTRL;                           /**< FTM Inverting Control, offset: 0x90 */
+  __IO uint32_t SWOCTRL;                           /**< FTM Software Output Control, offset: 0x94 */
+  __IO uint32_t PWMLOAD;                           /**< FTM PWM Load, offset: 0x98 */
+} FTM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- FTM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTM_Register_Masks FTM Register Masks
+ * @{
+ */
+
+/*! @name SC - Status And Control */
+#define FTM_SC_PS_MASK                           (0x7U)
+#define FTM_SC_PS_SHIFT                          (0U)
+#define FTM_SC_PS(x)                             (((uint32_t)(((uint32_t)(x)) << FTM_SC_PS_SHIFT)) & FTM_SC_PS_MASK)
+#define FTM_SC_CLKS_MASK                         (0x18U)
+#define FTM_SC_CLKS_SHIFT                        (3U)
+#define FTM_SC_CLKS(x)                           (((uint32_t)(((uint32_t)(x)) << FTM_SC_CLKS_SHIFT)) & FTM_SC_CLKS_MASK)
+#define FTM_SC_CPWMS_MASK                        (0x20U)
+#define FTM_SC_CPWMS_SHIFT                       (5U)
+#define FTM_SC_CPWMS(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_SC_CPWMS_SHIFT)) & FTM_SC_CPWMS_MASK)
+#define FTM_SC_TOIE_MASK                         (0x40U)
+#define FTM_SC_TOIE_SHIFT                        (6U)
+#define FTM_SC_TOIE(x)                           (((uint32_t)(((uint32_t)(x)) << FTM_SC_TOIE_SHIFT)) & FTM_SC_TOIE_MASK)
+#define FTM_SC_TOF_MASK                          (0x80U)
+#define FTM_SC_TOF_SHIFT                         (7U)
+#define FTM_SC_TOF(x)                            (((uint32_t)(((uint32_t)(x)) << FTM_SC_TOF_SHIFT)) & FTM_SC_TOF_MASK)
+
+/*! @name CNT - Counter */
+#define FTM_CNT_COUNT_MASK                       (0xFFFFU)
+#define FTM_CNT_COUNT_SHIFT                      (0U)
+#define FTM_CNT_COUNT(x)                         (((uint32_t)(((uint32_t)(x)) << FTM_CNT_COUNT_SHIFT)) & FTM_CNT_COUNT_MASK)
+
+/*! @name MOD - Modulo */
+#define FTM_MOD_MOD_MASK                         (0xFFFFU)
+#define FTM_MOD_MOD_SHIFT                        (0U)
+#define FTM_MOD_MOD(x)                           (((uint32_t)(((uint32_t)(x)) << FTM_MOD_MOD_SHIFT)) & FTM_MOD_MOD_MASK)
+
+/*! @name CnSC - Channel (n) Status And Control */
+#define FTM_CnSC_DMA_MASK                        (0x1U)
+#define FTM_CnSC_DMA_SHIFT                       (0U)
+#define FTM_CnSC_DMA(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_DMA_SHIFT)) & FTM_CnSC_DMA_MASK)
+#define FTM_CnSC_ELSA_MASK                       (0x4U)
+#define FTM_CnSC_ELSA_SHIFT                      (2U)
+#define FTM_CnSC_ELSA(x)                         (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_ELSA_SHIFT)) & FTM_CnSC_ELSA_MASK)
+#define FTM_CnSC_ELSB_MASK                       (0x8U)
+#define FTM_CnSC_ELSB_SHIFT                      (3U)
+#define FTM_CnSC_ELSB(x)                         (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_ELSB_SHIFT)) & FTM_CnSC_ELSB_MASK)
+#define FTM_CnSC_MSA_MASK                        (0x10U)
+#define FTM_CnSC_MSA_SHIFT                       (4U)
+#define FTM_CnSC_MSA(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_MSA_SHIFT)) & FTM_CnSC_MSA_MASK)
+#define FTM_CnSC_MSB_MASK                        (0x20U)
+#define FTM_CnSC_MSB_SHIFT                       (5U)
+#define FTM_CnSC_MSB(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_MSB_SHIFT)) & FTM_CnSC_MSB_MASK)
+#define FTM_CnSC_CHIE_MASK                       (0x40U)
+#define FTM_CnSC_CHIE_SHIFT                      (6U)
+#define FTM_CnSC_CHIE(x)                         (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_CHIE_SHIFT)) & FTM_CnSC_CHIE_MASK)
+#define FTM_CnSC_CHF_MASK                        (0x80U)
+#define FTM_CnSC_CHF_SHIFT                       (7U)
+#define FTM_CnSC_CHF(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_CnSC_CHF_SHIFT)) & FTM_CnSC_CHF_MASK)
+
+/* The count of FTM_CnSC */
+#define FTM_CnSC_COUNT                           (8U)
+
+/*! @name CnV - Channel (n) Value */
+#define FTM_CnV_VAL_MASK                         (0xFFFFU)
+#define FTM_CnV_VAL_SHIFT                        (0U)
+#define FTM_CnV_VAL(x)                           (((uint32_t)(((uint32_t)(x)) << FTM_CnV_VAL_SHIFT)) & FTM_CnV_VAL_MASK)
+
+/* The count of FTM_CnV */
+#define FTM_CnV_COUNT                            (8U)
+
+/*! @name CNTIN - Counter Initial Value */
+#define FTM_CNTIN_INIT_MASK                      (0xFFFFU)
+#define FTM_CNTIN_INIT_SHIFT                     (0U)
+#define FTM_CNTIN_INIT(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_CNTIN_INIT_SHIFT)) & FTM_CNTIN_INIT_MASK)
+
+/*! @name STATUS - Capture And Compare Status */
+#define FTM_STATUS_CH0F_MASK                     (0x1U)
+#define FTM_STATUS_CH0F_SHIFT                    (0U)
+#define FTM_STATUS_CH0F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH0F_SHIFT)) & FTM_STATUS_CH0F_MASK)
+#define FTM_STATUS_CH1F_MASK                     (0x2U)
+#define FTM_STATUS_CH1F_SHIFT                    (1U)
+#define FTM_STATUS_CH1F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH1F_SHIFT)) & FTM_STATUS_CH1F_MASK)
+#define FTM_STATUS_CH2F_MASK                     (0x4U)
+#define FTM_STATUS_CH2F_SHIFT                    (2U)
+#define FTM_STATUS_CH2F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH2F_SHIFT)) & FTM_STATUS_CH2F_MASK)
+#define FTM_STATUS_CH3F_MASK                     (0x8U)
+#define FTM_STATUS_CH3F_SHIFT                    (3U)
+#define FTM_STATUS_CH3F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH3F_SHIFT)) & FTM_STATUS_CH3F_MASK)
+#define FTM_STATUS_CH4F_MASK                     (0x10U)
+#define FTM_STATUS_CH4F_SHIFT                    (4U)
+#define FTM_STATUS_CH4F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH4F_SHIFT)) & FTM_STATUS_CH4F_MASK)
+#define FTM_STATUS_CH5F_MASK                     (0x20U)
+#define FTM_STATUS_CH5F_SHIFT                    (5U)
+#define FTM_STATUS_CH5F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH5F_SHIFT)) & FTM_STATUS_CH5F_MASK)
+#define FTM_STATUS_CH6F_MASK                     (0x40U)
+#define FTM_STATUS_CH6F_SHIFT                    (6U)
+#define FTM_STATUS_CH6F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH6F_SHIFT)) & FTM_STATUS_CH6F_MASK)
+#define FTM_STATUS_CH7F_MASK                     (0x80U)
+#define FTM_STATUS_CH7F_SHIFT                    (7U)
+#define FTM_STATUS_CH7F(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_STATUS_CH7F_SHIFT)) & FTM_STATUS_CH7F_MASK)
+
+/*! @name MODE - Features Mode Selection */
+#define FTM_MODE_FTMEN_MASK                      (0x1U)
+#define FTM_MODE_FTMEN_SHIFT                     (0U)
+#define FTM_MODE_FTMEN(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_MODE_FTMEN_SHIFT)) & FTM_MODE_FTMEN_MASK)
+#define FTM_MODE_INIT_MASK                       (0x2U)
+#define FTM_MODE_INIT_SHIFT                      (1U)
+#define FTM_MODE_INIT(x)                         (((uint32_t)(((uint32_t)(x)) << FTM_MODE_INIT_SHIFT)) & FTM_MODE_INIT_MASK)
+#define FTM_MODE_WPDIS_MASK                      (0x4U)
+#define FTM_MODE_WPDIS_SHIFT                     (2U)
+#define FTM_MODE_WPDIS(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_MODE_WPDIS_SHIFT)) & FTM_MODE_WPDIS_MASK)
+#define FTM_MODE_PWMSYNC_MASK                    (0x8U)
+#define FTM_MODE_PWMSYNC_SHIFT                   (3U)
+#define FTM_MODE_PWMSYNC(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_MODE_PWMSYNC_SHIFT)) & FTM_MODE_PWMSYNC_MASK)
+#define FTM_MODE_CAPTEST_MASK                    (0x10U)
+#define FTM_MODE_CAPTEST_SHIFT                   (4U)
+#define FTM_MODE_CAPTEST(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_MODE_CAPTEST_SHIFT)) & FTM_MODE_CAPTEST_MASK)
+#define FTM_MODE_FAULTM_MASK                     (0x60U)
+#define FTM_MODE_FAULTM_SHIFT                    (5U)
+#define FTM_MODE_FAULTM(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_MODE_FAULTM_SHIFT)) & FTM_MODE_FAULTM_MASK)
+#define FTM_MODE_FAULTIE_MASK                    (0x80U)
+#define FTM_MODE_FAULTIE_SHIFT                   (7U)
+#define FTM_MODE_FAULTIE(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_MODE_FAULTIE_SHIFT)) & FTM_MODE_FAULTIE_MASK)
+
+/*! @name SYNC - Synchronization */
+#define FTM_SYNC_CNTMIN_MASK                     (0x1U)
+#define FTM_SYNC_CNTMIN_SHIFT                    (0U)
+#define FTM_SYNC_CNTMIN(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_CNTMIN_SHIFT)) & FTM_SYNC_CNTMIN_MASK)
+#define FTM_SYNC_CNTMAX_MASK                     (0x2U)
+#define FTM_SYNC_CNTMAX_SHIFT                    (1U)
+#define FTM_SYNC_CNTMAX(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_CNTMAX_SHIFT)) & FTM_SYNC_CNTMAX_MASK)
+#define FTM_SYNC_REINIT_MASK                     (0x4U)
+#define FTM_SYNC_REINIT_SHIFT                    (2U)
+#define FTM_SYNC_REINIT(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_REINIT_SHIFT)) & FTM_SYNC_REINIT_MASK)
+#define FTM_SYNC_SYNCHOM_MASK                    (0x8U)
+#define FTM_SYNC_SYNCHOM_SHIFT                   (3U)
+#define FTM_SYNC_SYNCHOM(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_SYNCHOM_SHIFT)) & FTM_SYNC_SYNCHOM_MASK)
+#define FTM_SYNC_TRIG0_MASK                      (0x10U)
+#define FTM_SYNC_TRIG0_SHIFT                     (4U)
+#define FTM_SYNC_TRIG0(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_TRIG0_SHIFT)) & FTM_SYNC_TRIG0_MASK)
+#define FTM_SYNC_TRIG1_MASK                      (0x20U)
+#define FTM_SYNC_TRIG1_SHIFT                     (5U)
+#define FTM_SYNC_TRIG1(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_TRIG1_SHIFT)) & FTM_SYNC_TRIG1_MASK)
+#define FTM_SYNC_TRIG2_MASK                      (0x40U)
+#define FTM_SYNC_TRIG2_SHIFT                     (6U)
+#define FTM_SYNC_TRIG2(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_TRIG2_SHIFT)) & FTM_SYNC_TRIG2_MASK)
+#define FTM_SYNC_SWSYNC_MASK                     (0x80U)
+#define FTM_SYNC_SWSYNC_SHIFT                    (7U)
+#define FTM_SYNC_SWSYNC(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_SYNC_SWSYNC_SHIFT)) & FTM_SYNC_SWSYNC_MASK)
+
+/*! @name OUTINIT - Initial State For Channels Output */
+#define FTM_OUTINIT_CH0OI_MASK                   (0x1U)
+#define FTM_OUTINIT_CH0OI_SHIFT                  (0U)
+#define FTM_OUTINIT_CH0OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH0OI_SHIFT)) & FTM_OUTINIT_CH0OI_MASK)
+#define FTM_OUTINIT_CH1OI_MASK                   (0x2U)
+#define FTM_OUTINIT_CH1OI_SHIFT                  (1U)
+#define FTM_OUTINIT_CH1OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH1OI_SHIFT)) & FTM_OUTINIT_CH1OI_MASK)
+#define FTM_OUTINIT_CH2OI_MASK                   (0x4U)
+#define FTM_OUTINIT_CH2OI_SHIFT                  (2U)
+#define FTM_OUTINIT_CH2OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH2OI_SHIFT)) & FTM_OUTINIT_CH2OI_MASK)
+#define FTM_OUTINIT_CH3OI_MASK                   (0x8U)
+#define FTM_OUTINIT_CH3OI_SHIFT                  (3U)
+#define FTM_OUTINIT_CH3OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH3OI_SHIFT)) & FTM_OUTINIT_CH3OI_MASK)
+#define FTM_OUTINIT_CH4OI_MASK                   (0x10U)
+#define FTM_OUTINIT_CH4OI_SHIFT                  (4U)
+#define FTM_OUTINIT_CH4OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH4OI_SHIFT)) & FTM_OUTINIT_CH4OI_MASK)
+#define FTM_OUTINIT_CH5OI_MASK                   (0x20U)
+#define FTM_OUTINIT_CH5OI_SHIFT                  (5U)
+#define FTM_OUTINIT_CH5OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH5OI_SHIFT)) & FTM_OUTINIT_CH5OI_MASK)
+#define FTM_OUTINIT_CH6OI_MASK                   (0x40U)
+#define FTM_OUTINIT_CH6OI_SHIFT                  (6U)
+#define FTM_OUTINIT_CH6OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH6OI_SHIFT)) & FTM_OUTINIT_CH6OI_MASK)
+#define FTM_OUTINIT_CH7OI_MASK                   (0x80U)
+#define FTM_OUTINIT_CH7OI_SHIFT                  (7U)
+#define FTM_OUTINIT_CH7OI(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTINIT_CH7OI_SHIFT)) & FTM_OUTINIT_CH7OI_MASK)
+
+/*! @name OUTMASK - Output Mask */
+#define FTM_OUTMASK_CH0OM_MASK                   (0x1U)
+#define FTM_OUTMASK_CH0OM_SHIFT                  (0U)
+#define FTM_OUTMASK_CH0OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH0OM_SHIFT)) & FTM_OUTMASK_CH0OM_MASK)
+#define FTM_OUTMASK_CH1OM_MASK                   (0x2U)
+#define FTM_OUTMASK_CH1OM_SHIFT                  (1U)
+#define FTM_OUTMASK_CH1OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH1OM_SHIFT)) & FTM_OUTMASK_CH1OM_MASK)
+#define FTM_OUTMASK_CH2OM_MASK                   (0x4U)
+#define FTM_OUTMASK_CH2OM_SHIFT                  (2U)
+#define FTM_OUTMASK_CH2OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH2OM_SHIFT)) & FTM_OUTMASK_CH2OM_MASK)
+#define FTM_OUTMASK_CH3OM_MASK                   (0x8U)
+#define FTM_OUTMASK_CH3OM_SHIFT                  (3U)
+#define FTM_OUTMASK_CH3OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH3OM_SHIFT)) & FTM_OUTMASK_CH3OM_MASK)
+#define FTM_OUTMASK_CH4OM_MASK                   (0x10U)
+#define FTM_OUTMASK_CH4OM_SHIFT                  (4U)
+#define FTM_OUTMASK_CH4OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH4OM_SHIFT)) & FTM_OUTMASK_CH4OM_MASK)
+#define FTM_OUTMASK_CH5OM_MASK                   (0x20U)
+#define FTM_OUTMASK_CH5OM_SHIFT                  (5U)
+#define FTM_OUTMASK_CH5OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH5OM_SHIFT)) & FTM_OUTMASK_CH5OM_MASK)
+#define FTM_OUTMASK_CH6OM_MASK                   (0x40U)
+#define FTM_OUTMASK_CH6OM_SHIFT                  (6U)
+#define FTM_OUTMASK_CH6OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH6OM_SHIFT)) & FTM_OUTMASK_CH6OM_MASK)
+#define FTM_OUTMASK_CH7OM_MASK                   (0x80U)
+#define FTM_OUTMASK_CH7OM_SHIFT                  (7U)
+#define FTM_OUTMASK_CH7OM(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_OUTMASK_CH7OM_SHIFT)) & FTM_OUTMASK_CH7OM_MASK)
+
+/*! @name COMBINE - Function For Linked Channels */
+#define FTM_COMBINE_COMBINE0_MASK                (0x1U)
+#define FTM_COMBINE_COMBINE0_SHIFT               (0U)
+#define FTM_COMBINE_COMBINE0(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMBINE0_SHIFT)) & FTM_COMBINE_COMBINE0_MASK)
+#define FTM_COMBINE_COMP0_MASK                   (0x2U)
+#define FTM_COMBINE_COMP0_SHIFT                  (1U)
+#define FTM_COMBINE_COMP0(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMP0_SHIFT)) & FTM_COMBINE_COMP0_MASK)
+#define FTM_COMBINE_DECAPEN0_MASK                (0x4U)
+#define FTM_COMBINE_DECAPEN0_SHIFT               (2U)
+#define FTM_COMBINE_DECAPEN0(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAPEN0_SHIFT)) & FTM_COMBINE_DECAPEN0_MASK)
+#define FTM_COMBINE_DECAP0_MASK                  (0x8U)
+#define FTM_COMBINE_DECAP0_SHIFT                 (3U)
+#define FTM_COMBINE_DECAP0(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAP0_SHIFT)) & FTM_COMBINE_DECAP0_MASK)
+#define FTM_COMBINE_DTEN0_MASK                   (0x10U)
+#define FTM_COMBINE_DTEN0_SHIFT                  (4U)
+#define FTM_COMBINE_DTEN0(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DTEN0_SHIFT)) & FTM_COMBINE_DTEN0_MASK)
+#define FTM_COMBINE_SYNCEN0_MASK                 (0x20U)
+#define FTM_COMBINE_SYNCEN0_SHIFT                (5U)
+#define FTM_COMBINE_SYNCEN0(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_SYNCEN0_SHIFT)) & FTM_COMBINE_SYNCEN0_MASK)
+#define FTM_COMBINE_FAULTEN0_MASK                (0x40U)
+#define FTM_COMBINE_FAULTEN0_SHIFT               (6U)
+#define FTM_COMBINE_FAULTEN0(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_FAULTEN0_SHIFT)) & FTM_COMBINE_FAULTEN0_MASK)
+#define FTM_COMBINE_COMBINE1_MASK                (0x100U)
+#define FTM_COMBINE_COMBINE1_SHIFT               (8U)
+#define FTM_COMBINE_COMBINE1(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMBINE1_SHIFT)) & FTM_COMBINE_COMBINE1_MASK)
+#define FTM_COMBINE_COMP1_MASK                   (0x200U)
+#define FTM_COMBINE_COMP1_SHIFT                  (9U)
+#define FTM_COMBINE_COMP1(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMP1_SHIFT)) & FTM_COMBINE_COMP1_MASK)
+#define FTM_COMBINE_DECAPEN1_MASK                (0x400U)
+#define FTM_COMBINE_DECAPEN1_SHIFT               (10U)
+#define FTM_COMBINE_DECAPEN1(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAPEN1_SHIFT)) & FTM_COMBINE_DECAPEN1_MASK)
+#define FTM_COMBINE_DECAP1_MASK                  (0x800U)
+#define FTM_COMBINE_DECAP1_SHIFT                 (11U)
+#define FTM_COMBINE_DECAP1(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAP1_SHIFT)) & FTM_COMBINE_DECAP1_MASK)
+#define FTM_COMBINE_DTEN1_MASK                   (0x1000U)
+#define FTM_COMBINE_DTEN1_SHIFT                  (12U)
+#define FTM_COMBINE_DTEN1(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DTEN1_SHIFT)) & FTM_COMBINE_DTEN1_MASK)
+#define FTM_COMBINE_SYNCEN1_MASK                 (0x2000U)
+#define FTM_COMBINE_SYNCEN1_SHIFT                (13U)
+#define FTM_COMBINE_SYNCEN1(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_SYNCEN1_SHIFT)) & FTM_COMBINE_SYNCEN1_MASK)
+#define FTM_COMBINE_FAULTEN1_MASK                (0x4000U)
+#define FTM_COMBINE_FAULTEN1_SHIFT               (14U)
+#define FTM_COMBINE_FAULTEN1(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_FAULTEN1_SHIFT)) & FTM_COMBINE_FAULTEN1_MASK)
+#define FTM_COMBINE_COMBINE2_MASK                (0x10000U)
+#define FTM_COMBINE_COMBINE2_SHIFT               (16U)
+#define FTM_COMBINE_COMBINE2(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMBINE2_SHIFT)) & FTM_COMBINE_COMBINE2_MASK)
+#define FTM_COMBINE_COMP2_MASK                   (0x20000U)
+#define FTM_COMBINE_COMP2_SHIFT                  (17U)
+#define FTM_COMBINE_COMP2(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMP2_SHIFT)) & FTM_COMBINE_COMP2_MASK)
+#define FTM_COMBINE_DECAPEN2_MASK                (0x40000U)
+#define FTM_COMBINE_DECAPEN2_SHIFT               (18U)
+#define FTM_COMBINE_DECAPEN2(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAPEN2_SHIFT)) & FTM_COMBINE_DECAPEN2_MASK)
+#define FTM_COMBINE_DECAP2_MASK                  (0x80000U)
+#define FTM_COMBINE_DECAP2_SHIFT                 (19U)
+#define FTM_COMBINE_DECAP2(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAP2_SHIFT)) & FTM_COMBINE_DECAP2_MASK)
+#define FTM_COMBINE_DTEN2_MASK                   (0x100000U)
+#define FTM_COMBINE_DTEN2_SHIFT                  (20U)
+#define FTM_COMBINE_DTEN2(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DTEN2_SHIFT)) & FTM_COMBINE_DTEN2_MASK)
+#define FTM_COMBINE_SYNCEN2_MASK                 (0x200000U)
+#define FTM_COMBINE_SYNCEN2_SHIFT                (21U)
+#define FTM_COMBINE_SYNCEN2(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_SYNCEN2_SHIFT)) & FTM_COMBINE_SYNCEN2_MASK)
+#define FTM_COMBINE_FAULTEN2_MASK                (0x400000U)
+#define FTM_COMBINE_FAULTEN2_SHIFT               (22U)
+#define FTM_COMBINE_FAULTEN2(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_FAULTEN2_SHIFT)) & FTM_COMBINE_FAULTEN2_MASK)
+#define FTM_COMBINE_COMBINE3_MASK                (0x1000000U)
+#define FTM_COMBINE_COMBINE3_SHIFT               (24U)
+#define FTM_COMBINE_COMBINE3(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMBINE3_SHIFT)) & FTM_COMBINE_COMBINE3_MASK)
+#define FTM_COMBINE_COMP3_MASK                   (0x2000000U)
+#define FTM_COMBINE_COMP3_SHIFT                  (25U)
+#define FTM_COMBINE_COMP3(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_COMP3_SHIFT)) & FTM_COMBINE_COMP3_MASK)
+#define FTM_COMBINE_DECAPEN3_MASK                (0x4000000U)
+#define FTM_COMBINE_DECAPEN3_SHIFT               (26U)
+#define FTM_COMBINE_DECAPEN3(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAPEN3_SHIFT)) & FTM_COMBINE_DECAPEN3_MASK)
+#define FTM_COMBINE_DECAP3_MASK                  (0x8000000U)
+#define FTM_COMBINE_DECAP3_SHIFT                 (27U)
+#define FTM_COMBINE_DECAP3(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DECAP3_SHIFT)) & FTM_COMBINE_DECAP3_MASK)
+#define FTM_COMBINE_DTEN3_MASK                   (0x10000000U)
+#define FTM_COMBINE_DTEN3_SHIFT                  (28U)
+#define FTM_COMBINE_DTEN3(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_DTEN3_SHIFT)) & FTM_COMBINE_DTEN3_MASK)
+#define FTM_COMBINE_SYNCEN3_MASK                 (0x20000000U)
+#define FTM_COMBINE_SYNCEN3_SHIFT                (29U)
+#define FTM_COMBINE_SYNCEN3(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_SYNCEN3_SHIFT)) & FTM_COMBINE_SYNCEN3_MASK)
+#define FTM_COMBINE_FAULTEN3_MASK                (0x40000000U)
+#define FTM_COMBINE_FAULTEN3_SHIFT               (30U)
+#define FTM_COMBINE_FAULTEN3(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_COMBINE_FAULTEN3_SHIFT)) & FTM_COMBINE_FAULTEN3_MASK)
+
+/*! @name DEADTIME - Deadtime Insertion Control */
+#define FTM_DEADTIME_DTVAL_MASK                  (0x3FU)
+#define FTM_DEADTIME_DTVAL_SHIFT                 (0U)
+#define FTM_DEADTIME_DTVAL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_DEADTIME_DTVAL_SHIFT)) & FTM_DEADTIME_DTVAL_MASK)
+#define FTM_DEADTIME_DTPS_MASK                   (0xC0U)
+#define FTM_DEADTIME_DTPS_SHIFT                  (6U)
+#define FTM_DEADTIME_DTPS(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_DEADTIME_DTPS_SHIFT)) & FTM_DEADTIME_DTPS_MASK)
+
+/*! @name EXTTRIG - FTM External Trigger */
+#define FTM_EXTTRIG_CH2TRIG_MASK                 (0x1U)
+#define FTM_EXTTRIG_CH2TRIG_SHIFT                (0U)
+#define FTM_EXTTRIG_CH2TRIG(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_CH2TRIG_SHIFT)) & FTM_EXTTRIG_CH2TRIG_MASK)
+#define FTM_EXTTRIG_CH3TRIG_MASK                 (0x2U)
+#define FTM_EXTTRIG_CH3TRIG_SHIFT                (1U)
+#define FTM_EXTTRIG_CH3TRIG(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_CH3TRIG_SHIFT)) & FTM_EXTTRIG_CH3TRIG_MASK)
+#define FTM_EXTTRIG_CH4TRIG_MASK                 (0x4U)
+#define FTM_EXTTRIG_CH4TRIG_SHIFT                (2U)
+#define FTM_EXTTRIG_CH4TRIG(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_CH4TRIG_SHIFT)) & FTM_EXTTRIG_CH4TRIG_MASK)
+#define FTM_EXTTRIG_CH5TRIG_MASK                 (0x8U)
+#define FTM_EXTTRIG_CH5TRIG_SHIFT                (3U)
+#define FTM_EXTTRIG_CH5TRIG(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_CH5TRIG_SHIFT)) & FTM_EXTTRIG_CH5TRIG_MASK)
+#define FTM_EXTTRIG_CH0TRIG_MASK                 (0x10U)
+#define FTM_EXTTRIG_CH0TRIG_SHIFT                (4U)
+#define FTM_EXTTRIG_CH0TRIG(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_CH0TRIG_SHIFT)) & FTM_EXTTRIG_CH0TRIG_MASK)
+#define FTM_EXTTRIG_CH1TRIG_MASK                 (0x20U)
+#define FTM_EXTTRIG_CH1TRIG_SHIFT                (5U)
+#define FTM_EXTTRIG_CH1TRIG(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_CH1TRIG_SHIFT)) & FTM_EXTTRIG_CH1TRIG_MASK)
+#define FTM_EXTTRIG_INITTRIGEN_MASK              (0x40U)
+#define FTM_EXTTRIG_INITTRIGEN_SHIFT             (6U)
+#define FTM_EXTTRIG_INITTRIGEN(x)                (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_INITTRIGEN_SHIFT)) & FTM_EXTTRIG_INITTRIGEN_MASK)
+#define FTM_EXTTRIG_TRIGF_MASK                   (0x80U)
+#define FTM_EXTTRIG_TRIGF_SHIFT                  (7U)
+#define FTM_EXTTRIG_TRIGF(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_EXTTRIG_TRIGF_SHIFT)) & FTM_EXTTRIG_TRIGF_MASK)
+
+/*! @name POL - Channels Polarity */
+#define FTM_POL_POL0_MASK                        (0x1U)
+#define FTM_POL_POL0_SHIFT                       (0U)
+#define FTM_POL_POL0(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL0_SHIFT)) & FTM_POL_POL0_MASK)
+#define FTM_POL_POL1_MASK                        (0x2U)
+#define FTM_POL_POL1_SHIFT                       (1U)
+#define FTM_POL_POL1(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL1_SHIFT)) & FTM_POL_POL1_MASK)
+#define FTM_POL_POL2_MASK                        (0x4U)
+#define FTM_POL_POL2_SHIFT                       (2U)
+#define FTM_POL_POL2(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL2_SHIFT)) & FTM_POL_POL2_MASK)
+#define FTM_POL_POL3_MASK                        (0x8U)
+#define FTM_POL_POL3_SHIFT                       (3U)
+#define FTM_POL_POL3(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL3_SHIFT)) & FTM_POL_POL3_MASK)
+#define FTM_POL_POL4_MASK                        (0x10U)
+#define FTM_POL_POL4_SHIFT                       (4U)
+#define FTM_POL_POL4(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL4_SHIFT)) & FTM_POL_POL4_MASK)
+#define FTM_POL_POL5_MASK                        (0x20U)
+#define FTM_POL_POL5_SHIFT                       (5U)
+#define FTM_POL_POL5(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL5_SHIFT)) & FTM_POL_POL5_MASK)
+#define FTM_POL_POL6_MASK                        (0x40U)
+#define FTM_POL_POL6_SHIFT                       (6U)
+#define FTM_POL_POL6(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL6_SHIFT)) & FTM_POL_POL6_MASK)
+#define FTM_POL_POL7_MASK                        (0x80U)
+#define FTM_POL_POL7_SHIFT                       (7U)
+#define FTM_POL_POL7(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_POL_POL7_SHIFT)) & FTM_POL_POL7_MASK)
+
+/*! @name FMS - Fault Mode Status */
+#define FTM_FMS_FAULTF0_MASK                     (0x1U)
+#define FTM_FMS_FAULTF0_SHIFT                    (0U)
+#define FTM_FMS_FAULTF0(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_FMS_FAULTF0_SHIFT)) & FTM_FMS_FAULTF0_MASK)
+#define FTM_FMS_FAULTF1_MASK                     (0x2U)
+#define FTM_FMS_FAULTF1_SHIFT                    (1U)
+#define FTM_FMS_FAULTF1(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_FMS_FAULTF1_SHIFT)) & FTM_FMS_FAULTF1_MASK)
+#define FTM_FMS_FAULTF2_MASK                     (0x4U)
+#define FTM_FMS_FAULTF2_SHIFT                    (2U)
+#define FTM_FMS_FAULTF2(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_FMS_FAULTF2_SHIFT)) & FTM_FMS_FAULTF2_MASK)
+#define FTM_FMS_FAULTF3_MASK                     (0x8U)
+#define FTM_FMS_FAULTF3_SHIFT                    (3U)
+#define FTM_FMS_FAULTF3(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_FMS_FAULTF3_SHIFT)) & FTM_FMS_FAULTF3_MASK)
+#define FTM_FMS_FAULTIN_MASK                     (0x20U)
+#define FTM_FMS_FAULTIN_SHIFT                    (5U)
+#define FTM_FMS_FAULTIN(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_FMS_FAULTIN_SHIFT)) & FTM_FMS_FAULTIN_MASK)
+#define FTM_FMS_WPEN_MASK                        (0x40U)
+#define FTM_FMS_WPEN_SHIFT                       (6U)
+#define FTM_FMS_WPEN(x)                          (((uint32_t)(((uint32_t)(x)) << FTM_FMS_WPEN_SHIFT)) & FTM_FMS_WPEN_MASK)
+#define FTM_FMS_FAULTF_MASK                      (0x80U)
+#define FTM_FMS_FAULTF_SHIFT                     (7U)
+#define FTM_FMS_FAULTF(x)                        (((uint32_t)(((uint32_t)(x)) << FTM_FMS_FAULTF_SHIFT)) & FTM_FMS_FAULTF_MASK)
+
+/*! @name FILTER - Input Capture Filter Control */
+#define FTM_FILTER_CH0FVAL_MASK                  (0xFU)
+#define FTM_FILTER_CH0FVAL_SHIFT                 (0U)
+#define FTM_FILTER_CH0FVAL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FILTER_CH0FVAL_SHIFT)) & FTM_FILTER_CH0FVAL_MASK)
+#define FTM_FILTER_CH1FVAL_MASK                  (0xF0U)
+#define FTM_FILTER_CH1FVAL_SHIFT                 (4U)
+#define FTM_FILTER_CH1FVAL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FILTER_CH1FVAL_SHIFT)) & FTM_FILTER_CH1FVAL_MASK)
+#define FTM_FILTER_CH2FVAL_MASK                  (0xF00U)
+#define FTM_FILTER_CH2FVAL_SHIFT                 (8U)
+#define FTM_FILTER_CH2FVAL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FILTER_CH2FVAL_SHIFT)) & FTM_FILTER_CH2FVAL_MASK)
+#define FTM_FILTER_CH3FVAL_MASK                  (0xF000U)
+#define FTM_FILTER_CH3FVAL_SHIFT                 (12U)
+#define FTM_FILTER_CH3FVAL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FILTER_CH3FVAL_SHIFT)) & FTM_FILTER_CH3FVAL_MASK)
+
+/*! @name FLTCTRL - Fault Control */
+#define FTM_FLTCTRL_FAULT0EN_MASK                (0x1U)
+#define FTM_FLTCTRL_FAULT0EN_SHIFT               (0U)
+#define FTM_FLTCTRL_FAULT0EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FAULT0EN_SHIFT)) & FTM_FLTCTRL_FAULT0EN_MASK)
+#define FTM_FLTCTRL_FAULT1EN_MASK                (0x2U)
+#define FTM_FLTCTRL_FAULT1EN_SHIFT               (1U)
+#define FTM_FLTCTRL_FAULT1EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FAULT1EN_SHIFT)) & FTM_FLTCTRL_FAULT1EN_MASK)
+#define FTM_FLTCTRL_FAULT2EN_MASK                (0x4U)
+#define FTM_FLTCTRL_FAULT2EN_SHIFT               (2U)
+#define FTM_FLTCTRL_FAULT2EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FAULT2EN_SHIFT)) & FTM_FLTCTRL_FAULT2EN_MASK)
+#define FTM_FLTCTRL_FAULT3EN_MASK                (0x8U)
+#define FTM_FLTCTRL_FAULT3EN_SHIFT               (3U)
+#define FTM_FLTCTRL_FAULT3EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FAULT3EN_SHIFT)) & FTM_FLTCTRL_FAULT3EN_MASK)
+#define FTM_FLTCTRL_FFLTR0EN_MASK                (0x10U)
+#define FTM_FLTCTRL_FFLTR0EN_SHIFT               (4U)
+#define FTM_FLTCTRL_FFLTR0EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FFLTR0EN_SHIFT)) & FTM_FLTCTRL_FFLTR0EN_MASK)
+#define FTM_FLTCTRL_FFLTR1EN_MASK                (0x20U)
+#define FTM_FLTCTRL_FFLTR1EN_SHIFT               (5U)
+#define FTM_FLTCTRL_FFLTR1EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FFLTR1EN_SHIFT)) & FTM_FLTCTRL_FFLTR1EN_MASK)
+#define FTM_FLTCTRL_FFLTR2EN_MASK                (0x40U)
+#define FTM_FLTCTRL_FFLTR2EN_SHIFT               (6U)
+#define FTM_FLTCTRL_FFLTR2EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FFLTR2EN_SHIFT)) & FTM_FLTCTRL_FFLTR2EN_MASK)
+#define FTM_FLTCTRL_FFLTR3EN_MASK                (0x80U)
+#define FTM_FLTCTRL_FFLTR3EN_SHIFT               (7U)
+#define FTM_FLTCTRL_FFLTR3EN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FFLTR3EN_SHIFT)) & FTM_FLTCTRL_FFLTR3EN_MASK)
+#define FTM_FLTCTRL_FFVAL_MASK                   (0xF00U)
+#define FTM_FLTCTRL_FFVAL_SHIFT                  (8U)
+#define FTM_FLTCTRL_FFVAL(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_FLTCTRL_FFVAL_SHIFT)) & FTM_FLTCTRL_FFVAL_MASK)
+
+/*! @name QDCTRL - Quadrature Decoder Control And Status */
+#define FTM_QDCTRL_QUADEN_MASK                   (0x1U)
+#define FTM_QDCTRL_QUADEN_SHIFT                  (0U)
+#define FTM_QDCTRL_QUADEN(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_QUADEN_SHIFT)) & FTM_QDCTRL_QUADEN_MASK)
+#define FTM_QDCTRL_TOFDIR_MASK                   (0x2U)
+#define FTM_QDCTRL_TOFDIR_SHIFT                  (1U)
+#define FTM_QDCTRL_TOFDIR(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_TOFDIR_SHIFT)) & FTM_QDCTRL_TOFDIR_MASK)
+#define FTM_QDCTRL_QUADIR_MASK                   (0x4U)
+#define FTM_QDCTRL_QUADIR_SHIFT                  (2U)
+#define FTM_QDCTRL_QUADIR(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_QUADIR_SHIFT)) & FTM_QDCTRL_QUADIR_MASK)
+#define FTM_QDCTRL_QUADMODE_MASK                 (0x8U)
+#define FTM_QDCTRL_QUADMODE_SHIFT                (3U)
+#define FTM_QDCTRL_QUADMODE(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_QUADMODE_SHIFT)) & FTM_QDCTRL_QUADMODE_MASK)
+#define FTM_QDCTRL_PHBPOL_MASK                   (0x10U)
+#define FTM_QDCTRL_PHBPOL_SHIFT                  (4U)
+#define FTM_QDCTRL_PHBPOL(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_PHBPOL_SHIFT)) & FTM_QDCTRL_PHBPOL_MASK)
+#define FTM_QDCTRL_PHAPOL_MASK                   (0x20U)
+#define FTM_QDCTRL_PHAPOL_SHIFT                  (5U)
+#define FTM_QDCTRL_PHAPOL(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_PHAPOL_SHIFT)) & FTM_QDCTRL_PHAPOL_MASK)
+#define FTM_QDCTRL_PHBFLTREN_MASK                (0x40U)
+#define FTM_QDCTRL_PHBFLTREN_SHIFT               (6U)
+#define FTM_QDCTRL_PHBFLTREN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_PHBFLTREN_SHIFT)) & FTM_QDCTRL_PHBFLTREN_MASK)
+#define FTM_QDCTRL_PHAFLTREN_MASK                (0x80U)
+#define FTM_QDCTRL_PHAFLTREN_SHIFT               (7U)
+#define FTM_QDCTRL_PHAFLTREN(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_QDCTRL_PHAFLTREN_SHIFT)) & FTM_QDCTRL_PHAFLTREN_MASK)
+
+/*! @name CONF - Configuration */
+#define FTM_CONF_NUMTOF_MASK                     (0x1FU)
+#define FTM_CONF_NUMTOF_SHIFT                    (0U)
+#define FTM_CONF_NUMTOF(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_CONF_NUMTOF_SHIFT)) & FTM_CONF_NUMTOF_MASK)
+#define FTM_CONF_BDMMODE_MASK                    (0xC0U)
+#define FTM_CONF_BDMMODE_SHIFT                   (6U)
+#define FTM_CONF_BDMMODE(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_CONF_BDMMODE_SHIFT)) & FTM_CONF_BDMMODE_MASK)
+#define FTM_CONF_GTBEEN_MASK                     (0x200U)
+#define FTM_CONF_GTBEEN_SHIFT                    (9U)
+#define FTM_CONF_GTBEEN(x)                       (((uint32_t)(((uint32_t)(x)) << FTM_CONF_GTBEEN_SHIFT)) & FTM_CONF_GTBEEN_MASK)
+#define FTM_CONF_GTBEOUT_MASK                    (0x400U)
+#define FTM_CONF_GTBEOUT_SHIFT                   (10U)
+#define FTM_CONF_GTBEOUT(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_CONF_GTBEOUT_SHIFT)) & FTM_CONF_GTBEOUT_MASK)
+
+/*! @name FLTPOL - FTM Fault Input Polarity */
+#define FTM_FLTPOL_FLT0POL_MASK                  (0x1U)
+#define FTM_FLTPOL_FLT0POL_SHIFT                 (0U)
+#define FTM_FLTPOL_FLT0POL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FLTPOL_FLT0POL_SHIFT)) & FTM_FLTPOL_FLT0POL_MASK)
+#define FTM_FLTPOL_FLT1POL_MASK                  (0x2U)
+#define FTM_FLTPOL_FLT1POL_SHIFT                 (1U)
+#define FTM_FLTPOL_FLT1POL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FLTPOL_FLT1POL_SHIFT)) & FTM_FLTPOL_FLT1POL_MASK)
+#define FTM_FLTPOL_FLT2POL_MASK                  (0x4U)
+#define FTM_FLTPOL_FLT2POL_SHIFT                 (2U)
+#define FTM_FLTPOL_FLT2POL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FLTPOL_FLT2POL_SHIFT)) & FTM_FLTPOL_FLT2POL_MASK)
+#define FTM_FLTPOL_FLT3POL_MASK                  (0x8U)
+#define FTM_FLTPOL_FLT3POL_SHIFT                 (3U)
+#define FTM_FLTPOL_FLT3POL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_FLTPOL_FLT3POL_SHIFT)) & FTM_FLTPOL_FLT3POL_MASK)
+
+/*! @name SYNCONF - Synchronization Configuration */
+#define FTM_SYNCONF_HWTRIGMODE_MASK              (0x1U)
+#define FTM_SYNCONF_HWTRIGMODE_SHIFT             (0U)
+#define FTM_SYNCONF_HWTRIGMODE(x)                (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_HWTRIGMODE_SHIFT)) & FTM_SYNCONF_HWTRIGMODE_MASK)
+#define FTM_SYNCONF_CNTINC_MASK                  (0x4U)
+#define FTM_SYNCONF_CNTINC_SHIFT                 (2U)
+#define FTM_SYNCONF_CNTINC(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_CNTINC_SHIFT)) & FTM_SYNCONF_CNTINC_MASK)
+#define FTM_SYNCONF_INVC_MASK                    (0x10U)
+#define FTM_SYNCONF_INVC_SHIFT                   (4U)
+#define FTM_SYNCONF_INVC(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_INVC_SHIFT)) & FTM_SYNCONF_INVC_MASK)
+#define FTM_SYNCONF_SWOC_MASK                    (0x20U)
+#define FTM_SYNCONF_SWOC_SHIFT                   (5U)
+#define FTM_SYNCONF_SWOC(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SWOC_SHIFT)) & FTM_SYNCONF_SWOC_MASK)
+#define FTM_SYNCONF_SYNCMODE_MASK                (0x80U)
+#define FTM_SYNCONF_SYNCMODE_SHIFT               (7U)
+#define FTM_SYNCONF_SYNCMODE(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SYNCMODE_SHIFT)) & FTM_SYNCONF_SYNCMODE_MASK)
+#define FTM_SYNCONF_SWRSTCNT_MASK                (0x100U)
+#define FTM_SYNCONF_SWRSTCNT_SHIFT               (8U)
+#define FTM_SYNCONF_SWRSTCNT(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SWRSTCNT_SHIFT)) & FTM_SYNCONF_SWRSTCNT_MASK)
+#define FTM_SYNCONF_SWWRBUF_MASK                 (0x200U)
+#define FTM_SYNCONF_SWWRBUF_SHIFT                (9U)
+#define FTM_SYNCONF_SWWRBUF(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SWWRBUF_SHIFT)) & FTM_SYNCONF_SWWRBUF_MASK)
+#define FTM_SYNCONF_SWOM_MASK                    (0x400U)
+#define FTM_SYNCONF_SWOM_SHIFT                   (10U)
+#define FTM_SYNCONF_SWOM(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SWOM_SHIFT)) & FTM_SYNCONF_SWOM_MASK)
+#define FTM_SYNCONF_SWINVC_MASK                  (0x800U)
+#define FTM_SYNCONF_SWINVC_SHIFT                 (11U)
+#define FTM_SYNCONF_SWINVC(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SWINVC_SHIFT)) & FTM_SYNCONF_SWINVC_MASK)
+#define FTM_SYNCONF_SWSOC_MASK                   (0x1000U)
+#define FTM_SYNCONF_SWSOC_SHIFT                  (12U)
+#define FTM_SYNCONF_SWSOC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_SWSOC_SHIFT)) & FTM_SYNCONF_SWSOC_MASK)
+#define FTM_SYNCONF_HWRSTCNT_MASK                (0x10000U)
+#define FTM_SYNCONF_HWRSTCNT_SHIFT               (16U)
+#define FTM_SYNCONF_HWRSTCNT(x)                  (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_HWRSTCNT_SHIFT)) & FTM_SYNCONF_HWRSTCNT_MASK)
+#define FTM_SYNCONF_HWWRBUF_MASK                 (0x20000U)
+#define FTM_SYNCONF_HWWRBUF_SHIFT                (17U)
+#define FTM_SYNCONF_HWWRBUF(x)                   (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_HWWRBUF_SHIFT)) & FTM_SYNCONF_HWWRBUF_MASK)
+#define FTM_SYNCONF_HWOM_MASK                    (0x40000U)
+#define FTM_SYNCONF_HWOM_SHIFT                   (18U)
+#define FTM_SYNCONF_HWOM(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_HWOM_SHIFT)) & FTM_SYNCONF_HWOM_MASK)
+#define FTM_SYNCONF_HWINVC_MASK                  (0x80000U)
+#define FTM_SYNCONF_HWINVC_SHIFT                 (19U)
+#define FTM_SYNCONF_HWINVC(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_HWINVC_SHIFT)) & FTM_SYNCONF_HWINVC_MASK)
+#define FTM_SYNCONF_HWSOC_MASK                   (0x100000U)
+#define FTM_SYNCONF_HWSOC_SHIFT                  (20U)
+#define FTM_SYNCONF_HWSOC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SYNCONF_HWSOC_SHIFT)) & FTM_SYNCONF_HWSOC_MASK)
+
+/*! @name INVCTRL - FTM Inverting Control */
+#define FTM_INVCTRL_INV0EN_MASK                  (0x1U)
+#define FTM_INVCTRL_INV0EN_SHIFT                 (0U)
+#define FTM_INVCTRL_INV0EN(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_INVCTRL_INV0EN_SHIFT)) & FTM_INVCTRL_INV0EN_MASK)
+#define FTM_INVCTRL_INV1EN_MASK                  (0x2U)
+#define FTM_INVCTRL_INV1EN_SHIFT                 (1U)
+#define FTM_INVCTRL_INV1EN(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_INVCTRL_INV1EN_SHIFT)) & FTM_INVCTRL_INV1EN_MASK)
+#define FTM_INVCTRL_INV2EN_MASK                  (0x4U)
+#define FTM_INVCTRL_INV2EN_SHIFT                 (2U)
+#define FTM_INVCTRL_INV2EN(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_INVCTRL_INV2EN_SHIFT)) & FTM_INVCTRL_INV2EN_MASK)
+#define FTM_INVCTRL_INV3EN_MASK                  (0x8U)
+#define FTM_INVCTRL_INV3EN_SHIFT                 (3U)
+#define FTM_INVCTRL_INV3EN(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_INVCTRL_INV3EN_SHIFT)) & FTM_INVCTRL_INV3EN_MASK)
+
+/*! @name SWOCTRL - FTM Software Output Control */
+#define FTM_SWOCTRL_CH0OC_MASK                   (0x1U)
+#define FTM_SWOCTRL_CH0OC_SHIFT                  (0U)
+#define FTM_SWOCTRL_CH0OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH0OC_SHIFT)) & FTM_SWOCTRL_CH0OC_MASK)
+#define FTM_SWOCTRL_CH1OC_MASK                   (0x2U)
+#define FTM_SWOCTRL_CH1OC_SHIFT                  (1U)
+#define FTM_SWOCTRL_CH1OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH1OC_SHIFT)) & FTM_SWOCTRL_CH1OC_MASK)
+#define FTM_SWOCTRL_CH2OC_MASK                   (0x4U)
+#define FTM_SWOCTRL_CH2OC_SHIFT                  (2U)
+#define FTM_SWOCTRL_CH2OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH2OC_SHIFT)) & FTM_SWOCTRL_CH2OC_MASK)
+#define FTM_SWOCTRL_CH3OC_MASK                   (0x8U)
+#define FTM_SWOCTRL_CH3OC_SHIFT                  (3U)
+#define FTM_SWOCTRL_CH3OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH3OC_SHIFT)) & FTM_SWOCTRL_CH3OC_MASK)
+#define FTM_SWOCTRL_CH4OC_MASK                   (0x10U)
+#define FTM_SWOCTRL_CH4OC_SHIFT                  (4U)
+#define FTM_SWOCTRL_CH4OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH4OC_SHIFT)) & FTM_SWOCTRL_CH4OC_MASK)
+#define FTM_SWOCTRL_CH5OC_MASK                   (0x20U)
+#define FTM_SWOCTRL_CH5OC_SHIFT                  (5U)
+#define FTM_SWOCTRL_CH5OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH5OC_SHIFT)) & FTM_SWOCTRL_CH5OC_MASK)
+#define FTM_SWOCTRL_CH6OC_MASK                   (0x40U)
+#define FTM_SWOCTRL_CH6OC_SHIFT                  (6U)
+#define FTM_SWOCTRL_CH6OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH6OC_SHIFT)) & FTM_SWOCTRL_CH6OC_MASK)
+#define FTM_SWOCTRL_CH7OC_MASK                   (0x80U)
+#define FTM_SWOCTRL_CH7OC_SHIFT                  (7U)
+#define FTM_SWOCTRL_CH7OC(x)                     (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH7OC_SHIFT)) & FTM_SWOCTRL_CH7OC_MASK)
+#define FTM_SWOCTRL_CH0OCV_MASK                  (0x100U)
+#define FTM_SWOCTRL_CH0OCV_SHIFT                 (8U)
+#define FTM_SWOCTRL_CH0OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH0OCV_SHIFT)) & FTM_SWOCTRL_CH0OCV_MASK)
+#define FTM_SWOCTRL_CH1OCV_MASK                  (0x200U)
+#define FTM_SWOCTRL_CH1OCV_SHIFT                 (9U)
+#define FTM_SWOCTRL_CH1OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH1OCV_SHIFT)) & FTM_SWOCTRL_CH1OCV_MASK)
+#define FTM_SWOCTRL_CH2OCV_MASK                  (0x400U)
+#define FTM_SWOCTRL_CH2OCV_SHIFT                 (10U)
+#define FTM_SWOCTRL_CH2OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH2OCV_SHIFT)) & FTM_SWOCTRL_CH2OCV_MASK)
+#define FTM_SWOCTRL_CH3OCV_MASK                  (0x800U)
+#define FTM_SWOCTRL_CH3OCV_SHIFT                 (11U)
+#define FTM_SWOCTRL_CH3OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH3OCV_SHIFT)) & FTM_SWOCTRL_CH3OCV_MASK)
+#define FTM_SWOCTRL_CH4OCV_MASK                  (0x1000U)
+#define FTM_SWOCTRL_CH4OCV_SHIFT                 (12U)
+#define FTM_SWOCTRL_CH4OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH4OCV_SHIFT)) & FTM_SWOCTRL_CH4OCV_MASK)
+#define FTM_SWOCTRL_CH5OCV_MASK                  (0x2000U)
+#define FTM_SWOCTRL_CH5OCV_SHIFT                 (13U)
+#define FTM_SWOCTRL_CH5OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH5OCV_SHIFT)) & FTM_SWOCTRL_CH5OCV_MASK)
+#define FTM_SWOCTRL_CH6OCV_MASK                  (0x4000U)
+#define FTM_SWOCTRL_CH6OCV_SHIFT                 (14U)
+#define FTM_SWOCTRL_CH6OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH6OCV_SHIFT)) & FTM_SWOCTRL_CH6OCV_MASK)
+#define FTM_SWOCTRL_CH7OCV_MASK                  (0x8000U)
+#define FTM_SWOCTRL_CH7OCV_SHIFT                 (15U)
+#define FTM_SWOCTRL_CH7OCV(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_SWOCTRL_CH7OCV_SHIFT)) & FTM_SWOCTRL_CH7OCV_MASK)
+
+/*! @name PWMLOAD - FTM PWM Load */
+#define FTM_PWMLOAD_CH0SEL_MASK                  (0x1U)
+#define FTM_PWMLOAD_CH0SEL_SHIFT                 (0U)
+#define FTM_PWMLOAD_CH0SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH0SEL_SHIFT)) & FTM_PWMLOAD_CH0SEL_MASK)
+#define FTM_PWMLOAD_CH1SEL_MASK                  (0x2U)
+#define FTM_PWMLOAD_CH1SEL_SHIFT                 (1U)
+#define FTM_PWMLOAD_CH1SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH1SEL_SHIFT)) & FTM_PWMLOAD_CH1SEL_MASK)
+#define FTM_PWMLOAD_CH2SEL_MASK                  (0x4U)
+#define FTM_PWMLOAD_CH2SEL_SHIFT                 (2U)
+#define FTM_PWMLOAD_CH2SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH2SEL_SHIFT)) & FTM_PWMLOAD_CH2SEL_MASK)
+#define FTM_PWMLOAD_CH3SEL_MASK                  (0x8U)
+#define FTM_PWMLOAD_CH3SEL_SHIFT                 (3U)
+#define FTM_PWMLOAD_CH3SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH3SEL_SHIFT)) & FTM_PWMLOAD_CH3SEL_MASK)
+#define FTM_PWMLOAD_CH4SEL_MASK                  (0x10U)
+#define FTM_PWMLOAD_CH4SEL_SHIFT                 (4U)
+#define FTM_PWMLOAD_CH4SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH4SEL_SHIFT)) & FTM_PWMLOAD_CH4SEL_MASK)
+#define FTM_PWMLOAD_CH5SEL_MASK                  (0x20U)
+#define FTM_PWMLOAD_CH5SEL_SHIFT                 (5U)
+#define FTM_PWMLOAD_CH5SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH5SEL_SHIFT)) & FTM_PWMLOAD_CH5SEL_MASK)
+#define FTM_PWMLOAD_CH6SEL_MASK                  (0x40U)
+#define FTM_PWMLOAD_CH6SEL_SHIFT                 (6U)
+#define FTM_PWMLOAD_CH6SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH6SEL_SHIFT)) & FTM_PWMLOAD_CH6SEL_MASK)
+#define FTM_PWMLOAD_CH7SEL_MASK                  (0x80U)
+#define FTM_PWMLOAD_CH7SEL_SHIFT                 (7U)
+#define FTM_PWMLOAD_CH7SEL(x)                    (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_CH7SEL_SHIFT)) & FTM_PWMLOAD_CH7SEL_MASK)
+#define FTM_PWMLOAD_LDOK_MASK                    (0x200U)
+#define FTM_PWMLOAD_LDOK_SHIFT                   (9U)
+#define FTM_PWMLOAD_LDOK(x)                      (((uint32_t)(((uint32_t)(x)) << FTM_PWMLOAD_LDOK_SHIFT)) & FTM_PWMLOAD_LDOK_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group FTM_Register_Masks */
+
+
+/* FTM - Peripheral instance base addresses */
+/** Peripheral FTM0 base address */
+#define FTM0_BASE                                (0x40038000u)
+/** Peripheral FTM0 base pointer */
+#define FTM0                                     ((FTM_Type *)FTM0_BASE)
+/** Peripheral FTM1 base address */
+#define FTM1_BASE                                (0x40039000u)
+/** Peripheral FTM1 base pointer */
+#define FTM1                                     ((FTM_Type *)FTM1_BASE)
+/** Peripheral FTM2 base address */
+#define FTM2_BASE                                (0x4003A000u)
+/** Peripheral FTM2 base pointer */
+#define FTM2                                     ((FTM_Type *)FTM2_BASE)
+/** Peripheral FTM3 base address */
+#define FTM3_BASE                                (0x400B9000u)
+/** Peripheral FTM3 base pointer */
+#define FTM3                                     ((FTM_Type *)FTM3_BASE)
+/** Array initializer of FTM peripheral base addresses */
+#define FTM_BASE_ADDRS                           { FTM0_BASE, FTM1_BASE, FTM2_BASE, FTM3_BASE }
+/** Array initializer of FTM peripheral base pointers */
+#define FTM_BASE_PTRS                            { FTM0, FTM1, FTM2, FTM3 }
+/** Interrupt vectors for the FTM peripheral type */
+#define FTM_IRQS                                 { FTM0_IRQn, FTM1_IRQn, FTM2_IRQn, FTM3_IRQn }
+
+/*!
+ * @}
+ */ /* end of group FTM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Peripheral_Access_Layer GPIO Peripheral Access Layer
+ * @{
+ */
+
+/** GPIO - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PDOR;                              /**< Port Data Output Register, offset: 0x0 */
+  __O  uint32_t PSOR;                              /**< Port Set Output Register, offset: 0x4 */
+  __O  uint32_t PCOR;                              /**< Port Clear Output Register, offset: 0x8 */
+  __O  uint32_t PTOR;                              /**< Port Toggle Output Register, offset: 0xC */
+  __I  uint32_t PDIR;                              /**< Port Data Input Register, offset: 0x10 */
+  __IO uint32_t PDDR;                              /**< Port Data Direction Register, offset: 0x14 */
+} GPIO_Type;
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Masks GPIO Register Masks
+ * @{
+ */
+
+/*! @name PDOR - Port Data Output Register */
+#define GPIO_PDOR_PDO_MASK                       (0xFFFFFFFFU)
+#define GPIO_PDOR_PDO_SHIFT                      (0U)
+#define GPIO_PDOR_PDO(x)                         (((uint32_t)(((uint32_t)(x)) << GPIO_PDOR_PDO_SHIFT)) & GPIO_PDOR_PDO_MASK)
+
+/*! @name PSOR - Port Set Output Register */
+#define GPIO_PSOR_PTSO_MASK                      (0xFFFFFFFFU)
+#define GPIO_PSOR_PTSO_SHIFT                     (0U)
+#define GPIO_PSOR_PTSO(x)                        (((uint32_t)(((uint32_t)(x)) << GPIO_PSOR_PTSO_SHIFT)) & GPIO_PSOR_PTSO_MASK)
+
+/*! @name PCOR - Port Clear Output Register */
+#define GPIO_PCOR_PTCO_MASK                      (0xFFFFFFFFU)
+#define GPIO_PCOR_PTCO_SHIFT                     (0U)
+#define GPIO_PCOR_PTCO(x)                        (((uint32_t)(((uint32_t)(x)) << GPIO_PCOR_PTCO_SHIFT)) & GPIO_PCOR_PTCO_MASK)
+
+/*! @name PTOR - Port Toggle Output Register */
+#define GPIO_PTOR_PTTO_MASK                      (0xFFFFFFFFU)
+#define GPIO_PTOR_PTTO_SHIFT                     (0U)
+#define GPIO_PTOR_PTTO(x)                        (((uint32_t)(((uint32_t)(x)) << GPIO_PTOR_PTTO_SHIFT)) & GPIO_PTOR_PTTO_MASK)
+
+/*! @name PDIR - Port Data Input Register */
+#define GPIO_PDIR_PDI_MASK                       (0xFFFFFFFFU)
+#define GPIO_PDIR_PDI_SHIFT                      (0U)
+#define GPIO_PDIR_PDI(x)                         (((uint32_t)(((uint32_t)(x)) << GPIO_PDIR_PDI_SHIFT)) & GPIO_PDIR_PDI_MASK)
+
+/*! @name PDDR - Port Data Direction Register */
+#define GPIO_PDDR_PDD_MASK                       (0xFFFFFFFFU)
+#define GPIO_PDDR_PDD_SHIFT                      (0U)
+#define GPIO_PDDR_PDD(x)                         (((uint32_t)(((uint32_t)(x)) << GPIO_PDDR_PDD_SHIFT)) & GPIO_PDDR_PDD_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Masks */
+
+
+/* GPIO - Peripheral instance base addresses */
+/** Peripheral GPIOA base address */
+#define GPIOA_BASE                               (0x400FF000u)
+/** Peripheral GPIOA base pointer */
+#define GPIOA                                    ((GPIO_Type *)GPIOA_BASE)
+/** Peripheral GPIOB base address */
+#define GPIOB_BASE                               (0x400FF040u)
+/** Peripheral GPIOB base pointer */
+#define GPIOB                                    ((GPIO_Type *)GPIOB_BASE)
+/** Peripheral GPIOC base address */
+#define GPIOC_BASE                               (0x400FF080u)
+/** Peripheral GPIOC base pointer */
+#define GPIOC                                    ((GPIO_Type *)GPIOC_BASE)
+/** Peripheral GPIOD base address */
+#define GPIOD_BASE                               (0x400FF0C0u)
+/** Peripheral GPIOD base pointer */
+#define GPIOD                                    ((GPIO_Type *)GPIOD_BASE)
+/** Peripheral GPIOE base address */
+#define GPIOE_BASE                               (0x400FF100u)
+/** Peripheral GPIOE base pointer */
+#define GPIOE                                    ((GPIO_Type *)GPIOE_BASE)
+/** Array initializer of GPIO peripheral base addresses */
+#define GPIO_BASE_ADDRS                          { GPIOA_BASE, GPIOB_BASE, GPIOC_BASE, GPIOD_BASE, GPIOE_BASE }
+/** Array initializer of GPIO peripheral base pointers */
+#define GPIO_BASE_PTRS                           { GPIOA, GPIOB, GPIOC, GPIOD, GPIOE }
+
+/*!
+ * @}
+ */ /* end of group GPIO_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2C Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Peripheral_Access_Layer I2C Peripheral Access Layer
+ * @{
+ */
+
+/** I2C - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t A1;                                 /**< I2C Address Register 1, offset: 0x0 */
+  __IO uint8_t F;                                  /**< I2C Frequency Divider register, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< I2C Control Register 1, offset: 0x2 */
+  __IO uint8_t S;                                  /**< I2C Status register, offset: 0x3 */
+  __IO uint8_t D;                                  /**< I2C Data I/O register, offset: 0x4 */
+  __IO uint8_t C2;                                 /**< I2C Control Register 2, offset: 0x5 */
+  __IO uint8_t FLT;                                /**< I2C Programmable Input Glitch Filter register, offset: 0x6 */
+  __IO uint8_t RA;                                 /**< I2C Range Address register, offset: 0x7 */
+  __IO uint8_t SMB;                                /**< I2C SMBus Control and Status register, offset: 0x8 */
+  __IO uint8_t A2;                                 /**< I2C Address Register 2, offset: 0x9 */
+  __IO uint8_t SLTH;                               /**< I2C SCL Low Timeout Register High, offset: 0xA */
+  __IO uint8_t SLTL;                               /**< I2C SCL Low Timeout Register Low, offset: 0xB */
+} I2C_Type;
+
+/* ----------------------------------------------------------------------------
+   -- I2C Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Masks I2C Register Masks
+ * @{
+ */
+
+/*! @name A1 - I2C Address Register 1 */
+#define I2C_A1_AD_MASK                           (0xFEU)
+#define I2C_A1_AD_SHIFT                          (1U)
+#define I2C_A1_AD(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_A1_AD_SHIFT)) & I2C_A1_AD_MASK)
+
+/*! @name F - I2C Frequency Divider register */
+#define I2C_F_ICR_MASK                           (0x3FU)
+#define I2C_F_ICR_SHIFT                          (0U)
+#define I2C_F_ICR(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_F_ICR_SHIFT)) & I2C_F_ICR_MASK)
+#define I2C_F_MULT_MASK                          (0xC0U)
+#define I2C_F_MULT_SHIFT                         (6U)
+#define I2C_F_MULT(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_F_MULT_SHIFT)) & I2C_F_MULT_MASK)
+
+/*! @name C1 - I2C Control Register 1 */
+#define I2C_C1_DMAEN_MASK                        (0x1U)
+#define I2C_C1_DMAEN_SHIFT                       (0U)
+#define I2C_C1_DMAEN(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_C1_DMAEN_SHIFT)) & I2C_C1_DMAEN_MASK)
+#define I2C_C1_WUEN_MASK                         (0x2U)
+#define I2C_C1_WUEN_SHIFT                        (1U)
+#define I2C_C1_WUEN(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_C1_WUEN_SHIFT)) & I2C_C1_WUEN_MASK)
+#define I2C_C1_RSTA_MASK                         (0x4U)
+#define I2C_C1_RSTA_SHIFT                        (2U)
+#define I2C_C1_RSTA(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_C1_RSTA_SHIFT)) & I2C_C1_RSTA_MASK)
+#define I2C_C1_TXAK_MASK                         (0x8U)
+#define I2C_C1_TXAK_SHIFT                        (3U)
+#define I2C_C1_TXAK(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_C1_TXAK_SHIFT)) & I2C_C1_TXAK_MASK)
+#define I2C_C1_TX_MASK                           (0x10U)
+#define I2C_C1_TX_SHIFT                          (4U)
+#define I2C_C1_TX(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_C1_TX_SHIFT)) & I2C_C1_TX_MASK)
+#define I2C_C1_MST_MASK                          (0x20U)
+#define I2C_C1_MST_SHIFT                         (5U)
+#define I2C_C1_MST(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_C1_MST_SHIFT)) & I2C_C1_MST_MASK)
+#define I2C_C1_IICIE_MASK                        (0x40U)
+#define I2C_C1_IICIE_SHIFT                       (6U)
+#define I2C_C1_IICIE(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_C1_IICIE_SHIFT)) & I2C_C1_IICIE_MASK)
+#define I2C_C1_IICEN_MASK                        (0x80U)
+#define I2C_C1_IICEN_SHIFT                       (7U)
+#define I2C_C1_IICEN(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_C1_IICEN_SHIFT)) & I2C_C1_IICEN_MASK)
+
+/*! @name S - I2C Status register */
+#define I2C_S_RXAK_MASK                          (0x1U)
+#define I2C_S_RXAK_SHIFT                         (0U)
+#define I2C_S_RXAK(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_S_RXAK_SHIFT)) & I2C_S_RXAK_MASK)
+#define I2C_S_IICIF_MASK                         (0x2U)
+#define I2C_S_IICIF_SHIFT                        (1U)
+#define I2C_S_IICIF(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_S_IICIF_SHIFT)) & I2C_S_IICIF_MASK)
+#define I2C_S_SRW_MASK                           (0x4U)
+#define I2C_S_SRW_SHIFT                          (2U)
+#define I2C_S_SRW(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_S_SRW_SHIFT)) & I2C_S_SRW_MASK)
+#define I2C_S_RAM_MASK                           (0x8U)
+#define I2C_S_RAM_SHIFT                          (3U)
+#define I2C_S_RAM(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_S_RAM_SHIFT)) & I2C_S_RAM_MASK)
+#define I2C_S_ARBL_MASK                          (0x10U)
+#define I2C_S_ARBL_SHIFT                         (4U)
+#define I2C_S_ARBL(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_S_ARBL_SHIFT)) & I2C_S_ARBL_MASK)
+#define I2C_S_BUSY_MASK                          (0x20U)
+#define I2C_S_BUSY_SHIFT                         (5U)
+#define I2C_S_BUSY(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_S_BUSY_SHIFT)) & I2C_S_BUSY_MASK)
+#define I2C_S_IAAS_MASK                          (0x40U)
+#define I2C_S_IAAS_SHIFT                         (6U)
+#define I2C_S_IAAS(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_S_IAAS_SHIFT)) & I2C_S_IAAS_MASK)
+#define I2C_S_TCF_MASK                           (0x80U)
+#define I2C_S_TCF_SHIFT                          (7U)
+#define I2C_S_TCF(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_S_TCF_SHIFT)) & I2C_S_TCF_MASK)
+
+/*! @name D - I2C Data I/O register */
+#define I2C_D_DATA_MASK                          (0xFFU)
+#define I2C_D_DATA_SHIFT                         (0U)
+#define I2C_D_DATA(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_D_DATA_SHIFT)) & I2C_D_DATA_MASK)
+
+/*! @name C2 - I2C Control Register 2 */
+#define I2C_C2_AD_MASK                           (0x7U)
+#define I2C_C2_AD_SHIFT                          (0U)
+#define I2C_C2_AD(x)                             (((uint8_t)(((uint8_t)(x)) << I2C_C2_AD_SHIFT)) & I2C_C2_AD_MASK)
+#define I2C_C2_RMEN_MASK                         (0x8U)
+#define I2C_C2_RMEN_SHIFT                        (3U)
+#define I2C_C2_RMEN(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_C2_RMEN_SHIFT)) & I2C_C2_RMEN_MASK)
+#define I2C_C2_SBRC_MASK                         (0x10U)
+#define I2C_C2_SBRC_SHIFT                        (4U)
+#define I2C_C2_SBRC(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_C2_SBRC_SHIFT)) & I2C_C2_SBRC_MASK)
+#define I2C_C2_HDRS_MASK                         (0x20U)
+#define I2C_C2_HDRS_SHIFT                        (5U)
+#define I2C_C2_HDRS(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_C2_HDRS_SHIFT)) & I2C_C2_HDRS_MASK)
+#define I2C_C2_ADEXT_MASK                        (0x40U)
+#define I2C_C2_ADEXT_SHIFT                       (6U)
+#define I2C_C2_ADEXT(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_C2_ADEXT_SHIFT)) & I2C_C2_ADEXT_MASK)
+#define I2C_C2_GCAEN_MASK                        (0x80U)
+#define I2C_C2_GCAEN_SHIFT                       (7U)
+#define I2C_C2_GCAEN(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_C2_GCAEN_SHIFT)) & I2C_C2_GCAEN_MASK)
+
+/*! @name FLT - I2C Programmable Input Glitch Filter register */
+#define I2C_FLT_FLT_MASK                         (0xFU)
+#define I2C_FLT_FLT_SHIFT                        (0U)
+#define I2C_FLT_FLT(x)                           (((uint8_t)(((uint8_t)(x)) << I2C_FLT_FLT_SHIFT)) & I2C_FLT_FLT_MASK)
+#define I2C_FLT_STARTF_MASK                      (0x10U)
+#define I2C_FLT_STARTF_SHIFT                     (4U)
+#define I2C_FLT_STARTF(x)                        (((uint8_t)(((uint8_t)(x)) << I2C_FLT_STARTF_SHIFT)) & I2C_FLT_STARTF_MASK)
+#define I2C_FLT_SSIE_MASK                        (0x20U)
+#define I2C_FLT_SSIE_SHIFT                       (5U)
+#define I2C_FLT_SSIE(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_FLT_SSIE_SHIFT)) & I2C_FLT_SSIE_MASK)
+#define I2C_FLT_STOPF_MASK                       (0x40U)
+#define I2C_FLT_STOPF_SHIFT                      (6U)
+#define I2C_FLT_STOPF(x)                         (((uint8_t)(((uint8_t)(x)) << I2C_FLT_STOPF_SHIFT)) & I2C_FLT_STOPF_MASK)
+#define I2C_FLT_SHEN_MASK                        (0x80U)
+#define I2C_FLT_SHEN_SHIFT                       (7U)
+#define I2C_FLT_SHEN(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_FLT_SHEN_SHIFT)) & I2C_FLT_SHEN_MASK)
+
+/*! @name RA - I2C Range Address register */
+#define I2C_RA_RAD_MASK                          (0xFEU)
+#define I2C_RA_RAD_SHIFT                         (1U)
+#define I2C_RA_RAD(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_RA_RAD_SHIFT)) & I2C_RA_RAD_MASK)
+
+/*! @name SMB - I2C SMBus Control and Status register */
+#define I2C_SMB_SHTF2IE_MASK                     (0x1U)
+#define I2C_SMB_SHTF2IE_SHIFT                    (0U)
+#define I2C_SMB_SHTF2IE(x)                       (((uint8_t)(((uint8_t)(x)) << I2C_SMB_SHTF2IE_SHIFT)) & I2C_SMB_SHTF2IE_MASK)
+#define I2C_SMB_SHTF2_MASK                       (0x2U)
+#define I2C_SMB_SHTF2_SHIFT                      (1U)
+#define I2C_SMB_SHTF2(x)                         (((uint8_t)(((uint8_t)(x)) << I2C_SMB_SHTF2_SHIFT)) & I2C_SMB_SHTF2_MASK)
+#define I2C_SMB_SHTF1_MASK                       (0x4U)
+#define I2C_SMB_SHTF1_SHIFT                      (2U)
+#define I2C_SMB_SHTF1(x)                         (((uint8_t)(((uint8_t)(x)) << I2C_SMB_SHTF1_SHIFT)) & I2C_SMB_SHTF1_MASK)
+#define I2C_SMB_SLTF_MASK                        (0x8U)
+#define I2C_SMB_SLTF_SHIFT                       (3U)
+#define I2C_SMB_SLTF(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_SMB_SLTF_SHIFT)) & I2C_SMB_SLTF_MASK)
+#define I2C_SMB_TCKSEL_MASK                      (0x10U)
+#define I2C_SMB_TCKSEL_SHIFT                     (4U)
+#define I2C_SMB_TCKSEL(x)                        (((uint8_t)(((uint8_t)(x)) << I2C_SMB_TCKSEL_SHIFT)) & I2C_SMB_TCKSEL_MASK)
+#define I2C_SMB_SIICAEN_MASK                     (0x20U)
+#define I2C_SMB_SIICAEN_SHIFT                    (5U)
+#define I2C_SMB_SIICAEN(x)                       (((uint8_t)(((uint8_t)(x)) << I2C_SMB_SIICAEN_SHIFT)) & I2C_SMB_SIICAEN_MASK)
+#define I2C_SMB_ALERTEN_MASK                     (0x40U)
+#define I2C_SMB_ALERTEN_SHIFT                    (6U)
+#define I2C_SMB_ALERTEN(x)                       (((uint8_t)(((uint8_t)(x)) << I2C_SMB_ALERTEN_SHIFT)) & I2C_SMB_ALERTEN_MASK)
+#define I2C_SMB_FACK_MASK                        (0x80U)
+#define I2C_SMB_FACK_SHIFT                       (7U)
+#define I2C_SMB_FACK(x)                          (((uint8_t)(((uint8_t)(x)) << I2C_SMB_FACK_SHIFT)) & I2C_SMB_FACK_MASK)
+
+/*! @name A2 - I2C Address Register 2 */
+#define I2C_A2_SAD_MASK                          (0xFEU)
+#define I2C_A2_SAD_SHIFT                         (1U)
+#define I2C_A2_SAD(x)                            (((uint8_t)(((uint8_t)(x)) << I2C_A2_SAD_SHIFT)) & I2C_A2_SAD_MASK)
+
+/*! @name SLTH - I2C SCL Low Timeout Register High */
+#define I2C_SLTH_SSLT_MASK                       (0xFFU)
+#define I2C_SLTH_SSLT_SHIFT                      (0U)
+#define I2C_SLTH_SSLT(x)                         (((uint8_t)(((uint8_t)(x)) << I2C_SLTH_SSLT_SHIFT)) & I2C_SLTH_SSLT_MASK)
+
+/*! @name SLTL - I2C SCL Low Timeout Register Low */
+#define I2C_SLTL_SSLT_MASK                       (0xFFU)
+#define I2C_SLTL_SSLT_SHIFT                      (0U)
+#define I2C_SLTL_SSLT(x)                         (((uint8_t)(((uint8_t)(x)) << I2C_SLTL_SSLT_SHIFT)) & I2C_SLTL_SSLT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Masks */
+
+
+/* I2C - Peripheral instance base addresses */
+/** Peripheral I2C0 base address */
+#define I2C0_BASE                                (0x40066000u)
+/** Peripheral I2C0 base pointer */
+#define I2C0                                     ((I2C_Type *)I2C0_BASE)
+/** Peripheral I2C1 base address */
+#define I2C1_BASE                                (0x40067000u)
+/** Peripheral I2C1 base pointer */
+#define I2C1                                     ((I2C_Type *)I2C1_BASE)
+/** Peripheral I2C2 base address */
+#define I2C2_BASE                                (0x400E6000u)
+/** Peripheral I2C2 base pointer */
+#define I2C2                                     ((I2C_Type *)I2C2_BASE)
+/** Array initializer of I2C peripheral base addresses */
+#define I2C_BASE_ADDRS                           { I2C0_BASE, I2C1_BASE, I2C2_BASE }
+/** Array initializer of I2C peripheral base pointers */
+#define I2C_BASE_PTRS                            { I2C0, I2C1, I2C2 }
+/** Interrupt vectors for the I2C peripheral type */
+#define I2C_IRQS                                 { I2C0_IRQn, I2C1_IRQn, I2C2_IRQn }
+
+/*!
+ * @}
+ */ /* end of group I2C_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2S Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2S_Peripheral_Access_Layer I2S Peripheral Access Layer
+ * @{
+ */
+
+/** I2S - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TCSR;                              /**< SAI Transmit Control Register, offset: 0x0 */
+  __IO uint32_t TCR1;                              /**< SAI Transmit Configuration 1 Register, offset: 0x4 */
+  __IO uint32_t TCR2;                              /**< SAI Transmit Configuration 2 Register, offset: 0x8 */
+  __IO uint32_t TCR3;                              /**< SAI Transmit Configuration 3 Register, offset: 0xC */
+  __IO uint32_t TCR4;                              /**< SAI Transmit Configuration 4 Register, offset: 0x10 */
+  __IO uint32_t TCR5;                              /**< SAI Transmit Configuration 5 Register, offset: 0x14 */
+       uint8_t RESERVED_0[8];
+  __O  uint32_t TDR[2];                            /**< SAI Transmit Data Register, array offset: 0x20, array step: 0x4 */
+       uint8_t RESERVED_1[24];
+  __I  uint32_t TFR[2];                            /**< SAI Transmit FIFO Register, array offset: 0x40, array step: 0x4 */
+       uint8_t RESERVED_2[24];
+  __IO uint32_t TMR;                               /**< SAI Transmit Mask Register, offset: 0x60 */
+       uint8_t RESERVED_3[28];
+  __IO uint32_t RCSR;                              /**< SAI Receive Control Register, offset: 0x80 */
+  __IO uint32_t RCR1;                              /**< SAI Receive Configuration 1 Register, offset: 0x84 */
+  __IO uint32_t RCR2;                              /**< SAI Receive Configuration 2 Register, offset: 0x88 */
+  __IO uint32_t RCR3;                              /**< SAI Receive Configuration 3 Register, offset: 0x8C */
+  __IO uint32_t RCR4;                              /**< SAI Receive Configuration 4 Register, offset: 0x90 */
+  __IO uint32_t RCR5;                              /**< SAI Receive Configuration 5 Register, offset: 0x94 */
+       uint8_t RESERVED_4[8];
+  __I  uint32_t RDR[2];                            /**< SAI Receive Data Register, array offset: 0xA0, array step: 0x4 */
+       uint8_t RESERVED_5[24];
+  __I  uint32_t RFR[2];                            /**< SAI Receive FIFO Register, array offset: 0xC0, array step: 0x4 */
+       uint8_t RESERVED_6[24];
+  __IO uint32_t RMR;                               /**< SAI Receive Mask Register, offset: 0xE0 */
+       uint8_t RESERVED_7[28];
+  __IO uint32_t MCR;                               /**< SAI MCLK Control Register, offset: 0x100 */
+  __IO uint32_t MDR;                               /**< SAI MCLK Divide Register, offset: 0x104 */
+} I2S_Type;
+
+/* ----------------------------------------------------------------------------
+   -- I2S Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2S_Register_Masks I2S Register Masks
+ * @{
+ */
+
+/*! @name TCSR - SAI Transmit Control Register */
+#define I2S_TCSR_FRDE_MASK                       (0x1U)
+#define I2S_TCSR_FRDE_SHIFT                      (0U)
+#define I2S_TCSR_FRDE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FRDE_SHIFT)) & I2S_TCSR_FRDE_MASK)
+#define I2S_TCSR_FWDE_MASK                       (0x2U)
+#define I2S_TCSR_FWDE_SHIFT                      (1U)
+#define I2S_TCSR_FWDE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FWDE_SHIFT)) & I2S_TCSR_FWDE_MASK)
+#define I2S_TCSR_FRIE_MASK                       (0x100U)
+#define I2S_TCSR_FRIE_SHIFT                      (8U)
+#define I2S_TCSR_FRIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FRIE_SHIFT)) & I2S_TCSR_FRIE_MASK)
+#define I2S_TCSR_FWIE_MASK                       (0x200U)
+#define I2S_TCSR_FWIE_SHIFT                      (9U)
+#define I2S_TCSR_FWIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FWIE_SHIFT)) & I2S_TCSR_FWIE_MASK)
+#define I2S_TCSR_FEIE_MASK                       (0x400U)
+#define I2S_TCSR_FEIE_SHIFT                      (10U)
+#define I2S_TCSR_FEIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FEIE_SHIFT)) & I2S_TCSR_FEIE_MASK)
+#define I2S_TCSR_SEIE_MASK                       (0x800U)
+#define I2S_TCSR_SEIE_SHIFT                      (11U)
+#define I2S_TCSR_SEIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_SEIE_SHIFT)) & I2S_TCSR_SEIE_MASK)
+#define I2S_TCSR_WSIE_MASK                       (0x1000U)
+#define I2S_TCSR_WSIE_SHIFT                      (12U)
+#define I2S_TCSR_WSIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_WSIE_SHIFT)) & I2S_TCSR_WSIE_MASK)
+#define I2S_TCSR_FRF_MASK                        (0x10000U)
+#define I2S_TCSR_FRF_SHIFT                       (16U)
+#define I2S_TCSR_FRF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FRF_SHIFT)) & I2S_TCSR_FRF_MASK)
+#define I2S_TCSR_FWF_MASK                        (0x20000U)
+#define I2S_TCSR_FWF_SHIFT                       (17U)
+#define I2S_TCSR_FWF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FWF_SHIFT)) & I2S_TCSR_FWF_MASK)
+#define I2S_TCSR_FEF_MASK                        (0x40000U)
+#define I2S_TCSR_FEF_SHIFT                       (18U)
+#define I2S_TCSR_FEF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FEF_SHIFT)) & I2S_TCSR_FEF_MASK)
+#define I2S_TCSR_SEF_MASK                        (0x80000U)
+#define I2S_TCSR_SEF_SHIFT                       (19U)
+#define I2S_TCSR_SEF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_SEF_SHIFT)) & I2S_TCSR_SEF_MASK)
+#define I2S_TCSR_WSF_MASK                        (0x100000U)
+#define I2S_TCSR_WSF_SHIFT                       (20U)
+#define I2S_TCSR_WSF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_WSF_SHIFT)) & I2S_TCSR_WSF_MASK)
+#define I2S_TCSR_SR_MASK                         (0x1000000U)
+#define I2S_TCSR_SR_SHIFT                        (24U)
+#define I2S_TCSR_SR(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_SR_SHIFT)) & I2S_TCSR_SR_MASK)
+#define I2S_TCSR_FR_MASK                         (0x2000000U)
+#define I2S_TCSR_FR_SHIFT                        (25U)
+#define I2S_TCSR_FR(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_FR_SHIFT)) & I2S_TCSR_FR_MASK)
+#define I2S_TCSR_BCE_MASK                        (0x10000000U)
+#define I2S_TCSR_BCE_SHIFT                       (28U)
+#define I2S_TCSR_BCE(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_BCE_SHIFT)) & I2S_TCSR_BCE_MASK)
+#define I2S_TCSR_DBGE_MASK                       (0x20000000U)
+#define I2S_TCSR_DBGE_SHIFT                      (29U)
+#define I2S_TCSR_DBGE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_DBGE_SHIFT)) & I2S_TCSR_DBGE_MASK)
+#define I2S_TCSR_STOPE_MASK                      (0x40000000U)
+#define I2S_TCSR_STOPE_SHIFT                     (30U)
+#define I2S_TCSR_STOPE(x)                        (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_STOPE_SHIFT)) & I2S_TCSR_STOPE_MASK)
+#define I2S_TCSR_TE_MASK                         (0x80000000U)
+#define I2S_TCSR_TE_SHIFT                        (31U)
+#define I2S_TCSR_TE(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TCSR_TE_SHIFT)) & I2S_TCSR_TE_MASK)
+
+/*! @name TCR1 - SAI Transmit Configuration 1 Register */
+#define I2S_TCR1_TFW_MASK                        (0x7U)
+#define I2S_TCR1_TFW_SHIFT                       (0U)
+#define I2S_TCR1_TFW(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR1_TFW_SHIFT)) & I2S_TCR1_TFW_MASK)
+
+/*! @name TCR2 - SAI Transmit Configuration 2 Register */
+#define I2S_TCR2_DIV_MASK                        (0xFFU)
+#define I2S_TCR2_DIV_SHIFT                       (0U)
+#define I2S_TCR2_DIV(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_DIV_SHIFT)) & I2S_TCR2_DIV_MASK)
+#define I2S_TCR2_BCD_MASK                        (0x1000000U)
+#define I2S_TCR2_BCD_SHIFT                       (24U)
+#define I2S_TCR2_BCD(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_BCD_SHIFT)) & I2S_TCR2_BCD_MASK)
+#define I2S_TCR2_BCP_MASK                        (0x2000000U)
+#define I2S_TCR2_BCP_SHIFT                       (25U)
+#define I2S_TCR2_BCP(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_BCP_SHIFT)) & I2S_TCR2_BCP_MASK)
+#define I2S_TCR2_MSEL_MASK                       (0xC000000U)
+#define I2S_TCR2_MSEL_SHIFT                      (26U)
+#define I2S_TCR2_MSEL(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_MSEL_SHIFT)) & I2S_TCR2_MSEL_MASK)
+#define I2S_TCR2_BCI_MASK                        (0x10000000U)
+#define I2S_TCR2_BCI_SHIFT                       (28U)
+#define I2S_TCR2_BCI(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_BCI_SHIFT)) & I2S_TCR2_BCI_MASK)
+#define I2S_TCR2_BCS_MASK                        (0x20000000U)
+#define I2S_TCR2_BCS_SHIFT                       (29U)
+#define I2S_TCR2_BCS(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_BCS_SHIFT)) & I2S_TCR2_BCS_MASK)
+#define I2S_TCR2_SYNC_MASK                       (0xC0000000U)
+#define I2S_TCR2_SYNC_SHIFT                      (30U)
+#define I2S_TCR2_SYNC(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCR2_SYNC_SHIFT)) & I2S_TCR2_SYNC_MASK)
+
+/*! @name TCR3 - SAI Transmit Configuration 3 Register */
+#define I2S_TCR3_WDFL_MASK                       (0x1FU)
+#define I2S_TCR3_WDFL_SHIFT                      (0U)
+#define I2S_TCR3_WDFL(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCR3_WDFL_SHIFT)) & I2S_TCR3_WDFL_MASK)
+#define I2S_TCR3_TCE_MASK                        (0x30000U)
+#define I2S_TCR3_TCE_SHIFT                       (16U)
+#define I2S_TCR3_TCE(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR3_TCE_SHIFT)) & I2S_TCR3_TCE_MASK)
+
+/*! @name TCR4 - SAI Transmit Configuration 4 Register */
+#define I2S_TCR4_FSD_MASK                        (0x1U)
+#define I2S_TCR4_FSD_SHIFT                       (0U)
+#define I2S_TCR4_FSD(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR4_FSD_SHIFT)) & I2S_TCR4_FSD_MASK)
+#define I2S_TCR4_FSP_MASK                        (0x2U)
+#define I2S_TCR4_FSP_SHIFT                       (1U)
+#define I2S_TCR4_FSP(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR4_FSP_SHIFT)) & I2S_TCR4_FSP_MASK)
+#define I2S_TCR4_FSE_MASK                        (0x8U)
+#define I2S_TCR4_FSE_SHIFT                       (3U)
+#define I2S_TCR4_FSE(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR4_FSE_SHIFT)) & I2S_TCR4_FSE_MASK)
+#define I2S_TCR4_MF_MASK                         (0x10U)
+#define I2S_TCR4_MF_SHIFT                        (4U)
+#define I2S_TCR4_MF(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TCR4_MF_SHIFT)) & I2S_TCR4_MF_MASK)
+#define I2S_TCR4_SYWD_MASK                       (0x1F00U)
+#define I2S_TCR4_SYWD_SHIFT                      (8U)
+#define I2S_TCR4_SYWD(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCR4_SYWD_SHIFT)) & I2S_TCR4_SYWD_MASK)
+#define I2S_TCR4_FRSZ_MASK                       (0x1F0000U)
+#define I2S_TCR4_FRSZ_SHIFT                      (16U)
+#define I2S_TCR4_FRSZ(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_TCR4_FRSZ_SHIFT)) & I2S_TCR4_FRSZ_MASK)
+
+/*! @name TCR5 - SAI Transmit Configuration 5 Register */
+#define I2S_TCR5_FBT_MASK                        (0x1F00U)
+#define I2S_TCR5_FBT_SHIFT                       (8U)
+#define I2S_TCR5_FBT(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR5_FBT_SHIFT)) & I2S_TCR5_FBT_MASK)
+#define I2S_TCR5_W0W_MASK                        (0x1F0000U)
+#define I2S_TCR5_W0W_SHIFT                       (16U)
+#define I2S_TCR5_W0W(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR5_W0W_SHIFT)) & I2S_TCR5_W0W_MASK)
+#define I2S_TCR5_WNW_MASK                        (0x1F000000U)
+#define I2S_TCR5_WNW_SHIFT                       (24U)
+#define I2S_TCR5_WNW(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_TCR5_WNW_SHIFT)) & I2S_TCR5_WNW_MASK)
+
+/*! @name TDR - SAI Transmit Data Register */
+#define I2S_TDR_TDR_MASK                         (0xFFFFFFFFU)
+#define I2S_TDR_TDR_SHIFT                        (0U)
+#define I2S_TDR_TDR(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TDR_TDR_SHIFT)) & I2S_TDR_TDR_MASK)
+
+/* The count of I2S_TDR */
+#define I2S_TDR_COUNT                            (2U)
+
+/*! @name TFR - SAI Transmit FIFO Register */
+#define I2S_TFR_RFP_MASK                         (0xFU)
+#define I2S_TFR_RFP_SHIFT                        (0U)
+#define I2S_TFR_RFP(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TFR_RFP_SHIFT)) & I2S_TFR_RFP_MASK)
+#define I2S_TFR_WFP_MASK                         (0xF0000U)
+#define I2S_TFR_WFP_SHIFT                        (16U)
+#define I2S_TFR_WFP(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TFR_WFP_SHIFT)) & I2S_TFR_WFP_MASK)
+
+/* The count of I2S_TFR */
+#define I2S_TFR_COUNT                            (2U)
+
+/*! @name TMR - SAI Transmit Mask Register */
+#define I2S_TMR_TWM_MASK                         (0xFFFFFFFFU)
+#define I2S_TMR_TWM_SHIFT                        (0U)
+#define I2S_TMR_TWM(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_TMR_TWM_SHIFT)) & I2S_TMR_TWM_MASK)
+
+/*! @name RCSR - SAI Receive Control Register */
+#define I2S_RCSR_FRDE_MASK                       (0x1U)
+#define I2S_RCSR_FRDE_SHIFT                      (0U)
+#define I2S_RCSR_FRDE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FRDE_SHIFT)) & I2S_RCSR_FRDE_MASK)
+#define I2S_RCSR_FWDE_MASK                       (0x2U)
+#define I2S_RCSR_FWDE_SHIFT                      (1U)
+#define I2S_RCSR_FWDE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FWDE_SHIFT)) & I2S_RCSR_FWDE_MASK)
+#define I2S_RCSR_FRIE_MASK                       (0x100U)
+#define I2S_RCSR_FRIE_SHIFT                      (8U)
+#define I2S_RCSR_FRIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FRIE_SHIFT)) & I2S_RCSR_FRIE_MASK)
+#define I2S_RCSR_FWIE_MASK                       (0x200U)
+#define I2S_RCSR_FWIE_SHIFT                      (9U)
+#define I2S_RCSR_FWIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FWIE_SHIFT)) & I2S_RCSR_FWIE_MASK)
+#define I2S_RCSR_FEIE_MASK                       (0x400U)
+#define I2S_RCSR_FEIE_SHIFT                      (10U)
+#define I2S_RCSR_FEIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FEIE_SHIFT)) & I2S_RCSR_FEIE_MASK)
+#define I2S_RCSR_SEIE_MASK                       (0x800U)
+#define I2S_RCSR_SEIE_SHIFT                      (11U)
+#define I2S_RCSR_SEIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_SEIE_SHIFT)) & I2S_RCSR_SEIE_MASK)
+#define I2S_RCSR_WSIE_MASK                       (0x1000U)
+#define I2S_RCSR_WSIE_SHIFT                      (12U)
+#define I2S_RCSR_WSIE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_WSIE_SHIFT)) & I2S_RCSR_WSIE_MASK)
+#define I2S_RCSR_FRF_MASK                        (0x10000U)
+#define I2S_RCSR_FRF_SHIFT                       (16U)
+#define I2S_RCSR_FRF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FRF_SHIFT)) & I2S_RCSR_FRF_MASK)
+#define I2S_RCSR_FWF_MASK                        (0x20000U)
+#define I2S_RCSR_FWF_SHIFT                       (17U)
+#define I2S_RCSR_FWF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FWF_SHIFT)) & I2S_RCSR_FWF_MASK)
+#define I2S_RCSR_FEF_MASK                        (0x40000U)
+#define I2S_RCSR_FEF_SHIFT                       (18U)
+#define I2S_RCSR_FEF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FEF_SHIFT)) & I2S_RCSR_FEF_MASK)
+#define I2S_RCSR_SEF_MASK                        (0x80000U)
+#define I2S_RCSR_SEF_SHIFT                       (19U)
+#define I2S_RCSR_SEF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_SEF_SHIFT)) & I2S_RCSR_SEF_MASK)
+#define I2S_RCSR_WSF_MASK                        (0x100000U)
+#define I2S_RCSR_WSF_SHIFT                       (20U)
+#define I2S_RCSR_WSF(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_WSF_SHIFT)) & I2S_RCSR_WSF_MASK)
+#define I2S_RCSR_SR_MASK                         (0x1000000U)
+#define I2S_RCSR_SR_SHIFT                        (24U)
+#define I2S_RCSR_SR(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_SR_SHIFT)) & I2S_RCSR_SR_MASK)
+#define I2S_RCSR_FR_MASK                         (0x2000000U)
+#define I2S_RCSR_FR_SHIFT                        (25U)
+#define I2S_RCSR_FR(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_FR_SHIFT)) & I2S_RCSR_FR_MASK)
+#define I2S_RCSR_BCE_MASK                        (0x10000000U)
+#define I2S_RCSR_BCE_SHIFT                       (28U)
+#define I2S_RCSR_BCE(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_BCE_SHIFT)) & I2S_RCSR_BCE_MASK)
+#define I2S_RCSR_DBGE_MASK                       (0x20000000U)
+#define I2S_RCSR_DBGE_SHIFT                      (29U)
+#define I2S_RCSR_DBGE(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_DBGE_SHIFT)) & I2S_RCSR_DBGE_MASK)
+#define I2S_RCSR_STOPE_MASK                      (0x40000000U)
+#define I2S_RCSR_STOPE_SHIFT                     (30U)
+#define I2S_RCSR_STOPE(x)                        (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_STOPE_SHIFT)) & I2S_RCSR_STOPE_MASK)
+#define I2S_RCSR_RE_MASK                         (0x80000000U)
+#define I2S_RCSR_RE_SHIFT                        (31U)
+#define I2S_RCSR_RE(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RCSR_RE_SHIFT)) & I2S_RCSR_RE_MASK)
+
+/*! @name RCR1 - SAI Receive Configuration 1 Register */
+#define I2S_RCR1_RFW_MASK                        (0x7U)
+#define I2S_RCR1_RFW_SHIFT                       (0U)
+#define I2S_RCR1_RFW(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR1_RFW_SHIFT)) & I2S_RCR1_RFW_MASK)
+
+/*! @name RCR2 - SAI Receive Configuration 2 Register */
+#define I2S_RCR2_DIV_MASK                        (0xFFU)
+#define I2S_RCR2_DIV_SHIFT                       (0U)
+#define I2S_RCR2_DIV(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_DIV_SHIFT)) & I2S_RCR2_DIV_MASK)
+#define I2S_RCR2_BCD_MASK                        (0x1000000U)
+#define I2S_RCR2_BCD_SHIFT                       (24U)
+#define I2S_RCR2_BCD(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_BCD_SHIFT)) & I2S_RCR2_BCD_MASK)
+#define I2S_RCR2_BCP_MASK                        (0x2000000U)
+#define I2S_RCR2_BCP_SHIFT                       (25U)
+#define I2S_RCR2_BCP(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_BCP_SHIFT)) & I2S_RCR2_BCP_MASK)
+#define I2S_RCR2_MSEL_MASK                       (0xC000000U)
+#define I2S_RCR2_MSEL_SHIFT                      (26U)
+#define I2S_RCR2_MSEL(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_MSEL_SHIFT)) & I2S_RCR2_MSEL_MASK)
+#define I2S_RCR2_BCI_MASK                        (0x10000000U)
+#define I2S_RCR2_BCI_SHIFT                       (28U)
+#define I2S_RCR2_BCI(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_BCI_SHIFT)) & I2S_RCR2_BCI_MASK)
+#define I2S_RCR2_BCS_MASK                        (0x20000000U)
+#define I2S_RCR2_BCS_SHIFT                       (29U)
+#define I2S_RCR2_BCS(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_BCS_SHIFT)) & I2S_RCR2_BCS_MASK)
+#define I2S_RCR2_SYNC_MASK                       (0xC0000000U)
+#define I2S_RCR2_SYNC_SHIFT                      (30U)
+#define I2S_RCR2_SYNC(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCR2_SYNC_SHIFT)) & I2S_RCR2_SYNC_MASK)
+
+/*! @name RCR3 - SAI Receive Configuration 3 Register */
+#define I2S_RCR3_WDFL_MASK                       (0x1FU)
+#define I2S_RCR3_WDFL_SHIFT                      (0U)
+#define I2S_RCR3_WDFL(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCR3_WDFL_SHIFT)) & I2S_RCR3_WDFL_MASK)
+#define I2S_RCR3_RCE_MASK                        (0x30000U)
+#define I2S_RCR3_RCE_SHIFT                       (16U)
+#define I2S_RCR3_RCE(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR3_RCE_SHIFT)) & I2S_RCR3_RCE_MASK)
+
+/*! @name RCR4 - SAI Receive Configuration 4 Register */
+#define I2S_RCR4_FSD_MASK                        (0x1U)
+#define I2S_RCR4_FSD_SHIFT                       (0U)
+#define I2S_RCR4_FSD(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR4_FSD_SHIFT)) & I2S_RCR4_FSD_MASK)
+#define I2S_RCR4_FSP_MASK                        (0x2U)
+#define I2S_RCR4_FSP_SHIFT                       (1U)
+#define I2S_RCR4_FSP(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR4_FSP_SHIFT)) & I2S_RCR4_FSP_MASK)
+#define I2S_RCR4_FSE_MASK                        (0x8U)
+#define I2S_RCR4_FSE_SHIFT                       (3U)
+#define I2S_RCR4_FSE(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR4_FSE_SHIFT)) & I2S_RCR4_FSE_MASK)
+#define I2S_RCR4_MF_MASK                         (0x10U)
+#define I2S_RCR4_MF_SHIFT                        (4U)
+#define I2S_RCR4_MF(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RCR4_MF_SHIFT)) & I2S_RCR4_MF_MASK)
+#define I2S_RCR4_SYWD_MASK                       (0x1F00U)
+#define I2S_RCR4_SYWD_SHIFT                      (8U)
+#define I2S_RCR4_SYWD(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCR4_SYWD_SHIFT)) & I2S_RCR4_SYWD_MASK)
+#define I2S_RCR4_FRSZ_MASK                       (0x1F0000U)
+#define I2S_RCR4_FRSZ_SHIFT                      (16U)
+#define I2S_RCR4_FRSZ(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_RCR4_FRSZ_SHIFT)) & I2S_RCR4_FRSZ_MASK)
+
+/*! @name RCR5 - SAI Receive Configuration 5 Register */
+#define I2S_RCR5_FBT_MASK                        (0x1F00U)
+#define I2S_RCR5_FBT_SHIFT                       (8U)
+#define I2S_RCR5_FBT(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR5_FBT_SHIFT)) & I2S_RCR5_FBT_MASK)
+#define I2S_RCR5_W0W_MASK                        (0x1F0000U)
+#define I2S_RCR5_W0W_SHIFT                       (16U)
+#define I2S_RCR5_W0W(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR5_W0W_SHIFT)) & I2S_RCR5_W0W_MASK)
+#define I2S_RCR5_WNW_MASK                        (0x1F000000U)
+#define I2S_RCR5_WNW_SHIFT                       (24U)
+#define I2S_RCR5_WNW(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_RCR5_WNW_SHIFT)) & I2S_RCR5_WNW_MASK)
+
+/*! @name RDR - SAI Receive Data Register */
+#define I2S_RDR_RDR_MASK                         (0xFFFFFFFFU)
+#define I2S_RDR_RDR_SHIFT                        (0U)
+#define I2S_RDR_RDR(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RDR_RDR_SHIFT)) & I2S_RDR_RDR_MASK)
+
+/* The count of I2S_RDR */
+#define I2S_RDR_COUNT                            (2U)
+
+/*! @name RFR - SAI Receive FIFO Register */
+#define I2S_RFR_RFP_MASK                         (0xFU)
+#define I2S_RFR_RFP_SHIFT                        (0U)
+#define I2S_RFR_RFP(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RFR_RFP_SHIFT)) & I2S_RFR_RFP_MASK)
+#define I2S_RFR_WFP_MASK                         (0xF0000U)
+#define I2S_RFR_WFP_SHIFT                        (16U)
+#define I2S_RFR_WFP(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RFR_WFP_SHIFT)) & I2S_RFR_WFP_MASK)
+
+/* The count of I2S_RFR */
+#define I2S_RFR_COUNT                            (2U)
+
+/*! @name RMR - SAI Receive Mask Register */
+#define I2S_RMR_RWM_MASK                         (0xFFFFFFFFU)
+#define I2S_RMR_RWM_SHIFT                        (0U)
+#define I2S_RMR_RWM(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_RMR_RWM_SHIFT)) & I2S_RMR_RWM_MASK)
+
+/*! @name MCR - SAI MCLK Control Register */
+#define I2S_MCR_MICS_MASK                        (0x3000000U)
+#define I2S_MCR_MICS_SHIFT                       (24U)
+#define I2S_MCR_MICS(x)                          (((uint32_t)(((uint32_t)(x)) << I2S_MCR_MICS_SHIFT)) & I2S_MCR_MICS_MASK)
+#define I2S_MCR_MOE_MASK                         (0x40000000U)
+#define I2S_MCR_MOE_SHIFT                        (30U)
+#define I2S_MCR_MOE(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_MCR_MOE_SHIFT)) & I2S_MCR_MOE_MASK)
+#define I2S_MCR_DUF_MASK                         (0x80000000U)
+#define I2S_MCR_DUF_SHIFT                        (31U)
+#define I2S_MCR_DUF(x)                           (((uint32_t)(((uint32_t)(x)) << I2S_MCR_DUF_SHIFT)) & I2S_MCR_DUF_MASK)
+
+/*! @name MDR - SAI MCLK Divide Register */
+#define I2S_MDR_DIVIDE_MASK                      (0xFFFU)
+#define I2S_MDR_DIVIDE_SHIFT                     (0U)
+#define I2S_MDR_DIVIDE(x)                        (((uint32_t)(((uint32_t)(x)) << I2S_MDR_DIVIDE_SHIFT)) & I2S_MDR_DIVIDE_MASK)
+#define I2S_MDR_FRACT_MASK                       (0xFF000U)
+#define I2S_MDR_FRACT_SHIFT                      (12U)
+#define I2S_MDR_FRACT(x)                         (((uint32_t)(((uint32_t)(x)) << I2S_MDR_FRACT_SHIFT)) & I2S_MDR_FRACT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group I2S_Register_Masks */
+
+
+/* I2S - Peripheral instance base addresses */
+/** Peripheral I2S0 base address */
+#define I2S0_BASE                                (0x4002F000u)
+/** Peripheral I2S0 base pointer */
+#define I2S0                                     ((I2S_Type *)I2S0_BASE)
+/** Array initializer of I2S peripheral base addresses */
+#define I2S_BASE_ADDRS                           { I2S0_BASE }
+/** Array initializer of I2S peripheral base pointers */
+#define I2S_BASE_PTRS                            { I2S0 }
+/** Interrupt vectors for the I2S peripheral type */
+#define I2S_RX_IRQS                              { I2S0_Rx_IRQn }
+#define I2S_TX_IRQS                              { I2S0_Tx_IRQn }
+
+/*!
+ * @}
+ */ /* end of group I2S_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Peripheral_Access_Layer LLWU Peripheral Access Layer
+ * @{
+ */
+
+/** LLWU - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PE1;                                /**< LLWU Pin Enable 1 register, offset: 0x0 */
+  __IO uint8_t PE2;                                /**< LLWU Pin Enable 2 register, offset: 0x1 */
+  __IO uint8_t PE3;                                /**< LLWU Pin Enable 3 register, offset: 0x2 */
+  __IO uint8_t PE4;                                /**< LLWU Pin Enable 4 register, offset: 0x3 */
+  __IO uint8_t ME;                                 /**< LLWU Module Enable register, offset: 0x4 */
+  __IO uint8_t F1;                                 /**< LLWU Flag 1 register, offset: 0x5 */
+  __IO uint8_t F2;                                 /**< LLWU Flag 2 register, offset: 0x6 */
+  __I  uint8_t F3;                                 /**< LLWU Flag 3 register, offset: 0x7 */
+  __IO uint8_t FILT1;                              /**< LLWU Pin Filter 1 register, offset: 0x8 */
+  __IO uint8_t FILT2;                              /**< LLWU Pin Filter 2 register, offset: 0x9 */
+  __IO uint8_t RST;                                /**< LLWU Reset Enable register, offset: 0xA */
+} LLWU_Type;
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Masks LLWU Register Masks
+ * @{
+ */
+
+/*! @name PE1 - LLWU Pin Enable 1 register */
+#define LLWU_PE1_WUPE0_MASK                      (0x3U)
+#define LLWU_PE1_WUPE0_SHIFT                     (0U)
+#define LLWU_PE1_WUPE0(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE1_WUPE0_SHIFT)) & LLWU_PE1_WUPE0_MASK)
+#define LLWU_PE1_WUPE1_MASK                      (0xCU)
+#define LLWU_PE1_WUPE1_SHIFT                     (2U)
+#define LLWU_PE1_WUPE1(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE1_WUPE1_SHIFT)) & LLWU_PE1_WUPE1_MASK)
+#define LLWU_PE1_WUPE2_MASK                      (0x30U)
+#define LLWU_PE1_WUPE2_SHIFT                     (4U)
+#define LLWU_PE1_WUPE2(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE1_WUPE2_SHIFT)) & LLWU_PE1_WUPE2_MASK)
+#define LLWU_PE1_WUPE3_MASK                      (0xC0U)
+#define LLWU_PE1_WUPE3_SHIFT                     (6U)
+#define LLWU_PE1_WUPE3(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE1_WUPE3_SHIFT)) & LLWU_PE1_WUPE3_MASK)
+
+/*! @name PE2 - LLWU Pin Enable 2 register */
+#define LLWU_PE2_WUPE4_MASK                      (0x3U)
+#define LLWU_PE2_WUPE4_SHIFT                     (0U)
+#define LLWU_PE2_WUPE4(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE2_WUPE4_SHIFT)) & LLWU_PE2_WUPE4_MASK)
+#define LLWU_PE2_WUPE5_MASK                      (0xCU)
+#define LLWU_PE2_WUPE5_SHIFT                     (2U)
+#define LLWU_PE2_WUPE5(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE2_WUPE5_SHIFT)) & LLWU_PE2_WUPE5_MASK)
+#define LLWU_PE2_WUPE6_MASK                      (0x30U)
+#define LLWU_PE2_WUPE6_SHIFT                     (4U)
+#define LLWU_PE2_WUPE6(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE2_WUPE6_SHIFT)) & LLWU_PE2_WUPE6_MASK)
+#define LLWU_PE2_WUPE7_MASK                      (0xC0U)
+#define LLWU_PE2_WUPE7_SHIFT                     (6U)
+#define LLWU_PE2_WUPE7(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE2_WUPE7_SHIFT)) & LLWU_PE2_WUPE7_MASK)
+
+/*! @name PE3 - LLWU Pin Enable 3 register */
+#define LLWU_PE3_WUPE8_MASK                      (0x3U)
+#define LLWU_PE3_WUPE8_SHIFT                     (0U)
+#define LLWU_PE3_WUPE8(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE3_WUPE8_SHIFT)) & LLWU_PE3_WUPE8_MASK)
+#define LLWU_PE3_WUPE9_MASK                      (0xCU)
+#define LLWU_PE3_WUPE9_SHIFT                     (2U)
+#define LLWU_PE3_WUPE9(x)                        (((uint8_t)(((uint8_t)(x)) << LLWU_PE3_WUPE9_SHIFT)) & LLWU_PE3_WUPE9_MASK)
+#define LLWU_PE3_WUPE10_MASK                     (0x30U)
+#define LLWU_PE3_WUPE10_SHIFT                    (4U)
+#define LLWU_PE3_WUPE10(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_PE3_WUPE10_SHIFT)) & LLWU_PE3_WUPE10_MASK)
+#define LLWU_PE3_WUPE11_MASK                     (0xC0U)
+#define LLWU_PE3_WUPE11_SHIFT                    (6U)
+#define LLWU_PE3_WUPE11(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_PE3_WUPE11_SHIFT)) & LLWU_PE3_WUPE11_MASK)
+
+/*! @name PE4 - LLWU Pin Enable 4 register */
+#define LLWU_PE4_WUPE12_MASK                     (0x3U)
+#define LLWU_PE4_WUPE12_SHIFT                    (0U)
+#define LLWU_PE4_WUPE12(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_PE4_WUPE12_SHIFT)) & LLWU_PE4_WUPE12_MASK)
+#define LLWU_PE4_WUPE13_MASK                     (0xCU)
+#define LLWU_PE4_WUPE13_SHIFT                    (2U)
+#define LLWU_PE4_WUPE13(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_PE4_WUPE13_SHIFT)) & LLWU_PE4_WUPE13_MASK)
+#define LLWU_PE4_WUPE14_MASK                     (0x30U)
+#define LLWU_PE4_WUPE14_SHIFT                    (4U)
+#define LLWU_PE4_WUPE14(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_PE4_WUPE14_SHIFT)) & LLWU_PE4_WUPE14_MASK)
+#define LLWU_PE4_WUPE15_MASK                     (0xC0U)
+#define LLWU_PE4_WUPE15_SHIFT                    (6U)
+#define LLWU_PE4_WUPE15(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_PE4_WUPE15_SHIFT)) & LLWU_PE4_WUPE15_MASK)
+
+/*! @name ME - LLWU Module Enable register */
+#define LLWU_ME_WUME0_MASK                       (0x1U)
+#define LLWU_ME_WUME0_SHIFT                      (0U)
+#define LLWU_ME_WUME0(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME0_SHIFT)) & LLWU_ME_WUME0_MASK)
+#define LLWU_ME_WUME1_MASK                       (0x2U)
+#define LLWU_ME_WUME1_SHIFT                      (1U)
+#define LLWU_ME_WUME1(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME1_SHIFT)) & LLWU_ME_WUME1_MASK)
+#define LLWU_ME_WUME2_MASK                       (0x4U)
+#define LLWU_ME_WUME2_SHIFT                      (2U)
+#define LLWU_ME_WUME2(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME2_SHIFT)) & LLWU_ME_WUME2_MASK)
+#define LLWU_ME_WUME3_MASK                       (0x8U)
+#define LLWU_ME_WUME3_SHIFT                      (3U)
+#define LLWU_ME_WUME3(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME3_SHIFT)) & LLWU_ME_WUME3_MASK)
+#define LLWU_ME_WUME4_MASK                       (0x10U)
+#define LLWU_ME_WUME4_SHIFT                      (4U)
+#define LLWU_ME_WUME4(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME4_SHIFT)) & LLWU_ME_WUME4_MASK)
+#define LLWU_ME_WUME5_MASK                       (0x20U)
+#define LLWU_ME_WUME5_SHIFT                      (5U)
+#define LLWU_ME_WUME5(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME5_SHIFT)) & LLWU_ME_WUME5_MASK)
+#define LLWU_ME_WUME6_MASK                       (0x40U)
+#define LLWU_ME_WUME6_SHIFT                      (6U)
+#define LLWU_ME_WUME6(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME6_SHIFT)) & LLWU_ME_WUME6_MASK)
+#define LLWU_ME_WUME7_MASK                       (0x80U)
+#define LLWU_ME_WUME7_SHIFT                      (7U)
+#define LLWU_ME_WUME7(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_ME_WUME7_SHIFT)) & LLWU_ME_WUME7_MASK)
+
+/*! @name F1 - LLWU Flag 1 register */
+#define LLWU_F1_WUF0_MASK                        (0x1U)
+#define LLWU_F1_WUF0_SHIFT                       (0U)
+#define LLWU_F1_WUF0(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF0_SHIFT)) & LLWU_F1_WUF0_MASK)
+#define LLWU_F1_WUF1_MASK                        (0x2U)
+#define LLWU_F1_WUF1_SHIFT                       (1U)
+#define LLWU_F1_WUF1(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF1_SHIFT)) & LLWU_F1_WUF1_MASK)
+#define LLWU_F1_WUF2_MASK                        (0x4U)
+#define LLWU_F1_WUF2_SHIFT                       (2U)
+#define LLWU_F1_WUF2(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF2_SHIFT)) & LLWU_F1_WUF2_MASK)
+#define LLWU_F1_WUF3_MASK                        (0x8U)
+#define LLWU_F1_WUF3_SHIFT                       (3U)
+#define LLWU_F1_WUF3(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF3_SHIFT)) & LLWU_F1_WUF3_MASK)
+#define LLWU_F1_WUF4_MASK                        (0x10U)
+#define LLWU_F1_WUF4_SHIFT                       (4U)
+#define LLWU_F1_WUF4(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF4_SHIFT)) & LLWU_F1_WUF4_MASK)
+#define LLWU_F1_WUF5_MASK                        (0x20U)
+#define LLWU_F1_WUF5_SHIFT                       (5U)
+#define LLWU_F1_WUF5(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF5_SHIFT)) & LLWU_F1_WUF5_MASK)
+#define LLWU_F1_WUF6_MASK                        (0x40U)
+#define LLWU_F1_WUF6_SHIFT                       (6U)
+#define LLWU_F1_WUF6(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF6_SHIFT)) & LLWU_F1_WUF6_MASK)
+#define LLWU_F1_WUF7_MASK                        (0x80U)
+#define LLWU_F1_WUF7_SHIFT                       (7U)
+#define LLWU_F1_WUF7(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F1_WUF7_SHIFT)) & LLWU_F1_WUF7_MASK)
+
+/*! @name F2 - LLWU Flag 2 register */
+#define LLWU_F2_WUF8_MASK                        (0x1U)
+#define LLWU_F2_WUF8_SHIFT                       (0U)
+#define LLWU_F2_WUF8(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF8_SHIFT)) & LLWU_F2_WUF8_MASK)
+#define LLWU_F2_WUF9_MASK                        (0x2U)
+#define LLWU_F2_WUF9_SHIFT                       (1U)
+#define LLWU_F2_WUF9(x)                          (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF9_SHIFT)) & LLWU_F2_WUF9_MASK)
+#define LLWU_F2_WUF10_MASK                       (0x4U)
+#define LLWU_F2_WUF10_SHIFT                      (2U)
+#define LLWU_F2_WUF10(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF10_SHIFT)) & LLWU_F2_WUF10_MASK)
+#define LLWU_F2_WUF11_MASK                       (0x8U)
+#define LLWU_F2_WUF11_SHIFT                      (3U)
+#define LLWU_F2_WUF11(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF11_SHIFT)) & LLWU_F2_WUF11_MASK)
+#define LLWU_F2_WUF12_MASK                       (0x10U)
+#define LLWU_F2_WUF12_SHIFT                      (4U)
+#define LLWU_F2_WUF12(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF12_SHIFT)) & LLWU_F2_WUF12_MASK)
+#define LLWU_F2_WUF13_MASK                       (0x20U)
+#define LLWU_F2_WUF13_SHIFT                      (5U)
+#define LLWU_F2_WUF13(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF13_SHIFT)) & LLWU_F2_WUF13_MASK)
+#define LLWU_F2_WUF14_MASK                       (0x40U)
+#define LLWU_F2_WUF14_SHIFT                      (6U)
+#define LLWU_F2_WUF14(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF14_SHIFT)) & LLWU_F2_WUF14_MASK)
+#define LLWU_F2_WUF15_MASK                       (0x80U)
+#define LLWU_F2_WUF15_SHIFT                      (7U)
+#define LLWU_F2_WUF15(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F2_WUF15_SHIFT)) & LLWU_F2_WUF15_MASK)
+
+/*! @name F3 - LLWU Flag 3 register */
+#define LLWU_F3_MWUF0_MASK                       (0x1U)
+#define LLWU_F3_MWUF0_SHIFT                      (0U)
+#define LLWU_F3_MWUF0(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF0_SHIFT)) & LLWU_F3_MWUF0_MASK)
+#define LLWU_F3_MWUF1_MASK                       (0x2U)
+#define LLWU_F3_MWUF1_SHIFT                      (1U)
+#define LLWU_F3_MWUF1(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF1_SHIFT)) & LLWU_F3_MWUF1_MASK)
+#define LLWU_F3_MWUF2_MASK                       (0x4U)
+#define LLWU_F3_MWUF2_SHIFT                      (2U)
+#define LLWU_F3_MWUF2(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF2_SHIFT)) & LLWU_F3_MWUF2_MASK)
+#define LLWU_F3_MWUF3_MASK                       (0x8U)
+#define LLWU_F3_MWUF3_SHIFT                      (3U)
+#define LLWU_F3_MWUF3(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF3_SHIFT)) & LLWU_F3_MWUF3_MASK)
+#define LLWU_F3_MWUF4_MASK                       (0x10U)
+#define LLWU_F3_MWUF4_SHIFT                      (4U)
+#define LLWU_F3_MWUF4(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF4_SHIFT)) & LLWU_F3_MWUF4_MASK)
+#define LLWU_F3_MWUF5_MASK                       (0x20U)
+#define LLWU_F3_MWUF5_SHIFT                      (5U)
+#define LLWU_F3_MWUF5(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF5_SHIFT)) & LLWU_F3_MWUF5_MASK)
+#define LLWU_F3_MWUF6_MASK                       (0x40U)
+#define LLWU_F3_MWUF6_SHIFT                      (6U)
+#define LLWU_F3_MWUF6(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF6_SHIFT)) & LLWU_F3_MWUF6_MASK)
+#define LLWU_F3_MWUF7_MASK                       (0x80U)
+#define LLWU_F3_MWUF7_SHIFT                      (7U)
+#define LLWU_F3_MWUF7(x)                         (((uint8_t)(((uint8_t)(x)) << LLWU_F3_MWUF7_SHIFT)) & LLWU_F3_MWUF7_MASK)
+
+/*! @name FILT1 - LLWU Pin Filter 1 register */
+#define LLWU_FILT1_FILTSEL_MASK                  (0xFU)
+#define LLWU_FILT1_FILTSEL_SHIFT                 (0U)
+#define LLWU_FILT1_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x)) << LLWU_FILT1_FILTSEL_SHIFT)) & LLWU_FILT1_FILTSEL_MASK)
+#define LLWU_FILT1_FILTE_MASK                    (0x60U)
+#define LLWU_FILT1_FILTE_SHIFT                   (5U)
+#define LLWU_FILT1_FILTE(x)                      (((uint8_t)(((uint8_t)(x)) << LLWU_FILT1_FILTE_SHIFT)) & LLWU_FILT1_FILTE_MASK)
+#define LLWU_FILT1_FILTF_MASK                    (0x80U)
+#define LLWU_FILT1_FILTF_SHIFT                   (7U)
+#define LLWU_FILT1_FILTF(x)                      (((uint8_t)(((uint8_t)(x)) << LLWU_FILT1_FILTF_SHIFT)) & LLWU_FILT1_FILTF_MASK)
+
+/*! @name FILT2 - LLWU Pin Filter 2 register */
+#define LLWU_FILT2_FILTSEL_MASK                  (0xFU)
+#define LLWU_FILT2_FILTSEL_SHIFT                 (0U)
+#define LLWU_FILT2_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x)) << LLWU_FILT2_FILTSEL_SHIFT)) & LLWU_FILT2_FILTSEL_MASK)
+#define LLWU_FILT2_FILTE_MASK                    (0x60U)
+#define LLWU_FILT2_FILTE_SHIFT                   (5U)
+#define LLWU_FILT2_FILTE(x)                      (((uint8_t)(((uint8_t)(x)) << LLWU_FILT2_FILTE_SHIFT)) & LLWU_FILT2_FILTE_MASK)
+#define LLWU_FILT2_FILTF_MASK                    (0x80U)
+#define LLWU_FILT2_FILTF_SHIFT                   (7U)
+#define LLWU_FILT2_FILTF(x)                      (((uint8_t)(((uint8_t)(x)) << LLWU_FILT2_FILTF_SHIFT)) & LLWU_FILT2_FILTF_MASK)
+
+/*! @name RST - LLWU Reset Enable register */
+#define LLWU_RST_RSTFILT_MASK                    (0x1U)
+#define LLWU_RST_RSTFILT_SHIFT                   (0U)
+#define LLWU_RST_RSTFILT(x)                      (((uint8_t)(((uint8_t)(x)) << LLWU_RST_RSTFILT_SHIFT)) & LLWU_RST_RSTFILT_MASK)
+#define LLWU_RST_LLRSTE_MASK                     (0x2U)
+#define LLWU_RST_LLRSTE_SHIFT                    (1U)
+#define LLWU_RST_LLRSTE(x)                       (((uint8_t)(((uint8_t)(x)) << LLWU_RST_LLRSTE_SHIFT)) & LLWU_RST_LLRSTE_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Masks */
+
+
+/* LLWU - Peripheral instance base addresses */
+/** Peripheral LLWU base address */
+#define LLWU_BASE                                (0x4007C000u)
+/** Peripheral LLWU base pointer */
+#define LLWU                                     ((LLWU_Type *)LLWU_BASE)
+/** Array initializer of LLWU peripheral base addresses */
+#define LLWU_BASE_ADDRS                          { LLWU_BASE }
+/** Array initializer of LLWU peripheral base pointers */
+#define LLWU_BASE_PTRS                           { LLWU }
+/** Interrupt vectors for the LLWU peripheral type */
+#define LLWU_IRQS                                { LLWU_IRQn }
+
+/*!
+ * @}
+ */ /* end of group LLWU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Peripheral_Access_Layer LPTMR Peripheral Access Layer
+ * @{
+ */
+
+/** LPTMR - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CSR;                               /**< Low Power Timer Control Status Register, offset: 0x0 */
+  __IO uint32_t PSR;                               /**< Low Power Timer Prescale Register, offset: 0x4 */
+  __IO uint32_t CMR;                               /**< Low Power Timer Compare Register, offset: 0x8 */
+  __IO uint32_t CNR;                               /**< Low Power Timer Counter Register, offset: 0xC */
+} LPTMR_Type;
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Masks LPTMR Register Masks
+ * @{
+ */
+
+/*! @name CSR - Low Power Timer Control Status Register */
+#define LPTMR_CSR_TEN_MASK                       (0x1U)
+#define LPTMR_CSR_TEN_SHIFT                      (0U)
+#define LPTMR_CSR_TEN(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TEN_SHIFT)) & LPTMR_CSR_TEN_MASK)
+#define LPTMR_CSR_TMS_MASK                       (0x2U)
+#define LPTMR_CSR_TMS_SHIFT                      (1U)
+#define LPTMR_CSR_TMS(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TMS_SHIFT)) & LPTMR_CSR_TMS_MASK)
+#define LPTMR_CSR_TFC_MASK                       (0x4U)
+#define LPTMR_CSR_TFC_SHIFT                      (2U)
+#define LPTMR_CSR_TFC(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TFC_SHIFT)) & LPTMR_CSR_TFC_MASK)
+#define LPTMR_CSR_TPP_MASK                       (0x8U)
+#define LPTMR_CSR_TPP_SHIFT                      (3U)
+#define LPTMR_CSR_TPP(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TPP_SHIFT)) & LPTMR_CSR_TPP_MASK)
+#define LPTMR_CSR_TPS_MASK                       (0x30U)
+#define LPTMR_CSR_TPS_SHIFT                      (4U)
+#define LPTMR_CSR_TPS(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TPS_SHIFT)) & LPTMR_CSR_TPS_MASK)
+#define LPTMR_CSR_TIE_MASK                       (0x40U)
+#define LPTMR_CSR_TIE_SHIFT                      (6U)
+#define LPTMR_CSR_TIE(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TIE_SHIFT)) & LPTMR_CSR_TIE_MASK)
+#define LPTMR_CSR_TCF_MASK                       (0x80U)
+#define LPTMR_CSR_TCF_SHIFT                      (7U)
+#define LPTMR_CSR_TCF(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_CSR_TCF_SHIFT)) & LPTMR_CSR_TCF_MASK)
+
+/*! @name PSR - Low Power Timer Prescale Register */
+#define LPTMR_PSR_PCS_MASK                       (0x3U)
+#define LPTMR_PSR_PCS_SHIFT                      (0U)
+#define LPTMR_PSR_PCS(x)                         (((uint32_t)(((uint32_t)(x)) << LPTMR_PSR_PCS_SHIFT)) & LPTMR_PSR_PCS_MASK)
+#define LPTMR_PSR_PBYP_MASK                      (0x4U)
+#define LPTMR_PSR_PBYP_SHIFT                     (2U)
+#define LPTMR_PSR_PBYP(x)                        (((uint32_t)(((uint32_t)(x)) << LPTMR_PSR_PBYP_SHIFT)) & LPTMR_PSR_PBYP_MASK)
+#define LPTMR_PSR_PRESCALE_MASK                  (0x78U)
+#define LPTMR_PSR_PRESCALE_SHIFT                 (3U)
+#define LPTMR_PSR_PRESCALE(x)                    (((uint32_t)(((uint32_t)(x)) << LPTMR_PSR_PRESCALE_SHIFT)) & LPTMR_PSR_PRESCALE_MASK)
+
+/*! @name CMR - Low Power Timer Compare Register */
+#define LPTMR_CMR_COMPARE_MASK                   (0xFFFFU)
+#define LPTMR_CMR_COMPARE_SHIFT                  (0U)
+#define LPTMR_CMR_COMPARE(x)                     (((uint32_t)(((uint32_t)(x)) << LPTMR_CMR_COMPARE_SHIFT)) & LPTMR_CMR_COMPARE_MASK)
+
+/*! @name CNR - Low Power Timer Counter Register */
+#define LPTMR_CNR_COUNTER_MASK                   (0xFFFFU)
+#define LPTMR_CNR_COUNTER_SHIFT                  (0U)
+#define LPTMR_CNR_COUNTER(x)                     (((uint32_t)(((uint32_t)(x)) << LPTMR_CNR_COUNTER_SHIFT)) & LPTMR_CNR_COUNTER_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Masks */
+
+
+/* LPTMR - Peripheral instance base addresses */
+/** Peripheral LPTMR0 base address */
+#define LPTMR0_BASE                              (0x40040000u)
+/** Peripheral LPTMR0 base pointer */
+#define LPTMR0                                   ((LPTMR_Type *)LPTMR0_BASE)
+/** Array initializer of LPTMR peripheral base addresses */
+#define LPTMR_BASE_ADDRS                         { LPTMR0_BASE }
+/** Array initializer of LPTMR peripheral base pointers */
+#define LPTMR_BASE_PTRS                          { LPTMR0 }
+/** Interrupt vectors for the LPTMR peripheral type */
+#define LPTMR_IRQS                               { LPTMR0_IRQn }
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Peripheral_Access_Layer MCG Peripheral Access Layer
+ * @{
+ */
+
+/** MCG - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t C1;                                 /**< MCG Control 1 Register, offset: 0x0 */
+  __IO uint8_t C2;                                 /**< MCG Control 2 Register, offset: 0x1 */
+  __IO uint8_t C3;                                 /**< MCG Control 3 Register, offset: 0x2 */
+  __IO uint8_t C4;                                 /**< MCG Control 4 Register, offset: 0x3 */
+  __IO uint8_t C5;                                 /**< MCG Control 5 Register, offset: 0x4 */
+  __IO uint8_t C6;                                 /**< MCG Control 6 Register, offset: 0x5 */
+  __IO uint8_t S;                                  /**< MCG Status Register, offset: 0x6 */
+       uint8_t RESERVED_0[1];
+  __IO uint8_t SC;                                 /**< MCG Status and Control Register, offset: 0x8 */
+       uint8_t RESERVED_1[1];
+  __IO uint8_t ATCVH;                              /**< MCG Auto Trim Compare Value High Register, offset: 0xA */
+  __IO uint8_t ATCVL;                              /**< MCG Auto Trim Compare Value Low Register, offset: 0xB */
+  __IO uint8_t C7;                                 /**< MCG Control 7 Register, offset: 0xC */
+  __IO uint8_t C8;                                 /**< MCG Control 8 Register, offset: 0xD */
+} MCG_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MCG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Masks MCG Register Masks
+ * @{
+ */
+
+/*! @name C1 - MCG Control 1 Register */
+#define MCG_C1_IREFSTEN_MASK                     (0x1U)
+#define MCG_C1_IREFSTEN_SHIFT                    (0U)
+#define MCG_C1_IREFSTEN(x)                       (((uint8_t)(((uint8_t)(x)) << MCG_C1_IREFSTEN_SHIFT)) & MCG_C1_IREFSTEN_MASK)
+#define MCG_C1_IRCLKEN_MASK                      (0x2U)
+#define MCG_C1_IRCLKEN_SHIFT                     (1U)
+#define MCG_C1_IRCLKEN(x)                        (((uint8_t)(((uint8_t)(x)) << MCG_C1_IRCLKEN_SHIFT)) & MCG_C1_IRCLKEN_MASK)
+#define MCG_C1_IREFS_MASK                        (0x4U)
+#define MCG_C1_IREFS_SHIFT                       (2U)
+#define MCG_C1_IREFS(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C1_IREFS_SHIFT)) & MCG_C1_IREFS_MASK)
+#define MCG_C1_FRDIV_MASK                        (0x38U)
+#define MCG_C1_FRDIV_SHIFT                       (3U)
+#define MCG_C1_FRDIV(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C1_FRDIV_SHIFT)) & MCG_C1_FRDIV_MASK)
+#define MCG_C1_CLKS_MASK                         (0xC0U)
+#define MCG_C1_CLKS_SHIFT                        (6U)
+#define MCG_C1_CLKS(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_C1_CLKS_SHIFT)) & MCG_C1_CLKS_MASK)
+
+/*! @name C2 - MCG Control 2 Register */
+#define MCG_C2_IRCS_MASK                         (0x1U)
+#define MCG_C2_IRCS_SHIFT                        (0U)
+#define MCG_C2_IRCS(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_C2_IRCS_SHIFT)) & MCG_C2_IRCS_MASK)
+#define MCG_C2_LP_MASK                           (0x2U)
+#define MCG_C2_LP_SHIFT                          (1U)
+#define MCG_C2_LP(x)                             (((uint8_t)(((uint8_t)(x)) << MCG_C2_LP_SHIFT)) & MCG_C2_LP_MASK)
+#define MCG_C2_EREFS_MASK                        (0x4U)
+#define MCG_C2_EREFS_SHIFT                       (2U)
+#define MCG_C2_EREFS(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C2_EREFS_SHIFT)) & MCG_C2_EREFS_MASK)
+#define MCG_C2_HGO_MASK                          (0x8U)
+#define MCG_C2_HGO_SHIFT                         (3U)
+#define MCG_C2_HGO(x)                            (((uint8_t)(((uint8_t)(x)) << MCG_C2_HGO_SHIFT)) & MCG_C2_HGO_MASK)
+#define MCG_C2_RANGE_MASK                        (0x30U)
+#define MCG_C2_RANGE_SHIFT                       (4U)
+#define MCG_C2_RANGE(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C2_RANGE_SHIFT)) & MCG_C2_RANGE_MASK)
+#define MCG_C2_FCFTRIM_MASK                      (0x40U)
+#define MCG_C2_FCFTRIM_SHIFT                     (6U)
+#define MCG_C2_FCFTRIM(x)                        (((uint8_t)(((uint8_t)(x)) << MCG_C2_FCFTRIM_SHIFT)) & MCG_C2_FCFTRIM_MASK)
+#define MCG_C2_LOCRE0_MASK                       (0x80U)
+#define MCG_C2_LOCRE0_SHIFT                      (7U)
+#define MCG_C2_LOCRE0(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C2_LOCRE0_SHIFT)) & MCG_C2_LOCRE0_MASK)
+
+/*! @name C3 - MCG Control 3 Register */
+#define MCG_C3_SCTRIM_MASK                       (0xFFU)
+#define MCG_C3_SCTRIM_SHIFT                      (0U)
+#define MCG_C3_SCTRIM(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C3_SCTRIM_SHIFT)) & MCG_C3_SCTRIM_MASK)
+
+/*! @name C4 - MCG Control 4 Register */
+#define MCG_C4_SCFTRIM_MASK                      (0x1U)
+#define MCG_C4_SCFTRIM_SHIFT                     (0U)
+#define MCG_C4_SCFTRIM(x)                        (((uint8_t)(((uint8_t)(x)) << MCG_C4_SCFTRIM_SHIFT)) & MCG_C4_SCFTRIM_MASK)
+#define MCG_C4_FCTRIM_MASK                       (0x1EU)
+#define MCG_C4_FCTRIM_SHIFT                      (1U)
+#define MCG_C4_FCTRIM(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C4_FCTRIM_SHIFT)) & MCG_C4_FCTRIM_MASK)
+#define MCG_C4_DRST_DRS_MASK                     (0x60U)
+#define MCG_C4_DRST_DRS_SHIFT                    (5U)
+#define MCG_C4_DRST_DRS(x)                       (((uint8_t)(((uint8_t)(x)) << MCG_C4_DRST_DRS_SHIFT)) & MCG_C4_DRST_DRS_MASK)
+#define MCG_C4_DMX32_MASK                        (0x80U)
+#define MCG_C4_DMX32_SHIFT                       (7U)
+#define MCG_C4_DMX32(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C4_DMX32_SHIFT)) & MCG_C4_DMX32_MASK)
+
+/*! @name C5 - MCG Control 5 Register */
+#define MCG_C5_PRDIV0_MASK                       (0x1FU)
+#define MCG_C5_PRDIV0_SHIFT                      (0U)
+#define MCG_C5_PRDIV0(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C5_PRDIV0_SHIFT)) & MCG_C5_PRDIV0_MASK)
+#define MCG_C5_PLLSTEN0_MASK                     (0x20U)
+#define MCG_C5_PLLSTEN0_SHIFT                    (5U)
+#define MCG_C5_PLLSTEN0(x)                       (((uint8_t)(((uint8_t)(x)) << MCG_C5_PLLSTEN0_SHIFT)) & MCG_C5_PLLSTEN0_MASK)
+#define MCG_C5_PLLCLKEN0_MASK                    (0x40U)
+#define MCG_C5_PLLCLKEN0_SHIFT                   (6U)
+#define MCG_C5_PLLCLKEN0(x)                      (((uint8_t)(((uint8_t)(x)) << MCG_C5_PLLCLKEN0_SHIFT)) & MCG_C5_PLLCLKEN0_MASK)
+
+/*! @name C6 - MCG Control 6 Register */
+#define MCG_C6_VDIV0_MASK                        (0x1FU)
+#define MCG_C6_VDIV0_SHIFT                       (0U)
+#define MCG_C6_VDIV0(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C6_VDIV0_SHIFT)) & MCG_C6_VDIV0_MASK)
+#define MCG_C6_CME0_MASK                         (0x20U)
+#define MCG_C6_CME0_SHIFT                        (5U)
+#define MCG_C6_CME0(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_C6_CME0_SHIFT)) & MCG_C6_CME0_MASK)
+#define MCG_C6_PLLS_MASK                         (0x40U)
+#define MCG_C6_PLLS_SHIFT                        (6U)
+#define MCG_C6_PLLS(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_C6_PLLS_SHIFT)) & MCG_C6_PLLS_MASK)
+#define MCG_C6_LOLIE0_MASK                       (0x80U)
+#define MCG_C6_LOLIE0_SHIFT                      (7U)
+#define MCG_C6_LOLIE0(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C6_LOLIE0_SHIFT)) & MCG_C6_LOLIE0_MASK)
+
+/*! @name S - MCG Status Register */
+#define MCG_S_IRCST_MASK                         (0x1U)
+#define MCG_S_IRCST_SHIFT                        (0U)
+#define MCG_S_IRCST(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_S_IRCST_SHIFT)) & MCG_S_IRCST_MASK)
+#define MCG_S_OSCINIT0_MASK                      (0x2U)
+#define MCG_S_OSCINIT0_SHIFT                     (1U)
+#define MCG_S_OSCINIT0(x)                        (((uint8_t)(((uint8_t)(x)) << MCG_S_OSCINIT0_SHIFT)) & MCG_S_OSCINIT0_MASK)
+#define MCG_S_CLKST_MASK                         (0xCU)
+#define MCG_S_CLKST_SHIFT                        (2U)
+#define MCG_S_CLKST(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_S_CLKST_SHIFT)) & MCG_S_CLKST_MASK)
+#define MCG_S_IREFST_MASK                        (0x10U)
+#define MCG_S_IREFST_SHIFT                       (4U)
+#define MCG_S_IREFST(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_S_IREFST_SHIFT)) & MCG_S_IREFST_MASK)
+#define MCG_S_PLLST_MASK                         (0x20U)
+#define MCG_S_PLLST_SHIFT                        (5U)
+#define MCG_S_PLLST(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_S_PLLST_SHIFT)) & MCG_S_PLLST_MASK)
+#define MCG_S_LOCK0_MASK                         (0x40U)
+#define MCG_S_LOCK0_SHIFT                        (6U)
+#define MCG_S_LOCK0(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_S_LOCK0_SHIFT)) & MCG_S_LOCK0_MASK)
+#define MCG_S_LOLS0_MASK                         (0x80U)
+#define MCG_S_LOLS0_SHIFT                        (7U)
+#define MCG_S_LOLS0(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_S_LOLS0_SHIFT)) & MCG_S_LOLS0_MASK)
+
+/*! @name SC - MCG Status and Control Register */
+#define MCG_SC_LOCS0_MASK                        (0x1U)
+#define MCG_SC_LOCS0_SHIFT                       (0U)
+#define MCG_SC_LOCS0(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_SC_LOCS0_SHIFT)) & MCG_SC_LOCS0_MASK)
+#define MCG_SC_FCRDIV_MASK                       (0xEU)
+#define MCG_SC_FCRDIV_SHIFT                      (1U)
+#define MCG_SC_FCRDIV(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_SC_FCRDIV_SHIFT)) & MCG_SC_FCRDIV_MASK)
+#define MCG_SC_FLTPRSRV_MASK                     (0x10U)
+#define MCG_SC_FLTPRSRV_SHIFT                    (4U)
+#define MCG_SC_FLTPRSRV(x)                       (((uint8_t)(((uint8_t)(x)) << MCG_SC_FLTPRSRV_SHIFT)) & MCG_SC_FLTPRSRV_MASK)
+#define MCG_SC_ATMF_MASK                         (0x20U)
+#define MCG_SC_ATMF_SHIFT                        (5U)
+#define MCG_SC_ATMF(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_SC_ATMF_SHIFT)) & MCG_SC_ATMF_MASK)
+#define MCG_SC_ATMS_MASK                         (0x40U)
+#define MCG_SC_ATMS_SHIFT                        (6U)
+#define MCG_SC_ATMS(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_SC_ATMS_SHIFT)) & MCG_SC_ATMS_MASK)
+#define MCG_SC_ATME_MASK                         (0x80U)
+#define MCG_SC_ATME_SHIFT                        (7U)
+#define MCG_SC_ATME(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_SC_ATME_SHIFT)) & MCG_SC_ATME_MASK)
+
+/*! @name ATCVH - MCG Auto Trim Compare Value High Register */
+#define MCG_ATCVH_ATCVH_MASK                     (0xFFU)
+#define MCG_ATCVH_ATCVH_SHIFT                    (0U)
+#define MCG_ATCVH_ATCVH(x)                       (((uint8_t)(((uint8_t)(x)) << MCG_ATCVH_ATCVH_SHIFT)) & MCG_ATCVH_ATCVH_MASK)
+
+/*! @name ATCVL - MCG Auto Trim Compare Value Low Register */
+#define MCG_ATCVL_ATCVL_MASK                     (0xFFU)
+#define MCG_ATCVL_ATCVL_SHIFT                    (0U)
+#define MCG_ATCVL_ATCVL(x)                       (((uint8_t)(((uint8_t)(x)) << MCG_ATCVL_ATCVL_SHIFT)) & MCG_ATCVL_ATCVL_MASK)
+
+/*! @name C7 - MCG Control 7 Register */
+#define MCG_C7_OSCSEL_MASK                       (0x3U)
+#define MCG_C7_OSCSEL_SHIFT                      (0U)
+#define MCG_C7_OSCSEL(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C7_OSCSEL_SHIFT)) & MCG_C7_OSCSEL_MASK)
+
+/*! @name C8 - MCG Control 8 Register */
+#define MCG_C8_LOCS1_MASK                        (0x1U)
+#define MCG_C8_LOCS1_SHIFT                       (0U)
+#define MCG_C8_LOCS1(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C8_LOCS1_SHIFT)) & MCG_C8_LOCS1_MASK)
+#define MCG_C8_CME1_MASK                         (0x20U)
+#define MCG_C8_CME1_SHIFT                        (5U)
+#define MCG_C8_CME1(x)                           (((uint8_t)(((uint8_t)(x)) << MCG_C8_CME1_SHIFT)) & MCG_C8_CME1_MASK)
+#define MCG_C8_LOLRE_MASK                        (0x40U)
+#define MCG_C8_LOLRE_SHIFT                       (6U)
+#define MCG_C8_LOLRE(x)                          (((uint8_t)(((uint8_t)(x)) << MCG_C8_LOLRE_SHIFT)) & MCG_C8_LOLRE_MASK)
+#define MCG_C8_LOCRE1_MASK                       (0x80U)
+#define MCG_C8_LOCRE1_SHIFT                      (7U)
+#define MCG_C8_LOCRE1(x)                         (((uint8_t)(((uint8_t)(x)) << MCG_C8_LOCRE1_SHIFT)) & MCG_C8_LOCRE1_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Masks */
+
+
+/* MCG - Peripheral instance base addresses */
+/** Peripheral MCG base address */
+#define MCG_BASE                                 (0x40064000u)
+/** Peripheral MCG base pointer */
+#define MCG                                      ((MCG_Type *)MCG_BASE)
+/** Array initializer of MCG peripheral base addresses */
+#define MCG_BASE_ADDRS                           { MCG_BASE }
+/** Array initializer of MCG peripheral base pointers */
+#define MCG_BASE_PTRS                            { MCG }
+
+/*!
+ * @}
+ */ /* end of group MCG_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Peripheral_Access_Layer MCM Peripheral Access Layer
+ * @{
+ */
+
+/** MCM - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[8];
+  __I  uint16_t PLASC;                             /**< Crossbar Switch (AXBS) Slave Configuration, offset: 0x8 */
+  __I  uint16_t PLAMC;                             /**< Crossbar Switch (AXBS) Master Configuration, offset: 0xA */
+  __IO uint32_t CR;                                /**< Control Register, offset: 0xC */
+  __IO uint32_t ISCR;                              /**< Interrupt Status Register, offset: 0x10 */
+  __IO uint32_t ETBCC;                             /**< ETB Counter Control register, offset: 0x14 */
+  __IO uint32_t ETBRL;                             /**< ETB Reload register, offset: 0x18 */
+  __I  uint32_t ETBCNT;                            /**< ETB Counter Value register, offset: 0x1C */
+       uint8_t RESERVED_1[16];
+  __IO uint32_t PID;                               /**< Process ID register, offset: 0x30 */
+} MCM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Masks MCM Register Masks
+ * @{
+ */
+
+/*! @name PLASC - Crossbar Switch (AXBS) Slave Configuration */
+#define MCM_PLASC_ASC_MASK                       (0xFFU)
+#define MCM_PLASC_ASC_SHIFT                      (0U)
+#define MCM_PLASC_ASC(x)                         (((uint16_t)(((uint16_t)(x)) << MCM_PLASC_ASC_SHIFT)) & MCM_PLASC_ASC_MASK)
+
+/*! @name PLAMC - Crossbar Switch (AXBS) Master Configuration */
+#define MCM_PLAMC_AMC_MASK                       (0xFFU)
+#define MCM_PLAMC_AMC_SHIFT                      (0U)
+#define MCM_PLAMC_AMC(x)                         (((uint16_t)(((uint16_t)(x)) << MCM_PLAMC_AMC_SHIFT)) & MCM_PLAMC_AMC_MASK)
+
+/*! @name CR - Control Register */
+#define MCM_CR_SRAMUAP_MASK                      (0x3000000U)
+#define MCM_CR_SRAMUAP_SHIFT                     (24U)
+#define MCM_CR_SRAMUAP(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_CR_SRAMUAP_SHIFT)) & MCM_CR_SRAMUAP_MASK)
+#define MCM_CR_SRAMUWP_MASK                      (0x4000000U)
+#define MCM_CR_SRAMUWP_SHIFT                     (26U)
+#define MCM_CR_SRAMUWP(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_CR_SRAMUWP_SHIFT)) & MCM_CR_SRAMUWP_MASK)
+#define MCM_CR_SRAMLAP_MASK                      (0x30000000U)
+#define MCM_CR_SRAMLAP_SHIFT                     (28U)
+#define MCM_CR_SRAMLAP(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_CR_SRAMLAP_SHIFT)) & MCM_CR_SRAMLAP_MASK)
+#define MCM_CR_SRAMLWP_MASK                      (0x40000000U)
+#define MCM_CR_SRAMLWP_SHIFT                     (30U)
+#define MCM_CR_SRAMLWP(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_CR_SRAMLWP_SHIFT)) & MCM_CR_SRAMLWP_MASK)
+
+/*! @name ISCR - Interrupt Status Register */
+#define MCM_ISCR_IRQ_MASK                        (0x2U)
+#define MCM_ISCR_IRQ_SHIFT                       (1U)
+#define MCM_ISCR_IRQ(x)                          (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_IRQ_SHIFT)) & MCM_ISCR_IRQ_MASK)
+#define MCM_ISCR_NMI_MASK                        (0x4U)
+#define MCM_ISCR_NMI_SHIFT                       (2U)
+#define MCM_ISCR_NMI(x)                          (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_NMI_SHIFT)) & MCM_ISCR_NMI_MASK)
+#define MCM_ISCR_DHREQ_MASK                      (0x8U)
+#define MCM_ISCR_DHREQ_SHIFT                     (3U)
+#define MCM_ISCR_DHREQ(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_DHREQ_SHIFT)) & MCM_ISCR_DHREQ_MASK)
+#define MCM_ISCR_FIOC_MASK                       (0x100U)
+#define MCM_ISCR_FIOC_SHIFT                      (8U)
+#define MCM_ISCR_FIOC(x)                         (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FIOC_SHIFT)) & MCM_ISCR_FIOC_MASK)
+#define MCM_ISCR_FDZC_MASK                       (0x200U)
+#define MCM_ISCR_FDZC_SHIFT                      (9U)
+#define MCM_ISCR_FDZC(x)                         (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FDZC_SHIFT)) & MCM_ISCR_FDZC_MASK)
+#define MCM_ISCR_FOFC_MASK                       (0x400U)
+#define MCM_ISCR_FOFC_SHIFT                      (10U)
+#define MCM_ISCR_FOFC(x)                         (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FOFC_SHIFT)) & MCM_ISCR_FOFC_MASK)
+#define MCM_ISCR_FUFC_MASK                       (0x800U)
+#define MCM_ISCR_FUFC_SHIFT                      (11U)
+#define MCM_ISCR_FUFC(x)                         (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FUFC_SHIFT)) & MCM_ISCR_FUFC_MASK)
+#define MCM_ISCR_FIXC_MASK                       (0x1000U)
+#define MCM_ISCR_FIXC_SHIFT                      (12U)
+#define MCM_ISCR_FIXC(x)                         (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FIXC_SHIFT)) & MCM_ISCR_FIXC_MASK)
+#define MCM_ISCR_FIDC_MASK                       (0x8000U)
+#define MCM_ISCR_FIDC_SHIFT                      (15U)
+#define MCM_ISCR_FIDC(x)                         (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FIDC_SHIFT)) & MCM_ISCR_FIDC_MASK)
+#define MCM_ISCR_FIOCE_MASK                      (0x1000000U)
+#define MCM_ISCR_FIOCE_SHIFT                     (24U)
+#define MCM_ISCR_FIOCE(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FIOCE_SHIFT)) & MCM_ISCR_FIOCE_MASK)
+#define MCM_ISCR_FDZCE_MASK                      (0x2000000U)
+#define MCM_ISCR_FDZCE_SHIFT                     (25U)
+#define MCM_ISCR_FDZCE(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FDZCE_SHIFT)) & MCM_ISCR_FDZCE_MASK)
+#define MCM_ISCR_FOFCE_MASK                      (0x4000000U)
+#define MCM_ISCR_FOFCE_SHIFT                     (26U)
+#define MCM_ISCR_FOFCE(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FOFCE_SHIFT)) & MCM_ISCR_FOFCE_MASK)
+#define MCM_ISCR_FUFCE_MASK                      (0x8000000U)
+#define MCM_ISCR_FUFCE_SHIFT                     (27U)
+#define MCM_ISCR_FUFCE(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FUFCE_SHIFT)) & MCM_ISCR_FUFCE_MASK)
+#define MCM_ISCR_FIXCE_MASK                      (0x10000000U)
+#define MCM_ISCR_FIXCE_SHIFT                     (28U)
+#define MCM_ISCR_FIXCE(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FIXCE_SHIFT)) & MCM_ISCR_FIXCE_MASK)
+#define MCM_ISCR_FIDCE_MASK                      (0x80000000U)
+#define MCM_ISCR_FIDCE_SHIFT                     (31U)
+#define MCM_ISCR_FIDCE(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ISCR_FIDCE_SHIFT)) & MCM_ISCR_FIDCE_MASK)
+
+/*! @name ETBCC - ETB Counter Control register */
+#define MCM_ETBCC_CNTEN_MASK                     (0x1U)
+#define MCM_ETBCC_CNTEN_SHIFT                    (0U)
+#define MCM_ETBCC_CNTEN(x)                       (((uint32_t)(((uint32_t)(x)) << MCM_ETBCC_CNTEN_SHIFT)) & MCM_ETBCC_CNTEN_MASK)
+#define MCM_ETBCC_RSPT_MASK                      (0x6U)
+#define MCM_ETBCC_RSPT_SHIFT                     (1U)
+#define MCM_ETBCC_RSPT(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ETBCC_RSPT_SHIFT)) & MCM_ETBCC_RSPT_MASK)
+#define MCM_ETBCC_RLRQ_MASK                      (0x8U)
+#define MCM_ETBCC_RLRQ_SHIFT                     (3U)
+#define MCM_ETBCC_RLRQ(x)                        (((uint32_t)(((uint32_t)(x)) << MCM_ETBCC_RLRQ_SHIFT)) & MCM_ETBCC_RLRQ_MASK)
+#define MCM_ETBCC_ETDIS_MASK                     (0x10U)
+#define MCM_ETBCC_ETDIS_SHIFT                    (4U)
+#define MCM_ETBCC_ETDIS(x)                       (((uint32_t)(((uint32_t)(x)) << MCM_ETBCC_ETDIS_SHIFT)) & MCM_ETBCC_ETDIS_MASK)
+#define MCM_ETBCC_ITDIS_MASK                     (0x20U)
+#define MCM_ETBCC_ITDIS_SHIFT                    (5U)
+#define MCM_ETBCC_ITDIS(x)                       (((uint32_t)(((uint32_t)(x)) << MCM_ETBCC_ITDIS_SHIFT)) & MCM_ETBCC_ITDIS_MASK)
+
+/*! @name ETBRL - ETB Reload register */
+#define MCM_ETBRL_RELOAD_MASK                    (0x7FFU)
+#define MCM_ETBRL_RELOAD_SHIFT                   (0U)
+#define MCM_ETBRL_RELOAD(x)                      (((uint32_t)(((uint32_t)(x)) << MCM_ETBRL_RELOAD_SHIFT)) & MCM_ETBRL_RELOAD_MASK)
+
+/*! @name ETBCNT - ETB Counter Value register */
+#define MCM_ETBCNT_COUNTER_MASK                  (0x7FFU)
+#define MCM_ETBCNT_COUNTER_SHIFT                 (0U)
+#define MCM_ETBCNT_COUNTER(x)                    (((uint32_t)(((uint32_t)(x)) << MCM_ETBCNT_COUNTER_SHIFT)) & MCM_ETBCNT_COUNTER_MASK)
+
+/*! @name PID - Process ID register */
+#define MCM_PID_PID_MASK                         (0xFFU)
+#define MCM_PID_PID_SHIFT                        (0U)
+#define MCM_PID_PID(x)                           (((uint32_t)(((uint32_t)(x)) << MCM_PID_PID_SHIFT)) & MCM_PID_PID_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Masks */
+
+
+/* MCM - Peripheral instance base addresses */
+/** Peripheral MCM base address */
+#define MCM_BASE                                 (0xE0080000u)
+/** Peripheral MCM base pointer */
+#define MCM                                      ((MCM_Type *)MCM_BASE)
+/** Array initializer of MCM peripheral base addresses */
+#define MCM_BASE_ADDRS                           { MCM_BASE }
+/** Array initializer of MCM peripheral base pointers */
+#define MCM_BASE_PTRS                            { MCM }
+/** Interrupt vectors for the MCM peripheral type */
+#define MCM_IRQS                                 { MCM_IRQn }
+
+/*!
+ * @}
+ */ /* end of group MCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MPU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MPU_Peripheral_Access_Layer MPU Peripheral Access Layer
+ * @{
+ */
+
+/** MPU - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CESR;                              /**< Control/Error Status Register, offset: 0x0 */
+       uint8_t RESERVED_0[12];
+  struct {                                         /* offset: 0x10, array step: 0x8 */
+    __I  uint32_t EAR;                               /**< Error Address Register, slave port n, array offset: 0x10, array step: 0x8 */
+    __I  uint32_t EDR;                               /**< Error Detail Register, slave port n, array offset: 0x14, array step: 0x8 */
+  } SP[5];
+       uint8_t RESERVED_1[968];
+  __IO uint32_t WORD[12][4];                       /**< Region Descriptor n, Word 0..Region Descriptor n, Word 3, array offset: 0x400, array step: index*0x10, index2*0x4 */
+       uint8_t RESERVED_2[832];
+  __IO uint32_t RGDAAC[12];                        /**< Region Descriptor Alternate Access Control n, array offset: 0x800, array step: 0x4 */
+} MPU_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MPU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MPU_Register_Masks MPU Register Masks
+ * @{
+ */
+
+/*! @name CESR - Control/Error Status Register */
+#define MPU_CESR_VLD_MASK                        (0x1U)
+#define MPU_CESR_VLD_SHIFT                       (0U)
+#define MPU_CESR_VLD(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_CESR_VLD_SHIFT)) & MPU_CESR_VLD_MASK)
+#define MPU_CESR_NRGD_MASK                       (0xF00U)
+#define MPU_CESR_NRGD_SHIFT                      (8U)
+#define MPU_CESR_NRGD(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_CESR_NRGD_SHIFT)) & MPU_CESR_NRGD_MASK)
+#define MPU_CESR_NSP_MASK                        (0xF000U)
+#define MPU_CESR_NSP_SHIFT                       (12U)
+#define MPU_CESR_NSP(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_CESR_NSP_SHIFT)) & MPU_CESR_NSP_MASK)
+#define MPU_CESR_HRL_MASK                        (0xF0000U)
+#define MPU_CESR_HRL_SHIFT                       (16U)
+#define MPU_CESR_HRL(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_CESR_HRL_SHIFT)) & MPU_CESR_HRL_MASK)
+#define MPU_CESR_SPERR_MASK                      (0xF8000000U)
+#define MPU_CESR_SPERR_SHIFT                     (27U)
+#define MPU_CESR_SPERR(x)                        (((uint32_t)(((uint32_t)(x)) << MPU_CESR_SPERR_SHIFT)) & MPU_CESR_SPERR_MASK)
+
+/*! @name EAR - Error Address Register, slave port n */
+#define MPU_EAR_EADDR_MASK                       (0xFFFFFFFFU)
+#define MPU_EAR_EADDR_SHIFT                      (0U)
+#define MPU_EAR_EADDR(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_EAR_EADDR_SHIFT)) & MPU_EAR_EADDR_MASK)
+
+/* The count of MPU_EAR */
+#define MPU_EAR_COUNT                            (5U)
+
+/*! @name EDR - Error Detail Register, slave port n */
+#define MPU_EDR_ERW_MASK                         (0x1U)
+#define MPU_EDR_ERW_SHIFT                        (0U)
+#define MPU_EDR_ERW(x)                           (((uint32_t)(((uint32_t)(x)) << MPU_EDR_ERW_SHIFT)) & MPU_EDR_ERW_MASK)
+#define MPU_EDR_EATTR_MASK                       (0xEU)
+#define MPU_EDR_EATTR_SHIFT                      (1U)
+#define MPU_EDR_EATTR(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_EDR_EATTR_SHIFT)) & MPU_EDR_EATTR_MASK)
+#define MPU_EDR_EMN_MASK                         (0xF0U)
+#define MPU_EDR_EMN_SHIFT                        (4U)
+#define MPU_EDR_EMN(x)                           (((uint32_t)(((uint32_t)(x)) << MPU_EDR_EMN_SHIFT)) & MPU_EDR_EMN_MASK)
+#define MPU_EDR_EPID_MASK                        (0xFF00U)
+#define MPU_EDR_EPID_SHIFT                       (8U)
+#define MPU_EDR_EPID(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_EDR_EPID_SHIFT)) & MPU_EDR_EPID_MASK)
+#define MPU_EDR_EACD_MASK                        (0xFFFF0000U)
+#define MPU_EDR_EACD_SHIFT                       (16U)
+#define MPU_EDR_EACD(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_EDR_EACD_SHIFT)) & MPU_EDR_EACD_MASK)
+
+/* The count of MPU_EDR */
+#define MPU_EDR_COUNT                            (5U)
+
+/*! @name WORD - Region Descriptor n, Word 0..Region Descriptor n, Word 3 */
+#define MPU_WORD_VLD_MASK                        (0x1U)
+#define MPU_WORD_VLD_SHIFT                       (0U)
+#define MPU_WORD_VLD(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_WORD_VLD_SHIFT)) & MPU_WORD_VLD_MASK)
+#define MPU_WORD_M0UM_MASK                       (0x7U)
+#define MPU_WORD_M0UM_SHIFT                      (0U)
+#define MPU_WORD_M0UM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M0UM_SHIFT)) & MPU_WORD_M0UM_MASK)
+#define MPU_WORD_M0SM_MASK                       (0x18U)
+#define MPU_WORD_M0SM_SHIFT                      (3U)
+#define MPU_WORD_M0SM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M0SM_SHIFT)) & MPU_WORD_M0SM_MASK)
+#define MPU_WORD_M0PE_MASK                       (0x20U)
+#define MPU_WORD_M0PE_SHIFT                      (5U)
+#define MPU_WORD_M0PE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M0PE_SHIFT)) & MPU_WORD_M0PE_MASK)
+#define MPU_WORD_ENDADDR_MASK                    (0xFFFFFFE0U)
+#define MPU_WORD_ENDADDR_SHIFT                   (5U)
+#define MPU_WORD_ENDADDR(x)                      (((uint32_t)(((uint32_t)(x)) << MPU_WORD_ENDADDR_SHIFT)) & MPU_WORD_ENDADDR_MASK)
+#define MPU_WORD_SRTADDR_MASK                    (0xFFFFFFE0U)
+#define MPU_WORD_SRTADDR_SHIFT                   (5U)
+#define MPU_WORD_SRTADDR(x)                      (((uint32_t)(((uint32_t)(x)) << MPU_WORD_SRTADDR_SHIFT)) & MPU_WORD_SRTADDR_MASK)
+#define MPU_WORD_M1UM_MASK                       (0x1C0U)
+#define MPU_WORD_M1UM_SHIFT                      (6U)
+#define MPU_WORD_M1UM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M1UM_SHIFT)) & MPU_WORD_M1UM_MASK)
+#define MPU_WORD_M1SM_MASK                       (0x600U)
+#define MPU_WORD_M1SM_SHIFT                      (9U)
+#define MPU_WORD_M1SM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M1SM_SHIFT)) & MPU_WORD_M1SM_MASK)
+#define MPU_WORD_M1PE_MASK                       (0x800U)
+#define MPU_WORD_M1PE_SHIFT                      (11U)
+#define MPU_WORD_M1PE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M1PE_SHIFT)) & MPU_WORD_M1PE_MASK)
+#define MPU_WORD_M2UM_MASK                       (0x7000U)
+#define MPU_WORD_M2UM_SHIFT                      (12U)
+#define MPU_WORD_M2UM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M2UM_SHIFT)) & MPU_WORD_M2UM_MASK)
+#define MPU_WORD_M2SM_MASK                       (0x18000U)
+#define MPU_WORD_M2SM_SHIFT                      (15U)
+#define MPU_WORD_M2SM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M2SM_SHIFT)) & MPU_WORD_M2SM_MASK)
+#define MPU_WORD_PIDMASK_MASK                    (0xFF0000U)
+#define MPU_WORD_PIDMASK_SHIFT                   (16U)
+#define MPU_WORD_PIDMASK(x)                      (((uint32_t)(((uint32_t)(x)) << MPU_WORD_PIDMASK_SHIFT)) & MPU_WORD_PIDMASK_MASK)
+#define MPU_WORD_M2PE_MASK                       (0x20000U)
+#define MPU_WORD_M2PE_SHIFT                      (17U)
+#define MPU_WORD_M2PE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M2PE_SHIFT)) & MPU_WORD_M2PE_MASK)
+#define MPU_WORD_M3UM_MASK                       (0x1C0000U)
+#define MPU_WORD_M3UM_SHIFT                      (18U)
+#define MPU_WORD_M3UM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M3UM_SHIFT)) & MPU_WORD_M3UM_MASK)
+#define MPU_WORD_M3SM_MASK                       (0x600000U)
+#define MPU_WORD_M3SM_SHIFT                      (21U)
+#define MPU_WORD_M3SM(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M3SM_SHIFT)) & MPU_WORD_M3SM_MASK)
+#define MPU_WORD_M3PE_MASK                       (0x800000U)
+#define MPU_WORD_M3PE_SHIFT                      (23U)
+#define MPU_WORD_M3PE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M3PE_SHIFT)) & MPU_WORD_M3PE_MASK)
+#define MPU_WORD_PID_MASK                        (0xFF000000U)
+#define MPU_WORD_PID_SHIFT                       (24U)
+#define MPU_WORD_PID(x)                          (((uint32_t)(((uint32_t)(x)) << MPU_WORD_PID_SHIFT)) & MPU_WORD_PID_MASK)
+#define MPU_WORD_M4WE_MASK                       (0x1000000U)
+#define MPU_WORD_M4WE_SHIFT                      (24U)
+#define MPU_WORD_M4WE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M4WE_SHIFT)) & MPU_WORD_M4WE_MASK)
+#define MPU_WORD_M4RE_MASK                       (0x2000000U)
+#define MPU_WORD_M4RE_SHIFT                      (25U)
+#define MPU_WORD_M4RE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M4RE_SHIFT)) & MPU_WORD_M4RE_MASK)
+#define MPU_WORD_M5WE_MASK                       (0x4000000U)
+#define MPU_WORD_M5WE_SHIFT                      (26U)
+#define MPU_WORD_M5WE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M5WE_SHIFT)) & MPU_WORD_M5WE_MASK)
+#define MPU_WORD_M5RE_MASK                       (0x8000000U)
+#define MPU_WORD_M5RE_SHIFT                      (27U)
+#define MPU_WORD_M5RE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M5RE_SHIFT)) & MPU_WORD_M5RE_MASK)
+#define MPU_WORD_M6WE_MASK                       (0x10000000U)
+#define MPU_WORD_M6WE_SHIFT                      (28U)
+#define MPU_WORD_M6WE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M6WE_SHIFT)) & MPU_WORD_M6WE_MASK)
+#define MPU_WORD_M6RE_MASK                       (0x20000000U)
+#define MPU_WORD_M6RE_SHIFT                      (29U)
+#define MPU_WORD_M6RE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M6RE_SHIFT)) & MPU_WORD_M6RE_MASK)
+#define MPU_WORD_M7WE_MASK                       (0x40000000U)
+#define MPU_WORD_M7WE_SHIFT                      (30U)
+#define MPU_WORD_M7WE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M7WE_SHIFT)) & MPU_WORD_M7WE_MASK)
+#define MPU_WORD_M7RE_MASK                       (0x80000000U)
+#define MPU_WORD_M7RE_SHIFT                      (31U)
+#define MPU_WORD_M7RE(x)                         (((uint32_t)(((uint32_t)(x)) << MPU_WORD_M7RE_SHIFT)) & MPU_WORD_M7RE_MASK)
+
+/* The count of MPU_WORD */
+#define MPU_WORD_COUNT                           (12U)
+
+/* The count of MPU_WORD */
+#define MPU_WORD_COUNT2                          (4U)
+
+/*! @name RGDAAC - Region Descriptor Alternate Access Control n */
+#define MPU_RGDAAC_M0UM_MASK                     (0x7U)
+#define MPU_RGDAAC_M0UM_SHIFT                    (0U)
+#define MPU_RGDAAC_M0UM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M0UM_SHIFT)) & MPU_RGDAAC_M0UM_MASK)
+#define MPU_RGDAAC_M0SM_MASK                     (0x18U)
+#define MPU_RGDAAC_M0SM_SHIFT                    (3U)
+#define MPU_RGDAAC_M0SM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M0SM_SHIFT)) & MPU_RGDAAC_M0SM_MASK)
+#define MPU_RGDAAC_M0PE_MASK                     (0x20U)
+#define MPU_RGDAAC_M0PE_SHIFT                    (5U)
+#define MPU_RGDAAC_M0PE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M0PE_SHIFT)) & MPU_RGDAAC_M0PE_MASK)
+#define MPU_RGDAAC_M1UM_MASK                     (0x1C0U)
+#define MPU_RGDAAC_M1UM_SHIFT                    (6U)
+#define MPU_RGDAAC_M1UM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M1UM_SHIFT)) & MPU_RGDAAC_M1UM_MASK)
+#define MPU_RGDAAC_M1SM_MASK                     (0x600U)
+#define MPU_RGDAAC_M1SM_SHIFT                    (9U)
+#define MPU_RGDAAC_M1SM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M1SM_SHIFT)) & MPU_RGDAAC_M1SM_MASK)
+#define MPU_RGDAAC_M1PE_MASK                     (0x800U)
+#define MPU_RGDAAC_M1PE_SHIFT                    (11U)
+#define MPU_RGDAAC_M1PE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M1PE_SHIFT)) & MPU_RGDAAC_M1PE_MASK)
+#define MPU_RGDAAC_M2UM_MASK                     (0x7000U)
+#define MPU_RGDAAC_M2UM_SHIFT                    (12U)
+#define MPU_RGDAAC_M2UM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M2UM_SHIFT)) & MPU_RGDAAC_M2UM_MASK)
+#define MPU_RGDAAC_M2SM_MASK                     (0x18000U)
+#define MPU_RGDAAC_M2SM_SHIFT                    (15U)
+#define MPU_RGDAAC_M2SM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M2SM_SHIFT)) & MPU_RGDAAC_M2SM_MASK)
+#define MPU_RGDAAC_M2PE_MASK                     (0x20000U)
+#define MPU_RGDAAC_M2PE_SHIFT                    (17U)
+#define MPU_RGDAAC_M2PE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M2PE_SHIFT)) & MPU_RGDAAC_M2PE_MASK)
+#define MPU_RGDAAC_M3UM_MASK                     (0x1C0000U)
+#define MPU_RGDAAC_M3UM_SHIFT                    (18U)
+#define MPU_RGDAAC_M3UM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M3UM_SHIFT)) & MPU_RGDAAC_M3UM_MASK)
+#define MPU_RGDAAC_M3SM_MASK                     (0x600000U)
+#define MPU_RGDAAC_M3SM_SHIFT                    (21U)
+#define MPU_RGDAAC_M3SM(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M3SM_SHIFT)) & MPU_RGDAAC_M3SM_MASK)
+#define MPU_RGDAAC_M3PE_MASK                     (0x800000U)
+#define MPU_RGDAAC_M3PE_SHIFT                    (23U)
+#define MPU_RGDAAC_M3PE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M3PE_SHIFT)) & MPU_RGDAAC_M3PE_MASK)
+#define MPU_RGDAAC_M4WE_MASK                     (0x1000000U)
+#define MPU_RGDAAC_M4WE_SHIFT                    (24U)
+#define MPU_RGDAAC_M4WE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M4WE_SHIFT)) & MPU_RGDAAC_M4WE_MASK)
+#define MPU_RGDAAC_M4RE_MASK                     (0x2000000U)
+#define MPU_RGDAAC_M4RE_SHIFT                    (25U)
+#define MPU_RGDAAC_M4RE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M4RE_SHIFT)) & MPU_RGDAAC_M4RE_MASK)
+#define MPU_RGDAAC_M5WE_MASK                     (0x4000000U)
+#define MPU_RGDAAC_M5WE_SHIFT                    (26U)
+#define MPU_RGDAAC_M5WE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M5WE_SHIFT)) & MPU_RGDAAC_M5WE_MASK)
+#define MPU_RGDAAC_M5RE_MASK                     (0x8000000U)
+#define MPU_RGDAAC_M5RE_SHIFT                    (27U)
+#define MPU_RGDAAC_M5RE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M5RE_SHIFT)) & MPU_RGDAAC_M5RE_MASK)
+#define MPU_RGDAAC_M6WE_MASK                     (0x10000000U)
+#define MPU_RGDAAC_M6WE_SHIFT                    (28U)
+#define MPU_RGDAAC_M6WE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M6WE_SHIFT)) & MPU_RGDAAC_M6WE_MASK)
+#define MPU_RGDAAC_M6RE_MASK                     (0x20000000U)
+#define MPU_RGDAAC_M6RE_SHIFT                    (29U)
+#define MPU_RGDAAC_M6RE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M6RE_SHIFT)) & MPU_RGDAAC_M6RE_MASK)
+#define MPU_RGDAAC_M7WE_MASK                     (0x40000000U)
+#define MPU_RGDAAC_M7WE_SHIFT                    (30U)
+#define MPU_RGDAAC_M7WE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M7WE_SHIFT)) & MPU_RGDAAC_M7WE_MASK)
+#define MPU_RGDAAC_M7RE_MASK                     (0x80000000U)
+#define MPU_RGDAAC_M7RE_SHIFT                    (31U)
+#define MPU_RGDAAC_M7RE(x)                       (((uint32_t)(((uint32_t)(x)) << MPU_RGDAAC_M7RE_SHIFT)) & MPU_RGDAAC_M7RE_MASK)
+
+/* The count of MPU_RGDAAC */
+#define MPU_RGDAAC_COUNT                         (12U)
+
+
+/*!
+ * @}
+ */ /* end of group MPU_Register_Masks */
+
+
+/* MPU - Peripheral instance base addresses */
+/** Peripheral MPU base address */
+#define MPU_BASE                                 (0x4000D000u)
+/** Peripheral MPU base pointer */
+#define MPU                                      ((MPU_Type *)MPU_BASE)
+/** Array initializer of MPU peripheral base addresses */
+#define MPU_BASE_ADDRS                           { MPU_BASE }
+/** Array initializer of MPU peripheral base pointers */
+#define MPU_BASE_PTRS                            { MPU }
+
+/*!
+ * @}
+ */ /* end of group MPU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- NV Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Peripheral_Access_Layer NV Peripheral Access Layer
+ * @{
+ */
+
+/** NV - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t BACKKEY3;                           /**< Backdoor Comparison Key 3., offset: 0x0 */
+  __I  uint8_t BACKKEY2;                           /**< Backdoor Comparison Key 2., offset: 0x1 */
+  __I  uint8_t BACKKEY1;                           /**< Backdoor Comparison Key 1., offset: 0x2 */
+  __I  uint8_t BACKKEY0;                           /**< Backdoor Comparison Key 0., offset: 0x3 */
+  __I  uint8_t BACKKEY7;                           /**< Backdoor Comparison Key 7., offset: 0x4 */
+  __I  uint8_t BACKKEY6;                           /**< Backdoor Comparison Key 6., offset: 0x5 */
+  __I  uint8_t BACKKEY5;                           /**< Backdoor Comparison Key 5., offset: 0x6 */
+  __I  uint8_t BACKKEY4;                           /**< Backdoor Comparison Key 4., offset: 0x7 */
+  __I  uint8_t FPROT3;                             /**< Non-volatile P-Flash Protection 1 - Low Register, offset: 0x8 */
+  __I  uint8_t FPROT2;                             /**< Non-volatile P-Flash Protection 1 - High Register, offset: 0x9 */
+  __I  uint8_t FPROT1;                             /**< Non-volatile P-Flash Protection 0 - Low Register, offset: 0xA */
+  __I  uint8_t FPROT0;                             /**< Non-volatile P-Flash Protection 0 - High Register, offset: 0xB */
+  __I  uint8_t FSEC;                               /**< Non-volatile Flash Security Register, offset: 0xC */
+  __I  uint8_t FOPT;                               /**< Non-volatile Flash Option Register, offset: 0xD */
+  __I  uint8_t FEPROT;                             /**< Non-volatile EERAM Protection Register, offset: 0xE */
+  __I  uint8_t FDPROT;                             /**< Non-volatile D-Flash Protection Register, offset: 0xF */
+} NV_Type;
+
+/* ----------------------------------------------------------------------------
+   -- NV Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Masks NV Register Masks
+ * @{
+ */
+
+/*! @name BACKKEY3 - Backdoor Comparison Key 3. */
+#define NV_BACKKEY3_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY3_KEY_SHIFT                    (0U)
+#define NV_BACKKEY3_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY3_KEY_SHIFT)) & NV_BACKKEY3_KEY_MASK)
+
+/*! @name BACKKEY2 - Backdoor Comparison Key 2. */
+#define NV_BACKKEY2_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY2_KEY_SHIFT                    (0U)
+#define NV_BACKKEY2_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY2_KEY_SHIFT)) & NV_BACKKEY2_KEY_MASK)
+
+/*! @name BACKKEY1 - Backdoor Comparison Key 1. */
+#define NV_BACKKEY1_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY1_KEY_SHIFT                    (0U)
+#define NV_BACKKEY1_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY1_KEY_SHIFT)) & NV_BACKKEY1_KEY_MASK)
+
+/*! @name BACKKEY0 - Backdoor Comparison Key 0. */
+#define NV_BACKKEY0_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY0_KEY_SHIFT                    (0U)
+#define NV_BACKKEY0_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY0_KEY_SHIFT)) & NV_BACKKEY0_KEY_MASK)
+
+/*! @name BACKKEY7 - Backdoor Comparison Key 7. */
+#define NV_BACKKEY7_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY7_KEY_SHIFT                    (0U)
+#define NV_BACKKEY7_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY7_KEY_SHIFT)) & NV_BACKKEY7_KEY_MASK)
+
+/*! @name BACKKEY6 - Backdoor Comparison Key 6. */
+#define NV_BACKKEY6_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY6_KEY_SHIFT                    (0U)
+#define NV_BACKKEY6_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY6_KEY_SHIFT)) & NV_BACKKEY6_KEY_MASK)
+
+/*! @name BACKKEY5 - Backdoor Comparison Key 5. */
+#define NV_BACKKEY5_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY5_KEY_SHIFT                    (0U)
+#define NV_BACKKEY5_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY5_KEY_SHIFT)) & NV_BACKKEY5_KEY_MASK)
+
+/*! @name BACKKEY4 - Backdoor Comparison Key 4. */
+#define NV_BACKKEY4_KEY_MASK                     (0xFFU)
+#define NV_BACKKEY4_KEY_SHIFT                    (0U)
+#define NV_BACKKEY4_KEY(x)                       (((uint8_t)(((uint8_t)(x)) << NV_BACKKEY4_KEY_SHIFT)) & NV_BACKKEY4_KEY_MASK)
+
+/*! @name FPROT3 - Non-volatile P-Flash Protection 1 - Low Register */
+#define NV_FPROT3_PROT_MASK                      (0xFFU)
+#define NV_FPROT3_PROT_SHIFT                     (0U)
+#define NV_FPROT3_PROT(x)                        (((uint8_t)(((uint8_t)(x)) << NV_FPROT3_PROT_SHIFT)) & NV_FPROT3_PROT_MASK)
+
+/*! @name FPROT2 - Non-volatile P-Flash Protection 1 - High Register */
+#define NV_FPROT2_PROT_MASK                      (0xFFU)
+#define NV_FPROT2_PROT_SHIFT                     (0U)
+#define NV_FPROT2_PROT(x)                        (((uint8_t)(((uint8_t)(x)) << NV_FPROT2_PROT_SHIFT)) & NV_FPROT2_PROT_MASK)
+
+/*! @name FPROT1 - Non-volatile P-Flash Protection 0 - Low Register */
+#define NV_FPROT1_PROT_MASK                      (0xFFU)
+#define NV_FPROT1_PROT_SHIFT                     (0U)
+#define NV_FPROT1_PROT(x)                        (((uint8_t)(((uint8_t)(x)) << NV_FPROT1_PROT_SHIFT)) & NV_FPROT1_PROT_MASK)
+
+/*! @name FPROT0 - Non-volatile P-Flash Protection 0 - High Register */
+#define NV_FPROT0_PROT_MASK                      (0xFFU)
+#define NV_FPROT0_PROT_SHIFT                     (0U)
+#define NV_FPROT0_PROT(x)                        (((uint8_t)(((uint8_t)(x)) << NV_FPROT0_PROT_SHIFT)) & NV_FPROT0_PROT_MASK)
+
+/*! @name FSEC - Non-volatile Flash Security Register */
+#define NV_FSEC_SEC_MASK                         (0x3U)
+#define NV_FSEC_SEC_SHIFT                        (0U)
+#define NV_FSEC_SEC(x)                           (((uint8_t)(((uint8_t)(x)) << NV_FSEC_SEC_SHIFT)) & NV_FSEC_SEC_MASK)
+#define NV_FSEC_FSLACC_MASK                      (0xCU)
+#define NV_FSEC_FSLACC_SHIFT                     (2U)
+#define NV_FSEC_FSLACC(x)                        (((uint8_t)(((uint8_t)(x)) << NV_FSEC_FSLACC_SHIFT)) & NV_FSEC_FSLACC_MASK)
+#define NV_FSEC_MEEN_MASK                        (0x30U)
+#define NV_FSEC_MEEN_SHIFT                       (4U)
+#define NV_FSEC_MEEN(x)                          (((uint8_t)(((uint8_t)(x)) << NV_FSEC_MEEN_SHIFT)) & NV_FSEC_MEEN_MASK)
+#define NV_FSEC_KEYEN_MASK                       (0xC0U)
+#define NV_FSEC_KEYEN_SHIFT                      (6U)
+#define NV_FSEC_KEYEN(x)                         (((uint8_t)(((uint8_t)(x)) << NV_FSEC_KEYEN_SHIFT)) & NV_FSEC_KEYEN_MASK)
+
+/*! @name FOPT - Non-volatile Flash Option Register */
+#define NV_FOPT_LPBOOT_MASK                      (0x1U)
+#define NV_FOPT_LPBOOT_SHIFT                     (0U)
+#define NV_FOPT_LPBOOT(x)                        (((uint8_t)(((uint8_t)(x)) << NV_FOPT_LPBOOT_SHIFT)) & NV_FOPT_LPBOOT_MASK)
+#define NV_FOPT_EZPORT_DIS_MASK                  (0x2U)
+#define NV_FOPT_EZPORT_DIS_SHIFT                 (1U)
+#define NV_FOPT_EZPORT_DIS(x)                    (((uint8_t)(((uint8_t)(x)) << NV_FOPT_EZPORT_DIS_SHIFT)) & NV_FOPT_EZPORT_DIS_MASK)
+
+/*! @name FEPROT - Non-volatile EERAM Protection Register */
+#define NV_FEPROT_EPROT_MASK                     (0xFFU)
+#define NV_FEPROT_EPROT_SHIFT                    (0U)
+#define NV_FEPROT_EPROT(x)                       (((uint8_t)(((uint8_t)(x)) << NV_FEPROT_EPROT_SHIFT)) & NV_FEPROT_EPROT_MASK)
+
+/*! @name FDPROT - Non-volatile D-Flash Protection Register */
+#define NV_FDPROT_DPROT_MASK                     (0xFFU)
+#define NV_FDPROT_DPROT_SHIFT                    (0U)
+#define NV_FDPROT_DPROT(x)                       (((uint8_t)(((uint8_t)(x)) << NV_FDPROT_DPROT_SHIFT)) & NV_FDPROT_DPROT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Masks */
+
+
+/* NV - Peripheral instance base addresses */
+/** Peripheral FTFE_FlashConfig base address */
+#define FTFE_FlashConfig_BASE                    (0x400u)
+/** Peripheral FTFE_FlashConfig base pointer */
+#define FTFE_FlashConfig                         ((NV_Type *)FTFE_FlashConfig_BASE)
+/** Array initializer of NV peripheral base addresses */
+#define NV_BASE_ADDRS                            { FTFE_FlashConfig_BASE }
+/** Array initializer of NV peripheral base pointers */
+#define NV_BASE_PTRS                             { FTFE_FlashConfig }
+
+/*!
+ * @}
+ */ /* end of group NV_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- OSC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Peripheral_Access_Layer OSC Peripheral Access Layer
+ * @{
+ */
+
+/** OSC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR;                                 /**< OSC Control Register, offset: 0x0 */
+} OSC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- OSC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Masks OSC Register Masks
+ * @{
+ */
+
+/*! @name CR - OSC Control Register */
+#define OSC_CR_SC16P_MASK                        (0x1U)
+#define OSC_CR_SC16P_SHIFT                       (0U)
+#define OSC_CR_SC16P(x)                          (((uint8_t)(((uint8_t)(x)) << OSC_CR_SC16P_SHIFT)) & OSC_CR_SC16P_MASK)
+#define OSC_CR_SC8P_MASK                         (0x2U)
+#define OSC_CR_SC8P_SHIFT                        (1U)
+#define OSC_CR_SC8P(x)                           (((uint8_t)(((uint8_t)(x)) << OSC_CR_SC8P_SHIFT)) & OSC_CR_SC8P_MASK)
+#define OSC_CR_SC4P_MASK                         (0x4U)
+#define OSC_CR_SC4P_SHIFT                        (2U)
+#define OSC_CR_SC4P(x)                           (((uint8_t)(((uint8_t)(x)) << OSC_CR_SC4P_SHIFT)) & OSC_CR_SC4P_MASK)
+#define OSC_CR_SC2P_MASK                         (0x8U)
+#define OSC_CR_SC2P_SHIFT                        (3U)
+#define OSC_CR_SC2P(x)                           (((uint8_t)(((uint8_t)(x)) << OSC_CR_SC2P_SHIFT)) & OSC_CR_SC2P_MASK)
+#define OSC_CR_EREFSTEN_MASK                     (0x20U)
+#define OSC_CR_EREFSTEN_SHIFT                    (5U)
+#define OSC_CR_EREFSTEN(x)                       (((uint8_t)(((uint8_t)(x)) << OSC_CR_EREFSTEN_SHIFT)) & OSC_CR_EREFSTEN_MASK)
+#define OSC_CR_ERCLKEN_MASK                      (0x80U)
+#define OSC_CR_ERCLKEN_SHIFT                     (7U)
+#define OSC_CR_ERCLKEN(x)                        (((uint8_t)(((uint8_t)(x)) << OSC_CR_ERCLKEN_SHIFT)) & OSC_CR_ERCLKEN_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Masks */
+
+
+/* OSC - Peripheral instance base addresses */
+/** Peripheral OSC base address */
+#define OSC_BASE                                 (0x40065000u)
+/** Peripheral OSC base pointer */
+#define OSC                                      ((OSC_Type *)OSC_BASE)
+/** Array initializer of OSC peripheral base addresses */
+#define OSC_BASE_ADDRS                           { OSC_BASE }
+/** Array initializer of OSC peripheral base pointers */
+#define OSC_BASE_PTRS                            { OSC }
+
+/*!
+ * @}
+ */ /* end of group OSC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PDB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PDB_Peripheral_Access_Layer PDB Peripheral Access Layer
+ * @{
+ */
+
+/** PDB - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC;                                /**< Status and Control register, offset: 0x0 */
+  __IO uint32_t MOD;                               /**< Modulus register, offset: 0x4 */
+  __I  uint32_t CNT;                               /**< Counter register, offset: 0x8 */
+  __IO uint32_t IDLY;                              /**< Interrupt Delay register, offset: 0xC */
+  struct {                                         /* offset: 0x10, array step: 0x28 */
+    __IO uint32_t C1;                                /**< Channel n Control register 1, array offset: 0x10, array step: 0x28 */
+    __IO uint32_t S;                                 /**< Channel n Status register, array offset: 0x14, array step: 0x28 */
+    __IO uint32_t DLY[2];                            /**< Channel n Delay 0 register..Channel n Delay 1 register, array offset: 0x18, array step: index*0x28, index2*0x4 */
+         uint8_t RESERVED_0[24];
+  } CH[2];
+       uint8_t RESERVED_0[240];
+  struct {                                         /* offset: 0x150, array step: 0x8 */
+    __IO uint32_t INTC;                              /**< DAC Interval Trigger n Control register, array offset: 0x150, array step: 0x8 */
+    __IO uint32_t INT;                               /**< DAC Interval n register, array offset: 0x154, array step: 0x8 */
+  } DAC[2];
+       uint8_t RESERVED_1[48];
+  __IO uint32_t POEN;                              /**< Pulse-Out n Enable register, offset: 0x190 */
+  __IO uint32_t PODLY[3];                          /**< Pulse-Out n Delay register, array offset: 0x194, array step: 0x4 */
+} PDB_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PDB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PDB_Register_Masks PDB Register Masks
+ * @{
+ */
+
+/*! @name SC - Status and Control register */
+#define PDB_SC_LDOK_MASK                         (0x1U)
+#define PDB_SC_LDOK_SHIFT                        (0U)
+#define PDB_SC_LDOK(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_SC_LDOK_SHIFT)) & PDB_SC_LDOK_MASK)
+#define PDB_SC_CONT_MASK                         (0x2U)
+#define PDB_SC_CONT_SHIFT                        (1U)
+#define PDB_SC_CONT(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_SC_CONT_SHIFT)) & PDB_SC_CONT_MASK)
+#define PDB_SC_MULT_MASK                         (0xCU)
+#define PDB_SC_MULT_SHIFT                        (2U)
+#define PDB_SC_MULT(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_SC_MULT_SHIFT)) & PDB_SC_MULT_MASK)
+#define PDB_SC_PDBIE_MASK                        (0x20U)
+#define PDB_SC_PDBIE_SHIFT                       (5U)
+#define PDB_SC_PDBIE(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_SC_PDBIE_SHIFT)) & PDB_SC_PDBIE_MASK)
+#define PDB_SC_PDBIF_MASK                        (0x40U)
+#define PDB_SC_PDBIF_SHIFT                       (6U)
+#define PDB_SC_PDBIF(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_SC_PDBIF_SHIFT)) & PDB_SC_PDBIF_MASK)
+#define PDB_SC_PDBEN_MASK                        (0x80U)
+#define PDB_SC_PDBEN_SHIFT                       (7U)
+#define PDB_SC_PDBEN(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_SC_PDBEN_SHIFT)) & PDB_SC_PDBEN_MASK)
+#define PDB_SC_TRGSEL_MASK                       (0xF00U)
+#define PDB_SC_TRGSEL_SHIFT                      (8U)
+#define PDB_SC_TRGSEL(x)                         (((uint32_t)(((uint32_t)(x)) << PDB_SC_TRGSEL_SHIFT)) & PDB_SC_TRGSEL_MASK)
+#define PDB_SC_PRESCALER_MASK                    (0x7000U)
+#define PDB_SC_PRESCALER_SHIFT                   (12U)
+#define PDB_SC_PRESCALER(x)                      (((uint32_t)(((uint32_t)(x)) << PDB_SC_PRESCALER_SHIFT)) & PDB_SC_PRESCALER_MASK)
+#define PDB_SC_DMAEN_MASK                        (0x8000U)
+#define PDB_SC_DMAEN_SHIFT                       (15U)
+#define PDB_SC_DMAEN(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_SC_DMAEN_SHIFT)) & PDB_SC_DMAEN_MASK)
+#define PDB_SC_SWTRIG_MASK                       (0x10000U)
+#define PDB_SC_SWTRIG_SHIFT                      (16U)
+#define PDB_SC_SWTRIG(x)                         (((uint32_t)(((uint32_t)(x)) << PDB_SC_SWTRIG_SHIFT)) & PDB_SC_SWTRIG_MASK)
+#define PDB_SC_PDBEIE_MASK                       (0x20000U)
+#define PDB_SC_PDBEIE_SHIFT                      (17U)
+#define PDB_SC_PDBEIE(x)                         (((uint32_t)(((uint32_t)(x)) << PDB_SC_PDBEIE_SHIFT)) & PDB_SC_PDBEIE_MASK)
+#define PDB_SC_LDMOD_MASK                        (0xC0000U)
+#define PDB_SC_LDMOD_SHIFT                       (18U)
+#define PDB_SC_LDMOD(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_SC_LDMOD_SHIFT)) & PDB_SC_LDMOD_MASK)
+
+/*! @name MOD - Modulus register */
+#define PDB_MOD_MOD_MASK                         (0xFFFFU)
+#define PDB_MOD_MOD_SHIFT                        (0U)
+#define PDB_MOD_MOD(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_MOD_MOD_SHIFT)) & PDB_MOD_MOD_MASK)
+
+/*! @name CNT - Counter register */
+#define PDB_CNT_CNT_MASK                         (0xFFFFU)
+#define PDB_CNT_CNT_SHIFT                        (0U)
+#define PDB_CNT_CNT(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_CNT_CNT_SHIFT)) & PDB_CNT_CNT_MASK)
+
+/*! @name IDLY - Interrupt Delay register */
+#define PDB_IDLY_IDLY_MASK                       (0xFFFFU)
+#define PDB_IDLY_IDLY_SHIFT                      (0U)
+#define PDB_IDLY_IDLY(x)                         (((uint32_t)(((uint32_t)(x)) << PDB_IDLY_IDLY_SHIFT)) & PDB_IDLY_IDLY_MASK)
+
+/*! @name C1 - Channel n Control register 1 */
+#define PDB_C1_EN_MASK                           (0xFFU)
+#define PDB_C1_EN_SHIFT                          (0U)
+#define PDB_C1_EN(x)                             (((uint32_t)(((uint32_t)(x)) << PDB_C1_EN_SHIFT)) & PDB_C1_EN_MASK)
+#define PDB_C1_TOS_MASK                          (0xFF00U)
+#define PDB_C1_TOS_SHIFT                         (8U)
+#define PDB_C1_TOS(x)                            (((uint32_t)(((uint32_t)(x)) << PDB_C1_TOS_SHIFT)) & PDB_C1_TOS_MASK)
+#define PDB_C1_BB_MASK                           (0xFF0000U)
+#define PDB_C1_BB_SHIFT                          (16U)
+#define PDB_C1_BB(x)                             (((uint32_t)(((uint32_t)(x)) << PDB_C1_BB_SHIFT)) & PDB_C1_BB_MASK)
+
+/* The count of PDB_C1 */
+#define PDB_C1_COUNT                             (2U)
+
+/*! @name S - Channel n Status register */
+#define PDB_S_ERR_MASK                           (0xFFU)
+#define PDB_S_ERR_SHIFT                          (0U)
+#define PDB_S_ERR(x)                             (((uint32_t)(((uint32_t)(x)) << PDB_S_ERR_SHIFT)) & PDB_S_ERR_MASK)
+#define PDB_S_CF_MASK                            (0xFF0000U)
+#define PDB_S_CF_SHIFT                           (16U)
+#define PDB_S_CF(x)                              (((uint32_t)(((uint32_t)(x)) << PDB_S_CF_SHIFT)) & PDB_S_CF_MASK)
+
+/* The count of PDB_S */
+#define PDB_S_COUNT                              (2U)
+
+/*! @name DLY - Channel n Delay 0 register..Channel n Delay 1 register */
+#define PDB_DLY_DLY_MASK                         (0xFFFFU)
+#define PDB_DLY_DLY_SHIFT                        (0U)
+#define PDB_DLY_DLY(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_DLY_DLY_SHIFT)) & PDB_DLY_DLY_MASK)
+
+/* The count of PDB_DLY */
+#define PDB_DLY_COUNT                            (2U)
+
+/* The count of PDB_DLY */
+#define PDB_DLY_COUNT2                           (2U)
+
+/*! @name INTC - DAC Interval Trigger n Control register */
+#define PDB_INTC_TOE_MASK                        (0x1U)
+#define PDB_INTC_TOE_SHIFT                       (0U)
+#define PDB_INTC_TOE(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_INTC_TOE_SHIFT)) & PDB_INTC_TOE_MASK)
+#define PDB_INTC_EXT_MASK                        (0x2U)
+#define PDB_INTC_EXT_SHIFT                       (1U)
+#define PDB_INTC_EXT(x)                          (((uint32_t)(((uint32_t)(x)) << PDB_INTC_EXT_SHIFT)) & PDB_INTC_EXT_MASK)
+
+/* The count of PDB_INTC */
+#define PDB_INTC_COUNT                           (2U)
+
+/*! @name INT - DAC Interval n register */
+#define PDB_INT_INT_MASK                         (0xFFFFU)
+#define PDB_INT_INT_SHIFT                        (0U)
+#define PDB_INT_INT(x)                           (((uint32_t)(((uint32_t)(x)) << PDB_INT_INT_SHIFT)) & PDB_INT_INT_MASK)
+
+/* The count of PDB_INT */
+#define PDB_INT_COUNT                            (2U)
+
+/*! @name POEN - Pulse-Out n Enable register */
+#define PDB_POEN_POEN_MASK                       (0xFFU)
+#define PDB_POEN_POEN_SHIFT                      (0U)
+#define PDB_POEN_POEN(x)                         (((uint32_t)(((uint32_t)(x)) << PDB_POEN_POEN_SHIFT)) & PDB_POEN_POEN_MASK)
+
+/*! @name PODLY - Pulse-Out n Delay register */
+#define PDB_PODLY_DLY2_MASK                      (0xFFFFU)
+#define PDB_PODLY_DLY2_SHIFT                     (0U)
+#define PDB_PODLY_DLY2(x)                        (((uint32_t)(((uint32_t)(x)) << PDB_PODLY_DLY2_SHIFT)) & PDB_PODLY_DLY2_MASK)
+#define PDB_PODLY_DLY1_MASK                      (0xFFFF0000U)
+#define PDB_PODLY_DLY1_SHIFT                     (16U)
+#define PDB_PODLY_DLY1(x)                        (((uint32_t)(((uint32_t)(x)) << PDB_PODLY_DLY1_SHIFT)) & PDB_PODLY_DLY1_MASK)
+
+/* The count of PDB_PODLY */
+#define PDB_PODLY_COUNT                          (3U)
+
+
+/*!
+ * @}
+ */ /* end of group PDB_Register_Masks */
+
+
+/* PDB - Peripheral instance base addresses */
+/** Peripheral PDB0 base address */
+#define PDB0_BASE                                (0x40036000u)
+/** Peripheral PDB0 base pointer */
+#define PDB0                                     ((PDB_Type *)PDB0_BASE)
+/** Array initializer of PDB peripheral base addresses */
+#define PDB_BASE_ADDRS                           { PDB0_BASE }
+/** Array initializer of PDB peripheral base pointers */
+#define PDB_BASE_PTRS                            { PDB0 }
+/** Interrupt vectors for the PDB peripheral type */
+#define PDB_IRQS                                 { PDB0_IRQn }
+
+/*!
+ * @}
+ */ /* end of group PDB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PIT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Peripheral_Access_Layer PIT Peripheral Access Layer
+ * @{
+ */
+
+/** PIT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< PIT Module Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[252];
+  struct {                                         /* offset: 0x100, array step: 0x10 */
+    __IO uint32_t LDVAL;                             /**< Timer Load Value Register, array offset: 0x100, array step: 0x10 */
+    __I  uint32_t CVAL;                              /**< Current Timer Value Register, array offset: 0x104, array step: 0x10 */
+    __IO uint32_t TCTRL;                             /**< Timer Control Register, array offset: 0x108, array step: 0x10 */
+    __IO uint32_t TFLG;                              /**< Timer Flag Register, array offset: 0x10C, array step: 0x10 */
+  } CHANNEL[4];
+} PIT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PIT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Masks PIT Register Masks
+ * @{
+ */
+
+/*! @name MCR - PIT Module Control Register */
+#define PIT_MCR_FRZ_MASK                         (0x1U)
+#define PIT_MCR_FRZ_SHIFT                        (0U)
+#define PIT_MCR_FRZ(x)                           (((uint32_t)(((uint32_t)(x)) << PIT_MCR_FRZ_SHIFT)) & PIT_MCR_FRZ_MASK)
+#define PIT_MCR_MDIS_MASK                        (0x2U)
+#define PIT_MCR_MDIS_SHIFT                       (1U)
+#define PIT_MCR_MDIS(x)                          (((uint32_t)(((uint32_t)(x)) << PIT_MCR_MDIS_SHIFT)) & PIT_MCR_MDIS_MASK)
+
+/*! @name LDVAL - Timer Load Value Register */
+#define PIT_LDVAL_TSV_MASK                       (0xFFFFFFFFU)
+#define PIT_LDVAL_TSV_SHIFT                      (0U)
+#define PIT_LDVAL_TSV(x)                         (((uint32_t)(((uint32_t)(x)) << PIT_LDVAL_TSV_SHIFT)) & PIT_LDVAL_TSV_MASK)
+
+/* The count of PIT_LDVAL */
+#define PIT_LDVAL_COUNT                          (4U)
+
+/*! @name CVAL - Current Timer Value Register */
+#define PIT_CVAL_TVL_MASK                        (0xFFFFFFFFU)
+#define PIT_CVAL_TVL_SHIFT                       (0U)
+#define PIT_CVAL_TVL(x)                          (((uint32_t)(((uint32_t)(x)) << PIT_CVAL_TVL_SHIFT)) & PIT_CVAL_TVL_MASK)
+
+/* The count of PIT_CVAL */
+#define PIT_CVAL_COUNT                           (4U)
+
+/*! @name TCTRL - Timer Control Register */
+#define PIT_TCTRL_TEN_MASK                       (0x1U)
+#define PIT_TCTRL_TEN_SHIFT                      (0U)
+#define PIT_TCTRL_TEN(x)                         (((uint32_t)(((uint32_t)(x)) << PIT_TCTRL_TEN_SHIFT)) & PIT_TCTRL_TEN_MASK)
+#define PIT_TCTRL_TIE_MASK                       (0x2U)
+#define PIT_TCTRL_TIE_SHIFT                      (1U)
+#define PIT_TCTRL_TIE(x)                         (((uint32_t)(((uint32_t)(x)) << PIT_TCTRL_TIE_SHIFT)) & PIT_TCTRL_TIE_MASK)
+#define PIT_TCTRL_CHN_MASK                       (0x4U)
+#define PIT_TCTRL_CHN_SHIFT                      (2U)
+#define PIT_TCTRL_CHN(x)                         (((uint32_t)(((uint32_t)(x)) << PIT_TCTRL_CHN_SHIFT)) & PIT_TCTRL_CHN_MASK)
+
+/* The count of PIT_TCTRL */
+#define PIT_TCTRL_COUNT                          (4U)
+
+/*! @name TFLG - Timer Flag Register */
+#define PIT_TFLG_TIF_MASK                        (0x1U)
+#define PIT_TFLG_TIF_SHIFT                       (0U)
+#define PIT_TFLG_TIF(x)                          (((uint32_t)(((uint32_t)(x)) << PIT_TFLG_TIF_SHIFT)) & PIT_TFLG_TIF_MASK)
+
+/* The count of PIT_TFLG */
+#define PIT_TFLG_COUNT                           (4U)
+
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Masks */
+
+
+/* PIT - Peripheral instance base addresses */
+/** Peripheral PIT base address */
+#define PIT_BASE                                 (0x40037000u)
+/** Peripheral PIT base pointer */
+#define PIT                                      ((PIT_Type *)PIT_BASE)
+/** Array initializer of PIT peripheral base addresses */
+#define PIT_BASE_ADDRS                           { PIT_BASE }
+/** Array initializer of PIT peripheral base pointers */
+#define PIT_BASE_PTRS                            { PIT }
+/** Interrupt vectors for the PIT peripheral type */
+#define PIT_IRQS                                 { PIT0_IRQn, PIT1_IRQn, PIT2_IRQn, PIT3_IRQn }
+
+/*!
+ * @}
+ */ /* end of group PIT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Peripheral_Access_Layer PMC Peripheral Access Layer
+ * @{
+ */
+
+/** PMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t LVDSC1;                             /**< Low Voltage Detect Status And Control 1 register, offset: 0x0 */
+  __IO uint8_t LVDSC2;                             /**< Low Voltage Detect Status And Control 2 register, offset: 0x1 */
+  __IO uint8_t REGSC;                              /**< Regulator Status And Control register, offset: 0x2 */
+} PMC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Masks PMC Register Masks
+ * @{
+ */
+
+/*! @name LVDSC1 - Low Voltage Detect Status And Control 1 register */
+#define PMC_LVDSC1_LVDV_MASK                     (0x3U)
+#define PMC_LVDSC1_LVDV_SHIFT                    (0U)
+#define PMC_LVDSC1_LVDV(x)                       (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC1_LVDV_SHIFT)) & PMC_LVDSC1_LVDV_MASK)
+#define PMC_LVDSC1_LVDRE_MASK                    (0x10U)
+#define PMC_LVDSC1_LVDRE_SHIFT                   (4U)
+#define PMC_LVDSC1_LVDRE(x)                      (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC1_LVDRE_SHIFT)) & PMC_LVDSC1_LVDRE_MASK)
+#define PMC_LVDSC1_LVDIE_MASK                    (0x20U)
+#define PMC_LVDSC1_LVDIE_SHIFT                   (5U)
+#define PMC_LVDSC1_LVDIE(x)                      (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC1_LVDIE_SHIFT)) & PMC_LVDSC1_LVDIE_MASK)
+#define PMC_LVDSC1_LVDACK_MASK                   (0x40U)
+#define PMC_LVDSC1_LVDACK_SHIFT                  (6U)
+#define PMC_LVDSC1_LVDACK(x)                     (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC1_LVDACK_SHIFT)) & PMC_LVDSC1_LVDACK_MASK)
+#define PMC_LVDSC1_LVDF_MASK                     (0x80U)
+#define PMC_LVDSC1_LVDF_SHIFT                    (7U)
+#define PMC_LVDSC1_LVDF(x)                       (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC1_LVDF_SHIFT)) & PMC_LVDSC1_LVDF_MASK)
+
+/*! @name LVDSC2 - Low Voltage Detect Status And Control 2 register */
+#define PMC_LVDSC2_LVWV_MASK                     (0x3U)
+#define PMC_LVDSC2_LVWV_SHIFT                    (0U)
+#define PMC_LVDSC2_LVWV(x)                       (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC2_LVWV_SHIFT)) & PMC_LVDSC2_LVWV_MASK)
+#define PMC_LVDSC2_LVWIE_MASK                    (0x20U)
+#define PMC_LVDSC2_LVWIE_SHIFT                   (5U)
+#define PMC_LVDSC2_LVWIE(x)                      (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC2_LVWIE_SHIFT)) & PMC_LVDSC2_LVWIE_MASK)
+#define PMC_LVDSC2_LVWACK_MASK                   (0x40U)
+#define PMC_LVDSC2_LVWACK_SHIFT                  (6U)
+#define PMC_LVDSC2_LVWACK(x)                     (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC2_LVWACK_SHIFT)) & PMC_LVDSC2_LVWACK_MASK)
+#define PMC_LVDSC2_LVWF_MASK                     (0x80U)
+#define PMC_LVDSC2_LVWF_SHIFT                    (7U)
+#define PMC_LVDSC2_LVWF(x)                       (((uint8_t)(((uint8_t)(x)) << PMC_LVDSC2_LVWF_SHIFT)) & PMC_LVDSC2_LVWF_MASK)
+
+/*! @name REGSC - Regulator Status And Control register */
+#define PMC_REGSC_BGBE_MASK                      (0x1U)
+#define PMC_REGSC_BGBE_SHIFT                     (0U)
+#define PMC_REGSC_BGBE(x)                        (((uint8_t)(((uint8_t)(x)) << PMC_REGSC_BGBE_SHIFT)) & PMC_REGSC_BGBE_MASK)
+#define PMC_REGSC_REGONS_MASK                    (0x4U)
+#define PMC_REGSC_REGONS_SHIFT                   (2U)
+#define PMC_REGSC_REGONS(x)                      (((uint8_t)(((uint8_t)(x)) << PMC_REGSC_REGONS_SHIFT)) & PMC_REGSC_REGONS_MASK)
+#define PMC_REGSC_ACKISO_MASK                    (0x8U)
+#define PMC_REGSC_ACKISO_SHIFT                   (3U)
+#define PMC_REGSC_ACKISO(x)                      (((uint8_t)(((uint8_t)(x)) << PMC_REGSC_ACKISO_SHIFT)) & PMC_REGSC_ACKISO_MASK)
+#define PMC_REGSC_BGEN_MASK                      (0x10U)
+#define PMC_REGSC_BGEN_SHIFT                     (4U)
+#define PMC_REGSC_BGEN(x)                        (((uint8_t)(((uint8_t)(x)) << PMC_REGSC_BGEN_SHIFT)) & PMC_REGSC_BGEN_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Masks */
+
+
+/* PMC - Peripheral instance base addresses */
+/** Peripheral PMC base address */
+#define PMC_BASE                                 (0x4007D000u)
+/** Peripheral PMC base pointer */
+#define PMC                                      ((PMC_Type *)PMC_BASE)
+/** Array initializer of PMC peripheral base addresses */
+#define PMC_BASE_ADDRS                           { PMC_BASE }
+/** Array initializer of PMC peripheral base pointers */
+#define PMC_BASE_PTRS                            { PMC }
+/** Interrupt vectors for the PMC peripheral type */
+#define PMC_IRQS                                 { LVD_LVW_IRQn }
+
+/*!
+ * @}
+ */ /* end of group PMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PORT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Peripheral_Access_Layer PORT Peripheral Access Layer
+ * @{
+ */
+
+/** PORT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PCR[32];                           /**< Pin Control Register n, array offset: 0x0, array step: 0x4 */
+  __O  uint32_t GPCLR;                             /**< Global Pin Control Low Register, offset: 0x80 */
+  __O  uint32_t GPCHR;                             /**< Global Pin Control High Register, offset: 0x84 */
+       uint8_t RESERVED_0[24];
+  __IO uint32_t ISFR;                              /**< Interrupt Status Flag Register, offset: 0xA0 */
+       uint8_t RESERVED_1[28];
+  __IO uint32_t DFER;                              /**< Digital Filter Enable Register, offset: 0xC0 */
+  __IO uint32_t DFCR;                              /**< Digital Filter Clock Register, offset: 0xC4 */
+  __IO uint32_t DFWR;                              /**< Digital Filter Width Register, offset: 0xC8 */
+} PORT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PORT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Masks PORT Register Masks
+ * @{
+ */
+
+/*! @name PCR - Pin Control Register n */
+#define PORT_PCR_PS_MASK                         (0x1U)
+#define PORT_PCR_PS_SHIFT                        (0U)
+#define PORT_PCR_PS(x)                           (((uint32_t)(((uint32_t)(x)) << PORT_PCR_PS_SHIFT)) & PORT_PCR_PS_MASK)
+#define PORT_PCR_PE_MASK                         (0x2U)
+#define PORT_PCR_PE_SHIFT                        (1U)
+#define PORT_PCR_PE(x)                           (((uint32_t)(((uint32_t)(x)) << PORT_PCR_PE_SHIFT)) & PORT_PCR_PE_MASK)
+#define PORT_PCR_SRE_MASK                        (0x4U)
+#define PORT_PCR_SRE_SHIFT                       (2U)
+#define PORT_PCR_SRE(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_PCR_SRE_SHIFT)) & PORT_PCR_SRE_MASK)
+#define PORT_PCR_PFE_MASK                        (0x10U)
+#define PORT_PCR_PFE_SHIFT                       (4U)
+#define PORT_PCR_PFE(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_PCR_PFE_SHIFT)) & PORT_PCR_PFE_MASK)
+#define PORT_PCR_ODE_MASK                        (0x20U)
+#define PORT_PCR_ODE_SHIFT                       (5U)
+#define PORT_PCR_ODE(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_PCR_ODE_SHIFT)) & PORT_PCR_ODE_MASK)
+#define PORT_PCR_DSE_MASK                        (0x40U)
+#define PORT_PCR_DSE_SHIFT                       (6U)
+#define PORT_PCR_DSE(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_PCR_DSE_SHIFT)) & PORT_PCR_DSE_MASK)
+#define PORT_PCR_MUX_MASK                        (0x700U)
+#define PORT_PCR_MUX_SHIFT                       (8U)
+#define PORT_PCR_MUX(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_PCR_MUX_SHIFT)) & PORT_PCR_MUX_MASK)
+#define PORT_PCR_LK_MASK                         (0x8000U)
+#define PORT_PCR_LK_SHIFT                        (15U)
+#define PORT_PCR_LK(x)                           (((uint32_t)(((uint32_t)(x)) << PORT_PCR_LK_SHIFT)) & PORT_PCR_LK_MASK)
+#define PORT_PCR_IRQC_MASK                       (0xF0000U)
+#define PORT_PCR_IRQC_SHIFT                      (16U)
+#define PORT_PCR_IRQC(x)                         (((uint32_t)(((uint32_t)(x)) << PORT_PCR_IRQC_SHIFT)) & PORT_PCR_IRQC_MASK)
+#define PORT_PCR_ISF_MASK                        (0x1000000U)
+#define PORT_PCR_ISF_SHIFT                       (24U)
+#define PORT_PCR_ISF(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_PCR_ISF_SHIFT)) & PORT_PCR_ISF_MASK)
+
+/* The count of PORT_PCR */
+#define PORT_PCR_COUNT                           (32U)
+
+/*! @name GPCLR - Global Pin Control Low Register */
+#define PORT_GPCLR_GPWD_MASK                     (0xFFFFU)
+#define PORT_GPCLR_GPWD_SHIFT                    (0U)
+#define PORT_GPCLR_GPWD(x)                       (((uint32_t)(((uint32_t)(x)) << PORT_GPCLR_GPWD_SHIFT)) & PORT_GPCLR_GPWD_MASK)
+#define PORT_GPCLR_GPWE_MASK                     (0xFFFF0000U)
+#define PORT_GPCLR_GPWE_SHIFT                    (16U)
+#define PORT_GPCLR_GPWE(x)                       (((uint32_t)(((uint32_t)(x)) << PORT_GPCLR_GPWE_SHIFT)) & PORT_GPCLR_GPWE_MASK)
+
+/*! @name GPCHR - Global Pin Control High Register */
+#define PORT_GPCHR_GPWD_MASK                     (0xFFFFU)
+#define PORT_GPCHR_GPWD_SHIFT                    (0U)
+#define PORT_GPCHR_GPWD(x)                       (((uint32_t)(((uint32_t)(x)) << PORT_GPCHR_GPWD_SHIFT)) & PORT_GPCHR_GPWD_MASK)
+#define PORT_GPCHR_GPWE_MASK                     (0xFFFF0000U)
+#define PORT_GPCHR_GPWE_SHIFT                    (16U)
+#define PORT_GPCHR_GPWE(x)                       (((uint32_t)(((uint32_t)(x)) << PORT_GPCHR_GPWE_SHIFT)) & PORT_GPCHR_GPWE_MASK)
+
+/*! @name ISFR - Interrupt Status Flag Register */
+#define PORT_ISFR_ISF_MASK                       (0xFFFFFFFFU)
+#define PORT_ISFR_ISF_SHIFT                      (0U)
+#define PORT_ISFR_ISF(x)                         (((uint32_t)(((uint32_t)(x)) << PORT_ISFR_ISF_SHIFT)) & PORT_ISFR_ISF_MASK)
+
+/*! @name DFER - Digital Filter Enable Register */
+#define PORT_DFER_DFE_MASK                       (0xFFFFFFFFU)
+#define PORT_DFER_DFE_SHIFT                      (0U)
+#define PORT_DFER_DFE(x)                         (((uint32_t)(((uint32_t)(x)) << PORT_DFER_DFE_SHIFT)) & PORT_DFER_DFE_MASK)
+
+/*! @name DFCR - Digital Filter Clock Register */
+#define PORT_DFCR_CS_MASK                        (0x1U)
+#define PORT_DFCR_CS_SHIFT                       (0U)
+#define PORT_DFCR_CS(x)                          (((uint32_t)(((uint32_t)(x)) << PORT_DFCR_CS_SHIFT)) & PORT_DFCR_CS_MASK)
+
+/*! @name DFWR - Digital Filter Width Register */
+#define PORT_DFWR_FILT_MASK                      (0x1FU)
+#define PORT_DFWR_FILT_SHIFT                     (0U)
+#define PORT_DFWR_FILT(x)                        (((uint32_t)(((uint32_t)(x)) << PORT_DFWR_FILT_SHIFT)) & PORT_DFWR_FILT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Masks */
+
+
+/* PORT - Peripheral instance base addresses */
+/** Peripheral PORTA base address */
+#define PORTA_BASE                               (0x40049000u)
+/** Peripheral PORTA base pointer */
+#define PORTA                                    ((PORT_Type *)PORTA_BASE)
+/** Peripheral PORTB base address */
+#define PORTB_BASE                               (0x4004A000u)
+/** Peripheral PORTB base pointer */
+#define PORTB                                    ((PORT_Type *)PORTB_BASE)
+/** Peripheral PORTC base address */
+#define PORTC_BASE                               (0x4004B000u)
+/** Peripheral PORTC base pointer */
+#define PORTC                                    ((PORT_Type *)PORTC_BASE)
+/** Peripheral PORTD base address */
+#define PORTD_BASE                               (0x4004C000u)
+/** Peripheral PORTD base pointer */
+#define PORTD                                    ((PORT_Type *)PORTD_BASE)
+/** Peripheral PORTE base address */
+#define PORTE_BASE                               (0x4004D000u)
+/** Peripheral PORTE base pointer */
+#define PORTE                                    ((PORT_Type *)PORTE_BASE)
+/** Array initializer of PORT peripheral base addresses */
+#define PORT_BASE_ADDRS                          { PORTA_BASE, PORTB_BASE, PORTC_BASE, PORTD_BASE, PORTE_BASE }
+/** Array initializer of PORT peripheral base pointers */
+#define PORT_BASE_PTRS                           { PORTA, PORTB, PORTC, PORTD, PORTE }
+/** Interrupt vectors for the PORT peripheral type */
+#define PORT_IRQS                                { PORTA_IRQn, PORTB_IRQn, PORTC_IRQn, PORTD_IRQn, PORTE_IRQn }
+
+/*!
+ * @}
+ */ /* end of group PORT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Peripheral_Access_Layer RCM Peripheral Access Layer
+ * @{
+ */
+
+/** RCM - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t SRS0;                               /**< System Reset Status Register 0, offset: 0x0 */
+  __I  uint8_t SRS1;                               /**< System Reset Status Register 1, offset: 0x1 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t RPFC;                               /**< Reset Pin Filter Control register, offset: 0x4 */
+  __IO uint8_t RPFW;                               /**< Reset Pin Filter Width register, offset: 0x5 */
+       uint8_t RESERVED_1[1];
+  __I  uint8_t MR;                                 /**< Mode Register, offset: 0x7 */
+} RCM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Masks RCM Register Masks
+ * @{
+ */
+
+/*! @name SRS0 - System Reset Status Register 0 */
+#define RCM_SRS0_WAKEUP_MASK                     (0x1U)
+#define RCM_SRS0_WAKEUP_SHIFT                    (0U)
+#define RCM_SRS0_WAKEUP(x)                       (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_WAKEUP_SHIFT)) & RCM_SRS0_WAKEUP_MASK)
+#define RCM_SRS0_LVD_MASK                        (0x2U)
+#define RCM_SRS0_LVD_SHIFT                       (1U)
+#define RCM_SRS0_LVD(x)                          (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_LVD_SHIFT)) & RCM_SRS0_LVD_MASK)
+#define RCM_SRS0_LOC_MASK                        (0x4U)
+#define RCM_SRS0_LOC_SHIFT                       (2U)
+#define RCM_SRS0_LOC(x)                          (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_LOC_SHIFT)) & RCM_SRS0_LOC_MASK)
+#define RCM_SRS0_LOL_MASK                        (0x8U)
+#define RCM_SRS0_LOL_SHIFT                       (3U)
+#define RCM_SRS0_LOL(x)                          (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_LOL_SHIFT)) & RCM_SRS0_LOL_MASK)
+#define RCM_SRS0_WDOG_MASK                       (0x20U)
+#define RCM_SRS0_WDOG_SHIFT                      (5U)
+#define RCM_SRS0_WDOG(x)                         (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_WDOG_SHIFT)) & RCM_SRS0_WDOG_MASK)
+#define RCM_SRS0_PIN_MASK                        (0x40U)
+#define RCM_SRS0_PIN_SHIFT                       (6U)
+#define RCM_SRS0_PIN(x)                          (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_PIN_SHIFT)) & RCM_SRS0_PIN_MASK)
+#define RCM_SRS0_POR_MASK                        (0x80U)
+#define RCM_SRS0_POR_SHIFT                       (7U)
+#define RCM_SRS0_POR(x)                          (((uint8_t)(((uint8_t)(x)) << RCM_SRS0_POR_SHIFT)) & RCM_SRS0_POR_MASK)
+
+/*! @name SRS1 - System Reset Status Register 1 */
+#define RCM_SRS1_JTAG_MASK                       (0x1U)
+#define RCM_SRS1_JTAG_SHIFT                      (0U)
+#define RCM_SRS1_JTAG(x)                         (((uint8_t)(((uint8_t)(x)) << RCM_SRS1_JTAG_SHIFT)) & RCM_SRS1_JTAG_MASK)
+#define RCM_SRS1_LOCKUP_MASK                     (0x2U)
+#define RCM_SRS1_LOCKUP_SHIFT                    (1U)
+#define RCM_SRS1_LOCKUP(x)                       (((uint8_t)(((uint8_t)(x)) << RCM_SRS1_LOCKUP_SHIFT)) & RCM_SRS1_LOCKUP_MASK)
+#define RCM_SRS1_SW_MASK                         (0x4U)
+#define RCM_SRS1_SW_SHIFT                        (2U)
+#define RCM_SRS1_SW(x)                           (((uint8_t)(((uint8_t)(x)) << RCM_SRS1_SW_SHIFT)) & RCM_SRS1_SW_MASK)
+#define RCM_SRS1_MDM_AP_MASK                     (0x8U)
+#define RCM_SRS1_MDM_AP_SHIFT                    (3U)
+#define RCM_SRS1_MDM_AP(x)                       (((uint8_t)(((uint8_t)(x)) << RCM_SRS1_MDM_AP_SHIFT)) & RCM_SRS1_MDM_AP_MASK)
+#define RCM_SRS1_EZPT_MASK                       (0x10U)
+#define RCM_SRS1_EZPT_SHIFT                      (4U)
+#define RCM_SRS1_EZPT(x)                         (((uint8_t)(((uint8_t)(x)) << RCM_SRS1_EZPT_SHIFT)) & RCM_SRS1_EZPT_MASK)
+#define RCM_SRS1_SACKERR_MASK                    (0x20U)
+#define RCM_SRS1_SACKERR_SHIFT                   (5U)
+#define RCM_SRS1_SACKERR(x)                      (((uint8_t)(((uint8_t)(x)) << RCM_SRS1_SACKERR_SHIFT)) & RCM_SRS1_SACKERR_MASK)
+
+/*! @name RPFC - Reset Pin Filter Control register */
+#define RCM_RPFC_RSTFLTSRW_MASK                  (0x3U)
+#define RCM_RPFC_RSTFLTSRW_SHIFT                 (0U)
+#define RCM_RPFC_RSTFLTSRW(x)                    (((uint8_t)(((uint8_t)(x)) << RCM_RPFC_RSTFLTSRW_SHIFT)) & RCM_RPFC_RSTFLTSRW_MASK)
+#define RCM_RPFC_RSTFLTSS_MASK                   (0x4U)
+#define RCM_RPFC_RSTFLTSS_SHIFT                  (2U)
+#define RCM_RPFC_RSTFLTSS(x)                     (((uint8_t)(((uint8_t)(x)) << RCM_RPFC_RSTFLTSS_SHIFT)) & RCM_RPFC_RSTFLTSS_MASK)
+
+/*! @name RPFW - Reset Pin Filter Width register */
+#define RCM_RPFW_RSTFLTSEL_MASK                  (0x1FU)
+#define RCM_RPFW_RSTFLTSEL_SHIFT                 (0U)
+#define RCM_RPFW_RSTFLTSEL(x)                    (((uint8_t)(((uint8_t)(x)) << RCM_RPFW_RSTFLTSEL_SHIFT)) & RCM_RPFW_RSTFLTSEL_MASK)
+
+/*! @name MR - Mode Register */
+#define RCM_MR_EZP_MS_MASK                       (0x2U)
+#define RCM_MR_EZP_MS_SHIFT                      (1U)
+#define RCM_MR_EZP_MS(x)                         (((uint8_t)(((uint8_t)(x)) << RCM_MR_EZP_MS_SHIFT)) & RCM_MR_EZP_MS_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Masks */
+
+
+/* RCM - Peripheral instance base addresses */
+/** Peripheral RCM base address */
+#define RCM_BASE                                 (0x4007F000u)
+/** Peripheral RCM base pointer */
+#define RCM                                      ((RCM_Type *)RCM_BASE)
+/** Array initializer of RCM peripheral base addresses */
+#define RCM_BASE_ADDRS                           { RCM_BASE }
+/** Array initializer of RCM peripheral base pointers */
+#define RCM_BASE_PTRS                            { RCM }
+
+/*!
+ * @}
+ */ /* end of group RCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RFSYS Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFSYS_Peripheral_Access_Layer RFSYS Peripheral Access Layer
+ * @{
+ */
+
+/** RFSYS - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t REG[8];                            /**< Register file register, array offset: 0x0, array step: 0x4 */
+} RFSYS_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RFSYS Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFSYS_Register_Masks RFSYS Register Masks
+ * @{
+ */
+
+/*! @name REG - Register file register */
+#define RFSYS_REG_LL_MASK                        (0xFFU)
+#define RFSYS_REG_LL_SHIFT                       (0U)
+#define RFSYS_REG_LL(x)                          (((uint32_t)(((uint32_t)(x)) << RFSYS_REG_LL_SHIFT)) & RFSYS_REG_LL_MASK)
+#define RFSYS_REG_LH_MASK                        (0xFF00U)
+#define RFSYS_REG_LH_SHIFT                       (8U)
+#define RFSYS_REG_LH(x)                          (((uint32_t)(((uint32_t)(x)) << RFSYS_REG_LH_SHIFT)) & RFSYS_REG_LH_MASK)
+#define RFSYS_REG_HL_MASK                        (0xFF0000U)
+#define RFSYS_REG_HL_SHIFT                       (16U)
+#define RFSYS_REG_HL(x)                          (((uint32_t)(((uint32_t)(x)) << RFSYS_REG_HL_SHIFT)) & RFSYS_REG_HL_MASK)
+#define RFSYS_REG_HH_MASK                        (0xFF000000U)
+#define RFSYS_REG_HH_SHIFT                       (24U)
+#define RFSYS_REG_HH(x)                          (((uint32_t)(((uint32_t)(x)) << RFSYS_REG_HH_SHIFT)) & RFSYS_REG_HH_MASK)
+
+/* The count of RFSYS_REG */
+#define RFSYS_REG_COUNT                          (8U)
+
+
+/*!
+ * @}
+ */ /* end of group RFSYS_Register_Masks */
+
+
+/* RFSYS - Peripheral instance base addresses */
+/** Peripheral RFSYS base address */
+#define RFSYS_BASE                               (0x40041000u)
+/** Peripheral RFSYS base pointer */
+#define RFSYS                                    ((RFSYS_Type *)RFSYS_BASE)
+/** Array initializer of RFSYS peripheral base addresses */
+#define RFSYS_BASE_ADDRS                         { RFSYS_BASE }
+/** Array initializer of RFSYS peripheral base pointers */
+#define RFSYS_BASE_PTRS                          { RFSYS }
+
+/*!
+ * @}
+ */ /* end of group RFSYS_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RFVBAT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFVBAT_Peripheral_Access_Layer RFVBAT Peripheral Access Layer
+ * @{
+ */
+
+/** RFVBAT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t REG[8];                            /**< VBAT register file register, array offset: 0x0, array step: 0x4 */
+} RFVBAT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RFVBAT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFVBAT_Register_Masks RFVBAT Register Masks
+ * @{
+ */
+
+/*! @name REG - VBAT register file register */
+#define RFVBAT_REG_LL_MASK                       (0xFFU)
+#define RFVBAT_REG_LL_SHIFT                      (0U)
+#define RFVBAT_REG_LL(x)                         (((uint32_t)(((uint32_t)(x)) << RFVBAT_REG_LL_SHIFT)) & RFVBAT_REG_LL_MASK)
+#define RFVBAT_REG_LH_MASK                       (0xFF00U)
+#define RFVBAT_REG_LH_SHIFT                      (8U)
+#define RFVBAT_REG_LH(x)                         (((uint32_t)(((uint32_t)(x)) << RFVBAT_REG_LH_SHIFT)) & RFVBAT_REG_LH_MASK)
+#define RFVBAT_REG_HL_MASK                       (0xFF0000U)
+#define RFVBAT_REG_HL_SHIFT                      (16U)
+#define RFVBAT_REG_HL(x)                         (((uint32_t)(((uint32_t)(x)) << RFVBAT_REG_HL_SHIFT)) & RFVBAT_REG_HL_MASK)
+#define RFVBAT_REG_HH_MASK                       (0xFF000000U)
+#define RFVBAT_REG_HH_SHIFT                      (24U)
+#define RFVBAT_REG_HH(x)                         (((uint32_t)(((uint32_t)(x)) << RFVBAT_REG_HH_SHIFT)) & RFVBAT_REG_HH_MASK)
+
+/* The count of RFVBAT_REG */
+#define RFVBAT_REG_COUNT                         (8U)
+
+
+/*!
+ * @}
+ */ /* end of group RFVBAT_Register_Masks */
+
+
+/* RFVBAT - Peripheral instance base addresses */
+/** Peripheral RFVBAT base address */
+#define RFVBAT_BASE                              (0x4003E000u)
+/** Peripheral RFVBAT base pointer */
+#define RFVBAT                                   ((RFVBAT_Type *)RFVBAT_BASE)
+/** Array initializer of RFVBAT peripheral base addresses */
+#define RFVBAT_BASE_ADDRS                        { RFVBAT_BASE }
+/** Array initializer of RFVBAT peripheral base pointers */
+#define RFVBAT_BASE_PTRS                         { RFVBAT }
+
+/*!
+ * @}
+ */ /* end of group RFVBAT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RNG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RNG_Peripheral_Access_Layer RNG Peripheral Access Layer
+ * @{
+ */
+
+/** RNG - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CR;                                /**< RNGA Control Register, offset: 0x0 */
+  __I  uint32_t SR;                                /**< RNGA Status Register, offset: 0x4 */
+  __O  uint32_t ER;                                /**< RNGA Entropy Register, offset: 0x8 */
+  __I  uint32_t OR;                                /**< RNGA Output Register, offset: 0xC */
+} RNG_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RNG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RNG_Register_Masks RNG Register Masks
+ * @{
+ */
+
+/*! @name CR - RNGA Control Register */
+#define RNG_CR_GO_MASK                           (0x1U)
+#define RNG_CR_GO_SHIFT                          (0U)
+#define RNG_CR_GO(x)                             (((uint32_t)(((uint32_t)(x)) << RNG_CR_GO_SHIFT)) & RNG_CR_GO_MASK)
+#define RNG_CR_HA_MASK                           (0x2U)
+#define RNG_CR_HA_SHIFT                          (1U)
+#define RNG_CR_HA(x)                             (((uint32_t)(((uint32_t)(x)) << RNG_CR_HA_SHIFT)) & RNG_CR_HA_MASK)
+#define RNG_CR_INTM_MASK                         (0x4U)
+#define RNG_CR_INTM_SHIFT                        (2U)
+#define RNG_CR_INTM(x)                           (((uint32_t)(((uint32_t)(x)) << RNG_CR_INTM_SHIFT)) & RNG_CR_INTM_MASK)
+#define RNG_CR_CLRI_MASK                         (0x8U)
+#define RNG_CR_CLRI_SHIFT                        (3U)
+#define RNG_CR_CLRI(x)                           (((uint32_t)(((uint32_t)(x)) << RNG_CR_CLRI_SHIFT)) & RNG_CR_CLRI_MASK)
+#define RNG_CR_SLP_MASK                          (0x10U)
+#define RNG_CR_SLP_SHIFT                         (4U)
+#define RNG_CR_SLP(x)                            (((uint32_t)(((uint32_t)(x)) << RNG_CR_SLP_SHIFT)) & RNG_CR_SLP_MASK)
+
+/*! @name SR - RNGA Status Register */
+#define RNG_SR_SECV_MASK                         (0x1U)
+#define RNG_SR_SECV_SHIFT                        (0U)
+#define RNG_SR_SECV(x)                           (((uint32_t)(((uint32_t)(x)) << RNG_SR_SECV_SHIFT)) & RNG_SR_SECV_MASK)
+#define RNG_SR_LRS_MASK                          (0x2U)
+#define RNG_SR_LRS_SHIFT                         (1U)
+#define RNG_SR_LRS(x)                            (((uint32_t)(((uint32_t)(x)) << RNG_SR_LRS_SHIFT)) & RNG_SR_LRS_MASK)
+#define RNG_SR_ORU_MASK                          (0x4U)
+#define RNG_SR_ORU_SHIFT                         (2U)
+#define RNG_SR_ORU(x)                            (((uint32_t)(((uint32_t)(x)) << RNG_SR_ORU_SHIFT)) & RNG_SR_ORU_MASK)
+#define RNG_SR_ERRI_MASK                         (0x8U)
+#define RNG_SR_ERRI_SHIFT                        (3U)
+#define RNG_SR_ERRI(x)                           (((uint32_t)(((uint32_t)(x)) << RNG_SR_ERRI_SHIFT)) & RNG_SR_ERRI_MASK)
+#define RNG_SR_SLP_MASK                          (0x10U)
+#define RNG_SR_SLP_SHIFT                         (4U)
+#define RNG_SR_SLP(x)                            (((uint32_t)(((uint32_t)(x)) << RNG_SR_SLP_SHIFT)) & RNG_SR_SLP_MASK)
+#define RNG_SR_OREG_LVL_MASK                     (0xFF00U)
+#define RNG_SR_OREG_LVL_SHIFT                    (8U)
+#define RNG_SR_OREG_LVL(x)                       (((uint32_t)(((uint32_t)(x)) << RNG_SR_OREG_LVL_SHIFT)) & RNG_SR_OREG_LVL_MASK)
+#define RNG_SR_OREG_SIZE_MASK                    (0xFF0000U)
+#define RNG_SR_OREG_SIZE_SHIFT                   (16U)
+#define RNG_SR_OREG_SIZE(x)                      (((uint32_t)(((uint32_t)(x)) << RNG_SR_OREG_SIZE_SHIFT)) & RNG_SR_OREG_SIZE_MASK)
+
+/*! @name ER - RNGA Entropy Register */
+#define RNG_ER_EXT_ENT_MASK                      (0xFFFFFFFFU)
+#define RNG_ER_EXT_ENT_SHIFT                     (0U)
+#define RNG_ER_EXT_ENT(x)                        (((uint32_t)(((uint32_t)(x)) << RNG_ER_EXT_ENT_SHIFT)) & RNG_ER_EXT_ENT_MASK)
+
+/*! @name OR - RNGA Output Register */
+#define RNG_OR_RANDOUT_MASK                      (0xFFFFFFFFU)
+#define RNG_OR_RANDOUT_SHIFT                     (0U)
+#define RNG_OR_RANDOUT(x)                        (((uint32_t)(((uint32_t)(x)) << RNG_OR_RANDOUT_SHIFT)) & RNG_OR_RANDOUT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group RNG_Register_Masks */
+
+
+/* RNG - Peripheral instance base addresses */
+/** Peripheral RNG base address */
+#define RNG_BASE                                 (0x40029000u)
+/** Peripheral RNG base pointer */
+#define RNG                                      ((RNG_Type *)RNG_BASE)
+/** Array initializer of RNG peripheral base addresses */
+#define RNG_BASE_ADDRS                           { RNG_BASE }
+/** Array initializer of RNG peripheral base pointers */
+#define RNG_BASE_PTRS                            { RNG }
+/** Interrupt vectors for the RNG peripheral type */
+#define RNG_IRQS                                 { RNG_IRQn }
+
+/*!
+ * @}
+ */ /* end of group RNG_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RTC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Peripheral_Access_Layer RTC Peripheral Access Layer
+ * @{
+ */
+
+/** RTC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TSR;                               /**< RTC Time Seconds Register, offset: 0x0 */
+  __IO uint32_t TPR;                               /**< RTC Time Prescaler Register, offset: 0x4 */
+  __IO uint32_t TAR;                               /**< RTC Time Alarm Register, offset: 0x8 */
+  __IO uint32_t TCR;                               /**< RTC Time Compensation Register, offset: 0xC */
+  __IO uint32_t CR;                                /**< RTC Control Register, offset: 0x10 */
+  __IO uint32_t SR;                                /**< RTC Status Register, offset: 0x14 */
+  __IO uint32_t LR;                                /**< RTC Lock Register, offset: 0x18 */
+  __IO uint32_t IER;                               /**< RTC Interrupt Enable Register, offset: 0x1C */
+       uint8_t RESERVED_0[2016];
+  __IO uint32_t WAR;                               /**< RTC Write Access Register, offset: 0x800 */
+  __IO uint32_t RAR;                               /**< RTC Read Access Register, offset: 0x804 */
+} RTC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RTC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Masks RTC Register Masks
+ * @{
+ */
+
+/*! @name TSR - RTC Time Seconds Register */
+#define RTC_TSR_TSR_MASK                         (0xFFFFFFFFU)
+#define RTC_TSR_TSR_SHIFT                        (0U)
+#define RTC_TSR_TSR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TSR_TSR_SHIFT)) & RTC_TSR_TSR_MASK)
+
+/*! @name TPR - RTC Time Prescaler Register */
+#define RTC_TPR_TPR_MASK                         (0xFFFFU)
+#define RTC_TPR_TPR_SHIFT                        (0U)
+#define RTC_TPR_TPR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TPR_TPR_SHIFT)) & RTC_TPR_TPR_MASK)
+
+/*! @name TAR - RTC Time Alarm Register */
+#define RTC_TAR_TAR_MASK                         (0xFFFFFFFFU)
+#define RTC_TAR_TAR_SHIFT                        (0U)
+#define RTC_TAR_TAR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TAR_TAR_SHIFT)) & RTC_TAR_TAR_MASK)
+
+/*! @name TCR - RTC Time Compensation Register */
+#define RTC_TCR_TCR_MASK                         (0xFFU)
+#define RTC_TCR_TCR_SHIFT                        (0U)
+#define RTC_TCR_TCR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TCR_TCR_SHIFT)) & RTC_TCR_TCR_MASK)
+#define RTC_TCR_CIR_MASK                         (0xFF00U)
+#define RTC_TCR_CIR_SHIFT                        (8U)
+#define RTC_TCR_CIR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TCR_CIR_SHIFT)) & RTC_TCR_CIR_MASK)
+#define RTC_TCR_TCV_MASK                         (0xFF0000U)
+#define RTC_TCR_TCV_SHIFT                        (16U)
+#define RTC_TCR_TCV(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TCR_TCV_SHIFT)) & RTC_TCR_TCV_MASK)
+#define RTC_TCR_CIC_MASK                         (0xFF000000U)
+#define RTC_TCR_CIC_SHIFT                        (24U)
+#define RTC_TCR_CIC(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_TCR_CIC_SHIFT)) & RTC_TCR_CIC_MASK)
+
+/*! @name CR - RTC Control Register */
+#define RTC_CR_SWR_MASK                          (0x1U)
+#define RTC_CR_SWR_SHIFT                         (0U)
+#define RTC_CR_SWR(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_CR_SWR_SHIFT)) & RTC_CR_SWR_MASK)
+#define RTC_CR_WPE_MASK                          (0x2U)
+#define RTC_CR_WPE_SHIFT                         (1U)
+#define RTC_CR_WPE(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_CR_WPE_SHIFT)) & RTC_CR_WPE_MASK)
+#define RTC_CR_SUP_MASK                          (0x4U)
+#define RTC_CR_SUP_SHIFT                         (2U)
+#define RTC_CR_SUP(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_CR_SUP_SHIFT)) & RTC_CR_SUP_MASK)
+#define RTC_CR_UM_MASK                           (0x8U)
+#define RTC_CR_UM_SHIFT                          (3U)
+#define RTC_CR_UM(x)                             (((uint32_t)(((uint32_t)(x)) << RTC_CR_UM_SHIFT)) & RTC_CR_UM_MASK)
+#define RTC_CR_WPS_MASK                          (0x10U)
+#define RTC_CR_WPS_SHIFT                         (4U)
+#define RTC_CR_WPS(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_CR_WPS_SHIFT)) & RTC_CR_WPS_MASK)
+#define RTC_CR_OSCE_MASK                         (0x100U)
+#define RTC_CR_OSCE_SHIFT                        (8U)
+#define RTC_CR_OSCE(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_CR_OSCE_SHIFT)) & RTC_CR_OSCE_MASK)
+#define RTC_CR_CLKO_MASK                         (0x200U)
+#define RTC_CR_CLKO_SHIFT                        (9U)
+#define RTC_CR_CLKO(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_CR_CLKO_SHIFT)) & RTC_CR_CLKO_MASK)
+#define RTC_CR_SC16P_MASK                        (0x400U)
+#define RTC_CR_SC16P_SHIFT                       (10U)
+#define RTC_CR_SC16P(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_CR_SC16P_SHIFT)) & RTC_CR_SC16P_MASK)
+#define RTC_CR_SC8P_MASK                         (0x800U)
+#define RTC_CR_SC8P_SHIFT                        (11U)
+#define RTC_CR_SC8P(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_CR_SC8P_SHIFT)) & RTC_CR_SC8P_MASK)
+#define RTC_CR_SC4P_MASK                         (0x1000U)
+#define RTC_CR_SC4P_SHIFT                        (12U)
+#define RTC_CR_SC4P(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_CR_SC4P_SHIFT)) & RTC_CR_SC4P_MASK)
+#define RTC_CR_SC2P_MASK                         (0x2000U)
+#define RTC_CR_SC2P_SHIFT                        (13U)
+#define RTC_CR_SC2P(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_CR_SC2P_SHIFT)) & RTC_CR_SC2P_MASK)
+
+/*! @name SR - RTC Status Register */
+#define RTC_SR_TIF_MASK                          (0x1U)
+#define RTC_SR_TIF_SHIFT                         (0U)
+#define RTC_SR_TIF(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_SR_TIF_SHIFT)) & RTC_SR_TIF_MASK)
+#define RTC_SR_TOF_MASK                          (0x2U)
+#define RTC_SR_TOF_SHIFT                         (1U)
+#define RTC_SR_TOF(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_SR_TOF_SHIFT)) & RTC_SR_TOF_MASK)
+#define RTC_SR_TAF_MASK                          (0x4U)
+#define RTC_SR_TAF_SHIFT                         (2U)
+#define RTC_SR_TAF(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_SR_TAF_SHIFT)) & RTC_SR_TAF_MASK)
+#define RTC_SR_TCE_MASK                          (0x10U)
+#define RTC_SR_TCE_SHIFT                         (4U)
+#define RTC_SR_TCE(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_SR_TCE_SHIFT)) & RTC_SR_TCE_MASK)
+
+/*! @name LR - RTC Lock Register */
+#define RTC_LR_TCL_MASK                          (0x8U)
+#define RTC_LR_TCL_SHIFT                         (3U)
+#define RTC_LR_TCL(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_LR_TCL_SHIFT)) & RTC_LR_TCL_MASK)
+#define RTC_LR_CRL_MASK                          (0x10U)
+#define RTC_LR_CRL_SHIFT                         (4U)
+#define RTC_LR_CRL(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_LR_CRL_SHIFT)) & RTC_LR_CRL_MASK)
+#define RTC_LR_SRL_MASK                          (0x20U)
+#define RTC_LR_SRL_SHIFT                         (5U)
+#define RTC_LR_SRL(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_LR_SRL_SHIFT)) & RTC_LR_SRL_MASK)
+#define RTC_LR_LRL_MASK                          (0x40U)
+#define RTC_LR_LRL_SHIFT                         (6U)
+#define RTC_LR_LRL(x)                            (((uint32_t)(((uint32_t)(x)) << RTC_LR_LRL_SHIFT)) & RTC_LR_LRL_MASK)
+
+/*! @name IER - RTC Interrupt Enable Register */
+#define RTC_IER_TIIE_MASK                        (0x1U)
+#define RTC_IER_TIIE_SHIFT                       (0U)
+#define RTC_IER_TIIE(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_IER_TIIE_SHIFT)) & RTC_IER_TIIE_MASK)
+#define RTC_IER_TOIE_MASK                        (0x2U)
+#define RTC_IER_TOIE_SHIFT                       (1U)
+#define RTC_IER_TOIE(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_IER_TOIE_SHIFT)) & RTC_IER_TOIE_MASK)
+#define RTC_IER_TAIE_MASK                        (0x4U)
+#define RTC_IER_TAIE_SHIFT                       (2U)
+#define RTC_IER_TAIE(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_IER_TAIE_SHIFT)) & RTC_IER_TAIE_MASK)
+#define RTC_IER_TSIE_MASK                        (0x10U)
+#define RTC_IER_TSIE_SHIFT                       (4U)
+#define RTC_IER_TSIE(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_IER_TSIE_SHIFT)) & RTC_IER_TSIE_MASK)
+#define RTC_IER_WPON_MASK                        (0x80U)
+#define RTC_IER_WPON_SHIFT                       (7U)
+#define RTC_IER_WPON(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_IER_WPON_SHIFT)) & RTC_IER_WPON_MASK)
+
+/*! @name WAR - RTC Write Access Register */
+#define RTC_WAR_TSRW_MASK                        (0x1U)
+#define RTC_WAR_TSRW_SHIFT                       (0U)
+#define RTC_WAR_TSRW(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_WAR_TSRW_SHIFT)) & RTC_WAR_TSRW_MASK)
+#define RTC_WAR_TPRW_MASK                        (0x2U)
+#define RTC_WAR_TPRW_SHIFT                       (1U)
+#define RTC_WAR_TPRW(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_WAR_TPRW_SHIFT)) & RTC_WAR_TPRW_MASK)
+#define RTC_WAR_TARW_MASK                        (0x4U)
+#define RTC_WAR_TARW_SHIFT                       (2U)
+#define RTC_WAR_TARW(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_WAR_TARW_SHIFT)) & RTC_WAR_TARW_MASK)
+#define RTC_WAR_TCRW_MASK                        (0x8U)
+#define RTC_WAR_TCRW_SHIFT                       (3U)
+#define RTC_WAR_TCRW(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_WAR_TCRW_SHIFT)) & RTC_WAR_TCRW_MASK)
+#define RTC_WAR_CRW_MASK                         (0x10U)
+#define RTC_WAR_CRW_SHIFT                        (4U)
+#define RTC_WAR_CRW(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_WAR_CRW_SHIFT)) & RTC_WAR_CRW_MASK)
+#define RTC_WAR_SRW_MASK                         (0x20U)
+#define RTC_WAR_SRW_SHIFT                        (5U)
+#define RTC_WAR_SRW(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_WAR_SRW_SHIFT)) & RTC_WAR_SRW_MASK)
+#define RTC_WAR_LRW_MASK                         (0x40U)
+#define RTC_WAR_LRW_SHIFT                        (6U)
+#define RTC_WAR_LRW(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_WAR_LRW_SHIFT)) & RTC_WAR_LRW_MASK)
+#define RTC_WAR_IERW_MASK                        (0x80U)
+#define RTC_WAR_IERW_SHIFT                       (7U)
+#define RTC_WAR_IERW(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_WAR_IERW_SHIFT)) & RTC_WAR_IERW_MASK)
+
+/*! @name RAR - RTC Read Access Register */
+#define RTC_RAR_TSRR_MASK                        (0x1U)
+#define RTC_RAR_TSRR_SHIFT                       (0U)
+#define RTC_RAR_TSRR(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_RAR_TSRR_SHIFT)) & RTC_RAR_TSRR_MASK)
+#define RTC_RAR_TPRR_MASK                        (0x2U)
+#define RTC_RAR_TPRR_SHIFT                       (1U)
+#define RTC_RAR_TPRR(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_RAR_TPRR_SHIFT)) & RTC_RAR_TPRR_MASK)
+#define RTC_RAR_TARR_MASK                        (0x4U)
+#define RTC_RAR_TARR_SHIFT                       (2U)
+#define RTC_RAR_TARR(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_RAR_TARR_SHIFT)) & RTC_RAR_TARR_MASK)
+#define RTC_RAR_TCRR_MASK                        (0x8U)
+#define RTC_RAR_TCRR_SHIFT                       (3U)
+#define RTC_RAR_TCRR(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_RAR_TCRR_SHIFT)) & RTC_RAR_TCRR_MASK)
+#define RTC_RAR_CRR_MASK                         (0x10U)
+#define RTC_RAR_CRR_SHIFT                        (4U)
+#define RTC_RAR_CRR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_RAR_CRR_SHIFT)) & RTC_RAR_CRR_MASK)
+#define RTC_RAR_SRR_MASK                         (0x20U)
+#define RTC_RAR_SRR_SHIFT                        (5U)
+#define RTC_RAR_SRR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_RAR_SRR_SHIFT)) & RTC_RAR_SRR_MASK)
+#define RTC_RAR_LRR_MASK                         (0x40U)
+#define RTC_RAR_LRR_SHIFT                        (6U)
+#define RTC_RAR_LRR(x)                           (((uint32_t)(((uint32_t)(x)) << RTC_RAR_LRR_SHIFT)) & RTC_RAR_LRR_MASK)
+#define RTC_RAR_IERR_MASK                        (0x80U)
+#define RTC_RAR_IERR_SHIFT                       (7U)
+#define RTC_RAR_IERR(x)                          (((uint32_t)(((uint32_t)(x)) << RTC_RAR_IERR_SHIFT)) & RTC_RAR_IERR_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Masks */
+
+
+/* RTC - Peripheral instance base addresses */
+/** Peripheral RTC base address */
+#define RTC_BASE                                 (0x4003D000u)
+/** Peripheral RTC base pointer */
+#define RTC                                      ((RTC_Type *)RTC_BASE)
+/** Array initializer of RTC peripheral base addresses */
+#define RTC_BASE_ADDRS                           { RTC_BASE }
+/** Array initializer of RTC peripheral base pointers */
+#define RTC_BASE_PTRS                            { RTC }
+/** Interrupt vectors for the RTC peripheral type */
+#define RTC_IRQS                                 { RTC_IRQn }
+#define RTC_SECONDS_IRQS                         { RTC_Seconds_IRQn }
+
+/*!
+ * @}
+ */ /* end of group RTC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SDHC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDHC_Peripheral_Access_Layer SDHC Peripheral Access Layer
+ * @{
+ */
+
+/** SDHC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t DSADDR;                            /**< DMA System Address register, offset: 0x0 */
+  __IO uint32_t BLKATTR;                           /**< Block Attributes register, offset: 0x4 */
+  __IO uint32_t CMDARG;                            /**< Command Argument register, offset: 0x8 */
+  __IO uint32_t XFERTYP;                           /**< Transfer Type register, offset: 0xC */
+  __I  uint32_t CMDRSP[4];                         /**< Command Response 0..Command Response 3, array offset: 0x10, array step: 0x4 */
+  __IO uint32_t DATPORT;                           /**< Buffer Data Port register, offset: 0x20 */
+  __I  uint32_t PRSSTAT;                           /**< Present State register, offset: 0x24 */
+  __IO uint32_t PROCTL;                            /**< Protocol Control register, offset: 0x28 */
+  __IO uint32_t SYSCTL;                            /**< System Control register, offset: 0x2C */
+  __IO uint32_t IRQSTAT;                           /**< Interrupt Status register, offset: 0x30 */
+  __IO uint32_t IRQSTATEN;                         /**< Interrupt Status Enable register, offset: 0x34 */
+  __IO uint32_t IRQSIGEN;                          /**< Interrupt Signal Enable register, offset: 0x38 */
+  __I  uint32_t AC12ERR;                           /**< Auto CMD12 Error Status Register, offset: 0x3C */
+  __I  uint32_t HTCAPBLT;                          /**< Host Controller Capabilities, offset: 0x40 */
+  __IO uint32_t WML;                               /**< Watermark Level Register, offset: 0x44 */
+       uint8_t RESERVED_0[8];
+  __O  uint32_t FEVT;                              /**< Force Event register, offset: 0x50 */
+  __I  uint32_t ADMAES;                            /**< ADMA Error Status register, offset: 0x54 */
+  __IO uint32_t ADSADDR;                           /**< ADMA System Addressregister, offset: 0x58 */
+       uint8_t RESERVED_1[100];
+  __IO uint32_t VENDOR;                            /**< Vendor Specific register, offset: 0xC0 */
+  __IO uint32_t MMCBOOT;                           /**< MMC Boot register, offset: 0xC4 */
+       uint8_t RESERVED_2[52];
+  __I  uint32_t HOSTVER;                           /**< Host Controller Version, offset: 0xFC */
+} SDHC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SDHC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDHC_Register_Masks SDHC Register Masks
+ * @{
+ */
+
+/*! @name DSADDR - DMA System Address register */
+#define SDHC_DSADDR_DSADDR_MASK                  (0xFFFFFFFCU)
+#define SDHC_DSADDR_DSADDR_SHIFT                 (2U)
+#define SDHC_DSADDR_DSADDR(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_DSADDR_DSADDR_SHIFT)) & SDHC_DSADDR_DSADDR_MASK)
+
+/*! @name BLKATTR - Block Attributes register */
+#define SDHC_BLKATTR_BLKSIZE_MASK                (0x1FFFU)
+#define SDHC_BLKATTR_BLKSIZE_SHIFT               (0U)
+#define SDHC_BLKATTR_BLKSIZE(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_BLKATTR_BLKSIZE_SHIFT)) & SDHC_BLKATTR_BLKSIZE_MASK)
+#define SDHC_BLKATTR_BLKCNT_MASK                 (0xFFFF0000U)
+#define SDHC_BLKATTR_BLKCNT_SHIFT                (16U)
+#define SDHC_BLKATTR_BLKCNT(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_BLKATTR_BLKCNT_SHIFT)) & SDHC_BLKATTR_BLKCNT_MASK)
+
+/*! @name CMDARG - Command Argument register */
+#define SDHC_CMDARG_CMDARG_MASK                  (0xFFFFFFFFU)
+#define SDHC_CMDARG_CMDARG_SHIFT                 (0U)
+#define SDHC_CMDARG_CMDARG(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_CMDARG_CMDARG_SHIFT)) & SDHC_CMDARG_CMDARG_MASK)
+
+/*! @name XFERTYP - Transfer Type register */
+#define SDHC_XFERTYP_DMAEN_MASK                  (0x1U)
+#define SDHC_XFERTYP_DMAEN_SHIFT                 (0U)
+#define SDHC_XFERTYP_DMAEN(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_DMAEN_SHIFT)) & SDHC_XFERTYP_DMAEN_MASK)
+#define SDHC_XFERTYP_BCEN_MASK                   (0x2U)
+#define SDHC_XFERTYP_BCEN_SHIFT                  (1U)
+#define SDHC_XFERTYP_BCEN(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_BCEN_SHIFT)) & SDHC_XFERTYP_BCEN_MASK)
+#define SDHC_XFERTYP_AC12EN_MASK                 (0x4U)
+#define SDHC_XFERTYP_AC12EN_SHIFT                (2U)
+#define SDHC_XFERTYP_AC12EN(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_AC12EN_SHIFT)) & SDHC_XFERTYP_AC12EN_MASK)
+#define SDHC_XFERTYP_DTDSEL_MASK                 (0x10U)
+#define SDHC_XFERTYP_DTDSEL_SHIFT                (4U)
+#define SDHC_XFERTYP_DTDSEL(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_DTDSEL_SHIFT)) & SDHC_XFERTYP_DTDSEL_MASK)
+#define SDHC_XFERTYP_MSBSEL_MASK                 (0x20U)
+#define SDHC_XFERTYP_MSBSEL_SHIFT                (5U)
+#define SDHC_XFERTYP_MSBSEL(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_MSBSEL_SHIFT)) & SDHC_XFERTYP_MSBSEL_MASK)
+#define SDHC_XFERTYP_RSPTYP_MASK                 (0x30000U)
+#define SDHC_XFERTYP_RSPTYP_SHIFT                (16U)
+#define SDHC_XFERTYP_RSPTYP(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_RSPTYP_SHIFT)) & SDHC_XFERTYP_RSPTYP_MASK)
+#define SDHC_XFERTYP_CCCEN_MASK                  (0x80000U)
+#define SDHC_XFERTYP_CCCEN_SHIFT                 (19U)
+#define SDHC_XFERTYP_CCCEN(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_CCCEN_SHIFT)) & SDHC_XFERTYP_CCCEN_MASK)
+#define SDHC_XFERTYP_CICEN_MASK                  (0x100000U)
+#define SDHC_XFERTYP_CICEN_SHIFT                 (20U)
+#define SDHC_XFERTYP_CICEN(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_CICEN_SHIFT)) & SDHC_XFERTYP_CICEN_MASK)
+#define SDHC_XFERTYP_DPSEL_MASK                  (0x200000U)
+#define SDHC_XFERTYP_DPSEL_SHIFT                 (21U)
+#define SDHC_XFERTYP_DPSEL(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_DPSEL_SHIFT)) & SDHC_XFERTYP_DPSEL_MASK)
+#define SDHC_XFERTYP_CMDTYP_MASK                 (0xC00000U)
+#define SDHC_XFERTYP_CMDTYP_SHIFT                (22U)
+#define SDHC_XFERTYP_CMDTYP(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_CMDTYP_SHIFT)) & SDHC_XFERTYP_CMDTYP_MASK)
+#define SDHC_XFERTYP_CMDINX_MASK                 (0x3F000000U)
+#define SDHC_XFERTYP_CMDINX_SHIFT                (24U)
+#define SDHC_XFERTYP_CMDINX(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_XFERTYP_CMDINX_SHIFT)) & SDHC_XFERTYP_CMDINX_MASK)
+
+/*! @name CMDRSP - Command Response 0..Command Response 3 */
+#define SDHC_CMDRSP_CMDRSP0_MASK                 (0xFFFFFFFFU)
+#define SDHC_CMDRSP_CMDRSP0_SHIFT                (0U)
+#define SDHC_CMDRSP_CMDRSP0(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_CMDRSP_CMDRSP0_SHIFT)) & SDHC_CMDRSP_CMDRSP0_MASK)
+#define SDHC_CMDRSP_CMDRSP1_MASK                 (0xFFFFFFFFU)
+#define SDHC_CMDRSP_CMDRSP1_SHIFT                (0U)
+#define SDHC_CMDRSP_CMDRSP1(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_CMDRSP_CMDRSP1_SHIFT)) & SDHC_CMDRSP_CMDRSP1_MASK)
+#define SDHC_CMDRSP_CMDRSP2_MASK                 (0xFFFFFFFFU)
+#define SDHC_CMDRSP_CMDRSP2_SHIFT                (0U)
+#define SDHC_CMDRSP_CMDRSP2(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_CMDRSP_CMDRSP2_SHIFT)) & SDHC_CMDRSP_CMDRSP2_MASK)
+#define SDHC_CMDRSP_CMDRSP3_MASK                 (0xFFFFFFFFU)
+#define SDHC_CMDRSP_CMDRSP3_SHIFT                (0U)
+#define SDHC_CMDRSP_CMDRSP3(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_CMDRSP_CMDRSP3_SHIFT)) & SDHC_CMDRSP_CMDRSP3_MASK)
+
+/* The count of SDHC_CMDRSP */
+#define SDHC_CMDRSP_COUNT                        (4U)
+
+/*! @name DATPORT - Buffer Data Port register */
+#define SDHC_DATPORT_DATCONT_MASK                (0xFFFFFFFFU)
+#define SDHC_DATPORT_DATCONT_SHIFT               (0U)
+#define SDHC_DATPORT_DATCONT(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_DATPORT_DATCONT_SHIFT)) & SDHC_DATPORT_DATCONT_MASK)
+
+/*! @name PRSSTAT - Present State register */
+#define SDHC_PRSSTAT_CIHB_MASK                   (0x1U)
+#define SDHC_PRSSTAT_CIHB_SHIFT                  (0U)
+#define SDHC_PRSSTAT_CIHB(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_CIHB_SHIFT)) & SDHC_PRSSTAT_CIHB_MASK)
+#define SDHC_PRSSTAT_CDIHB_MASK                  (0x2U)
+#define SDHC_PRSSTAT_CDIHB_SHIFT                 (1U)
+#define SDHC_PRSSTAT_CDIHB(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_CDIHB_SHIFT)) & SDHC_PRSSTAT_CDIHB_MASK)
+#define SDHC_PRSSTAT_DLA_MASK                    (0x4U)
+#define SDHC_PRSSTAT_DLA_SHIFT                   (2U)
+#define SDHC_PRSSTAT_DLA(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_DLA_SHIFT)) & SDHC_PRSSTAT_DLA_MASK)
+#define SDHC_PRSSTAT_SDSTB_MASK                  (0x8U)
+#define SDHC_PRSSTAT_SDSTB_SHIFT                 (3U)
+#define SDHC_PRSSTAT_SDSTB(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_SDSTB_SHIFT)) & SDHC_PRSSTAT_SDSTB_MASK)
+#define SDHC_PRSSTAT_IPGOFF_MASK                 (0x10U)
+#define SDHC_PRSSTAT_IPGOFF_SHIFT                (4U)
+#define SDHC_PRSSTAT_IPGOFF(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_IPGOFF_SHIFT)) & SDHC_PRSSTAT_IPGOFF_MASK)
+#define SDHC_PRSSTAT_HCKOFF_MASK                 (0x20U)
+#define SDHC_PRSSTAT_HCKOFF_SHIFT                (5U)
+#define SDHC_PRSSTAT_HCKOFF(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_HCKOFF_SHIFT)) & SDHC_PRSSTAT_HCKOFF_MASK)
+#define SDHC_PRSSTAT_PEROFF_MASK                 (0x40U)
+#define SDHC_PRSSTAT_PEROFF_SHIFT                (6U)
+#define SDHC_PRSSTAT_PEROFF(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_PEROFF_SHIFT)) & SDHC_PRSSTAT_PEROFF_MASK)
+#define SDHC_PRSSTAT_SDOFF_MASK                  (0x80U)
+#define SDHC_PRSSTAT_SDOFF_SHIFT                 (7U)
+#define SDHC_PRSSTAT_SDOFF(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_SDOFF_SHIFT)) & SDHC_PRSSTAT_SDOFF_MASK)
+#define SDHC_PRSSTAT_WTA_MASK                    (0x100U)
+#define SDHC_PRSSTAT_WTA_SHIFT                   (8U)
+#define SDHC_PRSSTAT_WTA(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_WTA_SHIFT)) & SDHC_PRSSTAT_WTA_MASK)
+#define SDHC_PRSSTAT_RTA_MASK                    (0x200U)
+#define SDHC_PRSSTAT_RTA_SHIFT                   (9U)
+#define SDHC_PRSSTAT_RTA(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_RTA_SHIFT)) & SDHC_PRSSTAT_RTA_MASK)
+#define SDHC_PRSSTAT_BWEN_MASK                   (0x400U)
+#define SDHC_PRSSTAT_BWEN_SHIFT                  (10U)
+#define SDHC_PRSSTAT_BWEN(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_BWEN_SHIFT)) & SDHC_PRSSTAT_BWEN_MASK)
+#define SDHC_PRSSTAT_BREN_MASK                   (0x800U)
+#define SDHC_PRSSTAT_BREN_SHIFT                  (11U)
+#define SDHC_PRSSTAT_BREN(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_BREN_SHIFT)) & SDHC_PRSSTAT_BREN_MASK)
+#define SDHC_PRSSTAT_CINS_MASK                   (0x10000U)
+#define SDHC_PRSSTAT_CINS_SHIFT                  (16U)
+#define SDHC_PRSSTAT_CINS(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_CINS_SHIFT)) & SDHC_PRSSTAT_CINS_MASK)
+#define SDHC_PRSSTAT_CLSL_MASK                   (0x800000U)
+#define SDHC_PRSSTAT_CLSL_SHIFT                  (23U)
+#define SDHC_PRSSTAT_CLSL(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_CLSL_SHIFT)) & SDHC_PRSSTAT_CLSL_MASK)
+#define SDHC_PRSSTAT_DLSL_MASK                   (0xFF000000U)
+#define SDHC_PRSSTAT_DLSL_SHIFT                  (24U)
+#define SDHC_PRSSTAT_DLSL(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PRSSTAT_DLSL_SHIFT)) & SDHC_PRSSTAT_DLSL_MASK)
+
+/*! @name PROCTL - Protocol Control register */
+#define SDHC_PROCTL_LCTL_MASK                    (0x1U)
+#define SDHC_PROCTL_LCTL_SHIFT                   (0U)
+#define SDHC_PROCTL_LCTL(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_LCTL_SHIFT)) & SDHC_PROCTL_LCTL_MASK)
+#define SDHC_PROCTL_DTW_MASK                     (0x6U)
+#define SDHC_PROCTL_DTW_SHIFT                    (1U)
+#define SDHC_PROCTL_DTW(x)                       (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_DTW_SHIFT)) & SDHC_PROCTL_DTW_MASK)
+#define SDHC_PROCTL_D3CD_MASK                    (0x8U)
+#define SDHC_PROCTL_D3CD_SHIFT                   (3U)
+#define SDHC_PROCTL_D3CD(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_D3CD_SHIFT)) & SDHC_PROCTL_D3CD_MASK)
+#define SDHC_PROCTL_EMODE_MASK                   (0x30U)
+#define SDHC_PROCTL_EMODE_SHIFT                  (4U)
+#define SDHC_PROCTL_EMODE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_EMODE_SHIFT)) & SDHC_PROCTL_EMODE_MASK)
+#define SDHC_PROCTL_CDTL_MASK                    (0x40U)
+#define SDHC_PROCTL_CDTL_SHIFT                   (6U)
+#define SDHC_PROCTL_CDTL(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_CDTL_SHIFT)) & SDHC_PROCTL_CDTL_MASK)
+#define SDHC_PROCTL_CDSS_MASK                    (0x80U)
+#define SDHC_PROCTL_CDSS_SHIFT                   (7U)
+#define SDHC_PROCTL_CDSS(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_CDSS_SHIFT)) & SDHC_PROCTL_CDSS_MASK)
+#define SDHC_PROCTL_DMAS_MASK                    (0x300U)
+#define SDHC_PROCTL_DMAS_SHIFT                   (8U)
+#define SDHC_PROCTL_DMAS(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_DMAS_SHIFT)) & SDHC_PROCTL_DMAS_MASK)
+#define SDHC_PROCTL_SABGREQ_MASK                 (0x10000U)
+#define SDHC_PROCTL_SABGREQ_SHIFT                (16U)
+#define SDHC_PROCTL_SABGREQ(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_SABGREQ_SHIFT)) & SDHC_PROCTL_SABGREQ_MASK)
+#define SDHC_PROCTL_CREQ_MASK                    (0x20000U)
+#define SDHC_PROCTL_CREQ_SHIFT                   (17U)
+#define SDHC_PROCTL_CREQ(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_CREQ_SHIFT)) & SDHC_PROCTL_CREQ_MASK)
+#define SDHC_PROCTL_RWCTL_MASK                   (0x40000U)
+#define SDHC_PROCTL_RWCTL_SHIFT                  (18U)
+#define SDHC_PROCTL_RWCTL(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_RWCTL_SHIFT)) & SDHC_PROCTL_RWCTL_MASK)
+#define SDHC_PROCTL_IABG_MASK                    (0x80000U)
+#define SDHC_PROCTL_IABG_SHIFT                   (19U)
+#define SDHC_PROCTL_IABG(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_IABG_SHIFT)) & SDHC_PROCTL_IABG_MASK)
+#define SDHC_PROCTL_WECINT_MASK                  (0x1000000U)
+#define SDHC_PROCTL_WECINT_SHIFT                 (24U)
+#define SDHC_PROCTL_WECINT(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_WECINT_SHIFT)) & SDHC_PROCTL_WECINT_MASK)
+#define SDHC_PROCTL_WECINS_MASK                  (0x2000000U)
+#define SDHC_PROCTL_WECINS_SHIFT                 (25U)
+#define SDHC_PROCTL_WECINS(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_WECINS_SHIFT)) & SDHC_PROCTL_WECINS_MASK)
+#define SDHC_PROCTL_WECRM_MASK                   (0x4000000U)
+#define SDHC_PROCTL_WECRM_SHIFT                  (26U)
+#define SDHC_PROCTL_WECRM(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_PROCTL_WECRM_SHIFT)) & SDHC_PROCTL_WECRM_MASK)
+
+/*! @name SYSCTL - System Control register */
+#define SDHC_SYSCTL_IPGEN_MASK                   (0x1U)
+#define SDHC_SYSCTL_IPGEN_SHIFT                  (0U)
+#define SDHC_SYSCTL_IPGEN(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_IPGEN_SHIFT)) & SDHC_SYSCTL_IPGEN_MASK)
+#define SDHC_SYSCTL_HCKEN_MASK                   (0x2U)
+#define SDHC_SYSCTL_HCKEN_SHIFT                  (1U)
+#define SDHC_SYSCTL_HCKEN(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_HCKEN_SHIFT)) & SDHC_SYSCTL_HCKEN_MASK)
+#define SDHC_SYSCTL_PEREN_MASK                   (0x4U)
+#define SDHC_SYSCTL_PEREN_SHIFT                  (2U)
+#define SDHC_SYSCTL_PEREN(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_PEREN_SHIFT)) & SDHC_SYSCTL_PEREN_MASK)
+#define SDHC_SYSCTL_SDCLKEN_MASK                 (0x8U)
+#define SDHC_SYSCTL_SDCLKEN_SHIFT                (3U)
+#define SDHC_SYSCTL_SDCLKEN(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_SDCLKEN_SHIFT)) & SDHC_SYSCTL_SDCLKEN_MASK)
+#define SDHC_SYSCTL_DVS_MASK                     (0xF0U)
+#define SDHC_SYSCTL_DVS_SHIFT                    (4U)
+#define SDHC_SYSCTL_DVS(x)                       (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_DVS_SHIFT)) & SDHC_SYSCTL_DVS_MASK)
+#define SDHC_SYSCTL_SDCLKFS_MASK                 (0xFF00U)
+#define SDHC_SYSCTL_SDCLKFS_SHIFT                (8U)
+#define SDHC_SYSCTL_SDCLKFS(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_SDCLKFS_SHIFT)) & SDHC_SYSCTL_SDCLKFS_MASK)
+#define SDHC_SYSCTL_DTOCV_MASK                   (0xF0000U)
+#define SDHC_SYSCTL_DTOCV_SHIFT                  (16U)
+#define SDHC_SYSCTL_DTOCV(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_DTOCV_SHIFT)) & SDHC_SYSCTL_DTOCV_MASK)
+#define SDHC_SYSCTL_RSTA_MASK                    (0x1000000U)
+#define SDHC_SYSCTL_RSTA_SHIFT                   (24U)
+#define SDHC_SYSCTL_RSTA(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_RSTA_SHIFT)) & SDHC_SYSCTL_RSTA_MASK)
+#define SDHC_SYSCTL_RSTC_MASK                    (0x2000000U)
+#define SDHC_SYSCTL_RSTC_SHIFT                   (25U)
+#define SDHC_SYSCTL_RSTC(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_RSTC_SHIFT)) & SDHC_SYSCTL_RSTC_MASK)
+#define SDHC_SYSCTL_RSTD_MASK                    (0x4000000U)
+#define SDHC_SYSCTL_RSTD_SHIFT                   (26U)
+#define SDHC_SYSCTL_RSTD(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_RSTD_SHIFT)) & SDHC_SYSCTL_RSTD_MASK)
+#define SDHC_SYSCTL_INITA_MASK                   (0x8000000U)
+#define SDHC_SYSCTL_INITA_SHIFT                  (27U)
+#define SDHC_SYSCTL_INITA(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_SYSCTL_INITA_SHIFT)) & SDHC_SYSCTL_INITA_MASK)
+
+/*! @name IRQSTAT - Interrupt Status register */
+#define SDHC_IRQSTAT_CC_MASK                     (0x1U)
+#define SDHC_IRQSTAT_CC_SHIFT                    (0U)
+#define SDHC_IRQSTAT_CC(x)                       (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CC_SHIFT)) & SDHC_IRQSTAT_CC_MASK)
+#define SDHC_IRQSTAT_TC_MASK                     (0x2U)
+#define SDHC_IRQSTAT_TC_SHIFT                    (1U)
+#define SDHC_IRQSTAT_TC(x)                       (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_TC_SHIFT)) & SDHC_IRQSTAT_TC_MASK)
+#define SDHC_IRQSTAT_BGE_MASK                    (0x4U)
+#define SDHC_IRQSTAT_BGE_SHIFT                   (2U)
+#define SDHC_IRQSTAT_BGE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_BGE_SHIFT)) & SDHC_IRQSTAT_BGE_MASK)
+#define SDHC_IRQSTAT_DINT_MASK                   (0x8U)
+#define SDHC_IRQSTAT_DINT_SHIFT                  (3U)
+#define SDHC_IRQSTAT_DINT(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_DINT_SHIFT)) & SDHC_IRQSTAT_DINT_MASK)
+#define SDHC_IRQSTAT_BWR_MASK                    (0x10U)
+#define SDHC_IRQSTAT_BWR_SHIFT                   (4U)
+#define SDHC_IRQSTAT_BWR(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_BWR_SHIFT)) & SDHC_IRQSTAT_BWR_MASK)
+#define SDHC_IRQSTAT_BRR_MASK                    (0x20U)
+#define SDHC_IRQSTAT_BRR_SHIFT                   (5U)
+#define SDHC_IRQSTAT_BRR(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_BRR_SHIFT)) & SDHC_IRQSTAT_BRR_MASK)
+#define SDHC_IRQSTAT_CINS_MASK                   (0x40U)
+#define SDHC_IRQSTAT_CINS_SHIFT                  (6U)
+#define SDHC_IRQSTAT_CINS(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CINS_SHIFT)) & SDHC_IRQSTAT_CINS_MASK)
+#define SDHC_IRQSTAT_CRM_MASK                    (0x80U)
+#define SDHC_IRQSTAT_CRM_SHIFT                   (7U)
+#define SDHC_IRQSTAT_CRM(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CRM_SHIFT)) & SDHC_IRQSTAT_CRM_MASK)
+#define SDHC_IRQSTAT_CINT_MASK                   (0x100U)
+#define SDHC_IRQSTAT_CINT_SHIFT                  (8U)
+#define SDHC_IRQSTAT_CINT(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CINT_SHIFT)) & SDHC_IRQSTAT_CINT_MASK)
+#define SDHC_IRQSTAT_CTOE_MASK                   (0x10000U)
+#define SDHC_IRQSTAT_CTOE_SHIFT                  (16U)
+#define SDHC_IRQSTAT_CTOE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CTOE_SHIFT)) & SDHC_IRQSTAT_CTOE_MASK)
+#define SDHC_IRQSTAT_CCE_MASK                    (0x20000U)
+#define SDHC_IRQSTAT_CCE_SHIFT                   (17U)
+#define SDHC_IRQSTAT_CCE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CCE_SHIFT)) & SDHC_IRQSTAT_CCE_MASK)
+#define SDHC_IRQSTAT_CEBE_MASK                   (0x40000U)
+#define SDHC_IRQSTAT_CEBE_SHIFT                  (18U)
+#define SDHC_IRQSTAT_CEBE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CEBE_SHIFT)) & SDHC_IRQSTAT_CEBE_MASK)
+#define SDHC_IRQSTAT_CIE_MASK                    (0x80000U)
+#define SDHC_IRQSTAT_CIE_SHIFT                   (19U)
+#define SDHC_IRQSTAT_CIE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_CIE_SHIFT)) & SDHC_IRQSTAT_CIE_MASK)
+#define SDHC_IRQSTAT_DTOE_MASK                   (0x100000U)
+#define SDHC_IRQSTAT_DTOE_SHIFT                  (20U)
+#define SDHC_IRQSTAT_DTOE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_DTOE_SHIFT)) & SDHC_IRQSTAT_DTOE_MASK)
+#define SDHC_IRQSTAT_DCE_MASK                    (0x200000U)
+#define SDHC_IRQSTAT_DCE_SHIFT                   (21U)
+#define SDHC_IRQSTAT_DCE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_DCE_SHIFT)) & SDHC_IRQSTAT_DCE_MASK)
+#define SDHC_IRQSTAT_DEBE_MASK                   (0x400000U)
+#define SDHC_IRQSTAT_DEBE_SHIFT                  (22U)
+#define SDHC_IRQSTAT_DEBE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_DEBE_SHIFT)) & SDHC_IRQSTAT_DEBE_MASK)
+#define SDHC_IRQSTAT_AC12E_MASK                  (0x1000000U)
+#define SDHC_IRQSTAT_AC12E_SHIFT                 (24U)
+#define SDHC_IRQSTAT_AC12E(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_AC12E_SHIFT)) & SDHC_IRQSTAT_AC12E_MASK)
+#define SDHC_IRQSTAT_DMAE_MASK                   (0x10000000U)
+#define SDHC_IRQSTAT_DMAE_SHIFT                  (28U)
+#define SDHC_IRQSTAT_DMAE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTAT_DMAE_SHIFT)) & SDHC_IRQSTAT_DMAE_MASK)
+
+/*! @name IRQSTATEN - Interrupt Status Enable register */
+#define SDHC_IRQSTATEN_CCSEN_MASK                (0x1U)
+#define SDHC_IRQSTATEN_CCSEN_SHIFT               (0U)
+#define SDHC_IRQSTATEN_CCSEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CCSEN_SHIFT)) & SDHC_IRQSTATEN_CCSEN_MASK)
+#define SDHC_IRQSTATEN_TCSEN_MASK                (0x2U)
+#define SDHC_IRQSTATEN_TCSEN_SHIFT               (1U)
+#define SDHC_IRQSTATEN_TCSEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_TCSEN_SHIFT)) & SDHC_IRQSTATEN_TCSEN_MASK)
+#define SDHC_IRQSTATEN_BGESEN_MASK               (0x4U)
+#define SDHC_IRQSTATEN_BGESEN_SHIFT              (2U)
+#define SDHC_IRQSTATEN_BGESEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_BGESEN_SHIFT)) & SDHC_IRQSTATEN_BGESEN_MASK)
+#define SDHC_IRQSTATEN_DINTSEN_MASK              (0x8U)
+#define SDHC_IRQSTATEN_DINTSEN_SHIFT             (3U)
+#define SDHC_IRQSTATEN_DINTSEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_DINTSEN_SHIFT)) & SDHC_IRQSTATEN_DINTSEN_MASK)
+#define SDHC_IRQSTATEN_BWRSEN_MASK               (0x10U)
+#define SDHC_IRQSTATEN_BWRSEN_SHIFT              (4U)
+#define SDHC_IRQSTATEN_BWRSEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_BWRSEN_SHIFT)) & SDHC_IRQSTATEN_BWRSEN_MASK)
+#define SDHC_IRQSTATEN_BRRSEN_MASK               (0x20U)
+#define SDHC_IRQSTATEN_BRRSEN_SHIFT              (5U)
+#define SDHC_IRQSTATEN_BRRSEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_BRRSEN_SHIFT)) & SDHC_IRQSTATEN_BRRSEN_MASK)
+#define SDHC_IRQSTATEN_CINSEN_MASK               (0x40U)
+#define SDHC_IRQSTATEN_CINSEN_SHIFT              (6U)
+#define SDHC_IRQSTATEN_CINSEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CINSEN_SHIFT)) & SDHC_IRQSTATEN_CINSEN_MASK)
+#define SDHC_IRQSTATEN_CRMSEN_MASK               (0x80U)
+#define SDHC_IRQSTATEN_CRMSEN_SHIFT              (7U)
+#define SDHC_IRQSTATEN_CRMSEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CRMSEN_SHIFT)) & SDHC_IRQSTATEN_CRMSEN_MASK)
+#define SDHC_IRQSTATEN_CINTSEN_MASK              (0x100U)
+#define SDHC_IRQSTATEN_CINTSEN_SHIFT             (8U)
+#define SDHC_IRQSTATEN_CINTSEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CINTSEN_SHIFT)) & SDHC_IRQSTATEN_CINTSEN_MASK)
+#define SDHC_IRQSTATEN_CTOESEN_MASK              (0x10000U)
+#define SDHC_IRQSTATEN_CTOESEN_SHIFT             (16U)
+#define SDHC_IRQSTATEN_CTOESEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CTOESEN_SHIFT)) & SDHC_IRQSTATEN_CTOESEN_MASK)
+#define SDHC_IRQSTATEN_CCESEN_MASK               (0x20000U)
+#define SDHC_IRQSTATEN_CCESEN_SHIFT              (17U)
+#define SDHC_IRQSTATEN_CCESEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CCESEN_SHIFT)) & SDHC_IRQSTATEN_CCESEN_MASK)
+#define SDHC_IRQSTATEN_CEBESEN_MASK              (0x40000U)
+#define SDHC_IRQSTATEN_CEBESEN_SHIFT             (18U)
+#define SDHC_IRQSTATEN_CEBESEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CEBESEN_SHIFT)) & SDHC_IRQSTATEN_CEBESEN_MASK)
+#define SDHC_IRQSTATEN_CIESEN_MASK               (0x80000U)
+#define SDHC_IRQSTATEN_CIESEN_SHIFT              (19U)
+#define SDHC_IRQSTATEN_CIESEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_CIESEN_SHIFT)) & SDHC_IRQSTATEN_CIESEN_MASK)
+#define SDHC_IRQSTATEN_DTOESEN_MASK              (0x100000U)
+#define SDHC_IRQSTATEN_DTOESEN_SHIFT             (20U)
+#define SDHC_IRQSTATEN_DTOESEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_DTOESEN_SHIFT)) & SDHC_IRQSTATEN_DTOESEN_MASK)
+#define SDHC_IRQSTATEN_DCESEN_MASK               (0x200000U)
+#define SDHC_IRQSTATEN_DCESEN_SHIFT              (21U)
+#define SDHC_IRQSTATEN_DCESEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_DCESEN_SHIFT)) & SDHC_IRQSTATEN_DCESEN_MASK)
+#define SDHC_IRQSTATEN_DEBESEN_MASK              (0x400000U)
+#define SDHC_IRQSTATEN_DEBESEN_SHIFT             (22U)
+#define SDHC_IRQSTATEN_DEBESEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_DEBESEN_SHIFT)) & SDHC_IRQSTATEN_DEBESEN_MASK)
+#define SDHC_IRQSTATEN_AC12ESEN_MASK             (0x1000000U)
+#define SDHC_IRQSTATEN_AC12ESEN_SHIFT            (24U)
+#define SDHC_IRQSTATEN_AC12ESEN(x)               (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_AC12ESEN_SHIFT)) & SDHC_IRQSTATEN_AC12ESEN_MASK)
+#define SDHC_IRQSTATEN_DMAESEN_MASK              (0x10000000U)
+#define SDHC_IRQSTATEN_DMAESEN_SHIFT             (28U)
+#define SDHC_IRQSTATEN_DMAESEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSTATEN_DMAESEN_SHIFT)) & SDHC_IRQSTATEN_DMAESEN_MASK)
+
+/*! @name IRQSIGEN - Interrupt Signal Enable register */
+#define SDHC_IRQSIGEN_CCIEN_MASK                 (0x1U)
+#define SDHC_IRQSIGEN_CCIEN_SHIFT                (0U)
+#define SDHC_IRQSIGEN_CCIEN(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CCIEN_SHIFT)) & SDHC_IRQSIGEN_CCIEN_MASK)
+#define SDHC_IRQSIGEN_TCIEN_MASK                 (0x2U)
+#define SDHC_IRQSIGEN_TCIEN_SHIFT                (1U)
+#define SDHC_IRQSIGEN_TCIEN(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_TCIEN_SHIFT)) & SDHC_IRQSIGEN_TCIEN_MASK)
+#define SDHC_IRQSIGEN_BGEIEN_MASK                (0x4U)
+#define SDHC_IRQSIGEN_BGEIEN_SHIFT               (2U)
+#define SDHC_IRQSIGEN_BGEIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_BGEIEN_SHIFT)) & SDHC_IRQSIGEN_BGEIEN_MASK)
+#define SDHC_IRQSIGEN_DINTIEN_MASK               (0x8U)
+#define SDHC_IRQSIGEN_DINTIEN_SHIFT              (3U)
+#define SDHC_IRQSIGEN_DINTIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_DINTIEN_SHIFT)) & SDHC_IRQSIGEN_DINTIEN_MASK)
+#define SDHC_IRQSIGEN_BWRIEN_MASK                (0x10U)
+#define SDHC_IRQSIGEN_BWRIEN_SHIFT               (4U)
+#define SDHC_IRQSIGEN_BWRIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_BWRIEN_SHIFT)) & SDHC_IRQSIGEN_BWRIEN_MASK)
+#define SDHC_IRQSIGEN_BRRIEN_MASK                (0x20U)
+#define SDHC_IRQSIGEN_BRRIEN_SHIFT               (5U)
+#define SDHC_IRQSIGEN_BRRIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_BRRIEN_SHIFT)) & SDHC_IRQSIGEN_BRRIEN_MASK)
+#define SDHC_IRQSIGEN_CINSIEN_MASK               (0x40U)
+#define SDHC_IRQSIGEN_CINSIEN_SHIFT              (6U)
+#define SDHC_IRQSIGEN_CINSIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CINSIEN_SHIFT)) & SDHC_IRQSIGEN_CINSIEN_MASK)
+#define SDHC_IRQSIGEN_CRMIEN_MASK                (0x80U)
+#define SDHC_IRQSIGEN_CRMIEN_SHIFT               (7U)
+#define SDHC_IRQSIGEN_CRMIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CRMIEN_SHIFT)) & SDHC_IRQSIGEN_CRMIEN_MASK)
+#define SDHC_IRQSIGEN_CINTIEN_MASK               (0x100U)
+#define SDHC_IRQSIGEN_CINTIEN_SHIFT              (8U)
+#define SDHC_IRQSIGEN_CINTIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CINTIEN_SHIFT)) & SDHC_IRQSIGEN_CINTIEN_MASK)
+#define SDHC_IRQSIGEN_CTOEIEN_MASK               (0x10000U)
+#define SDHC_IRQSIGEN_CTOEIEN_SHIFT              (16U)
+#define SDHC_IRQSIGEN_CTOEIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CTOEIEN_SHIFT)) & SDHC_IRQSIGEN_CTOEIEN_MASK)
+#define SDHC_IRQSIGEN_CCEIEN_MASK                (0x20000U)
+#define SDHC_IRQSIGEN_CCEIEN_SHIFT               (17U)
+#define SDHC_IRQSIGEN_CCEIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CCEIEN_SHIFT)) & SDHC_IRQSIGEN_CCEIEN_MASK)
+#define SDHC_IRQSIGEN_CEBEIEN_MASK               (0x40000U)
+#define SDHC_IRQSIGEN_CEBEIEN_SHIFT              (18U)
+#define SDHC_IRQSIGEN_CEBEIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CEBEIEN_SHIFT)) & SDHC_IRQSIGEN_CEBEIEN_MASK)
+#define SDHC_IRQSIGEN_CIEIEN_MASK                (0x80000U)
+#define SDHC_IRQSIGEN_CIEIEN_SHIFT               (19U)
+#define SDHC_IRQSIGEN_CIEIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_CIEIEN_SHIFT)) & SDHC_IRQSIGEN_CIEIEN_MASK)
+#define SDHC_IRQSIGEN_DTOEIEN_MASK               (0x100000U)
+#define SDHC_IRQSIGEN_DTOEIEN_SHIFT              (20U)
+#define SDHC_IRQSIGEN_DTOEIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_DTOEIEN_SHIFT)) & SDHC_IRQSIGEN_DTOEIEN_MASK)
+#define SDHC_IRQSIGEN_DCEIEN_MASK                (0x200000U)
+#define SDHC_IRQSIGEN_DCEIEN_SHIFT               (21U)
+#define SDHC_IRQSIGEN_DCEIEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_DCEIEN_SHIFT)) & SDHC_IRQSIGEN_DCEIEN_MASK)
+#define SDHC_IRQSIGEN_DEBEIEN_MASK               (0x400000U)
+#define SDHC_IRQSIGEN_DEBEIEN_SHIFT              (22U)
+#define SDHC_IRQSIGEN_DEBEIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_DEBEIEN_SHIFT)) & SDHC_IRQSIGEN_DEBEIEN_MASK)
+#define SDHC_IRQSIGEN_AC12EIEN_MASK              (0x1000000U)
+#define SDHC_IRQSIGEN_AC12EIEN_SHIFT             (24U)
+#define SDHC_IRQSIGEN_AC12EIEN(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_AC12EIEN_SHIFT)) & SDHC_IRQSIGEN_AC12EIEN_MASK)
+#define SDHC_IRQSIGEN_DMAEIEN_MASK               (0x10000000U)
+#define SDHC_IRQSIGEN_DMAEIEN_SHIFT              (28U)
+#define SDHC_IRQSIGEN_DMAEIEN(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_IRQSIGEN_DMAEIEN_SHIFT)) & SDHC_IRQSIGEN_DMAEIEN_MASK)
+
+/*! @name AC12ERR - Auto CMD12 Error Status Register */
+#define SDHC_AC12ERR_AC12NE_MASK                 (0x1U)
+#define SDHC_AC12ERR_AC12NE_SHIFT                (0U)
+#define SDHC_AC12ERR_AC12NE(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_AC12ERR_AC12NE_SHIFT)) & SDHC_AC12ERR_AC12NE_MASK)
+#define SDHC_AC12ERR_AC12TOE_MASK                (0x2U)
+#define SDHC_AC12ERR_AC12TOE_SHIFT               (1U)
+#define SDHC_AC12ERR_AC12TOE(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_AC12ERR_AC12TOE_SHIFT)) & SDHC_AC12ERR_AC12TOE_MASK)
+#define SDHC_AC12ERR_AC12EBE_MASK                (0x4U)
+#define SDHC_AC12ERR_AC12EBE_SHIFT               (2U)
+#define SDHC_AC12ERR_AC12EBE(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_AC12ERR_AC12EBE_SHIFT)) & SDHC_AC12ERR_AC12EBE_MASK)
+#define SDHC_AC12ERR_AC12CE_MASK                 (0x8U)
+#define SDHC_AC12ERR_AC12CE_SHIFT                (3U)
+#define SDHC_AC12ERR_AC12CE(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_AC12ERR_AC12CE_SHIFT)) & SDHC_AC12ERR_AC12CE_MASK)
+#define SDHC_AC12ERR_AC12IE_MASK                 (0x10U)
+#define SDHC_AC12ERR_AC12IE_SHIFT                (4U)
+#define SDHC_AC12ERR_AC12IE(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_AC12ERR_AC12IE_SHIFT)) & SDHC_AC12ERR_AC12IE_MASK)
+#define SDHC_AC12ERR_CNIBAC12E_MASK              (0x80U)
+#define SDHC_AC12ERR_CNIBAC12E_SHIFT             (7U)
+#define SDHC_AC12ERR_CNIBAC12E(x)                (((uint32_t)(((uint32_t)(x)) << SDHC_AC12ERR_CNIBAC12E_SHIFT)) & SDHC_AC12ERR_CNIBAC12E_MASK)
+
+/*! @name HTCAPBLT - Host Controller Capabilities */
+#define SDHC_HTCAPBLT_MBL_MASK                   (0x70000U)
+#define SDHC_HTCAPBLT_MBL_SHIFT                  (16U)
+#define SDHC_HTCAPBLT_MBL(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_HTCAPBLT_MBL_SHIFT)) & SDHC_HTCAPBLT_MBL_MASK)
+#define SDHC_HTCAPBLT_ADMAS_MASK                 (0x100000U)
+#define SDHC_HTCAPBLT_ADMAS_SHIFT                (20U)
+#define SDHC_HTCAPBLT_ADMAS(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_HTCAPBLT_ADMAS_SHIFT)) & SDHC_HTCAPBLT_ADMAS_MASK)
+#define SDHC_HTCAPBLT_HSS_MASK                   (0x200000U)
+#define SDHC_HTCAPBLT_HSS_SHIFT                  (21U)
+#define SDHC_HTCAPBLT_HSS(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_HTCAPBLT_HSS_SHIFT)) & SDHC_HTCAPBLT_HSS_MASK)
+#define SDHC_HTCAPBLT_DMAS_MASK                  (0x400000U)
+#define SDHC_HTCAPBLT_DMAS_SHIFT                 (22U)
+#define SDHC_HTCAPBLT_DMAS(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_HTCAPBLT_DMAS_SHIFT)) & SDHC_HTCAPBLT_DMAS_MASK)
+#define SDHC_HTCAPBLT_SRS_MASK                   (0x800000U)
+#define SDHC_HTCAPBLT_SRS_SHIFT                  (23U)
+#define SDHC_HTCAPBLT_SRS(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_HTCAPBLT_SRS_SHIFT)) & SDHC_HTCAPBLT_SRS_MASK)
+#define SDHC_HTCAPBLT_VS33_MASK                  (0x1000000U)
+#define SDHC_HTCAPBLT_VS33_SHIFT                 (24U)
+#define SDHC_HTCAPBLT_VS33(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_HTCAPBLT_VS33_SHIFT)) & SDHC_HTCAPBLT_VS33_MASK)
+
+/*! @name WML - Watermark Level Register */
+#define SDHC_WML_RDWML_MASK                      (0xFFU)
+#define SDHC_WML_RDWML_SHIFT                     (0U)
+#define SDHC_WML_RDWML(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_WML_RDWML_SHIFT)) & SDHC_WML_RDWML_MASK)
+#define SDHC_WML_WRWML_MASK                      (0xFF0000U)
+#define SDHC_WML_WRWML_SHIFT                     (16U)
+#define SDHC_WML_WRWML(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_WML_WRWML_SHIFT)) & SDHC_WML_WRWML_MASK)
+
+/*! @name FEVT - Force Event register */
+#define SDHC_FEVT_AC12NE_MASK                    (0x1U)
+#define SDHC_FEVT_AC12NE_SHIFT                   (0U)
+#define SDHC_FEVT_AC12NE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_AC12NE_SHIFT)) & SDHC_FEVT_AC12NE_MASK)
+#define SDHC_FEVT_AC12TOE_MASK                   (0x2U)
+#define SDHC_FEVT_AC12TOE_SHIFT                  (1U)
+#define SDHC_FEVT_AC12TOE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_AC12TOE_SHIFT)) & SDHC_FEVT_AC12TOE_MASK)
+#define SDHC_FEVT_AC12CE_MASK                    (0x4U)
+#define SDHC_FEVT_AC12CE_SHIFT                   (2U)
+#define SDHC_FEVT_AC12CE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_AC12CE_SHIFT)) & SDHC_FEVT_AC12CE_MASK)
+#define SDHC_FEVT_AC12EBE_MASK                   (0x8U)
+#define SDHC_FEVT_AC12EBE_SHIFT                  (3U)
+#define SDHC_FEVT_AC12EBE(x)                     (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_AC12EBE_SHIFT)) & SDHC_FEVT_AC12EBE_MASK)
+#define SDHC_FEVT_AC12IE_MASK                    (0x10U)
+#define SDHC_FEVT_AC12IE_SHIFT                   (4U)
+#define SDHC_FEVT_AC12IE(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_AC12IE_SHIFT)) & SDHC_FEVT_AC12IE_MASK)
+#define SDHC_FEVT_CNIBAC12E_MASK                 (0x80U)
+#define SDHC_FEVT_CNIBAC12E_SHIFT                (7U)
+#define SDHC_FEVT_CNIBAC12E(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_CNIBAC12E_SHIFT)) & SDHC_FEVT_CNIBAC12E_MASK)
+#define SDHC_FEVT_CTOE_MASK                      (0x10000U)
+#define SDHC_FEVT_CTOE_SHIFT                     (16U)
+#define SDHC_FEVT_CTOE(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_CTOE_SHIFT)) & SDHC_FEVT_CTOE_MASK)
+#define SDHC_FEVT_CCE_MASK                       (0x20000U)
+#define SDHC_FEVT_CCE_SHIFT                      (17U)
+#define SDHC_FEVT_CCE(x)                         (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_CCE_SHIFT)) & SDHC_FEVT_CCE_MASK)
+#define SDHC_FEVT_CEBE_MASK                      (0x40000U)
+#define SDHC_FEVT_CEBE_SHIFT                     (18U)
+#define SDHC_FEVT_CEBE(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_CEBE_SHIFT)) & SDHC_FEVT_CEBE_MASK)
+#define SDHC_FEVT_CIE_MASK                       (0x80000U)
+#define SDHC_FEVT_CIE_SHIFT                      (19U)
+#define SDHC_FEVT_CIE(x)                         (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_CIE_SHIFT)) & SDHC_FEVT_CIE_MASK)
+#define SDHC_FEVT_DTOE_MASK                      (0x100000U)
+#define SDHC_FEVT_DTOE_SHIFT                     (20U)
+#define SDHC_FEVT_DTOE(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_DTOE_SHIFT)) & SDHC_FEVT_DTOE_MASK)
+#define SDHC_FEVT_DCE_MASK                       (0x200000U)
+#define SDHC_FEVT_DCE_SHIFT                      (21U)
+#define SDHC_FEVT_DCE(x)                         (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_DCE_SHIFT)) & SDHC_FEVT_DCE_MASK)
+#define SDHC_FEVT_DEBE_MASK                      (0x400000U)
+#define SDHC_FEVT_DEBE_SHIFT                     (22U)
+#define SDHC_FEVT_DEBE(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_DEBE_SHIFT)) & SDHC_FEVT_DEBE_MASK)
+#define SDHC_FEVT_AC12E_MASK                     (0x1000000U)
+#define SDHC_FEVT_AC12E_SHIFT                    (24U)
+#define SDHC_FEVT_AC12E(x)                       (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_AC12E_SHIFT)) & SDHC_FEVT_AC12E_MASK)
+#define SDHC_FEVT_DMAE_MASK                      (0x10000000U)
+#define SDHC_FEVT_DMAE_SHIFT                     (28U)
+#define SDHC_FEVT_DMAE(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_DMAE_SHIFT)) & SDHC_FEVT_DMAE_MASK)
+#define SDHC_FEVT_CINT_MASK                      (0x80000000U)
+#define SDHC_FEVT_CINT_SHIFT                     (31U)
+#define SDHC_FEVT_CINT(x)                        (((uint32_t)(((uint32_t)(x)) << SDHC_FEVT_CINT_SHIFT)) & SDHC_FEVT_CINT_MASK)
+
+/*! @name ADMAES - ADMA Error Status register */
+#define SDHC_ADMAES_ADMAES_MASK                  (0x3U)
+#define SDHC_ADMAES_ADMAES_SHIFT                 (0U)
+#define SDHC_ADMAES_ADMAES(x)                    (((uint32_t)(((uint32_t)(x)) << SDHC_ADMAES_ADMAES_SHIFT)) & SDHC_ADMAES_ADMAES_MASK)
+#define SDHC_ADMAES_ADMALME_MASK                 (0x4U)
+#define SDHC_ADMAES_ADMALME_SHIFT                (2U)
+#define SDHC_ADMAES_ADMALME(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_ADMAES_ADMALME_SHIFT)) & SDHC_ADMAES_ADMALME_MASK)
+#define SDHC_ADMAES_ADMADCE_MASK                 (0x8U)
+#define SDHC_ADMAES_ADMADCE_SHIFT                (3U)
+#define SDHC_ADMAES_ADMADCE(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_ADMAES_ADMADCE_SHIFT)) & SDHC_ADMAES_ADMADCE_MASK)
+
+/*! @name ADSADDR - ADMA System Addressregister */
+#define SDHC_ADSADDR_ADSADDR_MASK                (0xFFFFFFFCU)
+#define SDHC_ADSADDR_ADSADDR_SHIFT               (2U)
+#define SDHC_ADSADDR_ADSADDR(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_ADSADDR_ADSADDR_SHIFT)) & SDHC_ADSADDR_ADSADDR_MASK)
+
+/*! @name VENDOR - Vendor Specific register */
+#define SDHC_VENDOR_EXTDMAEN_MASK                (0x1U)
+#define SDHC_VENDOR_EXTDMAEN_SHIFT               (0U)
+#define SDHC_VENDOR_EXTDMAEN(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_VENDOR_EXTDMAEN_SHIFT)) & SDHC_VENDOR_EXTDMAEN_MASK)
+#define SDHC_VENDOR_EXBLKNU_MASK                 (0x2U)
+#define SDHC_VENDOR_EXBLKNU_SHIFT                (1U)
+#define SDHC_VENDOR_EXBLKNU(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_VENDOR_EXBLKNU_SHIFT)) & SDHC_VENDOR_EXBLKNU_MASK)
+#define SDHC_VENDOR_INTSTVAL_MASK                (0xFF0000U)
+#define SDHC_VENDOR_INTSTVAL_SHIFT               (16U)
+#define SDHC_VENDOR_INTSTVAL(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_VENDOR_INTSTVAL_SHIFT)) & SDHC_VENDOR_INTSTVAL_MASK)
+
+/*! @name MMCBOOT - MMC Boot register */
+#define SDHC_MMCBOOT_DTOCVACK_MASK               (0xFU)
+#define SDHC_MMCBOOT_DTOCVACK_SHIFT              (0U)
+#define SDHC_MMCBOOT_DTOCVACK(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_MMCBOOT_DTOCVACK_SHIFT)) & SDHC_MMCBOOT_DTOCVACK_MASK)
+#define SDHC_MMCBOOT_BOOTACK_MASK                (0x10U)
+#define SDHC_MMCBOOT_BOOTACK_SHIFT               (4U)
+#define SDHC_MMCBOOT_BOOTACK(x)                  (((uint32_t)(((uint32_t)(x)) << SDHC_MMCBOOT_BOOTACK_SHIFT)) & SDHC_MMCBOOT_BOOTACK_MASK)
+#define SDHC_MMCBOOT_BOOTMODE_MASK               (0x20U)
+#define SDHC_MMCBOOT_BOOTMODE_SHIFT              (5U)
+#define SDHC_MMCBOOT_BOOTMODE(x)                 (((uint32_t)(((uint32_t)(x)) << SDHC_MMCBOOT_BOOTMODE_SHIFT)) & SDHC_MMCBOOT_BOOTMODE_MASK)
+#define SDHC_MMCBOOT_BOOTEN_MASK                 (0x40U)
+#define SDHC_MMCBOOT_BOOTEN_SHIFT                (6U)
+#define SDHC_MMCBOOT_BOOTEN(x)                   (((uint32_t)(((uint32_t)(x)) << SDHC_MMCBOOT_BOOTEN_SHIFT)) & SDHC_MMCBOOT_BOOTEN_MASK)
+#define SDHC_MMCBOOT_AUTOSABGEN_MASK             (0x80U)
+#define SDHC_MMCBOOT_AUTOSABGEN_SHIFT            (7U)
+#define SDHC_MMCBOOT_AUTOSABGEN(x)               (((uint32_t)(((uint32_t)(x)) << SDHC_MMCBOOT_AUTOSABGEN_SHIFT)) & SDHC_MMCBOOT_AUTOSABGEN_MASK)
+#define SDHC_MMCBOOT_BOOTBLKCNT_MASK             (0xFFFF0000U)
+#define SDHC_MMCBOOT_BOOTBLKCNT_SHIFT            (16U)
+#define SDHC_MMCBOOT_BOOTBLKCNT(x)               (((uint32_t)(((uint32_t)(x)) << SDHC_MMCBOOT_BOOTBLKCNT_SHIFT)) & SDHC_MMCBOOT_BOOTBLKCNT_MASK)
+
+/*! @name HOSTVER - Host Controller Version */
+#define SDHC_HOSTVER_SVN_MASK                    (0xFFU)
+#define SDHC_HOSTVER_SVN_SHIFT                   (0U)
+#define SDHC_HOSTVER_SVN(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_HOSTVER_SVN_SHIFT)) & SDHC_HOSTVER_SVN_MASK)
+#define SDHC_HOSTVER_VVN_MASK                    (0xFF00U)
+#define SDHC_HOSTVER_VVN_SHIFT                   (8U)
+#define SDHC_HOSTVER_VVN(x)                      (((uint32_t)(((uint32_t)(x)) << SDHC_HOSTVER_VVN_SHIFT)) & SDHC_HOSTVER_VVN_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group SDHC_Register_Masks */
+
+
+/* SDHC - Peripheral instance base addresses */
+/** Peripheral SDHC base address */
+#define SDHC_BASE                                (0x400B1000u)
+/** Peripheral SDHC base pointer */
+#define SDHC                                     ((SDHC_Type *)SDHC_BASE)
+/** Array initializer of SDHC peripheral base addresses */
+#define SDHC_BASE_ADDRS                          { SDHC_BASE }
+/** Array initializer of SDHC peripheral base pointers */
+#define SDHC_BASE_PTRS                           { SDHC }
+/** Interrupt vectors for the SDHC peripheral type */
+#define SDHC_IRQS                                { SDHC_IRQn }
+
+/*!
+ * @}
+ */ /* end of group SDHC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SIM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Peripheral_Access_Layer SIM Peripheral Access Layer
+ * @{
+ */
+
+/** SIM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SOPT1;                             /**< System Options Register 1, offset: 0x0 */
+  __IO uint32_t SOPT1CFG;                          /**< SOPT1 Configuration Register, offset: 0x4 */
+       uint8_t RESERVED_0[4092];
+  __IO uint32_t SOPT2;                             /**< System Options Register 2, offset: 0x1004 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t SOPT4;                             /**< System Options Register 4, offset: 0x100C */
+  __IO uint32_t SOPT5;                             /**< System Options Register 5, offset: 0x1010 */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t SOPT7;                             /**< System Options Register 7, offset: 0x1018 */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t SDID;                              /**< System Device Identification Register, offset: 0x1024 */
+  __IO uint32_t SCGC1;                             /**< System Clock Gating Control Register 1, offset: 0x1028 */
+  __IO uint32_t SCGC2;                             /**< System Clock Gating Control Register 2, offset: 0x102C */
+  __IO uint32_t SCGC3;                             /**< System Clock Gating Control Register 3, offset: 0x1030 */
+  __IO uint32_t SCGC4;                             /**< System Clock Gating Control Register 4, offset: 0x1034 */
+  __IO uint32_t SCGC5;                             /**< System Clock Gating Control Register 5, offset: 0x1038 */
+  __IO uint32_t SCGC6;                             /**< System Clock Gating Control Register 6, offset: 0x103C */
+  __IO uint32_t SCGC7;                             /**< System Clock Gating Control Register 7, offset: 0x1040 */
+  __IO uint32_t CLKDIV1;                           /**< System Clock Divider Register 1, offset: 0x1044 */
+  __IO uint32_t CLKDIV2;                           /**< System Clock Divider Register 2, offset: 0x1048 */
+  __IO uint32_t FCFG1;                             /**< Flash Configuration Register 1, offset: 0x104C */
+  __I  uint32_t FCFG2;                             /**< Flash Configuration Register 2, offset: 0x1050 */
+  __I  uint32_t UIDH;                              /**< Unique Identification Register High, offset: 0x1054 */
+  __I  uint32_t UIDMH;                             /**< Unique Identification Register Mid-High, offset: 0x1058 */
+  __I  uint32_t UIDML;                             /**< Unique Identification Register Mid Low, offset: 0x105C */
+  __I  uint32_t UIDL;                              /**< Unique Identification Register Low, offset: 0x1060 */
+} SIM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SIM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Masks SIM Register Masks
+ * @{
+ */
+
+/*! @name SOPT1 - System Options Register 1 */
+#define SIM_SOPT1_RAMSIZE_MASK                   (0xF000U)
+#define SIM_SOPT1_RAMSIZE_SHIFT                  (12U)
+#define SIM_SOPT1_RAMSIZE(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1_RAMSIZE_SHIFT)) & SIM_SOPT1_RAMSIZE_MASK)
+#define SIM_SOPT1_OSC32KSEL_MASK                 (0xC0000U)
+#define SIM_SOPT1_OSC32KSEL_SHIFT                (18U)
+#define SIM_SOPT1_OSC32KSEL(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1_OSC32KSEL_SHIFT)) & SIM_SOPT1_OSC32KSEL_MASK)
+#define SIM_SOPT1_USBVSTBY_MASK                  (0x20000000U)
+#define SIM_SOPT1_USBVSTBY_SHIFT                 (29U)
+#define SIM_SOPT1_USBVSTBY(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1_USBVSTBY_SHIFT)) & SIM_SOPT1_USBVSTBY_MASK)
+#define SIM_SOPT1_USBSSTBY_MASK                  (0x40000000U)
+#define SIM_SOPT1_USBSSTBY_SHIFT                 (30U)
+#define SIM_SOPT1_USBSSTBY(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1_USBSSTBY_SHIFT)) & SIM_SOPT1_USBSSTBY_MASK)
+#define SIM_SOPT1_USBREGEN_MASK                  (0x80000000U)
+#define SIM_SOPT1_USBREGEN_SHIFT                 (31U)
+#define SIM_SOPT1_USBREGEN(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1_USBREGEN_SHIFT)) & SIM_SOPT1_USBREGEN_MASK)
+
+/*! @name SOPT1CFG - SOPT1 Configuration Register */
+#define SIM_SOPT1CFG_URWE_MASK                   (0x1000000U)
+#define SIM_SOPT1CFG_URWE_SHIFT                  (24U)
+#define SIM_SOPT1CFG_URWE(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1CFG_URWE_SHIFT)) & SIM_SOPT1CFG_URWE_MASK)
+#define SIM_SOPT1CFG_UVSWE_MASK                  (0x2000000U)
+#define SIM_SOPT1CFG_UVSWE_SHIFT                 (25U)
+#define SIM_SOPT1CFG_UVSWE(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1CFG_UVSWE_SHIFT)) & SIM_SOPT1CFG_UVSWE_MASK)
+#define SIM_SOPT1CFG_USSWE_MASK                  (0x4000000U)
+#define SIM_SOPT1CFG_USSWE_SHIFT                 (26U)
+#define SIM_SOPT1CFG_USSWE(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT1CFG_USSWE_SHIFT)) & SIM_SOPT1CFG_USSWE_MASK)
+
+/*! @name SOPT2 - System Options Register 2 */
+#define SIM_SOPT2_RTCCLKOUTSEL_MASK              (0x10U)
+#define SIM_SOPT2_RTCCLKOUTSEL_SHIFT             (4U)
+#define SIM_SOPT2_RTCCLKOUTSEL(x)                (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_RTCCLKOUTSEL_SHIFT)) & SIM_SOPT2_RTCCLKOUTSEL_MASK)
+#define SIM_SOPT2_CLKOUTSEL_MASK                 (0xE0U)
+#define SIM_SOPT2_CLKOUTSEL_SHIFT                (5U)
+#define SIM_SOPT2_CLKOUTSEL(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_CLKOUTSEL_SHIFT)) & SIM_SOPT2_CLKOUTSEL_MASK)
+#define SIM_SOPT2_FBSL_MASK                      (0x300U)
+#define SIM_SOPT2_FBSL_SHIFT                     (8U)
+#define SIM_SOPT2_FBSL(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_FBSL_SHIFT)) & SIM_SOPT2_FBSL_MASK)
+#define SIM_SOPT2_PTD7PAD_MASK                   (0x800U)
+#define SIM_SOPT2_PTD7PAD_SHIFT                  (11U)
+#define SIM_SOPT2_PTD7PAD(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_PTD7PAD_SHIFT)) & SIM_SOPT2_PTD7PAD_MASK)
+#define SIM_SOPT2_TRACECLKSEL_MASK               (0x1000U)
+#define SIM_SOPT2_TRACECLKSEL_SHIFT              (12U)
+#define SIM_SOPT2_TRACECLKSEL(x)                 (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_TRACECLKSEL_SHIFT)) & SIM_SOPT2_TRACECLKSEL_MASK)
+#define SIM_SOPT2_PLLFLLSEL_MASK                 (0x30000U)
+#define SIM_SOPT2_PLLFLLSEL_SHIFT                (16U)
+#define SIM_SOPT2_PLLFLLSEL(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_PLLFLLSEL_SHIFT)) & SIM_SOPT2_PLLFLLSEL_MASK)
+#define SIM_SOPT2_USBSRC_MASK                    (0x40000U)
+#define SIM_SOPT2_USBSRC_SHIFT                   (18U)
+#define SIM_SOPT2_USBSRC(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_USBSRC_SHIFT)) & SIM_SOPT2_USBSRC_MASK)
+#define SIM_SOPT2_RMIISRC_MASK                   (0x80000U)
+#define SIM_SOPT2_RMIISRC_SHIFT                  (19U)
+#define SIM_SOPT2_RMIISRC(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_RMIISRC_SHIFT)) & SIM_SOPT2_RMIISRC_MASK)
+#define SIM_SOPT2_TIMESRC_MASK                   (0x300000U)
+#define SIM_SOPT2_TIMESRC_SHIFT                  (20U)
+#define SIM_SOPT2_TIMESRC(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_TIMESRC_SHIFT)) & SIM_SOPT2_TIMESRC_MASK)
+#define SIM_SOPT2_SDHCSRC_MASK                   (0x30000000U)
+#define SIM_SOPT2_SDHCSRC_SHIFT                  (28U)
+#define SIM_SOPT2_SDHCSRC(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SOPT2_SDHCSRC_SHIFT)) & SIM_SOPT2_SDHCSRC_MASK)
+
+/*! @name SOPT4 - System Options Register 4 */
+#define SIM_SOPT4_FTM0FLT0_MASK                  (0x1U)
+#define SIM_SOPT4_FTM0FLT0_SHIFT                 (0U)
+#define SIM_SOPT4_FTM0FLT0(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM0FLT0_SHIFT)) & SIM_SOPT4_FTM0FLT0_MASK)
+#define SIM_SOPT4_FTM0FLT1_MASK                  (0x2U)
+#define SIM_SOPT4_FTM0FLT1_SHIFT                 (1U)
+#define SIM_SOPT4_FTM0FLT1(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM0FLT1_SHIFT)) & SIM_SOPT4_FTM0FLT1_MASK)
+#define SIM_SOPT4_FTM0FLT2_MASK                  (0x4U)
+#define SIM_SOPT4_FTM0FLT2_SHIFT                 (2U)
+#define SIM_SOPT4_FTM0FLT2(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM0FLT2_SHIFT)) & SIM_SOPT4_FTM0FLT2_MASK)
+#define SIM_SOPT4_FTM1FLT0_MASK                  (0x10U)
+#define SIM_SOPT4_FTM1FLT0_SHIFT                 (4U)
+#define SIM_SOPT4_FTM1FLT0(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM1FLT0_SHIFT)) & SIM_SOPT4_FTM1FLT0_MASK)
+#define SIM_SOPT4_FTM2FLT0_MASK                  (0x100U)
+#define SIM_SOPT4_FTM2FLT0_SHIFT                 (8U)
+#define SIM_SOPT4_FTM2FLT0(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM2FLT0_SHIFT)) & SIM_SOPT4_FTM2FLT0_MASK)
+#define SIM_SOPT4_FTM3FLT0_MASK                  (0x1000U)
+#define SIM_SOPT4_FTM3FLT0_SHIFT                 (12U)
+#define SIM_SOPT4_FTM3FLT0(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM3FLT0_SHIFT)) & SIM_SOPT4_FTM3FLT0_MASK)
+#define SIM_SOPT4_FTM1CH0SRC_MASK                (0xC0000U)
+#define SIM_SOPT4_FTM1CH0SRC_SHIFT               (18U)
+#define SIM_SOPT4_FTM1CH0SRC(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM1CH0SRC_SHIFT)) & SIM_SOPT4_FTM1CH0SRC_MASK)
+#define SIM_SOPT4_FTM2CH0SRC_MASK                (0x300000U)
+#define SIM_SOPT4_FTM2CH0SRC_SHIFT               (20U)
+#define SIM_SOPT4_FTM2CH0SRC(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM2CH0SRC_SHIFT)) & SIM_SOPT4_FTM2CH0SRC_MASK)
+#define SIM_SOPT4_FTM0CLKSEL_MASK                (0x1000000U)
+#define SIM_SOPT4_FTM0CLKSEL_SHIFT               (24U)
+#define SIM_SOPT4_FTM0CLKSEL(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM0CLKSEL_SHIFT)) & SIM_SOPT4_FTM0CLKSEL_MASK)
+#define SIM_SOPT4_FTM1CLKSEL_MASK                (0x2000000U)
+#define SIM_SOPT4_FTM1CLKSEL_SHIFT               (25U)
+#define SIM_SOPT4_FTM1CLKSEL(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM1CLKSEL_SHIFT)) & SIM_SOPT4_FTM1CLKSEL_MASK)
+#define SIM_SOPT4_FTM2CLKSEL_MASK                (0x4000000U)
+#define SIM_SOPT4_FTM2CLKSEL_SHIFT               (26U)
+#define SIM_SOPT4_FTM2CLKSEL(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM2CLKSEL_SHIFT)) & SIM_SOPT4_FTM2CLKSEL_MASK)
+#define SIM_SOPT4_FTM3CLKSEL_MASK                (0x8000000U)
+#define SIM_SOPT4_FTM3CLKSEL_SHIFT               (27U)
+#define SIM_SOPT4_FTM3CLKSEL(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM3CLKSEL_SHIFT)) & SIM_SOPT4_FTM3CLKSEL_MASK)
+#define SIM_SOPT4_FTM0TRG0SRC_MASK               (0x10000000U)
+#define SIM_SOPT4_FTM0TRG0SRC_SHIFT              (28U)
+#define SIM_SOPT4_FTM0TRG0SRC(x)                 (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM0TRG0SRC_SHIFT)) & SIM_SOPT4_FTM0TRG0SRC_MASK)
+#define SIM_SOPT4_FTM0TRG1SRC_MASK               (0x20000000U)
+#define SIM_SOPT4_FTM0TRG1SRC_SHIFT              (29U)
+#define SIM_SOPT4_FTM0TRG1SRC(x)                 (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM0TRG1SRC_SHIFT)) & SIM_SOPT4_FTM0TRG1SRC_MASK)
+#define SIM_SOPT4_FTM3TRG0SRC_MASK               (0x40000000U)
+#define SIM_SOPT4_FTM3TRG0SRC_SHIFT              (30U)
+#define SIM_SOPT4_FTM3TRG0SRC(x)                 (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM3TRG0SRC_SHIFT)) & SIM_SOPT4_FTM3TRG0SRC_MASK)
+#define SIM_SOPT4_FTM3TRG1SRC_MASK               (0x80000000U)
+#define SIM_SOPT4_FTM3TRG1SRC_SHIFT              (31U)
+#define SIM_SOPT4_FTM3TRG1SRC(x)                 (((uint32_t)(((uint32_t)(x)) << SIM_SOPT4_FTM3TRG1SRC_SHIFT)) & SIM_SOPT4_FTM3TRG1SRC_MASK)
+
+/*! @name SOPT5 - System Options Register 5 */
+#define SIM_SOPT5_UART0TXSRC_MASK                (0x3U)
+#define SIM_SOPT5_UART0TXSRC_SHIFT               (0U)
+#define SIM_SOPT5_UART0TXSRC(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT5_UART0TXSRC_SHIFT)) & SIM_SOPT5_UART0TXSRC_MASK)
+#define SIM_SOPT5_UART0RXSRC_MASK                (0xCU)
+#define SIM_SOPT5_UART0RXSRC_SHIFT               (2U)
+#define SIM_SOPT5_UART0RXSRC(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT5_UART0RXSRC_SHIFT)) & SIM_SOPT5_UART0RXSRC_MASK)
+#define SIM_SOPT5_UART1TXSRC_MASK                (0x30U)
+#define SIM_SOPT5_UART1TXSRC_SHIFT               (4U)
+#define SIM_SOPT5_UART1TXSRC(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT5_UART1TXSRC_SHIFT)) & SIM_SOPT5_UART1TXSRC_MASK)
+#define SIM_SOPT5_UART1RXSRC_MASK                (0xC0U)
+#define SIM_SOPT5_UART1RXSRC_SHIFT               (6U)
+#define SIM_SOPT5_UART1RXSRC(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT5_UART1RXSRC_SHIFT)) & SIM_SOPT5_UART1RXSRC_MASK)
+
+/*! @name SOPT7 - System Options Register 7 */
+#define SIM_SOPT7_ADC0TRGSEL_MASK                (0xFU)
+#define SIM_SOPT7_ADC0TRGSEL_SHIFT               (0U)
+#define SIM_SOPT7_ADC0TRGSEL(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT7_ADC0TRGSEL_SHIFT)) & SIM_SOPT7_ADC0TRGSEL_MASK)
+#define SIM_SOPT7_ADC0PRETRGSEL_MASK             (0x10U)
+#define SIM_SOPT7_ADC0PRETRGSEL_SHIFT            (4U)
+#define SIM_SOPT7_ADC0PRETRGSEL(x)               (((uint32_t)(((uint32_t)(x)) << SIM_SOPT7_ADC0PRETRGSEL_SHIFT)) & SIM_SOPT7_ADC0PRETRGSEL_MASK)
+#define SIM_SOPT7_ADC0ALTTRGEN_MASK              (0x80U)
+#define SIM_SOPT7_ADC0ALTTRGEN_SHIFT             (7U)
+#define SIM_SOPT7_ADC0ALTTRGEN(x)                (((uint32_t)(((uint32_t)(x)) << SIM_SOPT7_ADC0ALTTRGEN_SHIFT)) & SIM_SOPT7_ADC0ALTTRGEN_MASK)
+#define SIM_SOPT7_ADC1TRGSEL_MASK                (0xF00U)
+#define SIM_SOPT7_ADC1TRGSEL_SHIFT               (8U)
+#define SIM_SOPT7_ADC1TRGSEL(x)                  (((uint32_t)(((uint32_t)(x)) << SIM_SOPT7_ADC1TRGSEL_SHIFT)) & SIM_SOPT7_ADC1TRGSEL_MASK)
+#define SIM_SOPT7_ADC1PRETRGSEL_MASK             (0x1000U)
+#define SIM_SOPT7_ADC1PRETRGSEL_SHIFT            (12U)
+#define SIM_SOPT7_ADC1PRETRGSEL(x)               (((uint32_t)(((uint32_t)(x)) << SIM_SOPT7_ADC1PRETRGSEL_SHIFT)) & SIM_SOPT7_ADC1PRETRGSEL_MASK)
+#define SIM_SOPT7_ADC1ALTTRGEN_MASK              (0x8000U)
+#define SIM_SOPT7_ADC1ALTTRGEN_SHIFT             (15U)
+#define SIM_SOPT7_ADC1ALTTRGEN(x)                (((uint32_t)(((uint32_t)(x)) << SIM_SOPT7_ADC1ALTTRGEN_SHIFT)) & SIM_SOPT7_ADC1ALTTRGEN_MASK)
+
+/*! @name SDID - System Device Identification Register */
+#define SIM_SDID_PINID_MASK                      (0xFU)
+#define SIM_SDID_PINID_SHIFT                     (0U)
+#define SIM_SDID_PINID(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SDID_PINID_SHIFT)) & SIM_SDID_PINID_MASK)
+#define SIM_SDID_FAMID_MASK                      (0x70U)
+#define SIM_SDID_FAMID_SHIFT                     (4U)
+#define SIM_SDID_FAMID(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SDID_FAMID_SHIFT)) & SIM_SDID_FAMID_MASK)
+#define SIM_SDID_DIEID_MASK                      (0xF80U)
+#define SIM_SDID_DIEID_SHIFT                     (7U)
+#define SIM_SDID_DIEID(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SDID_DIEID_SHIFT)) & SIM_SDID_DIEID_MASK)
+#define SIM_SDID_REVID_MASK                      (0xF000U)
+#define SIM_SDID_REVID_SHIFT                     (12U)
+#define SIM_SDID_REVID(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SDID_REVID_SHIFT)) & SIM_SDID_REVID_MASK)
+#define SIM_SDID_SERIESID_MASK                   (0xF00000U)
+#define SIM_SDID_SERIESID_SHIFT                  (20U)
+#define SIM_SDID_SERIESID(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SDID_SERIESID_SHIFT)) & SIM_SDID_SERIESID_MASK)
+#define SIM_SDID_SUBFAMID_MASK                   (0xF000000U)
+#define SIM_SDID_SUBFAMID_SHIFT                  (24U)
+#define SIM_SDID_SUBFAMID(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SDID_SUBFAMID_SHIFT)) & SIM_SDID_SUBFAMID_MASK)
+#define SIM_SDID_FAMILYID_MASK                   (0xF0000000U)
+#define SIM_SDID_FAMILYID_SHIFT                  (28U)
+#define SIM_SDID_FAMILYID(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SDID_FAMILYID_SHIFT)) & SIM_SDID_FAMILYID_MASK)
+
+/*! @name SCGC1 - System Clock Gating Control Register 1 */
+#define SIM_SCGC1_I2C2_MASK                      (0x40U)
+#define SIM_SCGC1_I2C2_SHIFT                     (6U)
+#define SIM_SCGC1_I2C2(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC1_I2C2_SHIFT)) & SIM_SCGC1_I2C2_MASK)
+#define SIM_SCGC1_UART4_MASK                     (0x400U)
+#define SIM_SCGC1_UART4_SHIFT                    (10U)
+#define SIM_SCGC1_UART4(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC1_UART4_SHIFT)) & SIM_SCGC1_UART4_MASK)
+#define SIM_SCGC1_UART5_MASK                     (0x800U)
+#define SIM_SCGC1_UART5_SHIFT                    (11U)
+#define SIM_SCGC1_UART5(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC1_UART5_SHIFT)) & SIM_SCGC1_UART5_MASK)
+
+/*! @name SCGC2 - System Clock Gating Control Register 2 */
+#define SIM_SCGC2_ENET_MASK                      (0x1U)
+#define SIM_SCGC2_ENET_SHIFT                     (0U)
+#define SIM_SCGC2_ENET(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC2_ENET_SHIFT)) & SIM_SCGC2_ENET_MASK)
+#define SIM_SCGC2_DAC0_MASK                      (0x1000U)
+#define SIM_SCGC2_DAC0_SHIFT                     (12U)
+#define SIM_SCGC2_DAC0(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC2_DAC0_SHIFT)) & SIM_SCGC2_DAC0_MASK)
+#define SIM_SCGC2_DAC1_MASK                      (0x2000U)
+#define SIM_SCGC2_DAC1_SHIFT                     (13U)
+#define SIM_SCGC2_DAC1(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC2_DAC1_SHIFT)) & SIM_SCGC2_DAC1_MASK)
+
+/*! @name SCGC3 - System Clock Gating Control Register 3 */
+#define SIM_SCGC3_RNGA_MASK                      (0x1U)
+#define SIM_SCGC3_RNGA_SHIFT                     (0U)
+#define SIM_SCGC3_RNGA(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC3_RNGA_SHIFT)) & SIM_SCGC3_RNGA_MASK)
+#define SIM_SCGC3_SPI2_MASK                      (0x1000U)
+#define SIM_SCGC3_SPI2_SHIFT                     (12U)
+#define SIM_SCGC3_SPI2(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC3_SPI2_SHIFT)) & SIM_SCGC3_SPI2_MASK)
+#define SIM_SCGC3_SDHC_MASK                      (0x20000U)
+#define SIM_SCGC3_SDHC_SHIFT                     (17U)
+#define SIM_SCGC3_SDHC(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC3_SDHC_SHIFT)) & SIM_SCGC3_SDHC_MASK)
+#define SIM_SCGC3_FTM2_MASK                      (0x1000000U)
+#define SIM_SCGC3_FTM2_SHIFT                     (24U)
+#define SIM_SCGC3_FTM2(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC3_FTM2_SHIFT)) & SIM_SCGC3_FTM2_MASK)
+#define SIM_SCGC3_FTM3_MASK                      (0x2000000U)
+#define SIM_SCGC3_FTM3_SHIFT                     (25U)
+#define SIM_SCGC3_FTM3(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC3_FTM3_SHIFT)) & SIM_SCGC3_FTM3_MASK)
+#define SIM_SCGC3_ADC1_MASK                      (0x8000000U)
+#define SIM_SCGC3_ADC1_SHIFT                     (27U)
+#define SIM_SCGC3_ADC1(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC3_ADC1_SHIFT)) & SIM_SCGC3_ADC1_MASK)
+
+/*! @name SCGC4 - System Clock Gating Control Register 4 */
+#define SIM_SCGC4_EWM_MASK                       (0x2U)
+#define SIM_SCGC4_EWM_SHIFT                      (1U)
+#define SIM_SCGC4_EWM(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_EWM_SHIFT)) & SIM_SCGC4_EWM_MASK)
+#define SIM_SCGC4_CMT_MASK                       (0x4U)
+#define SIM_SCGC4_CMT_SHIFT                      (2U)
+#define SIM_SCGC4_CMT(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_CMT_SHIFT)) & SIM_SCGC4_CMT_MASK)
+#define SIM_SCGC4_I2C0_MASK                      (0x40U)
+#define SIM_SCGC4_I2C0_SHIFT                     (6U)
+#define SIM_SCGC4_I2C0(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_I2C0_SHIFT)) & SIM_SCGC4_I2C0_MASK)
+#define SIM_SCGC4_I2C1_MASK                      (0x80U)
+#define SIM_SCGC4_I2C1_SHIFT                     (7U)
+#define SIM_SCGC4_I2C1(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_I2C1_SHIFT)) & SIM_SCGC4_I2C1_MASK)
+#define SIM_SCGC4_UART0_MASK                     (0x400U)
+#define SIM_SCGC4_UART0_SHIFT                    (10U)
+#define SIM_SCGC4_UART0(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_UART0_SHIFT)) & SIM_SCGC4_UART0_MASK)
+#define SIM_SCGC4_UART1_MASK                     (0x800U)
+#define SIM_SCGC4_UART1_SHIFT                    (11U)
+#define SIM_SCGC4_UART1(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_UART1_SHIFT)) & SIM_SCGC4_UART1_MASK)
+#define SIM_SCGC4_UART2_MASK                     (0x1000U)
+#define SIM_SCGC4_UART2_SHIFT                    (12U)
+#define SIM_SCGC4_UART2(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_UART2_SHIFT)) & SIM_SCGC4_UART2_MASK)
+#define SIM_SCGC4_UART3_MASK                     (0x2000U)
+#define SIM_SCGC4_UART3_SHIFT                    (13U)
+#define SIM_SCGC4_UART3(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_UART3_SHIFT)) & SIM_SCGC4_UART3_MASK)
+#define SIM_SCGC4_USBOTG_MASK                    (0x40000U)
+#define SIM_SCGC4_USBOTG_SHIFT                   (18U)
+#define SIM_SCGC4_USBOTG(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_USBOTG_SHIFT)) & SIM_SCGC4_USBOTG_MASK)
+#define SIM_SCGC4_CMP_MASK                       (0x80000U)
+#define SIM_SCGC4_CMP_SHIFT                      (19U)
+#define SIM_SCGC4_CMP(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_CMP_SHIFT)) & SIM_SCGC4_CMP_MASK)
+#define SIM_SCGC4_VREF_MASK                      (0x100000U)
+#define SIM_SCGC4_VREF_SHIFT                     (20U)
+#define SIM_SCGC4_VREF(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC4_VREF_SHIFT)) & SIM_SCGC4_VREF_MASK)
+
+/*! @name SCGC5 - System Clock Gating Control Register 5 */
+#define SIM_SCGC5_LPTMR_MASK                     (0x1U)
+#define SIM_SCGC5_LPTMR_SHIFT                    (0U)
+#define SIM_SCGC5_LPTMR(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC5_LPTMR_SHIFT)) & SIM_SCGC5_LPTMR_MASK)
+#define SIM_SCGC5_PORTA_MASK                     (0x200U)
+#define SIM_SCGC5_PORTA_SHIFT                    (9U)
+#define SIM_SCGC5_PORTA(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC5_PORTA_SHIFT)) & SIM_SCGC5_PORTA_MASK)
+#define SIM_SCGC5_PORTB_MASK                     (0x400U)
+#define SIM_SCGC5_PORTB_SHIFT                    (10U)
+#define SIM_SCGC5_PORTB(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC5_PORTB_SHIFT)) & SIM_SCGC5_PORTB_MASK)
+#define SIM_SCGC5_PORTC_MASK                     (0x800U)
+#define SIM_SCGC5_PORTC_SHIFT                    (11U)
+#define SIM_SCGC5_PORTC(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC5_PORTC_SHIFT)) & SIM_SCGC5_PORTC_MASK)
+#define SIM_SCGC5_PORTD_MASK                     (0x1000U)
+#define SIM_SCGC5_PORTD_SHIFT                    (12U)
+#define SIM_SCGC5_PORTD(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC5_PORTD_SHIFT)) & SIM_SCGC5_PORTD_MASK)
+#define SIM_SCGC5_PORTE_MASK                     (0x2000U)
+#define SIM_SCGC5_PORTE_SHIFT                    (13U)
+#define SIM_SCGC5_PORTE(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_SCGC5_PORTE_SHIFT)) & SIM_SCGC5_PORTE_MASK)
+
+/*! @name SCGC6 - System Clock Gating Control Register 6 */
+#define SIM_SCGC6_FTF_MASK                       (0x1U)
+#define SIM_SCGC6_FTF_SHIFT                      (0U)
+#define SIM_SCGC6_FTF(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_FTF_SHIFT)) & SIM_SCGC6_FTF_MASK)
+#define SIM_SCGC6_DMAMUX_MASK                    (0x2U)
+#define SIM_SCGC6_DMAMUX_SHIFT                   (1U)
+#define SIM_SCGC6_DMAMUX(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_DMAMUX_SHIFT)) & SIM_SCGC6_DMAMUX_MASK)
+#define SIM_SCGC6_FLEXCAN0_MASK                  (0x10U)
+#define SIM_SCGC6_FLEXCAN0_SHIFT                 (4U)
+#define SIM_SCGC6_FLEXCAN0(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_FLEXCAN0_SHIFT)) & SIM_SCGC6_FLEXCAN0_MASK)
+#define SIM_SCGC6_RNGA_MASK                      (0x200U)
+#define SIM_SCGC6_RNGA_SHIFT                     (9U)
+#define SIM_SCGC6_RNGA(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_RNGA_SHIFT)) & SIM_SCGC6_RNGA_MASK)
+#define SIM_SCGC6_SPI0_MASK                      (0x1000U)
+#define SIM_SCGC6_SPI0_SHIFT                     (12U)
+#define SIM_SCGC6_SPI0(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_SPI0_SHIFT)) & SIM_SCGC6_SPI0_MASK)
+#define SIM_SCGC6_SPI1_MASK                      (0x2000U)
+#define SIM_SCGC6_SPI1_SHIFT                     (13U)
+#define SIM_SCGC6_SPI1(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_SPI1_SHIFT)) & SIM_SCGC6_SPI1_MASK)
+#define SIM_SCGC6_I2S_MASK                       (0x8000U)
+#define SIM_SCGC6_I2S_SHIFT                      (15U)
+#define SIM_SCGC6_I2S(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_I2S_SHIFT)) & SIM_SCGC6_I2S_MASK)
+#define SIM_SCGC6_CRC_MASK                       (0x40000U)
+#define SIM_SCGC6_CRC_SHIFT                      (18U)
+#define SIM_SCGC6_CRC(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_CRC_SHIFT)) & SIM_SCGC6_CRC_MASK)
+#define SIM_SCGC6_USBDCD_MASK                    (0x200000U)
+#define SIM_SCGC6_USBDCD_SHIFT                   (21U)
+#define SIM_SCGC6_USBDCD(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_USBDCD_SHIFT)) & SIM_SCGC6_USBDCD_MASK)
+#define SIM_SCGC6_PDB_MASK                       (0x400000U)
+#define SIM_SCGC6_PDB_SHIFT                      (22U)
+#define SIM_SCGC6_PDB(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_PDB_SHIFT)) & SIM_SCGC6_PDB_MASK)
+#define SIM_SCGC6_PIT_MASK                       (0x800000U)
+#define SIM_SCGC6_PIT_SHIFT                      (23U)
+#define SIM_SCGC6_PIT(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_PIT_SHIFT)) & SIM_SCGC6_PIT_MASK)
+#define SIM_SCGC6_FTM0_MASK                      (0x1000000U)
+#define SIM_SCGC6_FTM0_SHIFT                     (24U)
+#define SIM_SCGC6_FTM0(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_FTM0_SHIFT)) & SIM_SCGC6_FTM0_MASK)
+#define SIM_SCGC6_FTM1_MASK                      (0x2000000U)
+#define SIM_SCGC6_FTM1_SHIFT                     (25U)
+#define SIM_SCGC6_FTM1(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_FTM1_SHIFT)) & SIM_SCGC6_FTM1_MASK)
+#define SIM_SCGC6_FTM2_MASK                      (0x4000000U)
+#define SIM_SCGC6_FTM2_SHIFT                     (26U)
+#define SIM_SCGC6_FTM2(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_FTM2_SHIFT)) & SIM_SCGC6_FTM2_MASK)
+#define SIM_SCGC6_ADC0_MASK                      (0x8000000U)
+#define SIM_SCGC6_ADC0_SHIFT                     (27U)
+#define SIM_SCGC6_ADC0(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_ADC0_SHIFT)) & SIM_SCGC6_ADC0_MASK)
+#define SIM_SCGC6_RTC_MASK                       (0x20000000U)
+#define SIM_SCGC6_RTC_SHIFT                      (29U)
+#define SIM_SCGC6_RTC(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_RTC_SHIFT)) & SIM_SCGC6_RTC_MASK)
+#define SIM_SCGC6_DAC0_MASK                      (0x80000000U)
+#define SIM_SCGC6_DAC0_SHIFT                     (31U)
+#define SIM_SCGC6_DAC0(x)                        (((uint32_t)(((uint32_t)(x)) << SIM_SCGC6_DAC0_SHIFT)) & SIM_SCGC6_DAC0_MASK)
+
+/*! @name SCGC7 - System Clock Gating Control Register 7 */
+#define SIM_SCGC7_FLEXBUS_MASK                   (0x1U)
+#define SIM_SCGC7_FLEXBUS_SHIFT                  (0U)
+#define SIM_SCGC7_FLEXBUS(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_SCGC7_FLEXBUS_SHIFT)) & SIM_SCGC7_FLEXBUS_MASK)
+#define SIM_SCGC7_DMA_MASK                       (0x2U)
+#define SIM_SCGC7_DMA_SHIFT                      (1U)
+#define SIM_SCGC7_DMA(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC7_DMA_SHIFT)) & SIM_SCGC7_DMA_MASK)
+#define SIM_SCGC7_MPU_MASK                       (0x4U)
+#define SIM_SCGC7_MPU_SHIFT                      (2U)
+#define SIM_SCGC7_MPU(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_SCGC7_MPU_SHIFT)) & SIM_SCGC7_MPU_MASK)
+
+/*! @name CLKDIV1 - System Clock Divider Register 1 */
+#define SIM_CLKDIV1_OUTDIV4_MASK                 (0xF0000U)
+#define SIM_CLKDIV1_OUTDIV4_SHIFT                (16U)
+#define SIM_CLKDIV1_OUTDIV4(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_CLKDIV1_OUTDIV4_SHIFT)) & SIM_CLKDIV1_OUTDIV4_MASK)
+#define SIM_CLKDIV1_OUTDIV3_MASK                 (0xF00000U)
+#define SIM_CLKDIV1_OUTDIV3_SHIFT                (20U)
+#define SIM_CLKDIV1_OUTDIV3(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_CLKDIV1_OUTDIV3_SHIFT)) & SIM_CLKDIV1_OUTDIV3_MASK)
+#define SIM_CLKDIV1_OUTDIV2_MASK                 (0xF000000U)
+#define SIM_CLKDIV1_OUTDIV2_SHIFT                (24U)
+#define SIM_CLKDIV1_OUTDIV2(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_CLKDIV1_OUTDIV2_SHIFT)) & SIM_CLKDIV1_OUTDIV2_MASK)
+#define SIM_CLKDIV1_OUTDIV1_MASK                 (0xF0000000U)
+#define SIM_CLKDIV1_OUTDIV1_SHIFT                (28U)
+#define SIM_CLKDIV1_OUTDIV1(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_CLKDIV1_OUTDIV1_SHIFT)) & SIM_CLKDIV1_OUTDIV1_MASK)
+
+/*! @name CLKDIV2 - System Clock Divider Register 2 */
+#define SIM_CLKDIV2_USBFRAC_MASK                 (0x1U)
+#define SIM_CLKDIV2_USBFRAC_SHIFT                (0U)
+#define SIM_CLKDIV2_USBFRAC(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_CLKDIV2_USBFRAC_SHIFT)) & SIM_CLKDIV2_USBFRAC_MASK)
+#define SIM_CLKDIV2_USBDIV_MASK                  (0xEU)
+#define SIM_CLKDIV2_USBDIV_SHIFT                 (1U)
+#define SIM_CLKDIV2_USBDIV(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_CLKDIV2_USBDIV_SHIFT)) & SIM_CLKDIV2_USBDIV_MASK)
+
+/*! @name FCFG1 - Flash Configuration Register 1 */
+#define SIM_FCFG1_FLASHDIS_MASK                  (0x1U)
+#define SIM_FCFG1_FLASHDIS_SHIFT                 (0U)
+#define SIM_FCFG1_FLASHDIS(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_FCFG1_FLASHDIS_SHIFT)) & SIM_FCFG1_FLASHDIS_MASK)
+#define SIM_FCFG1_FLASHDOZE_MASK                 (0x2U)
+#define SIM_FCFG1_FLASHDOZE_SHIFT                (1U)
+#define SIM_FCFG1_FLASHDOZE(x)                   (((uint32_t)(((uint32_t)(x)) << SIM_FCFG1_FLASHDOZE_SHIFT)) & SIM_FCFG1_FLASHDOZE_MASK)
+#define SIM_FCFG1_DEPART_MASK                    (0xF00U)
+#define SIM_FCFG1_DEPART_SHIFT                   (8U)
+#define SIM_FCFG1_DEPART(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_FCFG1_DEPART_SHIFT)) & SIM_FCFG1_DEPART_MASK)
+#define SIM_FCFG1_EESIZE_MASK                    (0xF0000U)
+#define SIM_FCFG1_EESIZE_SHIFT                   (16U)
+#define SIM_FCFG1_EESIZE(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_FCFG1_EESIZE_SHIFT)) & SIM_FCFG1_EESIZE_MASK)
+#define SIM_FCFG1_PFSIZE_MASK                    (0xF000000U)
+#define SIM_FCFG1_PFSIZE_SHIFT                   (24U)
+#define SIM_FCFG1_PFSIZE(x)                      (((uint32_t)(((uint32_t)(x)) << SIM_FCFG1_PFSIZE_SHIFT)) & SIM_FCFG1_PFSIZE_MASK)
+#define SIM_FCFG1_NVMSIZE_MASK                   (0xF0000000U)
+#define SIM_FCFG1_NVMSIZE_SHIFT                  (28U)
+#define SIM_FCFG1_NVMSIZE(x)                     (((uint32_t)(((uint32_t)(x)) << SIM_FCFG1_NVMSIZE_SHIFT)) & SIM_FCFG1_NVMSIZE_MASK)
+
+/*! @name FCFG2 - Flash Configuration Register 2 */
+#define SIM_FCFG2_MAXADDR1_MASK                  (0x7F0000U)
+#define SIM_FCFG2_MAXADDR1_SHIFT                 (16U)
+#define SIM_FCFG2_MAXADDR1(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_FCFG2_MAXADDR1_SHIFT)) & SIM_FCFG2_MAXADDR1_MASK)
+#define SIM_FCFG2_PFLSH_MASK                     (0x800000U)
+#define SIM_FCFG2_PFLSH_SHIFT                    (23U)
+#define SIM_FCFG2_PFLSH(x)                       (((uint32_t)(((uint32_t)(x)) << SIM_FCFG2_PFLSH_SHIFT)) & SIM_FCFG2_PFLSH_MASK)
+#define SIM_FCFG2_MAXADDR0_MASK                  (0x7F000000U)
+#define SIM_FCFG2_MAXADDR0_SHIFT                 (24U)
+#define SIM_FCFG2_MAXADDR0(x)                    (((uint32_t)(((uint32_t)(x)) << SIM_FCFG2_MAXADDR0_SHIFT)) & SIM_FCFG2_MAXADDR0_MASK)
+
+/*! @name UIDH - Unique Identification Register High */
+#define SIM_UIDH_UID_MASK                        (0xFFFFFFFFU)
+#define SIM_UIDH_UID_SHIFT                       (0U)
+#define SIM_UIDH_UID(x)                          (((uint32_t)(((uint32_t)(x)) << SIM_UIDH_UID_SHIFT)) & SIM_UIDH_UID_MASK)
+
+/*! @name UIDMH - Unique Identification Register Mid-High */
+#define SIM_UIDMH_UID_MASK                       (0xFFFFFFFFU)
+#define SIM_UIDMH_UID_SHIFT                      (0U)
+#define SIM_UIDMH_UID(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_UIDMH_UID_SHIFT)) & SIM_UIDMH_UID_MASK)
+
+/*! @name UIDML - Unique Identification Register Mid Low */
+#define SIM_UIDML_UID_MASK                       (0xFFFFFFFFU)
+#define SIM_UIDML_UID_SHIFT                      (0U)
+#define SIM_UIDML_UID(x)                         (((uint32_t)(((uint32_t)(x)) << SIM_UIDML_UID_SHIFT)) & SIM_UIDML_UID_MASK)
+
+/*! @name UIDL - Unique Identification Register Low */
+#define SIM_UIDL_UID_MASK                        (0xFFFFFFFFU)
+#define SIM_UIDL_UID_SHIFT                       (0U)
+#define SIM_UIDL_UID(x)                          (((uint32_t)(((uint32_t)(x)) << SIM_UIDL_UID_SHIFT)) & SIM_UIDL_UID_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Masks */
+
+
+/* SIM - Peripheral instance base addresses */
+/** Peripheral SIM base address */
+#define SIM_BASE                                 (0x40047000u)
+/** Peripheral SIM base pointer */
+#define SIM                                      ((SIM_Type *)SIM_BASE)
+/** Array initializer of SIM peripheral base addresses */
+#define SIM_BASE_ADDRS                           { SIM_BASE }
+/** Array initializer of SIM peripheral base pointers */
+#define SIM_BASE_PTRS                            { SIM }
+
+/*!
+ * @}
+ */ /* end of group SIM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Peripheral_Access_Layer SMC Peripheral Access Layer
+ * @{
+ */
+
+/** SMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PMPROT;                             /**< Power Mode Protection register, offset: 0x0 */
+  __IO uint8_t PMCTRL;                             /**< Power Mode Control register, offset: 0x1 */
+  __IO uint8_t VLLSCTRL;                           /**< VLLS Control register, offset: 0x2 */
+  __I  uint8_t PMSTAT;                             /**< Power Mode Status register, offset: 0x3 */
+} SMC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Masks SMC Register Masks
+ * @{
+ */
+
+/*! @name PMPROT - Power Mode Protection register */
+#define SMC_PMPROT_AVLLS_MASK                    (0x2U)
+#define SMC_PMPROT_AVLLS_SHIFT                   (1U)
+#define SMC_PMPROT_AVLLS(x)                      (((uint8_t)(((uint8_t)(x)) << SMC_PMPROT_AVLLS_SHIFT)) & SMC_PMPROT_AVLLS_MASK)
+#define SMC_PMPROT_ALLS_MASK                     (0x8U)
+#define SMC_PMPROT_ALLS_SHIFT                    (3U)
+#define SMC_PMPROT_ALLS(x)                       (((uint8_t)(((uint8_t)(x)) << SMC_PMPROT_ALLS_SHIFT)) & SMC_PMPROT_ALLS_MASK)
+#define SMC_PMPROT_AVLP_MASK                     (0x20U)
+#define SMC_PMPROT_AVLP_SHIFT                    (5U)
+#define SMC_PMPROT_AVLP(x)                       (((uint8_t)(((uint8_t)(x)) << SMC_PMPROT_AVLP_SHIFT)) & SMC_PMPROT_AVLP_MASK)
+
+/*! @name PMCTRL - Power Mode Control register */
+#define SMC_PMCTRL_STOPM_MASK                    (0x7U)
+#define SMC_PMCTRL_STOPM_SHIFT                   (0U)
+#define SMC_PMCTRL_STOPM(x)                      (((uint8_t)(((uint8_t)(x)) << SMC_PMCTRL_STOPM_SHIFT)) & SMC_PMCTRL_STOPM_MASK)
+#define SMC_PMCTRL_STOPA_MASK                    (0x8U)
+#define SMC_PMCTRL_STOPA_SHIFT                   (3U)
+#define SMC_PMCTRL_STOPA(x)                      (((uint8_t)(((uint8_t)(x)) << SMC_PMCTRL_STOPA_SHIFT)) & SMC_PMCTRL_STOPA_MASK)
+#define SMC_PMCTRL_RUNM_MASK                     (0x60U)
+#define SMC_PMCTRL_RUNM_SHIFT                    (5U)
+#define SMC_PMCTRL_RUNM(x)                       (((uint8_t)(((uint8_t)(x)) << SMC_PMCTRL_RUNM_SHIFT)) & SMC_PMCTRL_RUNM_MASK)
+#define SMC_PMCTRL_LPWUI_MASK                    (0x80U)
+#define SMC_PMCTRL_LPWUI_SHIFT                   (7U)
+#define SMC_PMCTRL_LPWUI(x)                      (((uint8_t)(((uint8_t)(x)) << SMC_PMCTRL_LPWUI_SHIFT)) & SMC_PMCTRL_LPWUI_MASK)
+
+/*! @name VLLSCTRL - VLLS Control register */
+#define SMC_VLLSCTRL_VLLSM_MASK                  (0x7U)
+#define SMC_VLLSCTRL_VLLSM_SHIFT                 (0U)
+#define SMC_VLLSCTRL_VLLSM(x)                    (((uint8_t)(((uint8_t)(x)) << SMC_VLLSCTRL_VLLSM_SHIFT)) & SMC_VLLSCTRL_VLLSM_MASK)
+#define SMC_VLLSCTRL_PORPO_MASK                  (0x20U)
+#define SMC_VLLSCTRL_PORPO_SHIFT                 (5U)
+#define SMC_VLLSCTRL_PORPO(x)                    (((uint8_t)(((uint8_t)(x)) << SMC_VLLSCTRL_PORPO_SHIFT)) & SMC_VLLSCTRL_PORPO_MASK)
+
+/*! @name PMSTAT - Power Mode Status register */
+#define SMC_PMSTAT_PMSTAT_MASK                   (0x7FU)
+#define SMC_PMSTAT_PMSTAT_SHIFT                  (0U)
+#define SMC_PMSTAT_PMSTAT(x)                     (((uint8_t)(((uint8_t)(x)) << SMC_PMSTAT_PMSTAT_SHIFT)) & SMC_PMSTAT_PMSTAT_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Masks */
+
+
+/* SMC - Peripheral instance base addresses */
+/** Peripheral SMC base address */
+#define SMC_BASE                                 (0x4007E000u)
+/** Peripheral SMC base pointer */
+#define SMC                                      ((SMC_Type *)SMC_BASE)
+/** Array initializer of SMC peripheral base addresses */
+#define SMC_BASE_ADDRS                           { SMC_BASE }
+/** Array initializer of SMC peripheral base pointers */
+#define SMC_BASE_PTRS                            { SMC }
+
+/*!
+ * @}
+ */ /* end of group SMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SPI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Peripheral_Access_Layer SPI Peripheral Access Layer
+ * @{
+ */
+
+/** SPI - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< Module Configuration Register, offset: 0x0 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t TCR;                               /**< Transfer Count Register, offset: 0x8 */
+  union {                                          /* offset: 0xC */
+    __IO uint32_t CTAR[2];                           /**< Clock and Transfer Attributes Register (In Master Mode), array offset: 0xC, array step: 0x4 */
+    __IO uint32_t CTAR_SLAVE[1];                     /**< Clock and Transfer Attributes Register (In Slave Mode), array offset: 0xC, array step: 0x4 */
+  };
+       uint8_t RESERVED_1[24];
+  __IO uint32_t SR;                                /**< Status Register, offset: 0x2C */
+  __IO uint32_t RSER;                              /**< DMA/Interrupt Request Select and Enable Register, offset: 0x30 */
+  union {                                          /* offset: 0x34 */
+    __IO uint32_t PUSHR;                             /**< PUSH TX FIFO Register In Master Mode, offset: 0x34 */
+    __IO uint32_t PUSHR_SLAVE;                       /**< PUSH TX FIFO Register In Slave Mode, offset: 0x34 */
+  };
+  __I  uint32_t POPR;                              /**< POP RX FIFO Register, offset: 0x38 */
+  __I  uint32_t TXFR0;                             /**< Transmit FIFO Registers, offset: 0x3C */
+  __I  uint32_t TXFR1;                             /**< Transmit FIFO Registers, offset: 0x40 */
+  __I  uint32_t TXFR2;                             /**< Transmit FIFO Registers, offset: 0x44 */
+  __I  uint32_t TXFR3;                             /**< Transmit FIFO Registers, offset: 0x48 */
+       uint8_t RESERVED_2[48];
+  __I  uint32_t RXFR0;                             /**< Receive FIFO Registers, offset: 0x7C */
+  __I  uint32_t RXFR1;                             /**< Receive FIFO Registers, offset: 0x80 */
+  __I  uint32_t RXFR2;                             /**< Receive FIFO Registers, offset: 0x84 */
+  __I  uint32_t RXFR3;                             /**< Receive FIFO Registers, offset: 0x88 */
+} SPI_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SPI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Masks SPI Register Masks
+ * @{
+ */
+
+/*! @name MCR - Module Configuration Register */
+#define SPI_MCR_HALT_MASK                        (0x1U)
+#define SPI_MCR_HALT_SHIFT                       (0U)
+#define SPI_MCR_HALT(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_MCR_HALT_SHIFT)) & SPI_MCR_HALT_MASK)
+#define SPI_MCR_SMPL_PT_MASK                     (0x300U)
+#define SPI_MCR_SMPL_PT_SHIFT                    (8U)
+#define SPI_MCR_SMPL_PT(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_MCR_SMPL_PT_SHIFT)) & SPI_MCR_SMPL_PT_MASK)
+#define SPI_MCR_CLR_RXF_MASK                     (0x400U)
+#define SPI_MCR_CLR_RXF_SHIFT                    (10U)
+#define SPI_MCR_CLR_RXF(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_MCR_CLR_RXF_SHIFT)) & SPI_MCR_CLR_RXF_MASK)
+#define SPI_MCR_CLR_TXF_MASK                     (0x800U)
+#define SPI_MCR_CLR_TXF_SHIFT                    (11U)
+#define SPI_MCR_CLR_TXF(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_MCR_CLR_TXF_SHIFT)) & SPI_MCR_CLR_TXF_MASK)
+#define SPI_MCR_DIS_RXF_MASK                     (0x1000U)
+#define SPI_MCR_DIS_RXF_SHIFT                    (12U)
+#define SPI_MCR_DIS_RXF(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_MCR_DIS_RXF_SHIFT)) & SPI_MCR_DIS_RXF_MASK)
+#define SPI_MCR_DIS_TXF_MASK                     (0x2000U)
+#define SPI_MCR_DIS_TXF_SHIFT                    (13U)
+#define SPI_MCR_DIS_TXF(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_MCR_DIS_TXF_SHIFT)) & SPI_MCR_DIS_TXF_MASK)
+#define SPI_MCR_MDIS_MASK                        (0x4000U)
+#define SPI_MCR_MDIS_SHIFT                       (14U)
+#define SPI_MCR_MDIS(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_MCR_MDIS_SHIFT)) & SPI_MCR_MDIS_MASK)
+#define SPI_MCR_DOZE_MASK                        (0x8000U)
+#define SPI_MCR_DOZE_SHIFT                       (15U)
+#define SPI_MCR_DOZE(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_MCR_DOZE_SHIFT)) & SPI_MCR_DOZE_MASK)
+#define SPI_MCR_PCSIS_MASK                       (0x3F0000U)
+#define SPI_MCR_PCSIS_SHIFT                      (16U)
+#define SPI_MCR_PCSIS(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_MCR_PCSIS_SHIFT)) & SPI_MCR_PCSIS_MASK)
+#define SPI_MCR_ROOE_MASK                        (0x1000000U)
+#define SPI_MCR_ROOE_SHIFT                       (24U)
+#define SPI_MCR_ROOE(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_MCR_ROOE_SHIFT)) & SPI_MCR_ROOE_MASK)
+#define SPI_MCR_PCSSE_MASK                       (0x2000000U)
+#define SPI_MCR_PCSSE_SHIFT                      (25U)
+#define SPI_MCR_PCSSE(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_MCR_PCSSE_SHIFT)) & SPI_MCR_PCSSE_MASK)
+#define SPI_MCR_MTFE_MASK                        (0x4000000U)
+#define SPI_MCR_MTFE_SHIFT                       (26U)
+#define SPI_MCR_MTFE(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_MCR_MTFE_SHIFT)) & SPI_MCR_MTFE_MASK)
+#define SPI_MCR_FRZ_MASK                         (0x8000000U)
+#define SPI_MCR_FRZ_SHIFT                        (27U)
+#define SPI_MCR_FRZ(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_MCR_FRZ_SHIFT)) & SPI_MCR_FRZ_MASK)
+#define SPI_MCR_DCONF_MASK                       (0x30000000U)
+#define SPI_MCR_DCONF_SHIFT                      (28U)
+#define SPI_MCR_DCONF(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_MCR_DCONF_SHIFT)) & SPI_MCR_DCONF_MASK)
+#define SPI_MCR_CONT_SCKE_MASK                   (0x40000000U)
+#define SPI_MCR_CONT_SCKE_SHIFT                  (30U)
+#define SPI_MCR_CONT_SCKE(x)                     (((uint32_t)(((uint32_t)(x)) << SPI_MCR_CONT_SCKE_SHIFT)) & SPI_MCR_CONT_SCKE_MASK)
+#define SPI_MCR_MSTR_MASK                        (0x80000000U)
+#define SPI_MCR_MSTR_SHIFT                       (31U)
+#define SPI_MCR_MSTR(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_MCR_MSTR_SHIFT)) & SPI_MCR_MSTR_MASK)
+
+/*! @name TCR - Transfer Count Register */
+#define SPI_TCR_SPI_TCNT_MASK                    (0xFFFF0000U)
+#define SPI_TCR_SPI_TCNT_SHIFT                   (16U)
+#define SPI_TCR_SPI_TCNT(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_TCR_SPI_TCNT_SHIFT)) & SPI_TCR_SPI_TCNT_MASK)
+
+/*! @name CTAR - Clock and Transfer Attributes Register (In Master Mode) */
+#define SPI_CTAR_BR_MASK                         (0xFU)
+#define SPI_CTAR_BR_SHIFT                        (0U)
+#define SPI_CTAR_BR(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_BR_SHIFT)) & SPI_CTAR_BR_MASK)
+#define SPI_CTAR_DT_MASK                         (0xF0U)
+#define SPI_CTAR_DT_SHIFT                        (4U)
+#define SPI_CTAR_DT(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_DT_SHIFT)) & SPI_CTAR_DT_MASK)
+#define SPI_CTAR_ASC_MASK                        (0xF00U)
+#define SPI_CTAR_ASC_SHIFT                       (8U)
+#define SPI_CTAR_ASC(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_ASC_SHIFT)) & SPI_CTAR_ASC_MASK)
+#define SPI_CTAR_CSSCK_MASK                      (0xF000U)
+#define SPI_CTAR_CSSCK_SHIFT                     (12U)
+#define SPI_CTAR_CSSCK(x)                        (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_CSSCK_SHIFT)) & SPI_CTAR_CSSCK_MASK)
+#define SPI_CTAR_PBR_MASK                        (0x30000U)
+#define SPI_CTAR_PBR_SHIFT                       (16U)
+#define SPI_CTAR_PBR(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_PBR_SHIFT)) & SPI_CTAR_PBR_MASK)
+#define SPI_CTAR_PDT_MASK                        (0xC0000U)
+#define SPI_CTAR_PDT_SHIFT                       (18U)
+#define SPI_CTAR_PDT(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_PDT_SHIFT)) & SPI_CTAR_PDT_MASK)
+#define SPI_CTAR_PASC_MASK                       (0x300000U)
+#define SPI_CTAR_PASC_SHIFT                      (20U)
+#define SPI_CTAR_PASC(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_PASC_SHIFT)) & SPI_CTAR_PASC_MASK)
+#define SPI_CTAR_PCSSCK_MASK                     (0xC00000U)
+#define SPI_CTAR_PCSSCK_SHIFT                    (22U)
+#define SPI_CTAR_PCSSCK(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_PCSSCK_SHIFT)) & SPI_CTAR_PCSSCK_MASK)
+#define SPI_CTAR_LSBFE_MASK                      (0x1000000U)
+#define SPI_CTAR_LSBFE_SHIFT                     (24U)
+#define SPI_CTAR_LSBFE(x)                        (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_LSBFE_SHIFT)) & SPI_CTAR_LSBFE_MASK)
+#define SPI_CTAR_CPHA_MASK                       (0x2000000U)
+#define SPI_CTAR_CPHA_SHIFT                      (25U)
+#define SPI_CTAR_CPHA(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_CPHA_SHIFT)) & SPI_CTAR_CPHA_MASK)
+#define SPI_CTAR_CPOL_MASK                       (0x4000000U)
+#define SPI_CTAR_CPOL_SHIFT                      (26U)
+#define SPI_CTAR_CPOL(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_CPOL_SHIFT)) & SPI_CTAR_CPOL_MASK)
+#define SPI_CTAR_FMSZ_MASK                       (0x78000000U)
+#define SPI_CTAR_FMSZ_SHIFT                      (27U)
+#define SPI_CTAR_FMSZ(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_FMSZ_SHIFT)) & SPI_CTAR_FMSZ_MASK)
+#define SPI_CTAR_DBR_MASK                        (0x80000000U)
+#define SPI_CTAR_DBR_SHIFT                       (31U)
+#define SPI_CTAR_DBR(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_DBR_SHIFT)) & SPI_CTAR_DBR_MASK)
+
+/* The count of SPI_CTAR */
+#define SPI_CTAR_COUNT                           (2U)
+
+/*! @name CTAR_SLAVE - Clock and Transfer Attributes Register (In Slave Mode) */
+#define SPI_CTAR_SLAVE_CPHA_MASK                 (0x2000000U)
+#define SPI_CTAR_SLAVE_CPHA_SHIFT                (25U)
+#define SPI_CTAR_SLAVE_CPHA(x)                   (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_SLAVE_CPHA_SHIFT)) & SPI_CTAR_SLAVE_CPHA_MASK)
+#define SPI_CTAR_SLAVE_CPOL_MASK                 (0x4000000U)
+#define SPI_CTAR_SLAVE_CPOL_SHIFT                (26U)
+#define SPI_CTAR_SLAVE_CPOL(x)                   (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_SLAVE_CPOL_SHIFT)) & SPI_CTAR_SLAVE_CPOL_MASK)
+#define SPI_CTAR_SLAVE_FMSZ_MASK                 (0xF8000000U)
+#define SPI_CTAR_SLAVE_FMSZ_SHIFT                (27U)
+#define SPI_CTAR_SLAVE_FMSZ(x)                   (((uint32_t)(((uint32_t)(x)) << SPI_CTAR_SLAVE_FMSZ_SHIFT)) & SPI_CTAR_SLAVE_FMSZ_MASK)
+
+/* The count of SPI_CTAR_SLAVE */
+#define SPI_CTAR_SLAVE_COUNT                     (1U)
+
+/*! @name SR - Status Register */
+#define SPI_SR_POPNXTPTR_MASK                    (0xFU)
+#define SPI_SR_POPNXTPTR_SHIFT                   (0U)
+#define SPI_SR_POPNXTPTR(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_SR_POPNXTPTR_SHIFT)) & SPI_SR_POPNXTPTR_MASK)
+#define SPI_SR_RXCTR_MASK                        (0xF0U)
+#define SPI_SR_RXCTR_SHIFT                       (4U)
+#define SPI_SR_RXCTR(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_SR_RXCTR_SHIFT)) & SPI_SR_RXCTR_MASK)
+#define SPI_SR_TXNXTPTR_MASK                     (0xF00U)
+#define SPI_SR_TXNXTPTR_SHIFT                    (8U)
+#define SPI_SR_TXNXTPTR(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_SR_TXNXTPTR_SHIFT)) & SPI_SR_TXNXTPTR_MASK)
+#define SPI_SR_TXCTR_MASK                        (0xF000U)
+#define SPI_SR_TXCTR_SHIFT                       (12U)
+#define SPI_SR_TXCTR(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_SR_TXCTR_SHIFT)) & SPI_SR_TXCTR_MASK)
+#define SPI_SR_RFDF_MASK                         (0x20000U)
+#define SPI_SR_RFDF_SHIFT                        (17U)
+#define SPI_SR_RFDF(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_SR_RFDF_SHIFT)) & SPI_SR_RFDF_MASK)
+#define SPI_SR_RFOF_MASK                         (0x80000U)
+#define SPI_SR_RFOF_SHIFT                        (19U)
+#define SPI_SR_RFOF(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_SR_RFOF_SHIFT)) & SPI_SR_RFOF_MASK)
+#define SPI_SR_TFFF_MASK                         (0x2000000U)
+#define SPI_SR_TFFF_SHIFT                        (25U)
+#define SPI_SR_TFFF(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_SR_TFFF_SHIFT)) & SPI_SR_TFFF_MASK)
+#define SPI_SR_TFUF_MASK                         (0x8000000U)
+#define SPI_SR_TFUF_SHIFT                        (27U)
+#define SPI_SR_TFUF(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_SR_TFUF_SHIFT)) & SPI_SR_TFUF_MASK)
+#define SPI_SR_EOQF_MASK                         (0x10000000U)
+#define SPI_SR_EOQF_SHIFT                        (28U)
+#define SPI_SR_EOQF(x)                           (((uint32_t)(((uint32_t)(x)) << SPI_SR_EOQF_SHIFT)) & SPI_SR_EOQF_MASK)
+#define SPI_SR_TXRXS_MASK                        (0x40000000U)
+#define SPI_SR_TXRXS_SHIFT                       (30U)
+#define SPI_SR_TXRXS(x)                          (((uint32_t)(((uint32_t)(x)) << SPI_SR_TXRXS_SHIFT)) & SPI_SR_TXRXS_MASK)
+#define SPI_SR_TCF_MASK                          (0x80000000U)
+#define SPI_SR_TCF_SHIFT                         (31U)
+#define SPI_SR_TCF(x)                            (((uint32_t)(((uint32_t)(x)) << SPI_SR_TCF_SHIFT)) & SPI_SR_TCF_MASK)
+
+/*! @name RSER - DMA/Interrupt Request Select and Enable Register */
+#define SPI_RSER_RFDF_DIRS_MASK                  (0x10000U)
+#define SPI_RSER_RFDF_DIRS_SHIFT                 (16U)
+#define SPI_RSER_RFDF_DIRS(x)                    (((uint32_t)(((uint32_t)(x)) << SPI_RSER_RFDF_DIRS_SHIFT)) & SPI_RSER_RFDF_DIRS_MASK)
+#define SPI_RSER_RFDF_RE_MASK                    (0x20000U)
+#define SPI_RSER_RFDF_RE_SHIFT                   (17U)
+#define SPI_RSER_RFDF_RE(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RSER_RFDF_RE_SHIFT)) & SPI_RSER_RFDF_RE_MASK)
+#define SPI_RSER_RFOF_RE_MASK                    (0x80000U)
+#define SPI_RSER_RFOF_RE_SHIFT                   (19U)
+#define SPI_RSER_RFOF_RE(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RSER_RFOF_RE_SHIFT)) & SPI_RSER_RFOF_RE_MASK)
+#define SPI_RSER_TFFF_DIRS_MASK                  (0x1000000U)
+#define SPI_RSER_TFFF_DIRS_SHIFT                 (24U)
+#define SPI_RSER_TFFF_DIRS(x)                    (((uint32_t)(((uint32_t)(x)) << SPI_RSER_TFFF_DIRS_SHIFT)) & SPI_RSER_TFFF_DIRS_MASK)
+#define SPI_RSER_TFFF_RE_MASK                    (0x2000000U)
+#define SPI_RSER_TFFF_RE_SHIFT                   (25U)
+#define SPI_RSER_TFFF_RE(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RSER_TFFF_RE_SHIFT)) & SPI_RSER_TFFF_RE_MASK)
+#define SPI_RSER_TFUF_RE_MASK                    (0x8000000U)
+#define SPI_RSER_TFUF_RE_SHIFT                   (27U)
+#define SPI_RSER_TFUF_RE(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RSER_TFUF_RE_SHIFT)) & SPI_RSER_TFUF_RE_MASK)
+#define SPI_RSER_EOQF_RE_MASK                    (0x10000000U)
+#define SPI_RSER_EOQF_RE_SHIFT                   (28U)
+#define SPI_RSER_EOQF_RE(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RSER_EOQF_RE_SHIFT)) & SPI_RSER_EOQF_RE_MASK)
+#define SPI_RSER_TCF_RE_MASK                     (0x80000000U)
+#define SPI_RSER_TCF_RE_SHIFT                    (31U)
+#define SPI_RSER_TCF_RE(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_RSER_TCF_RE_SHIFT)) & SPI_RSER_TCF_RE_MASK)
+
+/*! @name PUSHR - PUSH TX FIFO Register In Master Mode */
+#define SPI_PUSHR_TXDATA_MASK                    (0xFFFFU)
+#define SPI_PUSHR_TXDATA_SHIFT                   (0U)
+#define SPI_PUSHR_TXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_TXDATA_SHIFT)) & SPI_PUSHR_TXDATA_MASK)
+#define SPI_PUSHR_PCS_MASK                       (0x3F0000U)
+#define SPI_PUSHR_PCS_SHIFT                      (16U)
+#define SPI_PUSHR_PCS(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_PCS_SHIFT)) & SPI_PUSHR_PCS_MASK)
+#define SPI_PUSHR_CTCNT_MASK                     (0x4000000U)
+#define SPI_PUSHR_CTCNT_SHIFT                    (26U)
+#define SPI_PUSHR_CTCNT(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_CTCNT_SHIFT)) & SPI_PUSHR_CTCNT_MASK)
+#define SPI_PUSHR_EOQ_MASK                       (0x8000000U)
+#define SPI_PUSHR_EOQ_SHIFT                      (27U)
+#define SPI_PUSHR_EOQ(x)                         (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_EOQ_SHIFT)) & SPI_PUSHR_EOQ_MASK)
+#define SPI_PUSHR_CTAS_MASK                      (0x70000000U)
+#define SPI_PUSHR_CTAS_SHIFT                     (28U)
+#define SPI_PUSHR_CTAS(x)                        (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_CTAS_SHIFT)) & SPI_PUSHR_CTAS_MASK)
+#define SPI_PUSHR_CONT_MASK                      (0x80000000U)
+#define SPI_PUSHR_CONT_SHIFT                     (31U)
+#define SPI_PUSHR_CONT(x)                        (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_CONT_SHIFT)) & SPI_PUSHR_CONT_MASK)
+
+/*! @name PUSHR_SLAVE - PUSH TX FIFO Register In Slave Mode */
+#define SPI_PUSHR_SLAVE_TXDATA_MASK              (0xFFFFFFFFU)
+#define SPI_PUSHR_SLAVE_TXDATA_SHIFT             (0U)
+#define SPI_PUSHR_SLAVE_TXDATA(x)                (((uint32_t)(((uint32_t)(x)) << SPI_PUSHR_SLAVE_TXDATA_SHIFT)) & SPI_PUSHR_SLAVE_TXDATA_MASK)
+
+/*! @name POPR - POP RX FIFO Register */
+#define SPI_POPR_RXDATA_MASK                     (0xFFFFFFFFU)
+#define SPI_POPR_RXDATA_SHIFT                    (0U)
+#define SPI_POPR_RXDATA(x)                       (((uint32_t)(((uint32_t)(x)) << SPI_POPR_RXDATA_SHIFT)) & SPI_POPR_RXDATA_MASK)
+
+/*! @name TXFR0 - Transmit FIFO Registers */
+#define SPI_TXFR0_TXDATA_MASK                    (0xFFFFU)
+#define SPI_TXFR0_TXDATA_SHIFT                   (0U)
+#define SPI_TXFR0_TXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_TXFR0_TXDATA_SHIFT)) & SPI_TXFR0_TXDATA_MASK)
+#define SPI_TXFR0_TXCMD_TXDATA_MASK              (0xFFFF0000U)
+#define SPI_TXFR0_TXCMD_TXDATA_SHIFT             (16U)
+#define SPI_TXFR0_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x)) << SPI_TXFR0_TXCMD_TXDATA_SHIFT)) & SPI_TXFR0_TXCMD_TXDATA_MASK)
+
+/*! @name TXFR1 - Transmit FIFO Registers */
+#define SPI_TXFR1_TXDATA_MASK                    (0xFFFFU)
+#define SPI_TXFR1_TXDATA_SHIFT                   (0U)
+#define SPI_TXFR1_TXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_TXFR1_TXDATA_SHIFT)) & SPI_TXFR1_TXDATA_MASK)
+#define SPI_TXFR1_TXCMD_TXDATA_MASK              (0xFFFF0000U)
+#define SPI_TXFR1_TXCMD_TXDATA_SHIFT             (16U)
+#define SPI_TXFR1_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x)) << SPI_TXFR1_TXCMD_TXDATA_SHIFT)) & SPI_TXFR1_TXCMD_TXDATA_MASK)
+
+/*! @name TXFR2 - Transmit FIFO Registers */
+#define SPI_TXFR2_TXDATA_MASK                    (0xFFFFU)
+#define SPI_TXFR2_TXDATA_SHIFT                   (0U)
+#define SPI_TXFR2_TXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_TXFR2_TXDATA_SHIFT)) & SPI_TXFR2_TXDATA_MASK)
+#define SPI_TXFR2_TXCMD_TXDATA_MASK              (0xFFFF0000U)
+#define SPI_TXFR2_TXCMD_TXDATA_SHIFT             (16U)
+#define SPI_TXFR2_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x)) << SPI_TXFR2_TXCMD_TXDATA_SHIFT)) & SPI_TXFR2_TXCMD_TXDATA_MASK)
+
+/*! @name TXFR3 - Transmit FIFO Registers */
+#define SPI_TXFR3_TXDATA_MASK                    (0xFFFFU)
+#define SPI_TXFR3_TXDATA_SHIFT                   (0U)
+#define SPI_TXFR3_TXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_TXFR3_TXDATA_SHIFT)) & SPI_TXFR3_TXDATA_MASK)
+#define SPI_TXFR3_TXCMD_TXDATA_MASK              (0xFFFF0000U)
+#define SPI_TXFR3_TXCMD_TXDATA_SHIFT             (16U)
+#define SPI_TXFR3_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x)) << SPI_TXFR3_TXCMD_TXDATA_SHIFT)) & SPI_TXFR3_TXCMD_TXDATA_MASK)
+
+/*! @name RXFR0 - Receive FIFO Registers */
+#define SPI_RXFR0_RXDATA_MASK                    (0xFFFFFFFFU)
+#define SPI_RXFR0_RXDATA_SHIFT                   (0U)
+#define SPI_RXFR0_RXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RXFR0_RXDATA_SHIFT)) & SPI_RXFR0_RXDATA_MASK)
+
+/*! @name RXFR1 - Receive FIFO Registers */
+#define SPI_RXFR1_RXDATA_MASK                    (0xFFFFFFFFU)
+#define SPI_RXFR1_RXDATA_SHIFT                   (0U)
+#define SPI_RXFR1_RXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RXFR1_RXDATA_SHIFT)) & SPI_RXFR1_RXDATA_MASK)
+
+/*! @name RXFR2 - Receive FIFO Registers */
+#define SPI_RXFR2_RXDATA_MASK                    (0xFFFFFFFFU)
+#define SPI_RXFR2_RXDATA_SHIFT                   (0U)
+#define SPI_RXFR2_RXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RXFR2_RXDATA_SHIFT)) & SPI_RXFR2_RXDATA_MASK)
+
+/*! @name RXFR3 - Receive FIFO Registers */
+#define SPI_RXFR3_RXDATA_MASK                    (0xFFFFFFFFU)
+#define SPI_RXFR3_RXDATA_SHIFT                   (0U)
+#define SPI_RXFR3_RXDATA(x)                      (((uint32_t)(((uint32_t)(x)) << SPI_RXFR3_RXDATA_SHIFT)) & SPI_RXFR3_RXDATA_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Masks */
+
+
+/* SPI - Peripheral instance base addresses */
+/** Peripheral SPI0 base address */
+#define SPI0_BASE                                (0x4002C000u)
+/** Peripheral SPI0 base pointer */
+#define SPI0                                     ((SPI_Type *)SPI0_BASE)
+/** Peripheral SPI1 base address */
+#define SPI1_BASE                                (0x4002D000u)
+/** Peripheral SPI1 base pointer */
+#define SPI1                                     ((SPI_Type *)SPI1_BASE)
+/** Peripheral SPI2 base address */
+#define SPI2_BASE                                (0x400AC000u)
+/** Peripheral SPI2 base pointer */
+#define SPI2                                     ((SPI_Type *)SPI2_BASE)
+/** Array initializer of SPI peripheral base addresses */
+#define SPI_BASE_ADDRS                           { SPI0_BASE, SPI1_BASE, SPI2_BASE }
+/** Array initializer of SPI peripheral base pointers */
+#define SPI_BASE_PTRS                            { SPI0, SPI1, SPI2 }
+/** Interrupt vectors for the SPI peripheral type */
+#define SPI_IRQS                                 { SPI0_IRQn, SPI1_IRQn, SPI2_IRQn }
+
+/*!
+ * @}
+ */ /* end of group SPI_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Peripheral_Access_Layer UART Peripheral Access Layer
+ * @{
+ */
+
+/** UART - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t BDH;                                /**< UART Baud Rate Registers: High, offset: 0x0 */
+  __IO uint8_t BDL;                                /**< UART Baud Rate Registers: Low, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< UART Control Register 1, offset: 0x2 */
+  __IO uint8_t C2;                                 /**< UART Control Register 2, offset: 0x3 */
+  __I  uint8_t S1;                                 /**< UART Status Register 1, offset: 0x4 */
+  __IO uint8_t S2;                                 /**< UART Status Register 2, offset: 0x5 */
+  __IO uint8_t C3;                                 /**< UART Control Register 3, offset: 0x6 */
+  __IO uint8_t D;                                  /**< UART Data Register, offset: 0x7 */
+  __IO uint8_t MA1;                                /**< UART Match Address Registers 1, offset: 0x8 */
+  __IO uint8_t MA2;                                /**< UART Match Address Registers 2, offset: 0x9 */
+  __IO uint8_t C4;                                 /**< UART Control Register 4, offset: 0xA */
+  __IO uint8_t C5;                                 /**< UART Control Register 5, offset: 0xB */
+  __I  uint8_t ED;                                 /**< UART Extended Data Register, offset: 0xC */
+  __IO uint8_t MODEM;                              /**< UART Modem Register, offset: 0xD */
+  __IO uint8_t IR;                                 /**< UART Infrared Register, offset: 0xE */
+       uint8_t RESERVED_0[1];
+  __IO uint8_t PFIFO;                              /**< UART FIFO Parameters, offset: 0x10 */
+  __IO uint8_t CFIFO;                              /**< UART FIFO Control Register, offset: 0x11 */
+  __IO uint8_t SFIFO;                              /**< UART FIFO Status Register, offset: 0x12 */
+  __IO uint8_t TWFIFO;                             /**< UART FIFO Transmit Watermark, offset: 0x13 */
+  __I  uint8_t TCFIFO;                             /**< UART FIFO Transmit Count, offset: 0x14 */
+  __IO uint8_t RWFIFO;                             /**< UART FIFO Receive Watermark, offset: 0x15 */
+  __I  uint8_t RCFIFO;                             /**< UART FIFO Receive Count, offset: 0x16 */
+       uint8_t RESERVED_1[1];
+  __IO uint8_t C7816;                              /**< UART 7816 Control Register, offset: 0x18 */
+  __IO uint8_t IE7816;                             /**< UART 7816 Interrupt Enable Register, offset: 0x19 */
+  __IO uint8_t IS7816;                             /**< UART 7816 Interrupt Status Register, offset: 0x1A */
+  union {                                          /* offset: 0x1B */
+    __IO uint8_t WP7816T0;                           /**< UART 7816 Wait Parameter Register, offset: 0x1B */
+    __IO uint8_t WP7816T1;                           /**< UART 7816 Wait Parameter Register, offset: 0x1B */
+  };
+  __IO uint8_t WN7816;                             /**< UART 7816 Wait N Register, offset: 0x1C */
+  __IO uint8_t WF7816;                             /**< UART 7816 Wait FD Register, offset: 0x1D */
+  __IO uint8_t ET7816;                             /**< UART 7816 Error Threshold Register, offset: 0x1E */
+  __IO uint8_t TL7816;                             /**< UART 7816 Transmit Length Register, offset: 0x1F */
+} UART_Type;
+
+/* ----------------------------------------------------------------------------
+   -- UART Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Masks UART Register Masks
+ * @{
+ */
+
+/*! @name BDH - UART Baud Rate Registers: High */
+#define UART_BDH_SBR_MASK                        (0x1FU)
+#define UART_BDH_SBR_SHIFT                       (0U)
+#define UART_BDH_SBR(x)                          (((uint8_t)(((uint8_t)(x)) << UART_BDH_SBR_SHIFT)) & UART_BDH_SBR_MASK)
+#define UART_BDH_SBNS_MASK                       (0x20U)
+#define UART_BDH_SBNS_SHIFT                      (5U)
+#define UART_BDH_SBNS(x)                         (((uint8_t)(((uint8_t)(x)) << UART_BDH_SBNS_SHIFT)) & UART_BDH_SBNS_MASK)
+#define UART_BDH_RXEDGIE_MASK                    (0x40U)
+#define UART_BDH_RXEDGIE_SHIFT                   (6U)
+#define UART_BDH_RXEDGIE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_BDH_RXEDGIE_SHIFT)) & UART_BDH_RXEDGIE_MASK)
+#define UART_BDH_LBKDIE_MASK                     (0x80U)
+#define UART_BDH_LBKDIE_SHIFT                    (7U)
+#define UART_BDH_LBKDIE(x)                       (((uint8_t)(((uint8_t)(x)) << UART_BDH_LBKDIE_SHIFT)) & UART_BDH_LBKDIE_MASK)
+
+/*! @name BDL - UART Baud Rate Registers: Low */
+#define UART_BDL_SBR_MASK                        (0xFFU)
+#define UART_BDL_SBR_SHIFT                       (0U)
+#define UART_BDL_SBR(x)                          (((uint8_t)(((uint8_t)(x)) << UART_BDL_SBR_SHIFT)) & UART_BDL_SBR_MASK)
+
+/*! @name C1 - UART Control Register 1 */
+#define UART_C1_PT_MASK                          (0x1U)
+#define UART_C1_PT_SHIFT                         (0U)
+#define UART_C1_PT(x)                            (((uint8_t)(((uint8_t)(x)) << UART_C1_PT_SHIFT)) & UART_C1_PT_MASK)
+#define UART_C1_PE_MASK                          (0x2U)
+#define UART_C1_PE_SHIFT                         (1U)
+#define UART_C1_PE(x)                            (((uint8_t)(((uint8_t)(x)) << UART_C1_PE_SHIFT)) & UART_C1_PE_MASK)
+#define UART_C1_ILT_MASK                         (0x4U)
+#define UART_C1_ILT_SHIFT                        (2U)
+#define UART_C1_ILT(x)                           (((uint8_t)(((uint8_t)(x)) << UART_C1_ILT_SHIFT)) & UART_C1_ILT_MASK)
+#define UART_C1_WAKE_MASK                        (0x8U)
+#define UART_C1_WAKE_SHIFT                       (3U)
+#define UART_C1_WAKE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C1_WAKE_SHIFT)) & UART_C1_WAKE_MASK)
+#define UART_C1_M_MASK                           (0x10U)
+#define UART_C1_M_SHIFT                          (4U)
+#define UART_C1_M(x)                             (((uint8_t)(((uint8_t)(x)) << UART_C1_M_SHIFT)) & UART_C1_M_MASK)
+#define UART_C1_RSRC_MASK                        (0x20U)
+#define UART_C1_RSRC_SHIFT                       (5U)
+#define UART_C1_RSRC(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C1_RSRC_SHIFT)) & UART_C1_RSRC_MASK)
+#define UART_C1_UARTSWAI_MASK                    (0x40U)
+#define UART_C1_UARTSWAI_SHIFT                   (6U)
+#define UART_C1_UARTSWAI(x)                      (((uint8_t)(((uint8_t)(x)) << UART_C1_UARTSWAI_SHIFT)) & UART_C1_UARTSWAI_MASK)
+#define UART_C1_LOOPS_MASK                       (0x80U)
+#define UART_C1_LOOPS_SHIFT                      (7U)
+#define UART_C1_LOOPS(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C1_LOOPS_SHIFT)) & UART_C1_LOOPS_MASK)
+
+/*! @name C2 - UART Control Register 2 */
+#define UART_C2_SBK_MASK                         (0x1U)
+#define UART_C2_SBK_SHIFT                        (0U)
+#define UART_C2_SBK(x)                           (((uint8_t)(((uint8_t)(x)) << UART_C2_SBK_SHIFT)) & UART_C2_SBK_MASK)
+#define UART_C2_RWU_MASK                         (0x2U)
+#define UART_C2_RWU_SHIFT                        (1U)
+#define UART_C2_RWU(x)                           (((uint8_t)(((uint8_t)(x)) << UART_C2_RWU_SHIFT)) & UART_C2_RWU_MASK)
+#define UART_C2_RE_MASK                          (0x4U)
+#define UART_C2_RE_SHIFT                         (2U)
+#define UART_C2_RE(x)                            (((uint8_t)(((uint8_t)(x)) << UART_C2_RE_SHIFT)) & UART_C2_RE_MASK)
+#define UART_C2_TE_MASK                          (0x8U)
+#define UART_C2_TE_SHIFT                         (3U)
+#define UART_C2_TE(x)                            (((uint8_t)(((uint8_t)(x)) << UART_C2_TE_SHIFT)) & UART_C2_TE_MASK)
+#define UART_C2_ILIE_MASK                        (0x10U)
+#define UART_C2_ILIE_SHIFT                       (4U)
+#define UART_C2_ILIE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C2_ILIE_SHIFT)) & UART_C2_ILIE_MASK)
+#define UART_C2_RIE_MASK                         (0x20U)
+#define UART_C2_RIE_SHIFT                        (5U)
+#define UART_C2_RIE(x)                           (((uint8_t)(((uint8_t)(x)) << UART_C2_RIE_SHIFT)) & UART_C2_RIE_MASK)
+#define UART_C2_TCIE_MASK                        (0x40U)
+#define UART_C2_TCIE_SHIFT                       (6U)
+#define UART_C2_TCIE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C2_TCIE_SHIFT)) & UART_C2_TCIE_MASK)
+#define UART_C2_TIE_MASK                         (0x80U)
+#define UART_C2_TIE_SHIFT                        (7U)
+#define UART_C2_TIE(x)                           (((uint8_t)(((uint8_t)(x)) << UART_C2_TIE_SHIFT)) & UART_C2_TIE_MASK)
+
+/*! @name S1 - UART Status Register 1 */
+#define UART_S1_PF_MASK                          (0x1U)
+#define UART_S1_PF_SHIFT                         (0U)
+#define UART_S1_PF(x)                            (((uint8_t)(((uint8_t)(x)) << UART_S1_PF_SHIFT)) & UART_S1_PF_MASK)
+#define UART_S1_FE_MASK                          (0x2U)
+#define UART_S1_FE_SHIFT                         (1U)
+#define UART_S1_FE(x)                            (((uint8_t)(((uint8_t)(x)) << UART_S1_FE_SHIFT)) & UART_S1_FE_MASK)
+#define UART_S1_NF_MASK                          (0x4U)
+#define UART_S1_NF_SHIFT                         (2U)
+#define UART_S1_NF(x)                            (((uint8_t)(((uint8_t)(x)) << UART_S1_NF_SHIFT)) & UART_S1_NF_MASK)
+#define UART_S1_OR_MASK                          (0x8U)
+#define UART_S1_OR_SHIFT                         (3U)
+#define UART_S1_OR(x)                            (((uint8_t)(((uint8_t)(x)) << UART_S1_OR_SHIFT)) & UART_S1_OR_MASK)
+#define UART_S1_IDLE_MASK                        (0x10U)
+#define UART_S1_IDLE_SHIFT                       (4U)
+#define UART_S1_IDLE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_S1_IDLE_SHIFT)) & UART_S1_IDLE_MASK)
+#define UART_S1_RDRF_MASK                        (0x20U)
+#define UART_S1_RDRF_SHIFT                       (5U)
+#define UART_S1_RDRF(x)                          (((uint8_t)(((uint8_t)(x)) << UART_S1_RDRF_SHIFT)) & UART_S1_RDRF_MASK)
+#define UART_S1_TC_MASK                          (0x40U)
+#define UART_S1_TC_SHIFT                         (6U)
+#define UART_S1_TC(x)                            (((uint8_t)(((uint8_t)(x)) << UART_S1_TC_SHIFT)) & UART_S1_TC_MASK)
+#define UART_S1_TDRE_MASK                        (0x80U)
+#define UART_S1_TDRE_SHIFT                       (7U)
+#define UART_S1_TDRE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_S1_TDRE_SHIFT)) & UART_S1_TDRE_MASK)
+
+/*! @name S2 - UART Status Register 2 */
+#define UART_S2_RAF_MASK                         (0x1U)
+#define UART_S2_RAF_SHIFT                        (0U)
+#define UART_S2_RAF(x)                           (((uint8_t)(((uint8_t)(x)) << UART_S2_RAF_SHIFT)) & UART_S2_RAF_MASK)
+#define UART_S2_LBKDE_MASK                       (0x2U)
+#define UART_S2_LBKDE_SHIFT                      (1U)
+#define UART_S2_LBKDE(x)                         (((uint8_t)(((uint8_t)(x)) << UART_S2_LBKDE_SHIFT)) & UART_S2_LBKDE_MASK)
+#define UART_S2_BRK13_MASK                       (0x4U)
+#define UART_S2_BRK13_SHIFT                      (2U)
+#define UART_S2_BRK13(x)                         (((uint8_t)(((uint8_t)(x)) << UART_S2_BRK13_SHIFT)) & UART_S2_BRK13_MASK)
+#define UART_S2_RWUID_MASK                       (0x8U)
+#define UART_S2_RWUID_SHIFT                      (3U)
+#define UART_S2_RWUID(x)                         (((uint8_t)(((uint8_t)(x)) << UART_S2_RWUID_SHIFT)) & UART_S2_RWUID_MASK)
+#define UART_S2_RXINV_MASK                       (0x10U)
+#define UART_S2_RXINV_SHIFT                      (4U)
+#define UART_S2_RXINV(x)                         (((uint8_t)(((uint8_t)(x)) << UART_S2_RXINV_SHIFT)) & UART_S2_RXINV_MASK)
+#define UART_S2_MSBF_MASK                        (0x20U)
+#define UART_S2_MSBF_SHIFT                       (5U)
+#define UART_S2_MSBF(x)                          (((uint8_t)(((uint8_t)(x)) << UART_S2_MSBF_SHIFT)) & UART_S2_MSBF_MASK)
+#define UART_S2_RXEDGIF_MASK                     (0x40U)
+#define UART_S2_RXEDGIF_SHIFT                    (6U)
+#define UART_S2_RXEDGIF(x)                       (((uint8_t)(((uint8_t)(x)) << UART_S2_RXEDGIF_SHIFT)) & UART_S2_RXEDGIF_MASK)
+#define UART_S2_LBKDIF_MASK                      (0x80U)
+#define UART_S2_LBKDIF_SHIFT                     (7U)
+#define UART_S2_LBKDIF(x)                        (((uint8_t)(((uint8_t)(x)) << UART_S2_LBKDIF_SHIFT)) & UART_S2_LBKDIF_MASK)
+
+/*! @name C3 - UART Control Register 3 */
+#define UART_C3_PEIE_MASK                        (0x1U)
+#define UART_C3_PEIE_SHIFT                       (0U)
+#define UART_C3_PEIE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C3_PEIE_SHIFT)) & UART_C3_PEIE_MASK)
+#define UART_C3_FEIE_MASK                        (0x2U)
+#define UART_C3_FEIE_SHIFT                       (1U)
+#define UART_C3_FEIE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C3_FEIE_SHIFT)) & UART_C3_FEIE_MASK)
+#define UART_C3_NEIE_MASK                        (0x4U)
+#define UART_C3_NEIE_SHIFT                       (2U)
+#define UART_C3_NEIE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C3_NEIE_SHIFT)) & UART_C3_NEIE_MASK)
+#define UART_C3_ORIE_MASK                        (0x8U)
+#define UART_C3_ORIE_SHIFT                       (3U)
+#define UART_C3_ORIE(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C3_ORIE_SHIFT)) & UART_C3_ORIE_MASK)
+#define UART_C3_TXINV_MASK                       (0x10U)
+#define UART_C3_TXINV_SHIFT                      (4U)
+#define UART_C3_TXINV(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C3_TXINV_SHIFT)) & UART_C3_TXINV_MASK)
+#define UART_C3_TXDIR_MASK                       (0x20U)
+#define UART_C3_TXDIR_SHIFT                      (5U)
+#define UART_C3_TXDIR(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C3_TXDIR_SHIFT)) & UART_C3_TXDIR_MASK)
+#define UART_C3_T8_MASK                          (0x40U)
+#define UART_C3_T8_SHIFT                         (6U)
+#define UART_C3_T8(x)                            (((uint8_t)(((uint8_t)(x)) << UART_C3_T8_SHIFT)) & UART_C3_T8_MASK)
+#define UART_C3_R8_MASK                          (0x80U)
+#define UART_C3_R8_SHIFT                         (7U)
+#define UART_C3_R8(x)                            (((uint8_t)(((uint8_t)(x)) << UART_C3_R8_SHIFT)) & UART_C3_R8_MASK)
+
+/*! @name D - UART Data Register */
+#define UART_D_RT_MASK                           (0xFFU)
+#define UART_D_RT_SHIFT                          (0U)
+#define UART_D_RT(x)                             (((uint8_t)(((uint8_t)(x)) << UART_D_RT_SHIFT)) & UART_D_RT_MASK)
+
+/*! @name MA1 - UART Match Address Registers 1 */
+#define UART_MA1_MA_MASK                         (0xFFU)
+#define UART_MA1_MA_SHIFT                        (0U)
+#define UART_MA1_MA(x)                           (((uint8_t)(((uint8_t)(x)) << UART_MA1_MA_SHIFT)) & UART_MA1_MA_MASK)
+
+/*! @name MA2 - UART Match Address Registers 2 */
+#define UART_MA2_MA_MASK                         (0xFFU)
+#define UART_MA2_MA_SHIFT                        (0U)
+#define UART_MA2_MA(x)                           (((uint8_t)(((uint8_t)(x)) << UART_MA2_MA_SHIFT)) & UART_MA2_MA_MASK)
+
+/*! @name C4 - UART Control Register 4 */
+#define UART_C4_BRFA_MASK                        (0x1FU)
+#define UART_C4_BRFA_SHIFT                       (0U)
+#define UART_C4_BRFA(x)                          (((uint8_t)(((uint8_t)(x)) << UART_C4_BRFA_SHIFT)) & UART_C4_BRFA_MASK)
+#define UART_C4_M10_MASK                         (0x20U)
+#define UART_C4_M10_SHIFT                        (5U)
+#define UART_C4_M10(x)                           (((uint8_t)(((uint8_t)(x)) << UART_C4_M10_SHIFT)) & UART_C4_M10_MASK)
+#define UART_C4_MAEN2_MASK                       (0x40U)
+#define UART_C4_MAEN2_SHIFT                      (6U)
+#define UART_C4_MAEN2(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C4_MAEN2_SHIFT)) & UART_C4_MAEN2_MASK)
+#define UART_C4_MAEN1_MASK                       (0x80U)
+#define UART_C4_MAEN1_SHIFT                      (7U)
+#define UART_C4_MAEN1(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C4_MAEN1_SHIFT)) & UART_C4_MAEN1_MASK)
+
+/*! @name C5 - UART Control Register 5 */
+#define UART_C5_LBKDDMAS_MASK                    (0x8U)
+#define UART_C5_LBKDDMAS_SHIFT                   (3U)
+#define UART_C5_LBKDDMAS(x)                      (((uint8_t)(((uint8_t)(x)) << UART_C5_LBKDDMAS_SHIFT)) & UART_C5_LBKDDMAS_MASK)
+#define UART_C5_ILDMAS_MASK                      (0x10U)
+#define UART_C5_ILDMAS_SHIFT                     (4U)
+#define UART_C5_ILDMAS(x)                        (((uint8_t)(((uint8_t)(x)) << UART_C5_ILDMAS_SHIFT)) & UART_C5_ILDMAS_MASK)
+#define UART_C5_RDMAS_MASK                       (0x20U)
+#define UART_C5_RDMAS_SHIFT                      (5U)
+#define UART_C5_RDMAS(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C5_RDMAS_SHIFT)) & UART_C5_RDMAS_MASK)
+#define UART_C5_TCDMAS_MASK                      (0x40U)
+#define UART_C5_TCDMAS_SHIFT                     (6U)
+#define UART_C5_TCDMAS(x)                        (((uint8_t)(((uint8_t)(x)) << UART_C5_TCDMAS_SHIFT)) & UART_C5_TCDMAS_MASK)
+#define UART_C5_TDMAS_MASK                       (0x80U)
+#define UART_C5_TDMAS_SHIFT                      (7U)
+#define UART_C5_TDMAS(x)                         (((uint8_t)(((uint8_t)(x)) << UART_C5_TDMAS_SHIFT)) & UART_C5_TDMAS_MASK)
+
+/*! @name ED - UART Extended Data Register */
+#define UART_ED_PARITYE_MASK                     (0x40U)
+#define UART_ED_PARITYE_SHIFT                    (6U)
+#define UART_ED_PARITYE(x)                       (((uint8_t)(((uint8_t)(x)) << UART_ED_PARITYE_SHIFT)) & UART_ED_PARITYE_MASK)
+#define UART_ED_NOISY_MASK                       (0x80U)
+#define UART_ED_NOISY_SHIFT                      (7U)
+#define UART_ED_NOISY(x)                         (((uint8_t)(((uint8_t)(x)) << UART_ED_NOISY_SHIFT)) & UART_ED_NOISY_MASK)
+
+/*! @name MODEM - UART Modem Register */
+#define UART_MODEM_TXCTSE_MASK                   (0x1U)
+#define UART_MODEM_TXCTSE_SHIFT                  (0U)
+#define UART_MODEM_TXCTSE(x)                     (((uint8_t)(((uint8_t)(x)) << UART_MODEM_TXCTSE_SHIFT)) & UART_MODEM_TXCTSE_MASK)
+#define UART_MODEM_TXRTSE_MASK                   (0x2U)
+#define UART_MODEM_TXRTSE_SHIFT                  (1U)
+#define UART_MODEM_TXRTSE(x)                     (((uint8_t)(((uint8_t)(x)) << UART_MODEM_TXRTSE_SHIFT)) & UART_MODEM_TXRTSE_MASK)
+#define UART_MODEM_TXRTSPOL_MASK                 (0x4U)
+#define UART_MODEM_TXRTSPOL_SHIFT                (2U)
+#define UART_MODEM_TXRTSPOL(x)                   (((uint8_t)(((uint8_t)(x)) << UART_MODEM_TXRTSPOL_SHIFT)) & UART_MODEM_TXRTSPOL_MASK)
+#define UART_MODEM_RXRTSE_MASK                   (0x8U)
+#define UART_MODEM_RXRTSE_SHIFT                  (3U)
+#define UART_MODEM_RXRTSE(x)                     (((uint8_t)(((uint8_t)(x)) << UART_MODEM_RXRTSE_SHIFT)) & UART_MODEM_RXRTSE_MASK)
+
+/*! @name IR - UART Infrared Register */
+#define UART_IR_TNP_MASK                         (0x3U)
+#define UART_IR_TNP_SHIFT                        (0U)
+#define UART_IR_TNP(x)                           (((uint8_t)(((uint8_t)(x)) << UART_IR_TNP_SHIFT)) & UART_IR_TNP_MASK)
+#define UART_IR_IREN_MASK                        (0x4U)
+#define UART_IR_IREN_SHIFT                       (2U)
+#define UART_IR_IREN(x)                          (((uint8_t)(((uint8_t)(x)) << UART_IR_IREN_SHIFT)) & UART_IR_IREN_MASK)
+
+/*! @name PFIFO - UART FIFO Parameters */
+#define UART_PFIFO_RXFIFOSIZE_MASK               (0x7U)
+#define UART_PFIFO_RXFIFOSIZE_SHIFT              (0U)
+#define UART_PFIFO_RXFIFOSIZE(x)                 (((uint8_t)(((uint8_t)(x)) << UART_PFIFO_RXFIFOSIZE_SHIFT)) & UART_PFIFO_RXFIFOSIZE_MASK)
+#define UART_PFIFO_RXFE_MASK                     (0x8U)
+#define UART_PFIFO_RXFE_SHIFT                    (3U)
+#define UART_PFIFO_RXFE(x)                       (((uint8_t)(((uint8_t)(x)) << UART_PFIFO_RXFE_SHIFT)) & UART_PFIFO_RXFE_MASK)
+#define UART_PFIFO_TXFIFOSIZE_MASK               (0x70U)
+#define UART_PFIFO_TXFIFOSIZE_SHIFT              (4U)
+#define UART_PFIFO_TXFIFOSIZE(x)                 (((uint8_t)(((uint8_t)(x)) << UART_PFIFO_TXFIFOSIZE_SHIFT)) & UART_PFIFO_TXFIFOSIZE_MASK)
+#define UART_PFIFO_TXFE_MASK                     (0x80U)
+#define UART_PFIFO_TXFE_SHIFT                    (7U)
+#define UART_PFIFO_TXFE(x)                       (((uint8_t)(((uint8_t)(x)) << UART_PFIFO_TXFE_SHIFT)) & UART_PFIFO_TXFE_MASK)
+
+/*! @name CFIFO - UART FIFO Control Register */
+#define UART_CFIFO_RXUFE_MASK                    (0x1U)
+#define UART_CFIFO_RXUFE_SHIFT                   (0U)
+#define UART_CFIFO_RXUFE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_CFIFO_RXUFE_SHIFT)) & UART_CFIFO_RXUFE_MASK)
+#define UART_CFIFO_TXOFE_MASK                    (0x2U)
+#define UART_CFIFO_TXOFE_SHIFT                   (1U)
+#define UART_CFIFO_TXOFE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_CFIFO_TXOFE_SHIFT)) & UART_CFIFO_TXOFE_MASK)
+#define UART_CFIFO_RXOFE_MASK                    (0x4U)
+#define UART_CFIFO_RXOFE_SHIFT                   (2U)
+#define UART_CFIFO_RXOFE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_CFIFO_RXOFE_SHIFT)) & UART_CFIFO_RXOFE_MASK)
+#define UART_CFIFO_RXFLUSH_MASK                  (0x40U)
+#define UART_CFIFO_RXFLUSH_SHIFT                 (6U)
+#define UART_CFIFO_RXFLUSH(x)                    (((uint8_t)(((uint8_t)(x)) << UART_CFIFO_RXFLUSH_SHIFT)) & UART_CFIFO_RXFLUSH_MASK)
+#define UART_CFIFO_TXFLUSH_MASK                  (0x80U)
+#define UART_CFIFO_TXFLUSH_SHIFT                 (7U)
+#define UART_CFIFO_TXFLUSH(x)                    (((uint8_t)(((uint8_t)(x)) << UART_CFIFO_TXFLUSH_SHIFT)) & UART_CFIFO_TXFLUSH_MASK)
+
+/*! @name SFIFO - UART FIFO Status Register */
+#define UART_SFIFO_RXUF_MASK                     (0x1U)
+#define UART_SFIFO_RXUF_SHIFT                    (0U)
+#define UART_SFIFO_RXUF(x)                       (((uint8_t)(((uint8_t)(x)) << UART_SFIFO_RXUF_SHIFT)) & UART_SFIFO_RXUF_MASK)
+#define UART_SFIFO_TXOF_MASK                     (0x2U)
+#define UART_SFIFO_TXOF_SHIFT                    (1U)
+#define UART_SFIFO_TXOF(x)                       (((uint8_t)(((uint8_t)(x)) << UART_SFIFO_TXOF_SHIFT)) & UART_SFIFO_TXOF_MASK)
+#define UART_SFIFO_RXOF_MASK                     (0x4U)
+#define UART_SFIFO_RXOF_SHIFT                    (2U)
+#define UART_SFIFO_RXOF(x)                       (((uint8_t)(((uint8_t)(x)) << UART_SFIFO_RXOF_SHIFT)) & UART_SFIFO_RXOF_MASK)
+#define UART_SFIFO_RXEMPT_MASK                   (0x40U)
+#define UART_SFIFO_RXEMPT_SHIFT                  (6U)
+#define UART_SFIFO_RXEMPT(x)                     (((uint8_t)(((uint8_t)(x)) << UART_SFIFO_RXEMPT_SHIFT)) & UART_SFIFO_RXEMPT_MASK)
+#define UART_SFIFO_TXEMPT_MASK                   (0x80U)
+#define UART_SFIFO_TXEMPT_SHIFT                  (7U)
+#define UART_SFIFO_TXEMPT(x)                     (((uint8_t)(((uint8_t)(x)) << UART_SFIFO_TXEMPT_SHIFT)) & UART_SFIFO_TXEMPT_MASK)
+
+/*! @name TWFIFO - UART FIFO Transmit Watermark */
+#define UART_TWFIFO_TXWATER_MASK                 (0xFFU)
+#define UART_TWFIFO_TXWATER_SHIFT                (0U)
+#define UART_TWFIFO_TXWATER(x)                   (((uint8_t)(((uint8_t)(x)) << UART_TWFIFO_TXWATER_SHIFT)) & UART_TWFIFO_TXWATER_MASK)
+
+/*! @name TCFIFO - UART FIFO Transmit Count */
+#define UART_TCFIFO_TXCOUNT_MASK                 (0xFFU)
+#define UART_TCFIFO_TXCOUNT_SHIFT                (0U)
+#define UART_TCFIFO_TXCOUNT(x)                   (((uint8_t)(((uint8_t)(x)) << UART_TCFIFO_TXCOUNT_SHIFT)) & UART_TCFIFO_TXCOUNT_MASK)
+
+/*! @name RWFIFO - UART FIFO Receive Watermark */
+#define UART_RWFIFO_RXWATER_MASK                 (0xFFU)
+#define UART_RWFIFO_RXWATER_SHIFT                (0U)
+#define UART_RWFIFO_RXWATER(x)                   (((uint8_t)(((uint8_t)(x)) << UART_RWFIFO_RXWATER_SHIFT)) & UART_RWFIFO_RXWATER_MASK)
+
+/*! @name RCFIFO - UART FIFO Receive Count */
+#define UART_RCFIFO_RXCOUNT_MASK                 (0xFFU)
+#define UART_RCFIFO_RXCOUNT_SHIFT                (0U)
+#define UART_RCFIFO_RXCOUNT(x)                   (((uint8_t)(((uint8_t)(x)) << UART_RCFIFO_RXCOUNT_SHIFT)) & UART_RCFIFO_RXCOUNT_MASK)
+
+/*! @name C7816 - UART 7816 Control Register */
+#define UART_C7816_ISO_7816E_MASK                (0x1U)
+#define UART_C7816_ISO_7816E_SHIFT               (0U)
+#define UART_C7816_ISO_7816E(x)                  (((uint8_t)(((uint8_t)(x)) << UART_C7816_ISO_7816E_SHIFT)) & UART_C7816_ISO_7816E_MASK)
+#define UART_C7816_TTYPE_MASK                    (0x2U)
+#define UART_C7816_TTYPE_SHIFT                   (1U)
+#define UART_C7816_TTYPE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_C7816_TTYPE_SHIFT)) & UART_C7816_TTYPE_MASK)
+#define UART_C7816_INIT_MASK                     (0x4U)
+#define UART_C7816_INIT_SHIFT                    (2U)
+#define UART_C7816_INIT(x)                       (((uint8_t)(((uint8_t)(x)) << UART_C7816_INIT_SHIFT)) & UART_C7816_INIT_MASK)
+#define UART_C7816_ANACK_MASK                    (0x8U)
+#define UART_C7816_ANACK_SHIFT                   (3U)
+#define UART_C7816_ANACK(x)                      (((uint8_t)(((uint8_t)(x)) << UART_C7816_ANACK_SHIFT)) & UART_C7816_ANACK_MASK)
+#define UART_C7816_ONACK_MASK                    (0x10U)
+#define UART_C7816_ONACK_SHIFT                   (4U)
+#define UART_C7816_ONACK(x)                      (((uint8_t)(((uint8_t)(x)) << UART_C7816_ONACK_SHIFT)) & UART_C7816_ONACK_MASK)
+
+/*! @name IE7816 - UART 7816 Interrupt Enable Register */
+#define UART_IE7816_RXTE_MASK                    (0x1U)
+#define UART_IE7816_RXTE_SHIFT                   (0U)
+#define UART_IE7816_RXTE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_IE7816_RXTE_SHIFT)) & UART_IE7816_RXTE_MASK)
+#define UART_IE7816_TXTE_MASK                    (0x2U)
+#define UART_IE7816_TXTE_SHIFT                   (1U)
+#define UART_IE7816_TXTE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_IE7816_TXTE_SHIFT)) & UART_IE7816_TXTE_MASK)
+#define UART_IE7816_GTVE_MASK                    (0x4U)
+#define UART_IE7816_GTVE_SHIFT                   (2U)
+#define UART_IE7816_GTVE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_IE7816_GTVE_SHIFT)) & UART_IE7816_GTVE_MASK)
+#define UART_IE7816_INITDE_MASK                  (0x10U)
+#define UART_IE7816_INITDE_SHIFT                 (4U)
+#define UART_IE7816_INITDE(x)                    (((uint8_t)(((uint8_t)(x)) << UART_IE7816_INITDE_SHIFT)) & UART_IE7816_INITDE_MASK)
+#define UART_IE7816_BWTE_MASK                    (0x20U)
+#define UART_IE7816_BWTE_SHIFT                   (5U)
+#define UART_IE7816_BWTE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_IE7816_BWTE_SHIFT)) & UART_IE7816_BWTE_MASK)
+#define UART_IE7816_CWTE_MASK                    (0x40U)
+#define UART_IE7816_CWTE_SHIFT                   (6U)
+#define UART_IE7816_CWTE(x)                      (((uint8_t)(((uint8_t)(x)) << UART_IE7816_CWTE_SHIFT)) & UART_IE7816_CWTE_MASK)
+#define UART_IE7816_WTE_MASK                     (0x80U)
+#define UART_IE7816_WTE_SHIFT                    (7U)
+#define UART_IE7816_WTE(x)                       (((uint8_t)(((uint8_t)(x)) << UART_IE7816_WTE_SHIFT)) & UART_IE7816_WTE_MASK)
+
+/*! @name IS7816 - UART 7816 Interrupt Status Register */
+#define UART_IS7816_RXT_MASK                     (0x1U)
+#define UART_IS7816_RXT_SHIFT                    (0U)
+#define UART_IS7816_RXT(x)                       (((uint8_t)(((uint8_t)(x)) << UART_IS7816_RXT_SHIFT)) & UART_IS7816_RXT_MASK)
+#define UART_IS7816_TXT_MASK                     (0x2U)
+#define UART_IS7816_TXT_SHIFT                    (1U)
+#define UART_IS7816_TXT(x)                       (((uint8_t)(((uint8_t)(x)) << UART_IS7816_TXT_SHIFT)) & UART_IS7816_TXT_MASK)
+#define UART_IS7816_GTV_MASK                     (0x4U)
+#define UART_IS7816_GTV_SHIFT                    (2U)
+#define UART_IS7816_GTV(x)                       (((uint8_t)(((uint8_t)(x)) << UART_IS7816_GTV_SHIFT)) & UART_IS7816_GTV_MASK)
+#define UART_IS7816_INITD_MASK                   (0x10U)
+#define UART_IS7816_INITD_SHIFT                  (4U)
+#define UART_IS7816_INITD(x)                     (((uint8_t)(((uint8_t)(x)) << UART_IS7816_INITD_SHIFT)) & UART_IS7816_INITD_MASK)
+#define UART_IS7816_BWT_MASK                     (0x20U)
+#define UART_IS7816_BWT_SHIFT                    (5U)
+#define UART_IS7816_BWT(x)                       (((uint8_t)(((uint8_t)(x)) << UART_IS7816_BWT_SHIFT)) & UART_IS7816_BWT_MASK)
+#define UART_IS7816_CWT_MASK                     (0x40U)
+#define UART_IS7816_CWT_SHIFT                    (6U)
+#define UART_IS7816_CWT(x)                       (((uint8_t)(((uint8_t)(x)) << UART_IS7816_CWT_SHIFT)) & UART_IS7816_CWT_MASK)
+#define UART_IS7816_WT_MASK                      (0x80U)
+#define UART_IS7816_WT_SHIFT                     (7U)
+#define UART_IS7816_WT(x)                        (((uint8_t)(((uint8_t)(x)) << UART_IS7816_WT_SHIFT)) & UART_IS7816_WT_MASK)
+
+/*! @name WP7816T0 - UART 7816 Wait Parameter Register */
+#define UART_WP7816T0_WI_MASK                    (0xFFU)
+#define UART_WP7816T0_WI_SHIFT                   (0U)
+#define UART_WP7816T0_WI(x)                      (((uint8_t)(((uint8_t)(x)) << UART_WP7816T0_WI_SHIFT)) & UART_WP7816T0_WI_MASK)
+
+/*! @name WP7816T1 - UART 7816 Wait Parameter Register */
+#define UART_WP7816T1_BWI_MASK                   (0xFU)
+#define UART_WP7816T1_BWI_SHIFT                  (0U)
+#define UART_WP7816T1_BWI(x)                     (((uint8_t)(((uint8_t)(x)) << UART_WP7816T1_BWI_SHIFT)) & UART_WP7816T1_BWI_MASK)
+#define UART_WP7816T1_CWI_MASK                   (0xF0U)
+#define UART_WP7816T1_CWI_SHIFT                  (4U)
+#define UART_WP7816T1_CWI(x)                     (((uint8_t)(((uint8_t)(x)) << UART_WP7816T1_CWI_SHIFT)) & UART_WP7816T1_CWI_MASK)
+
+/*! @name WN7816 - UART 7816 Wait N Register */
+#define UART_WN7816_GTN_MASK                     (0xFFU)
+#define UART_WN7816_GTN_SHIFT                    (0U)
+#define UART_WN7816_GTN(x)                       (((uint8_t)(((uint8_t)(x)) << UART_WN7816_GTN_SHIFT)) & UART_WN7816_GTN_MASK)
+
+/*! @name WF7816 - UART 7816 Wait FD Register */
+#define UART_WF7816_GTFD_MASK                    (0xFFU)
+#define UART_WF7816_GTFD_SHIFT                   (0U)
+#define UART_WF7816_GTFD(x)                      (((uint8_t)(((uint8_t)(x)) << UART_WF7816_GTFD_SHIFT)) & UART_WF7816_GTFD_MASK)
+
+/*! @name ET7816 - UART 7816 Error Threshold Register */
+#define UART_ET7816_RXTHRESHOLD_MASK             (0xFU)
+#define UART_ET7816_RXTHRESHOLD_SHIFT            (0U)
+#define UART_ET7816_RXTHRESHOLD(x)               (((uint8_t)(((uint8_t)(x)) << UART_ET7816_RXTHRESHOLD_SHIFT)) & UART_ET7816_RXTHRESHOLD_MASK)
+#define UART_ET7816_TXTHRESHOLD_MASK             (0xF0U)
+#define UART_ET7816_TXTHRESHOLD_SHIFT            (4U)
+#define UART_ET7816_TXTHRESHOLD(x)               (((uint8_t)(((uint8_t)(x)) << UART_ET7816_TXTHRESHOLD_SHIFT)) & UART_ET7816_TXTHRESHOLD_MASK)
+
+/*! @name TL7816 - UART 7816 Transmit Length Register */
+#define UART_TL7816_TLEN_MASK                    (0xFFU)
+#define UART_TL7816_TLEN_SHIFT                   (0U)
+#define UART_TL7816_TLEN(x)                      (((uint8_t)(((uint8_t)(x)) << UART_TL7816_TLEN_SHIFT)) & UART_TL7816_TLEN_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Masks */
+
+
+/* UART - Peripheral instance base addresses */
+/** Peripheral UART0 base address */
+#define UART0_BASE                               (0x4006A000u)
+/** Peripheral UART0 base pointer */
+#define UART0                                    ((UART_Type *)UART0_BASE)
+/** Peripheral UART1 base address */
+#define UART1_BASE                               (0x4006B000u)
+/** Peripheral UART1 base pointer */
+#define UART1                                    ((UART_Type *)UART1_BASE)
+/** Peripheral UART2 base address */
+#define UART2_BASE                               (0x4006C000u)
+/** Peripheral UART2 base pointer */
+#define UART2                                    ((UART_Type *)UART2_BASE)
+/** Peripheral UART3 base address */
+#define UART3_BASE                               (0x4006D000u)
+/** Peripheral UART3 base pointer */
+#define UART3                                    ((UART_Type *)UART3_BASE)
+/** Peripheral UART4 base address */
+#define UART4_BASE                               (0x400EA000u)
+/** Peripheral UART4 base pointer */
+#define UART4                                    ((UART_Type *)UART4_BASE)
+/** Peripheral UART5 base address */
+#define UART5_BASE                               (0x400EB000u)
+/** Peripheral UART5 base pointer */
+#define UART5                                    ((UART_Type *)UART5_BASE)
+/** Array initializer of UART peripheral base addresses */
+#define UART_BASE_ADDRS                          { UART0_BASE, UART1_BASE, UART2_BASE, UART3_BASE, UART4_BASE, UART5_BASE }
+/** Array initializer of UART peripheral base pointers */
+#define UART_BASE_PTRS                           { UART0, UART1, UART2, UART3, UART4, UART5 }
+/** Interrupt vectors for the UART peripheral type */
+#define UART_RX_TX_IRQS                          { UART0_RX_TX_IRQn, UART1_RX_TX_IRQn, UART2_RX_TX_IRQn, UART3_RX_TX_IRQn, UART4_RX_TX_IRQn, UART5_RX_TX_IRQn }
+#define UART_ERR_IRQS                            { UART0_ERR_IRQn, UART1_ERR_IRQn, UART2_ERR_IRQn, UART3_ERR_IRQn, UART4_ERR_IRQn, UART5_ERR_IRQn }
+#define UART_LON_IRQS                            { UART0_LON_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn }
+
+/*!
+ * @}
+ */ /* end of group UART_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- USB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USB_Peripheral_Access_Layer USB Peripheral Access Layer
+ * @{
+ */
+
+/** USB - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t PERID;                              /**< Peripheral ID register, offset: 0x0 */
+       uint8_t RESERVED_0[3];
+  __I  uint8_t IDCOMP;                             /**< Peripheral ID Complement register, offset: 0x4 */
+       uint8_t RESERVED_1[3];
+  __I  uint8_t REV;                                /**< Peripheral Revision register, offset: 0x8 */
+       uint8_t RESERVED_2[3];
+  __I  uint8_t ADDINFO;                            /**< Peripheral Additional Info register, offset: 0xC */
+       uint8_t RESERVED_3[3];
+  __IO uint8_t OTGISTAT;                           /**< OTG Interrupt Status register, offset: 0x10 */
+       uint8_t RESERVED_4[3];
+  __IO uint8_t OTGICR;                             /**< OTG Interrupt Control register, offset: 0x14 */
+       uint8_t RESERVED_5[3];
+  __IO uint8_t OTGSTAT;                            /**< OTG Status register, offset: 0x18 */
+       uint8_t RESERVED_6[3];
+  __IO uint8_t OTGCTL;                             /**< OTG Control register, offset: 0x1C */
+       uint8_t RESERVED_7[99];
+  __IO uint8_t ISTAT;                              /**< Interrupt Status register, offset: 0x80 */
+       uint8_t RESERVED_8[3];
+  __IO uint8_t INTEN;                              /**< Interrupt Enable register, offset: 0x84 */
+       uint8_t RESERVED_9[3];
+  __IO uint8_t ERRSTAT;                            /**< Error Interrupt Status register, offset: 0x88 */
+       uint8_t RESERVED_10[3];
+  __IO uint8_t ERREN;                              /**< Error Interrupt Enable register, offset: 0x8C */
+       uint8_t RESERVED_11[3];
+  __I  uint8_t STAT;                               /**< Status register, offset: 0x90 */
+       uint8_t RESERVED_12[3];
+  __IO uint8_t CTL;                                /**< Control register, offset: 0x94 */
+       uint8_t RESERVED_13[3];
+  __IO uint8_t ADDR;                               /**< Address register, offset: 0x98 */
+       uint8_t RESERVED_14[3];
+  __IO uint8_t BDTPAGE1;                           /**< BDT Page register 1, offset: 0x9C */
+       uint8_t RESERVED_15[3];
+  __IO uint8_t FRMNUML;                            /**< Frame Number register Low, offset: 0xA0 */
+       uint8_t RESERVED_16[3];
+  __IO uint8_t FRMNUMH;                            /**< Frame Number register High, offset: 0xA4 */
+       uint8_t RESERVED_17[3];
+  __IO uint8_t TOKEN;                              /**< Token register, offset: 0xA8 */
+       uint8_t RESERVED_18[3];
+  __IO uint8_t SOFTHLD;                            /**< SOF Threshold register, offset: 0xAC */
+       uint8_t RESERVED_19[3];
+  __IO uint8_t BDTPAGE2;                           /**< BDT Page Register 2, offset: 0xB0 */
+       uint8_t RESERVED_20[3];
+  __IO uint8_t BDTPAGE3;                           /**< BDT Page Register 3, offset: 0xB4 */
+       uint8_t RESERVED_21[11];
+  struct {                                         /* offset: 0xC0, array step: 0x4 */
+    __IO uint8_t ENDPT;                              /**< Endpoint Control register, array offset: 0xC0, array step: 0x4 */
+         uint8_t RESERVED_0[3];
+  } ENDPOINT[16];
+  __IO uint8_t USBCTRL;                            /**< USB Control register, offset: 0x100 */
+       uint8_t RESERVED_22[3];
+  __I  uint8_t OBSERVE;                            /**< USB OTG Observe register, offset: 0x104 */
+       uint8_t RESERVED_23[3];
+  __IO uint8_t CONTROL;                            /**< USB OTG Control register, offset: 0x108 */
+       uint8_t RESERVED_24[3];
+  __IO uint8_t USBTRC0;                            /**< USB Transceiver Control register 0, offset: 0x10C */
+       uint8_t RESERVED_25[7];
+  __IO uint8_t USBFRMADJUST;                       /**< Frame Adjust Register, offset: 0x114 */
+       uint8_t RESERVED_26[43];
+  __IO uint8_t CLK_RECOVER_CTRL;                   /**< USB Clock recovery control, offset: 0x140 */
+       uint8_t RESERVED_27[3];
+  __IO uint8_t CLK_RECOVER_IRC_EN;                 /**< IRC48M oscillator enable register, offset: 0x144 */
+       uint8_t RESERVED_28[23];
+  __IO uint8_t CLK_RECOVER_INT_STATUS;             /**< Clock recovery separated interrupt status, offset: 0x15C */
+} USB_Type;
+
+/* ----------------------------------------------------------------------------
+   -- USB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USB_Register_Masks USB Register Masks
+ * @{
+ */
+
+/*! @name PERID - Peripheral ID register */
+#define USB_PERID_ID_MASK                        (0x3FU)
+#define USB_PERID_ID_SHIFT                       (0U)
+#define USB_PERID_ID(x)                          (((uint8_t)(((uint8_t)(x)) << USB_PERID_ID_SHIFT)) & USB_PERID_ID_MASK)
+
+/*! @name IDCOMP - Peripheral ID Complement register */
+#define USB_IDCOMP_NID_MASK                      (0x3FU)
+#define USB_IDCOMP_NID_SHIFT                     (0U)
+#define USB_IDCOMP_NID(x)                        (((uint8_t)(((uint8_t)(x)) << USB_IDCOMP_NID_SHIFT)) & USB_IDCOMP_NID_MASK)
+
+/*! @name REV - Peripheral Revision register */
+#define USB_REV_REV_MASK                         (0xFFU)
+#define USB_REV_REV_SHIFT                        (0U)
+#define USB_REV_REV(x)                           (((uint8_t)(((uint8_t)(x)) << USB_REV_REV_SHIFT)) & USB_REV_REV_MASK)
+
+/*! @name ADDINFO - Peripheral Additional Info register */
+#define USB_ADDINFO_IEHOST_MASK                  (0x1U)
+#define USB_ADDINFO_IEHOST_SHIFT                 (0U)
+#define USB_ADDINFO_IEHOST(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ADDINFO_IEHOST_SHIFT)) & USB_ADDINFO_IEHOST_MASK)
+#define USB_ADDINFO_IRQNUM_MASK                  (0xF8U)
+#define USB_ADDINFO_IRQNUM_SHIFT                 (3U)
+#define USB_ADDINFO_IRQNUM(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ADDINFO_IRQNUM_SHIFT)) & USB_ADDINFO_IRQNUM_MASK)
+
+/*! @name OTGISTAT - OTG Interrupt Status register */
+#define USB_OTGISTAT_AVBUSCHG_MASK               (0x1U)
+#define USB_OTGISTAT_AVBUSCHG_SHIFT              (0U)
+#define USB_OTGISTAT_AVBUSCHG(x)                 (((uint8_t)(((uint8_t)(x)) << USB_OTGISTAT_AVBUSCHG_SHIFT)) & USB_OTGISTAT_AVBUSCHG_MASK)
+#define USB_OTGISTAT_B_SESS_CHG_MASK             (0x4U)
+#define USB_OTGISTAT_B_SESS_CHG_SHIFT            (2U)
+#define USB_OTGISTAT_B_SESS_CHG(x)               (((uint8_t)(((uint8_t)(x)) << USB_OTGISTAT_B_SESS_CHG_SHIFT)) & USB_OTGISTAT_B_SESS_CHG_MASK)
+#define USB_OTGISTAT_SESSVLDCHG_MASK             (0x8U)
+#define USB_OTGISTAT_SESSVLDCHG_SHIFT            (3U)
+#define USB_OTGISTAT_SESSVLDCHG(x)               (((uint8_t)(((uint8_t)(x)) << USB_OTGISTAT_SESSVLDCHG_SHIFT)) & USB_OTGISTAT_SESSVLDCHG_MASK)
+#define USB_OTGISTAT_LINE_STATE_CHG_MASK         (0x20U)
+#define USB_OTGISTAT_LINE_STATE_CHG_SHIFT        (5U)
+#define USB_OTGISTAT_LINE_STATE_CHG(x)           (((uint8_t)(((uint8_t)(x)) << USB_OTGISTAT_LINE_STATE_CHG_SHIFT)) & USB_OTGISTAT_LINE_STATE_CHG_MASK)
+#define USB_OTGISTAT_ONEMSEC_MASK                (0x40U)
+#define USB_OTGISTAT_ONEMSEC_SHIFT               (6U)
+#define USB_OTGISTAT_ONEMSEC(x)                  (((uint8_t)(((uint8_t)(x)) << USB_OTGISTAT_ONEMSEC_SHIFT)) & USB_OTGISTAT_ONEMSEC_MASK)
+#define USB_OTGISTAT_IDCHG_MASK                  (0x80U)
+#define USB_OTGISTAT_IDCHG_SHIFT                 (7U)
+#define USB_OTGISTAT_IDCHG(x)                    (((uint8_t)(((uint8_t)(x)) << USB_OTGISTAT_IDCHG_SHIFT)) & USB_OTGISTAT_IDCHG_MASK)
+
+/*! @name OTGICR - OTG Interrupt Control register */
+#define USB_OTGICR_AVBUSEN_MASK                  (0x1U)
+#define USB_OTGICR_AVBUSEN_SHIFT                 (0U)
+#define USB_OTGICR_AVBUSEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_OTGICR_AVBUSEN_SHIFT)) & USB_OTGICR_AVBUSEN_MASK)
+#define USB_OTGICR_BSESSEN_MASK                  (0x4U)
+#define USB_OTGICR_BSESSEN_SHIFT                 (2U)
+#define USB_OTGICR_BSESSEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_OTGICR_BSESSEN_SHIFT)) & USB_OTGICR_BSESSEN_MASK)
+#define USB_OTGICR_SESSVLDEN_MASK                (0x8U)
+#define USB_OTGICR_SESSVLDEN_SHIFT               (3U)
+#define USB_OTGICR_SESSVLDEN(x)                  (((uint8_t)(((uint8_t)(x)) << USB_OTGICR_SESSVLDEN_SHIFT)) & USB_OTGICR_SESSVLDEN_MASK)
+#define USB_OTGICR_LINESTATEEN_MASK              (0x20U)
+#define USB_OTGICR_LINESTATEEN_SHIFT             (5U)
+#define USB_OTGICR_LINESTATEEN(x)                (((uint8_t)(((uint8_t)(x)) << USB_OTGICR_LINESTATEEN_SHIFT)) & USB_OTGICR_LINESTATEEN_MASK)
+#define USB_OTGICR_ONEMSECEN_MASK                (0x40U)
+#define USB_OTGICR_ONEMSECEN_SHIFT               (6U)
+#define USB_OTGICR_ONEMSECEN(x)                  (((uint8_t)(((uint8_t)(x)) << USB_OTGICR_ONEMSECEN_SHIFT)) & USB_OTGICR_ONEMSECEN_MASK)
+#define USB_OTGICR_IDEN_MASK                     (0x80U)
+#define USB_OTGICR_IDEN_SHIFT                    (7U)
+#define USB_OTGICR_IDEN(x)                       (((uint8_t)(((uint8_t)(x)) << USB_OTGICR_IDEN_SHIFT)) & USB_OTGICR_IDEN_MASK)
+
+/*! @name OTGSTAT - OTG Status register */
+#define USB_OTGSTAT_AVBUSVLD_MASK                (0x1U)
+#define USB_OTGSTAT_AVBUSVLD_SHIFT               (0U)
+#define USB_OTGSTAT_AVBUSVLD(x)                  (((uint8_t)(((uint8_t)(x)) << USB_OTGSTAT_AVBUSVLD_SHIFT)) & USB_OTGSTAT_AVBUSVLD_MASK)
+#define USB_OTGSTAT_BSESSEND_MASK                (0x4U)
+#define USB_OTGSTAT_BSESSEND_SHIFT               (2U)
+#define USB_OTGSTAT_BSESSEND(x)                  (((uint8_t)(((uint8_t)(x)) << USB_OTGSTAT_BSESSEND_SHIFT)) & USB_OTGSTAT_BSESSEND_MASK)
+#define USB_OTGSTAT_SESS_VLD_MASK                (0x8U)
+#define USB_OTGSTAT_SESS_VLD_SHIFT               (3U)
+#define USB_OTGSTAT_SESS_VLD(x)                  (((uint8_t)(((uint8_t)(x)) << USB_OTGSTAT_SESS_VLD_SHIFT)) & USB_OTGSTAT_SESS_VLD_MASK)
+#define USB_OTGSTAT_LINESTATESTABLE_MASK         (0x20U)
+#define USB_OTGSTAT_LINESTATESTABLE_SHIFT        (5U)
+#define USB_OTGSTAT_LINESTATESTABLE(x)           (((uint8_t)(((uint8_t)(x)) << USB_OTGSTAT_LINESTATESTABLE_SHIFT)) & USB_OTGSTAT_LINESTATESTABLE_MASK)
+#define USB_OTGSTAT_ONEMSECEN_MASK               (0x40U)
+#define USB_OTGSTAT_ONEMSECEN_SHIFT              (6U)
+#define USB_OTGSTAT_ONEMSECEN(x)                 (((uint8_t)(((uint8_t)(x)) << USB_OTGSTAT_ONEMSECEN_SHIFT)) & USB_OTGSTAT_ONEMSECEN_MASK)
+#define USB_OTGSTAT_ID_MASK                      (0x80U)
+#define USB_OTGSTAT_ID_SHIFT                     (7U)
+#define USB_OTGSTAT_ID(x)                        (((uint8_t)(((uint8_t)(x)) << USB_OTGSTAT_ID_SHIFT)) & USB_OTGSTAT_ID_MASK)
+
+/*! @name OTGCTL - OTG Control register */
+#define USB_OTGCTL_OTGEN_MASK                    (0x4U)
+#define USB_OTGCTL_OTGEN_SHIFT                   (2U)
+#define USB_OTGCTL_OTGEN(x)                      (((uint8_t)(((uint8_t)(x)) << USB_OTGCTL_OTGEN_SHIFT)) & USB_OTGCTL_OTGEN_MASK)
+#define USB_OTGCTL_DMLOW_MASK                    (0x10U)
+#define USB_OTGCTL_DMLOW_SHIFT                   (4U)
+#define USB_OTGCTL_DMLOW(x)                      (((uint8_t)(((uint8_t)(x)) << USB_OTGCTL_DMLOW_SHIFT)) & USB_OTGCTL_DMLOW_MASK)
+#define USB_OTGCTL_DPLOW_MASK                    (0x20U)
+#define USB_OTGCTL_DPLOW_SHIFT                   (5U)
+#define USB_OTGCTL_DPLOW(x)                      (((uint8_t)(((uint8_t)(x)) << USB_OTGCTL_DPLOW_SHIFT)) & USB_OTGCTL_DPLOW_MASK)
+#define USB_OTGCTL_DPHIGH_MASK                   (0x80U)
+#define USB_OTGCTL_DPHIGH_SHIFT                  (7U)
+#define USB_OTGCTL_DPHIGH(x)                     (((uint8_t)(((uint8_t)(x)) << USB_OTGCTL_DPHIGH_SHIFT)) & USB_OTGCTL_DPHIGH_MASK)
+
+/*! @name ISTAT - Interrupt Status register */
+#define USB_ISTAT_USBRST_MASK                    (0x1U)
+#define USB_ISTAT_USBRST_SHIFT                   (0U)
+#define USB_ISTAT_USBRST(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_USBRST_SHIFT)) & USB_ISTAT_USBRST_MASK)
+#define USB_ISTAT_ERROR_MASK                     (0x2U)
+#define USB_ISTAT_ERROR_SHIFT                    (1U)
+#define USB_ISTAT_ERROR(x)                       (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_ERROR_SHIFT)) & USB_ISTAT_ERROR_MASK)
+#define USB_ISTAT_SOFTOK_MASK                    (0x4U)
+#define USB_ISTAT_SOFTOK_SHIFT                   (2U)
+#define USB_ISTAT_SOFTOK(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_SOFTOK_SHIFT)) & USB_ISTAT_SOFTOK_MASK)
+#define USB_ISTAT_TOKDNE_MASK                    (0x8U)
+#define USB_ISTAT_TOKDNE_SHIFT                   (3U)
+#define USB_ISTAT_TOKDNE(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_TOKDNE_SHIFT)) & USB_ISTAT_TOKDNE_MASK)
+#define USB_ISTAT_SLEEP_MASK                     (0x10U)
+#define USB_ISTAT_SLEEP_SHIFT                    (4U)
+#define USB_ISTAT_SLEEP(x)                       (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_SLEEP_SHIFT)) & USB_ISTAT_SLEEP_MASK)
+#define USB_ISTAT_RESUME_MASK                    (0x20U)
+#define USB_ISTAT_RESUME_SHIFT                   (5U)
+#define USB_ISTAT_RESUME(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_RESUME_SHIFT)) & USB_ISTAT_RESUME_MASK)
+#define USB_ISTAT_ATTACH_MASK                    (0x40U)
+#define USB_ISTAT_ATTACH_SHIFT                   (6U)
+#define USB_ISTAT_ATTACH(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_ATTACH_SHIFT)) & USB_ISTAT_ATTACH_MASK)
+#define USB_ISTAT_STALL_MASK                     (0x80U)
+#define USB_ISTAT_STALL_SHIFT                    (7U)
+#define USB_ISTAT_STALL(x)                       (((uint8_t)(((uint8_t)(x)) << USB_ISTAT_STALL_SHIFT)) & USB_ISTAT_STALL_MASK)
+
+/*! @name INTEN - Interrupt Enable register */
+#define USB_INTEN_USBRSTEN_MASK                  (0x1U)
+#define USB_INTEN_USBRSTEN_SHIFT                 (0U)
+#define USB_INTEN_USBRSTEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_INTEN_USBRSTEN_SHIFT)) & USB_INTEN_USBRSTEN_MASK)
+#define USB_INTEN_ERROREN_MASK                   (0x2U)
+#define USB_INTEN_ERROREN_SHIFT                  (1U)
+#define USB_INTEN_ERROREN(x)                     (((uint8_t)(((uint8_t)(x)) << USB_INTEN_ERROREN_SHIFT)) & USB_INTEN_ERROREN_MASK)
+#define USB_INTEN_SOFTOKEN_MASK                  (0x4U)
+#define USB_INTEN_SOFTOKEN_SHIFT                 (2U)
+#define USB_INTEN_SOFTOKEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_INTEN_SOFTOKEN_SHIFT)) & USB_INTEN_SOFTOKEN_MASK)
+#define USB_INTEN_TOKDNEEN_MASK                  (0x8U)
+#define USB_INTEN_TOKDNEEN_SHIFT                 (3U)
+#define USB_INTEN_TOKDNEEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_INTEN_TOKDNEEN_SHIFT)) & USB_INTEN_TOKDNEEN_MASK)
+#define USB_INTEN_SLEEPEN_MASK                   (0x10U)
+#define USB_INTEN_SLEEPEN_SHIFT                  (4U)
+#define USB_INTEN_SLEEPEN(x)                     (((uint8_t)(((uint8_t)(x)) << USB_INTEN_SLEEPEN_SHIFT)) & USB_INTEN_SLEEPEN_MASK)
+#define USB_INTEN_RESUMEEN_MASK                  (0x20U)
+#define USB_INTEN_RESUMEEN_SHIFT                 (5U)
+#define USB_INTEN_RESUMEEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_INTEN_RESUMEEN_SHIFT)) & USB_INTEN_RESUMEEN_MASK)
+#define USB_INTEN_ATTACHEN_MASK                  (0x40U)
+#define USB_INTEN_ATTACHEN_SHIFT                 (6U)
+#define USB_INTEN_ATTACHEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_INTEN_ATTACHEN_SHIFT)) & USB_INTEN_ATTACHEN_MASK)
+#define USB_INTEN_STALLEN_MASK                   (0x80U)
+#define USB_INTEN_STALLEN_SHIFT                  (7U)
+#define USB_INTEN_STALLEN(x)                     (((uint8_t)(((uint8_t)(x)) << USB_INTEN_STALLEN_SHIFT)) & USB_INTEN_STALLEN_MASK)
+
+/*! @name ERRSTAT - Error Interrupt Status register */
+#define USB_ERRSTAT_PIDERR_MASK                  (0x1U)
+#define USB_ERRSTAT_PIDERR_SHIFT                 (0U)
+#define USB_ERRSTAT_PIDERR(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_PIDERR_SHIFT)) & USB_ERRSTAT_PIDERR_MASK)
+#define USB_ERRSTAT_CRC5EOF_MASK                 (0x2U)
+#define USB_ERRSTAT_CRC5EOF_SHIFT                (1U)
+#define USB_ERRSTAT_CRC5EOF(x)                   (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_CRC5EOF_SHIFT)) & USB_ERRSTAT_CRC5EOF_MASK)
+#define USB_ERRSTAT_CRC16_MASK                   (0x4U)
+#define USB_ERRSTAT_CRC16_SHIFT                  (2U)
+#define USB_ERRSTAT_CRC16(x)                     (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_CRC16_SHIFT)) & USB_ERRSTAT_CRC16_MASK)
+#define USB_ERRSTAT_DFN8_MASK                    (0x8U)
+#define USB_ERRSTAT_DFN8_SHIFT                   (3U)
+#define USB_ERRSTAT_DFN8(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_DFN8_SHIFT)) & USB_ERRSTAT_DFN8_MASK)
+#define USB_ERRSTAT_BTOERR_MASK                  (0x10U)
+#define USB_ERRSTAT_BTOERR_SHIFT                 (4U)
+#define USB_ERRSTAT_BTOERR(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_BTOERR_SHIFT)) & USB_ERRSTAT_BTOERR_MASK)
+#define USB_ERRSTAT_DMAERR_MASK                  (0x20U)
+#define USB_ERRSTAT_DMAERR_SHIFT                 (5U)
+#define USB_ERRSTAT_DMAERR(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_DMAERR_SHIFT)) & USB_ERRSTAT_DMAERR_MASK)
+#define USB_ERRSTAT_BTSERR_MASK                  (0x80U)
+#define USB_ERRSTAT_BTSERR_SHIFT                 (7U)
+#define USB_ERRSTAT_BTSERR(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERRSTAT_BTSERR_SHIFT)) & USB_ERRSTAT_BTSERR_MASK)
+
+/*! @name ERREN - Error Interrupt Enable register */
+#define USB_ERREN_PIDERREN_MASK                  (0x1U)
+#define USB_ERREN_PIDERREN_SHIFT                 (0U)
+#define USB_ERREN_PIDERREN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERREN_PIDERREN_SHIFT)) & USB_ERREN_PIDERREN_MASK)
+#define USB_ERREN_CRC5EOFEN_MASK                 (0x2U)
+#define USB_ERREN_CRC5EOFEN_SHIFT                (1U)
+#define USB_ERREN_CRC5EOFEN(x)                   (((uint8_t)(((uint8_t)(x)) << USB_ERREN_CRC5EOFEN_SHIFT)) & USB_ERREN_CRC5EOFEN_MASK)
+#define USB_ERREN_CRC16EN_MASK                   (0x4U)
+#define USB_ERREN_CRC16EN_SHIFT                  (2U)
+#define USB_ERREN_CRC16EN(x)                     (((uint8_t)(((uint8_t)(x)) << USB_ERREN_CRC16EN_SHIFT)) & USB_ERREN_CRC16EN_MASK)
+#define USB_ERREN_DFN8EN_MASK                    (0x8U)
+#define USB_ERREN_DFN8EN_SHIFT                   (3U)
+#define USB_ERREN_DFN8EN(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ERREN_DFN8EN_SHIFT)) & USB_ERREN_DFN8EN_MASK)
+#define USB_ERREN_BTOERREN_MASK                  (0x10U)
+#define USB_ERREN_BTOERREN_SHIFT                 (4U)
+#define USB_ERREN_BTOERREN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERREN_BTOERREN_SHIFT)) & USB_ERREN_BTOERREN_MASK)
+#define USB_ERREN_DMAERREN_MASK                  (0x20U)
+#define USB_ERREN_DMAERREN_SHIFT                 (5U)
+#define USB_ERREN_DMAERREN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERREN_DMAERREN_SHIFT)) & USB_ERREN_DMAERREN_MASK)
+#define USB_ERREN_BTSERREN_MASK                  (0x80U)
+#define USB_ERREN_BTSERREN_SHIFT                 (7U)
+#define USB_ERREN_BTSERREN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ERREN_BTSERREN_SHIFT)) & USB_ERREN_BTSERREN_MASK)
+
+/*! @name STAT - Status register */
+#define USB_STAT_ODD_MASK                        (0x4U)
+#define USB_STAT_ODD_SHIFT                       (2U)
+#define USB_STAT_ODD(x)                          (((uint8_t)(((uint8_t)(x)) << USB_STAT_ODD_SHIFT)) & USB_STAT_ODD_MASK)
+#define USB_STAT_TX_MASK                         (0x8U)
+#define USB_STAT_TX_SHIFT                        (3U)
+#define USB_STAT_TX(x)                           (((uint8_t)(((uint8_t)(x)) << USB_STAT_TX_SHIFT)) & USB_STAT_TX_MASK)
+#define USB_STAT_ENDP_MASK                       (0xF0U)
+#define USB_STAT_ENDP_SHIFT                      (4U)
+#define USB_STAT_ENDP(x)                         (((uint8_t)(((uint8_t)(x)) << USB_STAT_ENDP_SHIFT)) & USB_STAT_ENDP_MASK)
+
+/*! @name CTL - Control register */
+#define USB_CTL_USBENSOFEN_MASK                  (0x1U)
+#define USB_CTL_USBENSOFEN_SHIFT                 (0U)
+#define USB_CTL_USBENSOFEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_CTL_USBENSOFEN_SHIFT)) & USB_CTL_USBENSOFEN_MASK)
+#define USB_CTL_ODDRST_MASK                      (0x2U)
+#define USB_CTL_ODDRST_SHIFT                     (1U)
+#define USB_CTL_ODDRST(x)                        (((uint8_t)(((uint8_t)(x)) << USB_CTL_ODDRST_SHIFT)) & USB_CTL_ODDRST_MASK)
+#define USB_CTL_RESUME_MASK                      (0x4U)
+#define USB_CTL_RESUME_SHIFT                     (2U)
+#define USB_CTL_RESUME(x)                        (((uint8_t)(((uint8_t)(x)) << USB_CTL_RESUME_SHIFT)) & USB_CTL_RESUME_MASK)
+#define USB_CTL_HOSTMODEEN_MASK                  (0x8U)
+#define USB_CTL_HOSTMODEEN_SHIFT                 (3U)
+#define USB_CTL_HOSTMODEEN(x)                    (((uint8_t)(((uint8_t)(x)) << USB_CTL_HOSTMODEEN_SHIFT)) & USB_CTL_HOSTMODEEN_MASK)
+#define USB_CTL_RESET_MASK                       (0x10U)
+#define USB_CTL_RESET_SHIFT                      (4U)
+#define USB_CTL_RESET(x)                         (((uint8_t)(((uint8_t)(x)) << USB_CTL_RESET_SHIFT)) & USB_CTL_RESET_MASK)
+#define USB_CTL_TXSUSPENDTOKENBUSY_MASK          (0x20U)
+#define USB_CTL_TXSUSPENDTOKENBUSY_SHIFT         (5U)
+#define USB_CTL_TXSUSPENDTOKENBUSY(x)            (((uint8_t)(((uint8_t)(x)) << USB_CTL_TXSUSPENDTOKENBUSY_SHIFT)) & USB_CTL_TXSUSPENDTOKENBUSY_MASK)
+#define USB_CTL_SE0_MASK                         (0x40U)
+#define USB_CTL_SE0_SHIFT                        (6U)
+#define USB_CTL_SE0(x)                           (((uint8_t)(((uint8_t)(x)) << USB_CTL_SE0_SHIFT)) & USB_CTL_SE0_MASK)
+#define USB_CTL_JSTATE_MASK                      (0x80U)
+#define USB_CTL_JSTATE_SHIFT                     (7U)
+#define USB_CTL_JSTATE(x)                        (((uint8_t)(((uint8_t)(x)) << USB_CTL_JSTATE_SHIFT)) & USB_CTL_JSTATE_MASK)
+
+/*! @name ADDR - Address register */
+#define USB_ADDR_ADDR_MASK                       (0x7FU)
+#define USB_ADDR_ADDR_SHIFT                      (0U)
+#define USB_ADDR_ADDR(x)                         (((uint8_t)(((uint8_t)(x)) << USB_ADDR_ADDR_SHIFT)) & USB_ADDR_ADDR_MASK)
+#define USB_ADDR_LSEN_MASK                       (0x80U)
+#define USB_ADDR_LSEN_SHIFT                      (7U)
+#define USB_ADDR_LSEN(x)                         (((uint8_t)(((uint8_t)(x)) << USB_ADDR_LSEN_SHIFT)) & USB_ADDR_LSEN_MASK)
+
+/*! @name BDTPAGE1 - BDT Page register 1 */
+#define USB_BDTPAGE1_BDTBA_MASK                  (0xFEU)
+#define USB_BDTPAGE1_BDTBA_SHIFT                 (1U)
+#define USB_BDTPAGE1_BDTBA(x)                    (((uint8_t)(((uint8_t)(x)) << USB_BDTPAGE1_BDTBA_SHIFT)) & USB_BDTPAGE1_BDTBA_MASK)
+
+/*! @name FRMNUML - Frame Number register Low */
+#define USB_FRMNUML_FRM_MASK                     (0xFFU)
+#define USB_FRMNUML_FRM_SHIFT                    (0U)
+#define USB_FRMNUML_FRM(x)                       (((uint8_t)(((uint8_t)(x)) << USB_FRMNUML_FRM_SHIFT)) & USB_FRMNUML_FRM_MASK)
+
+/*! @name FRMNUMH - Frame Number register High */
+#define USB_FRMNUMH_FRM_MASK                     (0x7U)
+#define USB_FRMNUMH_FRM_SHIFT                    (0U)
+#define USB_FRMNUMH_FRM(x)                       (((uint8_t)(((uint8_t)(x)) << USB_FRMNUMH_FRM_SHIFT)) & USB_FRMNUMH_FRM_MASK)
+
+/*! @name TOKEN - Token register */
+#define USB_TOKEN_TOKENENDPT_MASK                (0xFU)
+#define USB_TOKEN_TOKENENDPT_SHIFT               (0U)
+#define USB_TOKEN_TOKENENDPT(x)                  (((uint8_t)(((uint8_t)(x)) << USB_TOKEN_TOKENENDPT_SHIFT)) & USB_TOKEN_TOKENENDPT_MASK)
+#define USB_TOKEN_TOKENPID_MASK                  (0xF0U)
+#define USB_TOKEN_TOKENPID_SHIFT                 (4U)
+#define USB_TOKEN_TOKENPID(x)                    (((uint8_t)(((uint8_t)(x)) << USB_TOKEN_TOKENPID_SHIFT)) & USB_TOKEN_TOKENPID_MASK)
+
+/*! @name SOFTHLD - SOF Threshold register */
+#define USB_SOFTHLD_CNT_MASK                     (0xFFU)
+#define USB_SOFTHLD_CNT_SHIFT                    (0U)
+#define USB_SOFTHLD_CNT(x)                       (((uint8_t)(((uint8_t)(x)) << USB_SOFTHLD_CNT_SHIFT)) & USB_SOFTHLD_CNT_MASK)
+
+/*! @name BDTPAGE2 - BDT Page Register 2 */
+#define USB_BDTPAGE2_BDTBA_MASK                  (0xFFU)
+#define USB_BDTPAGE2_BDTBA_SHIFT                 (0U)
+#define USB_BDTPAGE2_BDTBA(x)                    (((uint8_t)(((uint8_t)(x)) << USB_BDTPAGE2_BDTBA_SHIFT)) & USB_BDTPAGE2_BDTBA_MASK)
+
+/*! @name BDTPAGE3 - BDT Page Register 3 */
+#define USB_BDTPAGE3_BDTBA_MASK                  (0xFFU)
+#define USB_BDTPAGE3_BDTBA_SHIFT                 (0U)
+#define USB_BDTPAGE3_BDTBA(x)                    (((uint8_t)(((uint8_t)(x)) << USB_BDTPAGE3_BDTBA_SHIFT)) & USB_BDTPAGE3_BDTBA_MASK)
+
+/*! @name ENDPT - Endpoint Control register */
+#define USB_ENDPT_EPHSHK_MASK                    (0x1U)
+#define USB_ENDPT_EPHSHK_SHIFT                   (0U)
+#define USB_ENDPT_EPHSHK(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_EPHSHK_SHIFT)) & USB_ENDPT_EPHSHK_MASK)
+#define USB_ENDPT_EPSTALL_MASK                   (0x2U)
+#define USB_ENDPT_EPSTALL_SHIFT                  (1U)
+#define USB_ENDPT_EPSTALL(x)                     (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_EPSTALL_SHIFT)) & USB_ENDPT_EPSTALL_MASK)
+#define USB_ENDPT_EPTXEN_MASK                    (0x4U)
+#define USB_ENDPT_EPTXEN_SHIFT                   (2U)
+#define USB_ENDPT_EPTXEN(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_EPTXEN_SHIFT)) & USB_ENDPT_EPTXEN_MASK)
+#define USB_ENDPT_EPRXEN_MASK                    (0x8U)
+#define USB_ENDPT_EPRXEN_SHIFT                   (3U)
+#define USB_ENDPT_EPRXEN(x)                      (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_EPRXEN_SHIFT)) & USB_ENDPT_EPRXEN_MASK)
+#define USB_ENDPT_EPCTLDIS_MASK                  (0x10U)
+#define USB_ENDPT_EPCTLDIS_SHIFT                 (4U)
+#define USB_ENDPT_EPCTLDIS(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_EPCTLDIS_SHIFT)) & USB_ENDPT_EPCTLDIS_MASK)
+#define USB_ENDPT_RETRYDIS_MASK                  (0x40U)
+#define USB_ENDPT_RETRYDIS_SHIFT                 (6U)
+#define USB_ENDPT_RETRYDIS(x)                    (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_RETRYDIS_SHIFT)) & USB_ENDPT_RETRYDIS_MASK)
+#define USB_ENDPT_HOSTWOHUB_MASK                 (0x80U)
+#define USB_ENDPT_HOSTWOHUB_SHIFT                (7U)
+#define USB_ENDPT_HOSTWOHUB(x)                   (((uint8_t)(((uint8_t)(x)) << USB_ENDPT_HOSTWOHUB_SHIFT)) & USB_ENDPT_HOSTWOHUB_MASK)
+
+/* The count of USB_ENDPT */
+#define USB_ENDPT_COUNT                          (16U)
+
+/*! @name USBCTRL - USB Control register */
+#define USB_USBCTRL_PDE_MASK                     (0x40U)
+#define USB_USBCTRL_PDE_SHIFT                    (6U)
+#define USB_USBCTRL_PDE(x)                       (((uint8_t)(((uint8_t)(x)) << USB_USBCTRL_PDE_SHIFT)) & USB_USBCTRL_PDE_MASK)
+#define USB_USBCTRL_SUSP_MASK                    (0x80U)
+#define USB_USBCTRL_SUSP_SHIFT                   (7U)
+#define USB_USBCTRL_SUSP(x)                      (((uint8_t)(((uint8_t)(x)) << USB_USBCTRL_SUSP_SHIFT)) & USB_USBCTRL_SUSP_MASK)
+
+/*! @name OBSERVE - USB OTG Observe register */
+#define USB_OBSERVE_DMPD_MASK                    (0x10U)
+#define USB_OBSERVE_DMPD_SHIFT                   (4U)
+#define USB_OBSERVE_DMPD(x)                      (((uint8_t)(((uint8_t)(x)) << USB_OBSERVE_DMPD_SHIFT)) & USB_OBSERVE_DMPD_MASK)
+#define USB_OBSERVE_DPPD_MASK                    (0x40U)
+#define USB_OBSERVE_DPPD_SHIFT                   (6U)
+#define USB_OBSERVE_DPPD(x)                      (((uint8_t)(((uint8_t)(x)) << USB_OBSERVE_DPPD_SHIFT)) & USB_OBSERVE_DPPD_MASK)
+#define USB_OBSERVE_DPPU_MASK                    (0x80U)
+#define USB_OBSERVE_DPPU_SHIFT                   (7U)
+#define USB_OBSERVE_DPPU(x)                      (((uint8_t)(((uint8_t)(x)) << USB_OBSERVE_DPPU_SHIFT)) & USB_OBSERVE_DPPU_MASK)
+
+/*! @name CONTROL - USB OTG Control register */
+#define USB_CONTROL_DPPULLUPNONOTG_MASK          (0x10U)
+#define USB_CONTROL_DPPULLUPNONOTG_SHIFT         (4U)
+#define USB_CONTROL_DPPULLUPNONOTG(x)            (((uint8_t)(((uint8_t)(x)) << USB_CONTROL_DPPULLUPNONOTG_SHIFT)) & USB_CONTROL_DPPULLUPNONOTG_MASK)
+
+/*! @name USBTRC0 - USB Transceiver Control register 0 */
+#define USB_USBTRC0_USB_RESUME_INT_MASK          (0x1U)
+#define USB_USBTRC0_USB_RESUME_INT_SHIFT         (0U)
+#define USB_USBTRC0_USB_RESUME_INT(x)            (((uint8_t)(((uint8_t)(x)) << USB_USBTRC0_USB_RESUME_INT_SHIFT)) & USB_USBTRC0_USB_RESUME_INT_MASK)
+#define USB_USBTRC0_SYNC_DET_MASK                (0x2U)
+#define USB_USBTRC0_SYNC_DET_SHIFT               (1U)
+#define USB_USBTRC0_SYNC_DET(x)                  (((uint8_t)(((uint8_t)(x)) << USB_USBTRC0_SYNC_DET_SHIFT)) & USB_USBTRC0_SYNC_DET_MASK)
+#define USB_USBTRC0_USB_CLK_RECOVERY_INT_MASK    (0x4U)
+#define USB_USBTRC0_USB_CLK_RECOVERY_INT_SHIFT   (2U)
+#define USB_USBTRC0_USB_CLK_RECOVERY_INT(x)      (((uint8_t)(((uint8_t)(x)) << USB_USBTRC0_USB_CLK_RECOVERY_INT_SHIFT)) & USB_USBTRC0_USB_CLK_RECOVERY_INT_MASK)
+#define USB_USBTRC0_USBRESMEN_MASK               (0x20U)
+#define USB_USBTRC0_USBRESMEN_SHIFT              (5U)
+#define USB_USBTRC0_USBRESMEN(x)                 (((uint8_t)(((uint8_t)(x)) << USB_USBTRC0_USBRESMEN_SHIFT)) & USB_USBTRC0_USBRESMEN_MASK)
+#define USB_USBTRC0_USBRESET_MASK                (0x80U)
+#define USB_USBTRC0_USBRESET_SHIFT               (7U)
+#define USB_USBTRC0_USBRESET(x)                  (((uint8_t)(((uint8_t)(x)) << USB_USBTRC0_USBRESET_SHIFT)) & USB_USBTRC0_USBRESET_MASK)
+
+/*! @name USBFRMADJUST - Frame Adjust Register */
+#define USB_USBFRMADJUST_ADJ_MASK                (0xFFU)
+#define USB_USBFRMADJUST_ADJ_SHIFT               (0U)
+#define USB_USBFRMADJUST_ADJ(x)                  (((uint8_t)(((uint8_t)(x)) << USB_USBFRMADJUST_ADJ_SHIFT)) & USB_USBFRMADJUST_ADJ_MASK)
+
+/*! @name CLK_RECOVER_CTRL - USB Clock recovery control */
+#define USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN_MASK (0x20U)
+#define USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN_SHIFT (5U)
+#define USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN(x) (((uint8_t)(((uint8_t)(x)) << USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN_SHIFT)) & USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN_MASK)
+#define USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN_MASK (0x40U)
+#define USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN_SHIFT (6U)
+#define USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN(x) (((uint8_t)(((uint8_t)(x)) << USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN_SHIFT)) & USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN_MASK)
+#define USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_MASK (0x80U)
+#define USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_SHIFT (7U)
+#define USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN(x) (((uint8_t)(((uint8_t)(x)) << USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_SHIFT)) & USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_MASK)
+
+/*! @name CLK_RECOVER_IRC_EN - IRC48M oscillator enable register */
+#define USB_CLK_RECOVER_IRC_EN_REG_EN_MASK       (0x1U)
+#define USB_CLK_RECOVER_IRC_EN_REG_EN_SHIFT      (0U)
+#define USB_CLK_RECOVER_IRC_EN_REG_EN(x)         (((uint8_t)(((uint8_t)(x)) << USB_CLK_RECOVER_IRC_EN_REG_EN_SHIFT)) & USB_CLK_RECOVER_IRC_EN_REG_EN_MASK)
+#define USB_CLK_RECOVER_IRC_EN_IRC_EN_MASK       (0x2U)
+#define USB_CLK_RECOVER_IRC_EN_IRC_EN_SHIFT      (1U)
+#define USB_CLK_RECOVER_IRC_EN_IRC_EN(x)         (((uint8_t)(((uint8_t)(x)) << USB_CLK_RECOVER_IRC_EN_IRC_EN_SHIFT)) & USB_CLK_RECOVER_IRC_EN_IRC_EN_MASK)
+
+/*! @name CLK_RECOVER_INT_STATUS - Clock recovery separated interrupt status */
+#define USB_CLK_RECOVER_INT_STATUS_OVF_ERROR_MASK (0x10U)
+#define USB_CLK_RECOVER_INT_STATUS_OVF_ERROR_SHIFT (4U)
+#define USB_CLK_RECOVER_INT_STATUS_OVF_ERROR(x)  (((uint8_t)(((uint8_t)(x)) << USB_CLK_RECOVER_INT_STATUS_OVF_ERROR_SHIFT)) & USB_CLK_RECOVER_INT_STATUS_OVF_ERROR_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group USB_Register_Masks */
+
+
+/* USB - Peripheral instance base addresses */
+/** Peripheral USB0 base address */
+#define USB0_BASE                                (0x40072000u)
+/** Peripheral USB0 base pointer */
+#define USB0                                     ((USB_Type *)USB0_BASE)
+/** Array initializer of USB peripheral base addresses */
+#define USB_BASE_ADDRS                           { USB0_BASE }
+/** Array initializer of USB peripheral base pointers */
+#define USB_BASE_PTRS                            { USB0 }
+/** Interrupt vectors for the USB peripheral type */
+#define USB_IRQS                                 { USB0_IRQn }
+
+/*!
+ * @}
+ */ /* end of group USB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- USBDCD Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USBDCD_Peripheral_Access_Layer USBDCD Peripheral Access Layer
+ * @{
+ */
+
+/** USBDCD - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CONTROL;                           /**< Control register, offset: 0x0 */
+  __IO uint32_t CLOCK;                             /**< Clock register, offset: 0x4 */
+  __I  uint32_t STATUS;                            /**< Status register, offset: 0x8 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t TIMER0;                            /**< TIMER0 register, offset: 0x10 */
+  __IO uint32_t TIMER1;                            /**< TIMER1 register, offset: 0x14 */
+  union {                                          /* offset: 0x18 */
+    __IO uint32_t TIMER2_BC11;                       /**< TIMER2_BC11 register, offset: 0x18 */
+    __IO uint32_t TIMER2_BC12;                       /**< TIMER2_BC12 register, offset: 0x18 */
+  };
+} USBDCD_Type;
+
+/* ----------------------------------------------------------------------------
+   -- USBDCD Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USBDCD_Register_Masks USBDCD Register Masks
+ * @{
+ */
+
+/*! @name CONTROL - Control register */
+#define USBDCD_CONTROL_IACK_MASK                 (0x1U)
+#define USBDCD_CONTROL_IACK_SHIFT                (0U)
+#define USBDCD_CONTROL_IACK(x)                   (((uint32_t)(((uint32_t)(x)) << USBDCD_CONTROL_IACK_SHIFT)) & USBDCD_CONTROL_IACK_MASK)
+#define USBDCD_CONTROL_IF_MASK                   (0x100U)
+#define USBDCD_CONTROL_IF_SHIFT                  (8U)
+#define USBDCD_CONTROL_IF(x)                     (((uint32_t)(((uint32_t)(x)) << USBDCD_CONTROL_IF_SHIFT)) & USBDCD_CONTROL_IF_MASK)
+#define USBDCD_CONTROL_IE_MASK                   (0x10000U)
+#define USBDCD_CONTROL_IE_SHIFT                  (16U)
+#define USBDCD_CONTROL_IE(x)                     (((uint32_t)(((uint32_t)(x)) << USBDCD_CONTROL_IE_SHIFT)) & USBDCD_CONTROL_IE_MASK)
+#define USBDCD_CONTROL_BC12_MASK                 (0x20000U)
+#define USBDCD_CONTROL_BC12_SHIFT                (17U)
+#define USBDCD_CONTROL_BC12(x)                   (((uint32_t)(((uint32_t)(x)) << USBDCD_CONTROL_BC12_SHIFT)) & USBDCD_CONTROL_BC12_MASK)
+#define USBDCD_CONTROL_START_MASK                (0x1000000U)
+#define USBDCD_CONTROL_START_SHIFT               (24U)
+#define USBDCD_CONTROL_START(x)                  (((uint32_t)(((uint32_t)(x)) << USBDCD_CONTROL_START_SHIFT)) & USBDCD_CONTROL_START_MASK)
+#define USBDCD_CONTROL_SR_MASK                   (0x2000000U)
+#define USBDCD_CONTROL_SR_SHIFT                  (25U)
+#define USBDCD_CONTROL_SR(x)                     (((uint32_t)(((uint32_t)(x)) << USBDCD_CONTROL_SR_SHIFT)) & USBDCD_CONTROL_SR_MASK)
+
+/*! @name CLOCK - Clock register */
+#define USBDCD_CLOCK_CLOCK_UNIT_MASK             (0x1U)
+#define USBDCD_CLOCK_CLOCK_UNIT_SHIFT            (0U)
+#define USBDCD_CLOCK_CLOCK_UNIT(x)               (((uint32_t)(((uint32_t)(x)) << USBDCD_CLOCK_CLOCK_UNIT_SHIFT)) & USBDCD_CLOCK_CLOCK_UNIT_MASK)
+#define USBDCD_CLOCK_CLOCK_SPEED_MASK            (0xFFCU)
+#define USBDCD_CLOCK_CLOCK_SPEED_SHIFT           (2U)
+#define USBDCD_CLOCK_CLOCK_SPEED(x)              (((uint32_t)(((uint32_t)(x)) << USBDCD_CLOCK_CLOCK_SPEED_SHIFT)) & USBDCD_CLOCK_CLOCK_SPEED_MASK)
+
+/*! @name STATUS - Status register */
+#define USBDCD_STATUS_SEQ_RES_MASK               (0x30000U)
+#define USBDCD_STATUS_SEQ_RES_SHIFT              (16U)
+#define USBDCD_STATUS_SEQ_RES(x)                 (((uint32_t)(((uint32_t)(x)) << USBDCD_STATUS_SEQ_RES_SHIFT)) & USBDCD_STATUS_SEQ_RES_MASK)
+#define USBDCD_STATUS_SEQ_STAT_MASK              (0xC0000U)
+#define USBDCD_STATUS_SEQ_STAT_SHIFT             (18U)
+#define USBDCD_STATUS_SEQ_STAT(x)                (((uint32_t)(((uint32_t)(x)) << USBDCD_STATUS_SEQ_STAT_SHIFT)) & USBDCD_STATUS_SEQ_STAT_MASK)
+#define USBDCD_STATUS_ERR_MASK                   (0x100000U)
+#define USBDCD_STATUS_ERR_SHIFT                  (20U)
+#define USBDCD_STATUS_ERR(x)                     (((uint32_t)(((uint32_t)(x)) << USBDCD_STATUS_ERR_SHIFT)) & USBDCD_STATUS_ERR_MASK)
+#define USBDCD_STATUS_TO_MASK                    (0x200000U)
+#define USBDCD_STATUS_TO_SHIFT                   (21U)
+#define USBDCD_STATUS_TO(x)                      (((uint32_t)(((uint32_t)(x)) << USBDCD_STATUS_TO_SHIFT)) & USBDCD_STATUS_TO_MASK)
+#define USBDCD_STATUS_ACTIVE_MASK                (0x400000U)
+#define USBDCD_STATUS_ACTIVE_SHIFT               (22U)
+#define USBDCD_STATUS_ACTIVE(x)                  (((uint32_t)(((uint32_t)(x)) << USBDCD_STATUS_ACTIVE_SHIFT)) & USBDCD_STATUS_ACTIVE_MASK)
+
+/*! @name TIMER0 - TIMER0 register */
+#define USBDCD_TIMER0_TUNITCON_MASK              (0xFFFU)
+#define USBDCD_TIMER0_TUNITCON_SHIFT             (0U)
+#define USBDCD_TIMER0_TUNITCON(x)                (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER0_TUNITCON_SHIFT)) & USBDCD_TIMER0_TUNITCON_MASK)
+#define USBDCD_TIMER0_TSEQ_INIT_MASK             (0x3FF0000U)
+#define USBDCD_TIMER0_TSEQ_INIT_SHIFT            (16U)
+#define USBDCD_TIMER0_TSEQ_INIT(x)               (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER0_TSEQ_INIT_SHIFT)) & USBDCD_TIMER0_TSEQ_INIT_MASK)
+
+/*! @name TIMER1 - TIMER1 register */
+#define USBDCD_TIMER1_TVDPSRC_ON_MASK            (0x3FFU)
+#define USBDCD_TIMER1_TVDPSRC_ON_SHIFT           (0U)
+#define USBDCD_TIMER1_TVDPSRC_ON(x)              (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER1_TVDPSRC_ON_SHIFT)) & USBDCD_TIMER1_TVDPSRC_ON_MASK)
+#define USBDCD_TIMER1_TDCD_DBNC_MASK             (0x3FF0000U)
+#define USBDCD_TIMER1_TDCD_DBNC_SHIFT            (16U)
+#define USBDCD_TIMER1_TDCD_DBNC(x)               (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER1_TDCD_DBNC_SHIFT)) & USBDCD_TIMER1_TDCD_DBNC_MASK)
+
+/*! @name TIMER2_BC11 - TIMER2_BC11 register */
+#define USBDCD_TIMER2_BC11_CHECK_DM_MASK         (0xFU)
+#define USBDCD_TIMER2_BC11_CHECK_DM_SHIFT        (0U)
+#define USBDCD_TIMER2_BC11_CHECK_DM(x)           (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER2_BC11_CHECK_DM_SHIFT)) & USBDCD_TIMER2_BC11_CHECK_DM_MASK)
+#define USBDCD_TIMER2_BC11_TVDPSRC_CON_MASK      (0x3FF0000U)
+#define USBDCD_TIMER2_BC11_TVDPSRC_CON_SHIFT     (16U)
+#define USBDCD_TIMER2_BC11_TVDPSRC_CON(x)        (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER2_BC11_TVDPSRC_CON_SHIFT)) & USBDCD_TIMER2_BC11_TVDPSRC_CON_MASK)
+
+/*! @name TIMER2_BC12 - TIMER2_BC12 register */
+#define USBDCD_TIMER2_BC12_TVDMSRC_ON_MASK       (0x3FFU)
+#define USBDCD_TIMER2_BC12_TVDMSRC_ON_SHIFT      (0U)
+#define USBDCD_TIMER2_BC12_TVDMSRC_ON(x)         (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER2_BC12_TVDMSRC_ON_SHIFT)) & USBDCD_TIMER2_BC12_TVDMSRC_ON_MASK)
+#define USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_MASK  (0x3FF0000U)
+#define USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_SHIFT (16U)
+#define USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD(x)    (((uint32_t)(((uint32_t)(x)) << USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_SHIFT)) & USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group USBDCD_Register_Masks */
+
+
+/* USBDCD - Peripheral instance base addresses */
+/** Peripheral USBDCD base address */
+#define USBDCD_BASE                              (0x40035000u)
+/** Peripheral USBDCD base pointer */
+#define USBDCD                                   ((USBDCD_Type *)USBDCD_BASE)
+/** Array initializer of USBDCD peripheral base addresses */
+#define USBDCD_BASE_ADDRS                        { USBDCD_BASE }
+/** Array initializer of USBDCD peripheral base pointers */
+#define USBDCD_BASE_PTRS                         { USBDCD }
+/** Interrupt vectors for the USBDCD peripheral type */
+#define USBDCD_IRQS                              { USBDCD_IRQn }
+
+/*!
+ * @}
+ */ /* end of group USBDCD_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- VREF Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup VREF_Peripheral_Access_Layer VREF Peripheral Access Layer
+ * @{
+ */
+
+/** VREF - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t TRM;                                /**< VREF Trim Register, offset: 0x0 */
+  __IO uint8_t SC;                                 /**< VREF Status and Control Register, offset: 0x1 */
+} VREF_Type;
+
+/* ----------------------------------------------------------------------------
+   -- VREF Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup VREF_Register_Masks VREF Register Masks
+ * @{
+ */
+
+/*! @name TRM - VREF Trim Register */
+#define VREF_TRM_TRIM_MASK                       (0x3FU)
+#define VREF_TRM_TRIM_SHIFT                      (0U)
+#define VREF_TRM_TRIM(x)                         (((uint8_t)(((uint8_t)(x)) << VREF_TRM_TRIM_SHIFT)) & VREF_TRM_TRIM_MASK)
+#define VREF_TRM_CHOPEN_MASK                     (0x40U)
+#define VREF_TRM_CHOPEN_SHIFT                    (6U)
+#define VREF_TRM_CHOPEN(x)                       (((uint8_t)(((uint8_t)(x)) << VREF_TRM_CHOPEN_SHIFT)) & VREF_TRM_CHOPEN_MASK)
+
+/*! @name SC - VREF Status and Control Register */
+#define VREF_SC_MODE_LV_MASK                     (0x3U)
+#define VREF_SC_MODE_LV_SHIFT                    (0U)
+#define VREF_SC_MODE_LV(x)                       (((uint8_t)(((uint8_t)(x)) << VREF_SC_MODE_LV_SHIFT)) & VREF_SC_MODE_LV_MASK)
+#define VREF_SC_VREFST_MASK                      (0x4U)
+#define VREF_SC_VREFST_SHIFT                     (2U)
+#define VREF_SC_VREFST(x)                        (((uint8_t)(((uint8_t)(x)) << VREF_SC_VREFST_SHIFT)) & VREF_SC_VREFST_MASK)
+#define VREF_SC_ICOMPEN_MASK                     (0x20U)
+#define VREF_SC_ICOMPEN_SHIFT                    (5U)
+#define VREF_SC_ICOMPEN(x)                       (((uint8_t)(((uint8_t)(x)) << VREF_SC_ICOMPEN_SHIFT)) & VREF_SC_ICOMPEN_MASK)
+#define VREF_SC_REGEN_MASK                       (0x40U)
+#define VREF_SC_REGEN_SHIFT                      (6U)
+#define VREF_SC_REGEN(x)                         (((uint8_t)(((uint8_t)(x)) << VREF_SC_REGEN_SHIFT)) & VREF_SC_REGEN_MASK)
+#define VREF_SC_VREFEN_MASK                      (0x80U)
+#define VREF_SC_VREFEN_SHIFT                     (7U)
+#define VREF_SC_VREFEN(x)                        (((uint8_t)(((uint8_t)(x)) << VREF_SC_VREFEN_SHIFT)) & VREF_SC_VREFEN_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group VREF_Register_Masks */
+
+
+/* VREF - Peripheral instance base addresses */
+/** Peripheral VREF base address */
+#define VREF_BASE                                (0x40074000u)
+/** Peripheral VREF base pointer */
+#define VREF                                     ((VREF_Type *)VREF_BASE)
+/** Array initializer of VREF peripheral base addresses */
+#define VREF_BASE_ADDRS                          { VREF_BASE }
+/** Array initializer of VREF peripheral base pointers */
+#define VREF_BASE_PTRS                           { VREF }
+
+/*!
+ * @}
+ */ /* end of group VREF_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- WDOG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Peripheral_Access_Layer WDOG Peripheral Access Layer
+ * @{
+ */
+
+/** WDOG - Register Layout Typedef */
+typedef struct {
+  __IO uint16_t STCTRLH;                           /**< Watchdog Status and Control Register High, offset: 0x0 */
+  __IO uint16_t STCTRLL;                           /**< Watchdog Status and Control Register Low, offset: 0x2 */
+  __IO uint16_t TOVALH;                            /**< Watchdog Time-out Value Register High, offset: 0x4 */
+  __IO uint16_t TOVALL;                            /**< Watchdog Time-out Value Register Low, offset: 0x6 */
+  __IO uint16_t WINH;                              /**< Watchdog Window Register High, offset: 0x8 */
+  __IO uint16_t WINL;                              /**< Watchdog Window Register Low, offset: 0xA */
+  __IO uint16_t REFRESH;                           /**< Watchdog Refresh register, offset: 0xC */
+  __IO uint16_t UNLOCK;                            /**< Watchdog Unlock register, offset: 0xE */
+  __IO uint16_t TMROUTH;                           /**< Watchdog Timer Output Register High, offset: 0x10 */
+  __IO uint16_t TMROUTL;                           /**< Watchdog Timer Output Register Low, offset: 0x12 */
+  __IO uint16_t RSTCNT;                            /**< Watchdog Reset Count register, offset: 0x14 */
+  __IO uint16_t PRESC;                             /**< Watchdog Prescaler register, offset: 0x16 */
+} WDOG_Type;
+
+/* ----------------------------------------------------------------------------
+   -- WDOG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Register_Masks WDOG Register Masks
+ * @{
+ */
+
+/*! @name STCTRLH - Watchdog Status and Control Register High */
+#define WDOG_STCTRLH_WDOGEN_MASK                 (0x1U)
+#define WDOG_STCTRLH_WDOGEN_SHIFT                (0U)
+#define WDOG_STCTRLH_WDOGEN(x)                   (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_WDOGEN_SHIFT)) & WDOG_STCTRLH_WDOGEN_MASK)
+#define WDOG_STCTRLH_CLKSRC_MASK                 (0x2U)
+#define WDOG_STCTRLH_CLKSRC_SHIFT                (1U)
+#define WDOG_STCTRLH_CLKSRC(x)                   (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_CLKSRC_SHIFT)) & WDOG_STCTRLH_CLKSRC_MASK)
+#define WDOG_STCTRLH_IRQRSTEN_MASK               (0x4U)
+#define WDOG_STCTRLH_IRQRSTEN_SHIFT              (2U)
+#define WDOG_STCTRLH_IRQRSTEN(x)                 (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_IRQRSTEN_SHIFT)) & WDOG_STCTRLH_IRQRSTEN_MASK)
+#define WDOG_STCTRLH_WINEN_MASK                  (0x8U)
+#define WDOG_STCTRLH_WINEN_SHIFT                 (3U)
+#define WDOG_STCTRLH_WINEN(x)                    (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_WINEN_SHIFT)) & WDOG_STCTRLH_WINEN_MASK)
+#define WDOG_STCTRLH_ALLOWUPDATE_MASK            (0x10U)
+#define WDOG_STCTRLH_ALLOWUPDATE_SHIFT           (4U)
+#define WDOG_STCTRLH_ALLOWUPDATE(x)              (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_ALLOWUPDATE_SHIFT)) & WDOG_STCTRLH_ALLOWUPDATE_MASK)
+#define WDOG_STCTRLH_DBGEN_MASK                  (0x20U)
+#define WDOG_STCTRLH_DBGEN_SHIFT                 (5U)
+#define WDOG_STCTRLH_DBGEN(x)                    (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_DBGEN_SHIFT)) & WDOG_STCTRLH_DBGEN_MASK)
+#define WDOG_STCTRLH_STOPEN_MASK                 (0x40U)
+#define WDOG_STCTRLH_STOPEN_SHIFT                (6U)
+#define WDOG_STCTRLH_STOPEN(x)                   (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_STOPEN_SHIFT)) & WDOG_STCTRLH_STOPEN_MASK)
+#define WDOG_STCTRLH_WAITEN_MASK                 (0x80U)
+#define WDOG_STCTRLH_WAITEN_SHIFT                (7U)
+#define WDOG_STCTRLH_WAITEN(x)                   (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_WAITEN_SHIFT)) & WDOG_STCTRLH_WAITEN_MASK)
+#define WDOG_STCTRLH_TESTWDOG_MASK               (0x400U)
+#define WDOG_STCTRLH_TESTWDOG_SHIFT              (10U)
+#define WDOG_STCTRLH_TESTWDOG(x)                 (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_TESTWDOG_SHIFT)) & WDOG_STCTRLH_TESTWDOG_MASK)
+#define WDOG_STCTRLH_TESTSEL_MASK                (0x800U)
+#define WDOG_STCTRLH_TESTSEL_SHIFT               (11U)
+#define WDOG_STCTRLH_TESTSEL(x)                  (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_TESTSEL_SHIFT)) & WDOG_STCTRLH_TESTSEL_MASK)
+#define WDOG_STCTRLH_BYTESEL_MASK                (0x3000U)
+#define WDOG_STCTRLH_BYTESEL_SHIFT               (12U)
+#define WDOG_STCTRLH_BYTESEL(x)                  (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_BYTESEL_SHIFT)) & WDOG_STCTRLH_BYTESEL_MASK)
+#define WDOG_STCTRLH_DISTESTWDOG_MASK            (0x4000U)
+#define WDOG_STCTRLH_DISTESTWDOG_SHIFT           (14U)
+#define WDOG_STCTRLH_DISTESTWDOG(x)              (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLH_DISTESTWDOG_SHIFT)) & WDOG_STCTRLH_DISTESTWDOG_MASK)
+
+/*! @name STCTRLL - Watchdog Status and Control Register Low */
+#define WDOG_STCTRLL_INTFLG_MASK                 (0x8000U)
+#define WDOG_STCTRLL_INTFLG_SHIFT                (15U)
+#define WDOG_STCTRLL_INTFLG(x)                   (((uint16_t)(((uint16_t)(x)) << WDOG_STCTRLL_INTFLG_SHIFT)) & WDOG_STCTRLL_INTFLG_MASK)
+
+/*! @name TOVALH - Watchdog Time-out Value Register High */
+#define WDOG_TOVALH_TOVALHIGH_MASK               (0xFFFFU)
+#define WDOG_TOVALH_TOVALHIGH_SHIFT              (0U)
+#define WDOG_TOVALH_TOVALHIGH(x)                 (((uint16_t)(((uint16_t)(x)) << WDOG_TOVALH_TOVALHIGH_SHIFT)) & WDOG_TOVALH_TOVALHIGH_MASK)
+
+/*! @name TOVALL - Watchdog Time-out Value Register Low */
+#define WDOG_TOVALL_TOVALLOW_MASK                (0xFFFFU)
+#define WDOG_TOVALL_TOVALLOW_SHIFT               (0U)
+#define WDOG_TOVALL_TOVALLOW(x)                  (((uint16_t)(((uint16_t)(x)) << WDOG_TOVALL_TOVALLOW_SHIFT)) & WDOG_TOVALL_TOVALLOW_MASK)
+
+/*! @name WINH - Watchdog Window Register High */
+#define WDOG_WINH_WINHIGH_MASK                   (0xFFFFU)
+#define WDOG_WINH_WINHIGH_SHIFT                  (0U)
+#define WDOG_WINH_WINHIGH(x)                     (((uint16_t)(((uint16_t)(x)) << WDOG_WINH_WINHIGH_SHIFT)) & WDOG_WINH_WINHIGH_MASK)
+
+/*! @name WINL - Watchdog Window Register Low */
+#define WDOG_WINL_WINLOW_MASK                    (0xFFFFU)
+#define WDOG_WINL_WINLOW_SHIFT                   (0U)
+#define WDOG_WINL_WINLOW(x)                      (((uint16_t)(((uint16_t)(x)) << WDOG_WINL_WINLOW_SHIFT)) & WDOG_WINL_WINLOW_MASK)
+
+/*! @name REFRESH - Watchdog Refresh register */
+#define WDOG_REFRESH_WDOGREFRESH_MASK            (0xFFFFU)
+#define WDOG_REFRESH_WDOGREFRESH_SHIFT           (0U)
+#define WDOG_REFRESH_WDOGREFRESH(x)              (((uint16_t)(((uint16_t)(x)) << WDOG_REFRESH_WDOGREFRESH_SHIFT)) & WDOG_REFRESH_WDOGREFRESH_MASK)
+
+/*! @name UNLOCK - Watchdog Unlock register */
+#define WDOG_UNLOCK_WDOGUNLOCK_MASK              (0xFFFFU)
+#define WDOG_UNLOCK_WDOGUNLOCK_SHIFT             (0U)
+#define WDOG_UNLOCK_WDOGUNLOCK(x)                (((uint16_t)(((uint16_t)(x)) << WDOG_UNLOCK_WDOGUNLOCK_SHIFT)) & WDOG_UNLOCK_WDOGUNLOCK_MASK)
+
+/*! @name TMROUTH - Watchdog Timer Output Register High */
+#define WDOG_TMROUTH_TIMEROUTHIGH_MASK           (0xFFFFU)
+#define WDOG_TMROUTH_TIMEROUTHIGH_SHIFT          (0U)
+#define WDOG_TMROUTH_TIMEROUTHIGH(x)             (((uint16_t)(((uint16_t)(x)) << WDOG_TMROUTH_TIMEROUTHIGH_SHIFT)) & WDOG_TMROUTH_TIMEROUTHIGH_MASK)
+
+/*! @name TMROUTL - Watchdog Timer Output Register Low */
+#define WDOG_TMROUTL_TIMEROUTLOW_MASK            (0xFFFFU)
+#define WDOG_TMROUTL_TIMEROUTLOW_SHIFT           (0U)
+#define WDOG_TMROUTL_TIMEROUTLOW(x)              (((uint16_t)(((uint16_t)(x)) << WDOG_TMROUTL_TIMEROUTLOW_SHIFT)) & WDOG_TMROUTL_TIMEROUTLOW_MASK)
+
+/*! @name RSTCNT - Watchdog Reset Count register */
+#define WDOG_RSTCNT_RSTCNT_MASK                  (0xFFFFU)
+#define WDOG_RSTCNT_RSTCNT_SHIFT                 (0U)
+#define WDOG_RSTCNT_RSTCNT(x)                    (((uint16_t)(((uint16_t)(x)) << WDOG_RSTCNT_RSTCNT_SHIFT)) & WDOG_RSTCNT_RSTCNT_MASK)
+
+/*! @name PRESC - Watchdog Prescaler register */
+#define WDOG_PRESC_PRESCVAL_MASK                 (0x700U)
+#define WDOG_PRESC_PRESCVAL_SHIFT                (8U)
+#define WDOG_PRESC_PRESCVAL(x)                   (((uint16_t)(((uint16_t)(x)) << WDOG_PRESC_PRESCVAL_SHIFT)) & WDOG_PRESC_PRESCVAL_MASK)
+
+
+/*!
+ * @}
+ */ /* end of group WDOG_Register_Masks */
+
+
+/* WDOG - Peripheral instance base addresses */
+/** Peripheral WDOG base address */
+#define WDOG_BASE                                (0x40052000u)
+/** Peripheral WDOG base pointer */
+#define WDOG                                     ((WDOG_Type *)WDOG_BASE)
+/** Array initializer of WDOG peripheral base addresses */
+#define WDOG_BASE_ADDRS                          { WDOG_BASE }
+/** Array initializer of WDOG peripheral base pointers */
+#define WDOG_BASE_PTRS                           { WDOG }
+/** Interrupt vectors for the WDOG peripheral type */
+#define WDOG_IRQS                                { WDOG_EWM_IRQn }
+
+/*!
+ * @}
+ */ /* end of group WDOG_Peripheral_Access_Layer */
+
+
+/*
+** End of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma pop
+#elif defined(__CWCC__)
+  #pragma pop
+#elif defined(__GNUC__)
+  /* leave anonymous unions enabled */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=default
+#else
+  #error Not supported compiler type
+#endif
+
+/*!
+ * @}
+ */ /* end of group Peripheral_access_layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SDK Compatibility
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDK_Compatibility_Symbols SDK Compatibility
+ * @{
+ */
+
+#define ENET_RMON_R_DROP_REG(base)               ENET_IEEE_R_DROP_REG(base)
+#define ENET_RMON_R_FRAME_OK_REG(base)           ENET_IEEE_R_FRAME_OK_REG(base)
+#define MCG_C2_EREFS0_MASK                       MCG_C2_EREFS_MASK
+#define MCG_C2_EREFS0_SHIFT                      MCG_C2_EREFS_SHIFT
+#define MCG_C2_HGO0_MASK                         MCG_C2_HGO_MASK
+#define MCG_C2_HGO0_SHIFT                        MCG_C2_HGO_SHIFT
+#define MCG_C2_RANGE0_MASK                       MCG_C2_RANGE_MASK
+#define MCG_C2_RANGE0_SHIFT                      MCG_C2_RANGE_SHIFT
+#define MCG_C2_RANGE0(x)                         MCG_C2_RANGE(x)
+#define MCM_ISR_REG(base)                        MCM_ISCR_REG(base)
+#define MCM_ISR_FIOC_MASK                        MCM_ISCR_FIOC_MASK
+#define MCM_ISR_FIOC_SHIFT                       MCM_ISCR_FIOC_SHIFT
+#define MCM_ISR_FDZC_MASK                        MCM_ISCR_FDZC_MASK
+#define MCM_ISR_FDZC_SHIFT                       MCM_ISCR_FDZC_SHIFT
+#define MCM_ISR_FOFC_MASK                        MCM_ISCR_FOFC_MASK
+#define MCM_ISR_FOFC_SHIFT                       MCM_ISCR_FOFC_SHIFT
+#define MCM_ISR_FUFC_MASK                        MCM_ISCR_FUFC_MASK
+#define MCM_ISR_FUFC_SHIFT                       MCM_ISCR_FUFC_SHIFT
+#define MCM_ISR_FIXC_MASK                        MCM_ISCR_FIXC_MASK
+#define MCM_ISR_FIXC_SHIFT                       MCM_ISCR_FIXC_SHIFT
+#define MCM_ISR_FIDC_MASK                        MCM_ISCR_FIDC_MASK
+#define MCM_ISR_FIDC_SHIFT                       MCM_ISCR_FIDC_SHIFT
+#define MCM_ISR_FIOCE_MASK                       MCM_ISCR_FIOCE_MASK
+#define MCM_ISR_FIOCE_SHIFT                      MCM_ISCR_FIOCE_SHIFT
+#define MCM_ISR_FDZCE_MASK                       MCM_ISCR_FDZCE_MASK
+#define MCM_ISR_FDZCE_SHIFT                      MCM_ISCR_FDZCE_SHIFT
+#define MCM_ISR_FOFCE_MASK                       MCM_ISCR_FOFCE_MASK
+#define MCM_ISR_FOFCE_SHIFT                      MCM_ISCR_FOFCE_SHIFT
+#define MCM_ISR_FUFCE_MASK                       MCM_ISCR_FUFCE_MASK
+#define MCM_ISR_FUFCE_SHIFT                      MCM_ISCR_FUFCE_SHIFT
+#define MCM_ISR_FIXCE_MASK                       MCM_ISCR_FIXCE_MASK
+#define MCM_ISR_FIXCE_SHIFT                      MCM_ISCR_FIXCE_SHIFT
+#define MCM_ISR_FIDCE_MASK                       MCM_ISCR_FIDCE_MASK
+#define MCM_ISR_FIDCE_SHIFT                      MCM_ISCR_FIDCE_SHIFT
+#define DSPI0                                    SPI0
+#define DSPI1                                    SPI1
+#define DSPI2                                    SPI2
+#define FLEXCAN0                                 CAN0
+#define PTA_BASE                                 GPIOA_BASE
+#define PTA                                      GPIOA
+#define PTB_BASE                                 GPIOB_BASE
+#define PTB                                      GPIOB
+#define PTC_BASE                                 GPIOC_BASE
+#define PTC                                      GPIOC
+#define PTD_BASE                                 GPIOD_BASE
+#define PTD                                      GPIOD
+#define PTE_BASE                                 GPIOE_BASE
+#define PTE                                      GPIOE
+#define UART_WP7816_T_TYPE0_REG(base)            UART_WP7816T0_REG(base)
+#define UART_WP7816_T_TYPE1_REG(base)            UART_WP7816T1_REG(base)
+#define UART_WP7816_T_TYPE0_WI_MASK              UART_WP7816T0_WI_MASK
+#define UART_WP7816_T_TYPE0_WI_SHIFT             UART_WP7816T0_WI_SHIFT
+#define UART_WP7816_T_TYPE0_WI(x)                UART_WP7816T0_WI(x)
+#define UART_WP7816_T_TYPE1_BWI_MASK             UART_WP7816T1_BWI_MASK
+#define UART_WP7816_T_TYPE1_BWI_SHIFT            UART_WP7816T1_BWI_SHIFT
+#define UART_WP7816_T_TYPE1_BWI(x)               UART_WP7816T1_BWI(x)
+#define UART_WP7816_T_TYPE1_CWI_MASK             UART_WP7816T1_CWI_MASK
+#define UART_WP7816_T_TYPE1_CWI_SHIFT            UART_WP7816T1_CWI_SHIFT
+#define UART_WP7816_T_TYPE1_CWI(x)               UART_WP7816T1_CWI(x)
+#define Watchdog_IRQn                            WDOG_EWM_IRQn
+#define Watchdog_IRQHandler                      WDOG_EWM_IRQHandler
+#define LPTimer_IRQn                             LPTMR0_IRQn
+#define LPTimer_IRQHandler                       LPTMR0_IRQHandler
+#define LLW_IRQn                                 LLWU_IRQn
+#define LLW_IRQHandler                           LLWU_IRQHandler
+#define DMAMUX0                                  DMAMUX
+#define WDOG0                                    WDOG
+#define MCM0                                     MCM
+#define RTC0                                     RTC
+
+/*!
+ * @}
+ */ /* end of group SDK_Compatibility_Symbols */
+
+
+#endif  /* _MK64F12_H_ */
+

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/MK64F12_features.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/MK64F12_features.h
@@ -1,0 +1,2370 @@
+/*
+** ###################################################################
+**     Version:             rev. 2.15, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Chip specific module features.
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2013-08-12)
+**         Initial version.
+**     - rev. 2.0 (2013-10-29)
+**         Register accessor macros added to the memory map.
+**         Symbols for Processor Expert memory map compatibility added to the memory map.
+**         Startup file for gcc has been updated according to CMSIS 3.2.
+**         System initialization updated.
+**         MCG - registers updated.
+**         PORTA, PORTB, PORTC, PORTE - registers for digital filter removed.
+**     - rev. 2.1 (2013-10-30)
+**         Definition of BITBAND macros updated to support peripherals with 32-bit acces disabled.
+**     - rev. 2.2 (2013-12-09)
+**         DMA - EARS register removed.
+**         AIPS0, AIPS1 - MPRA register updated.
+**     - rev. 2.3 (2014-01-24)
+**         Update according to reference manual rev. 2
+**         ENET, MCG, MCM, SIM, USB - registers updated
+**     - rev. 2.4 (2014-01-30)
+**         Added single maximum value generation and a constrain to varying feature values that only numbers can have maximum.
+**     - rev. 2.5 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**     - rev. 2.6 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**         Module access macro module_BASES replaced by module_BASE_PTRS.
+**     - rev. 2.7 (2014-08-28)
+**         Update of system files - default clock configuration changed.
+**         Update of startup files - possibility to override DefaultISR added.
+**     - rev. 2.8 (2014-10-14)
+**         Interrupt INT_LPTimer renamed to INT_LPTMR0, interrupt INT_Watchdog renamed to INT_WDOG_EWM.
+**     - rev. 2.9 (2015-01-21)
+**         Added FSL_FEATURE_SOC_peripheral_COUNT with number of peripheral instances
+**     - rev. 2.10 (2015-02-19)
+**         Renamed interrupt vector LLW to LLWU.
+**     - rev. 2.11 (2015-05-19)
+**         FSL_FEATURE_SOC_CAU_COUNT remamed to FSL_FEATURE_SOC_MMCAU_COUNT.
+**         Added FSL_FEATURE_SOC_peripheral_COUNT for TRNG and HSADC.
+**         Added features for PDB and PORT.
+**     - rev. 2.12 (2015-05-25)
+**         Added FSL_FEATURE_FLASH_PFLASH_START_ADDRESS
+**     - rev. 2.13 (2015-05-27)
+**         Several USB features added.
+**     - rev. 2.14 (2015-06-08)
+**         FTM features BUS_CLOCK and FAST_CLOCK removed.
+**     - rev. 2.15 (2016-03-21)
+**         Added MK64FN1M0CAJ12 part.
+**
+** ###################################################################
+*/
+
+#ifndef _MK64F12_FEATURES_H_
+#define _MK64F12_FEATURES_H_
+
+/* SOC module features */
+
+#if defined(CPU_MK64FN1M0CAJ12) || defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLQ12) || defined(CPU_MK64FN1M0VMD12) || \
+    defined(CPU_MK64FX512VDC12) || defined(CPU_MK64FX512VLQ12) || defined(CPU_MK64FX512VMD12)
+    /* @brief ACMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_ACMP_COUNT (0)
+    /* @brief ADC16 availability on the SoC. */
+    #define FSL_FEATURE_SOC_ADC16_COUNT (2)
+    /* @brief ADC12 availability on the SoC. */
+    #define FSL_FEATURE_SOC_ADC12_COUNT (0)
+    /* @brief AFE availability on the SoC. */
+    #define FSL_FEATURE_SOC_AFE_COUNT (0)
+    /* @brief AIPS availability on the SoC. */
+    #define FSL_FEATURE_SOC_AIPS_COUNT (2)
+    /* @brief AOI availability on the SoC. */
+    #define FSL_FEATURE_SOC_AOI_COUNT (0)
+    /* @brief AXBS availability on the SoC. */
+    #define FSL_FEATURE_SOC_AXBS_COUNT (1)
+    /* @brief ASMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_ASMC_COUNT (0)
+    /* @brief CADC availability on the SoC. */
+    #define FSL_FEATURE_SOC_CADC_COUNT (0)
+    /* @brief FLEXCAN availability on the SoC. */
+    #define FSL_FEATURE_SOC_FLEXCAN_COUNT (1)
+    /* @brief MMCAU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MMCAU_COUNT (1)
+    /* @brief CMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_CMP_COUNT (3)
+    /* @brief CMT availability on the SoC. */
+    #define FSL_FEATURE_SOC_CMT_COUNT (1)
+    /* @brief CNC availability on the SoC. */
+    #define FSL_FEATURE_SOC_CNC_COUNT (0)
+    /* @brief CRC availability on the SoC. */
+    #define FSL_FEATURE_SOC_CRC_COUNT (1)
+    /* @brief DAC availability on the SoC. */
+    #define FSL_FEATURE_SOC_DAC_COUNT (2)
+    /* @brief DAC32 availability on the SoC. */
+    #define FSL_FEATURE_SOC_DAC32_COUNT (0)
+    /* @brief DCDC availability on the SoC. */
+    #define FSL_FEATURE_SOC_DCDC_COUNT (0)
+    /* @brief DDR availability on the SoC. */
+    #define FSL_FEATURE_SOC_DDR_COUNT (0)
+    /* @brief DMA availability on the SoC. */
+    #define FSL_FEATURE_SOC_DMA_COUNT (0)
+    /* @brief EDMA availability on the SoC. */
+    #define FSL_FEATURE_SOC_EDMA_COUNT (1)
+    /* @brief DMAMUX availability on the SoC. */
+    #define FSL_FEATURE_SOC_DMAMUX_COUNT (1)
+    /* @brief DRY availability on the SoC. */
+    #define FSL_FEATURE_SOC_DRY_COUNT (0)
+    /* @brief DSPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_DSPI_COUNT (3)
+    /* @brief EMVSIM availability on the SoC. */
+    #define FSL_FEATURE_SOC_EMVSIM_COUNT (0)
+    /* @brief ENC availability on the SoC. */
+    #define FSL_FEATURE_SOC_ENC_COUNT (0)
+    /* @brief ENET availability on the SoC. */
+    #define FSL_FEATURE_SOC_ENET_COUNT (1)
+    /* @brief EWM availability on the SoC. */
+    #define FSL_FEATURE_SOC_EWM_COUNT (1)
+    /* @brief FB availability on the SoC. */
+    #define FSL_FEATURE_SOC_FB_COUNT (1)
+    /* @brief FGPIO availability on the SoC. */
+    #define FSL_FEATURE_SOC_FGPIO_COUNT (0)
+    /* @brief FLEXIO availability on the SoC. */
+    #define FSL_FEATURE_SOC_FLEXIO_COUNT (0)
+    /* @brief FMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_FMC_COUNT (1)
+    /* @brief FSKDT availability on the SoC. */
+    #define FSL_FEATURE_SOC_FSKDT_COUNT (0)
+    /* @brief FTFA availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTFA_COUNT (0)
+    /* @brief FTFE availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTFE_COUNT (1)
+    /* @brief FTFL availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTFL_COUNT (0)
+    /* @brief FTM availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTM_COUNT (4)
+    /* @brief FTMRA availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTMRA_COUNT (0)
+    /* @brief FTMRE availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTMRE_COUNT (0)
+    /* @brief FTMRH availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTMRH_COUNT (0)
+    /* @brief GPIO availability on the SoC. */
+    #define FSL_FEATURE_SOC_GPIO_COUNT (5)
+    /* @brief HSADC availability on the SoC. */
+    #define FSL_FEATURE_SOC_HSADC_COUNT (0)
+    /* @brief I2C availability on the SoC. */
+    #define FSL_FEATURE_SOC_I2C_COUNT (3)
+    /* @brief I2S availability on the SoC. */
+    #define FSL_FEATURE_SOC_I2S_COUNT (1)
+    /* @brief ICS availability on the SoC. */
+    #define FSL_FEATURE_SOC_ICS_COUNT (0)
+    /* @brief INTMUX availability on the SoC. */
+    #define FSL_FEATURE_SOC_INTMUX_COUNT (0)
+    /* @brief IRQ availability on the SoC. */
+    #define FSL_FEATURE_SOC_IRQ_COUNT (0)
+    /* @brief KBI availability on the SoC. */
+    #define FSL_FEATURE_SOC_KBI_COUNT (0)
+    /* @brief SLCD availability on the SoC. */
+    #define FSL_FEATURE_SOC_SLCD_COUNT (0)
+    /* @brief LCDC availability on the SoC. */
+    #define FSL_FEATURE_SOC_LCDC_COUNT (0)
+    /* @brief LDO availability on the SoC. */
+    #define FSL_FEATURE_SOC_LDO_COUNT (0)
+    /* @brief LLWU availability on the SoC. */
+    #define FSL_FEATURE_SOC_LLWU_COUNT (1)
+    /* @brief LMEM availability on the SoC. */
+    #define FSL_FEATURE_SOC_LMEM_COUNT (0)
+    /* @brief LPI2C availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPI2C_COUNT (0)
+    /* @brief LPIT availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPIT_COUNT (0)
+    /* @brief LPSCI availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPSCI_COUNT (0)
+    /* @brief LPSPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPSPI_COUNT (0)
+    /* @brief LPTMR availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPTMR_COUNT (1)
+    /* @brief LPTPM availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPTPM_COUNT (0)
+    /* @brief LPUART availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPUART_COUNT (0)
+    /* @brief LTC availability on the SoC. */
+    #define FSL_FEATURE_SOC_LTC_COUNT (0)
+    /* @brief MC availability on the SoC. */
+    #define FSL_FEATURE_SOC_MC_COUNT (0)
+    /* @brief MCG availability on the SoC. */
+    #define FSL_FEATURE_SOC_MCG_COUNT (1)
+    /* @brief MCGLITE availability on the SoC. */
+    #define FSL_FEATURE_SOC_MCGLITE_COUNT (0)
+    /* @brief MCM availability on the SoC. */
+    #define FSL_FEATURE_SOC_MCM_COUNT (1)
+    /* @brief MMAU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MMAU_COUNT (0)
+    /* @brief MMDVSQ availability on the SoC. */
+    #define FSL_FEATURE_SOC_MMDVSQ_COUNT (0)
+    /* @brief MPU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MPU_COUNT (1)
+    /* @brief MSCAN availability on the SoC. */
+    #define FSL_FEATURE_SOC_MSCAN_COUNT (0)
+    /* @brief MSCM availability on the SoC. */
+    #define FSL_FEATURE_SOC_MSCM_COUNT (0)
+    /* @brief MTB availability on the SoC. */
+    #define FSL_FEATURE_SOC_MTB_COUNT (0)
+    /* @brief MTBDWT availability on the SoC. */
+    #define FSL_FEATURE_SOC_MTBDWT_COUNT (0)
+    /* @brief MU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MU_COUNT (0)
+    /* @brief NFC availability on the SoC. */
+    #define FSL_FEATURE_SOC_NFC_COUNT (0)
+    /* @brief OPAMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_OPAMP_COUNT (0)
+    /* @brief OSC availability on the SoC. */
+    #define FSL_FEATURE_SOC_OSC_COUNT (1)
+    /* @brief OSC32 availability on the SoC. */
+    #define FSL_FEATURE_SOC_OSC32_COUNT (0)
+    /* @brief OTFAD availability on the SoC. */
+    #define FSL_FEATURE_SOC_OTFAD_COUNT (0)
+    /* @brief PDB availability on the SoC. */
+    #define FSL_FEATURE_SOC_PDB_COUNT (1)
+    /* @brief PCC availability on the SoC. */
+    #define FSL_FEATURE_SOC_PCC_COUNT (0)
+    /* @brief PGA availability on the SoC. */
+    #define FSL_FEATURE_SOC_PGA_COUNT (0)
+    /* @brief PIT availability on the SoC. */
+    #define FSL_FEATURE_SOC_PIT_COUNT (1)
+    /* @brief PMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_PMC_COUNT (1)
+    /* @brief PORT availability on the SoC. */
+    #define FSL_FEATURE_SOC_PORT_COUNT (5)
+    /* @brief PWM availability on the SoC. */
+    #define FSL_FEATURE_SOC_PWM_COUNT (0)
+    /* @brief PWT availability on the SoC. */
+    #define FSL_FEATURE_SOC_PWT_COUNT (0)
+    /* @brief QuadSPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_QuadSPI_COUNT (0)
+    /* @brief RCM availability on the SoC. */
+    #define FSL_FEATURE_SOC_RCM_COUNT (1)
+    /* @brief RFSYS availability on the SoC. */
+    #define FSL_FEATURE_SOC_RFSYS_COUNT (1)
+    /* @brief RFVBAT availability on the SoC. */
+    #define FSL_FEATURE_SOC_RFVBAT_COUNT (1)
+    /* @brief RNG availability on the SoC. */
+    #define FSL_FEATURE_SOC_RNG_COUNT (1)
+    /* @brief RNGB availability on the SoC. */
+    #define FSL_FEATURE_SOC_RNGB_COUNT (0)
+    /* @brief ROM availability on the SoC. */
+    #define FSL_FEATURE_SOC_ROM_COUNT (0)
+    /* @brief RSIM availability on the SoC. */
+    #define FSL_FEATURE_SOC_RSIM_COUNT (0)
+    /* @brief RTC availability on the SoC. */
+    #define FSL_FEATURE_SOC_RTC_COUNT (1)
+    /* @brief SCG availability on the SoC. */
+    #define FSL_FEATURE_SOC_SCG_COUNT (0)
+    /* @brief SCI availability on the SoC. */
+    #define FSL_FEATURE_SOC_SCI_COUNT (0)
+    /* @brief SDHC availability on the SoC. */
+    #define FSL_FEATURE_SOC_SDHC_COUNT (1)
+    /* @brief SDRAM availability on the SoC. */
+    #define FSL_FEATURE_SOC_SDRAM_COUNT (0)
+    /* @brief SEMA42 availability on the SoC. */
+    #define FSL_FEATURE_SOC_SEMA42_COUNT (0)
+    /* @brief SIM availability on the SoC. */
+    #define FSL_FEATURE_SOC_SIM_COUNT (1)
+    /* @brief SMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_SMC_COUNT (1)
+    /* @brief SPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_SPI_COUNT (0)
+    /* @brief TMR availability on the SoC. */
+    #define FSL_FEATURE_SOC_TMR_COUNT (0)
+    /* @brief TPM availability on the SoC. */
+    #define FSL_FEATURE_SOC_TPM_COUNT (0)
+    /* @brief TRGMUX availability on the SoC. */
+    #define FSL_FEATURE_SOC_TRGMUX_COUNT (0)
+    /* @brief TRIAMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_TRIAMP_COUNT (0)
+    /* @brief TRNG availability on the SoC. */
+    #define FSL_FEATURE_SOC_TRNG_COUNT (0)
+    /* @brief TSI availability on the SoC. */
+    #define FSL_FEATURE_SOC_TSI_COUNT (0)
+    /* @brief TSTMR availability on the SoC. */
+    #define FSL_FEATURE_SOC_TSTMR_COUNT (0)
+    /* @brief UART availability on the SoC. */
+    #define FSL_FEATURE_SOC_UART_COUNT (6)
+    /* @brief USB availability on the SoC. */
+    #define FSL_FEATURE_SOC_USB_COUNT (1)
+    /* @brief USBDCD availability on the SoC. */
+    #define FSL_FEATURE_SOC_USBDCD_COUNT (1)
+    /* @brief USBHSDCD availability on the SoC. */
+    #define FSL_FEATURE_SOC_USBHSDCD_COUNT (0)
+    /* @brief USBPHY availability on the SoC. */
+    #define FSL_FEATURE_SOC_USBPHY_COUNT (0)
+    /* @brief VREF availability on the SoC. */
+    #define FSL_FEATURE_SOC_VREF_COUNT (1)
+    /* @brief WDOG availability on the SoC. */
+    #define FSL_FEATURE_SOC_WDOG_COUNT (1)
+    /* @brief XBAR availability on the SoC. */
+    #define FSL_FEATURE_SOC_XBAR_COUNT (0)
+    /* @brief XBARA availability on the SoC. */
+    #define FSL_FEATURE_SOC_XBARA_COUNT (0)
+    /* @brief XBARB availability on the SoC. */
+    #define FSL_FEATURE_SOC_XBARB_COUNT (0)
+    /* @brief XCVR availability on the SoC. */
+    #define FSL_FEATURE_SOC_XCVR_COUNT (0)
+    /* @brief XRDC availability on the SoC. */
+    #define FSL_FEATURE_SOC_XRDC_COUNT (0)
+    /* @brief ZLL availability on the SoC. */
+    #define FSL_FEATURE_SOC_ZLL_COUNT (0)
+#elif defined(CPU_MK64FN1M0VLL12) || defined(CPU_MK64FX512VLL12)
+    /* @brief ACMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_ACMP_COUNT (0)
+    /* @brief ADC16 availability on the SoC. */
+    #define FSL_FEATURE_SOC_ADC16_COUNT (2)
+    /* @brief ADC12 availability on the SoC. */
+    #define FSL_FEATURE_SOC_ADC12_COUNT (0)
+    /* @brief AFE availability on the SoC. */
+    #define FSL_FEATURE_SOC_AFE_COUNT (0)
+    /* @brief AIPS availability on the SoC. */
+    #define FSL_FEATURE_SOC_AIPS_COUNT (2)
+    /* @brief AOI availability on the SoC. */
+    #define FSL_FEATURE_SOC_AOI_COUNT (0)
+    /* @brief AXBS availability on the SoC. */
+    #define FSL_FEATURE_SOC_AXBS_COUNT (1)
+    /* @brief ASMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_ASMC_COUNT (0)
+    /* @brief CADC availability on the SoC. */
+    #define FSL_FEATURE_SOC_CADC_COUNT (0)
+    /* @brief FLEXCAN availability on the SoC. */
+    #define FSL_FEATURE_SOC_FLEXCAN_COUNT (1)
+    /* @brief MMCAU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MMCAU_COUNT (1)
+    /* @brief CMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_CMP_COUNT (3)
+    /* @brief CMT availability on the SoC. */
+    #define FSL_FEATURE_SOC_CMT_COUNT (1)
+    /* @brief CNC availability on the SoC. */
+    #define FSL_FEATURE_SOC_CNC_COUNT (0)
+    /* @brief CRC availability on the SoC. */
+    #define FSL_FEATURE_SOC_CRC_COUNT (1)
+    /* @brief DAC availability on the SoC. */
+    #define FSL_FEATURE_SOC_DAC_COUNT (1)
+    /* @brief DAC32 availability on the SoC. */
+    #define FSL_FEATURE_SOC_DAC32_COUNT (0)
+    /* @brief DCDC availability on the SoC. */
+    #define FSL_FEATURE_SOC_DCDC_COUNT (0)
+    /* @brief DDR availability on the SoC. */
+    #define FSL_FEATURE_SOC_DDR_COUNT (0)
+    /* @brief DMA availability on the SoC. */
+    #define FSL_FEATURE_SOC_DMA_COUNT (0)
+    /* @brief EDMA availability on the SoC. */
+    #define FSL_FEATURE_SOC_EDMA_COUNT (1)
+    /* @brief DMAMUX availability on the SoC. */
+    #define FSL_FEATURE_SOC_DMAMUX_COUNT (1)
+    /* @brief DRY availability on the SoC. */
+    #define FSL_FEATURE_SOC_DRY_COUNT (0)
+    /* @brief DSPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_DSPI_COUNT (3)
+    /* @brief EMVSIM availability on the SoC. */
+    #define FSL_FEATURE_SOC_EMVSIM_COUNT (0)
+    /* @brief ENC availability on the SoC. */
+    #define FSL_FEATURE_SOC_ENC_COUNT (0)
+    /* @brief ENET availability on the SoC. */
+    #define FSL_FEATURE_SOC_ENET_COUNT (1)
+    /* @brief EWM availability on the SoC. */
+    #define FSL_FEATURE_SOC_EWM_COUNT (1)
+    /* @brief FB availability on the SoC. */
+    #define FSL_FEATURE_SOC_FB_COUNT (1)
+    /* @brief FGPIO availability on the SoC. */
+    #define FSL_FEATURE_SOC_FGPIO_COUNT (0)
+    /* @brief FLEXIO availability on the SoC. */
+    #define FSL_FEATURE_SOC_FLEXIO_COUNT (0)
+    /* @brief FMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_FMC_COUNT (1)
+    /* @brief FSKDT availability on the SoC. */
+    #define FSL_FEATURE_SOC_FSKDT_COUNT (0)
+    /* @brief FTFA availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTFA_COUNT (0)
+    /* @brief FTFE availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTFE_COUNT (1)
+    /* @brief FTFL availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTFL_COUNT (0)
+    /* @brief FTM availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTM_COUNT (4)
+    /* @brief FTMRA availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTMRA_COUNT (0)
+    /* @brief FTMRE availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTMRE_COUNT (0)
+    /* @brief FTMRH availability on the SoC. */
+    #define FSL_FEATURE_SOC_FTMRH_COUNT (0)
+    /* @brief GPIO availability on the SoC. */
+    #define FSL_FEATURE_SOC_GPIO_COUNT (5)
+    /* @brief HSADC availability on the SoC. */
+    #define FSL_FEATURE_SOC_HSADC_COUNT (0)
+    /* @brief I2C availability on the SoC. */
+    #define FSL_FEATURE_SOC_I2C_COUNT (3)
+    /* @brief I2S availability on the SoC. */
+    #define FSL_FEATURE_SOC_I2S_COUNT (1)
+    /* @brief ICS availability on the SoC. */
+    #define FSL_FEATURE_SOC_ICS_COUNT (0)
+    /* @brief INTMUX availability on the SoC. */
+    #define FSL_FEATURE_SOC_INTMUX_COUNT (0)
+    /* @brief IRQ availability on the SoC. */
+    #define FSL_FEATURE_SOC_IRQ_COUNT (0)
+    /* @brief KBI availability on the SoC. */
+    #define FSL_FEATURE_SOC_KBI_COUNT (0)
+    /* @brief SLCD availability on the SoC. */
+    #define FSL_FEATURE_SOC_SLCD_COUNT (0)
+    /* @brief LCDC availability on the SoC. */
+    #define FSL_FEATURE_SOC_LCDC_COUNT (0)
+    /* @brief LDO availability on the SoC. */
+    #define FSL_FEATURE_SOC_LDO_COUNT (0)
+    /* @brief LLWU availability on the SoC. */
+    #define FSL_FEATURE_SOC_LLWU_COUNT (1)
+    /* @brief LMEM availability on the SoC. */
+    #define FSL_FEATURE_SOC_LMEM_COUNT (0)
+    /* @brief LPI2C availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPI2C_COUNT (0)
+    /* @brief LPIT availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPIT_COUNT (0)
+    /* @brief LPSCI availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPSCI_COUNT (0)
+    /* @brief LPSPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPSPI_COUNT (0)
+    /* @brief LPTMR availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPTMR_COUNT (1)
+    /* @brief LPTPM availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPTPM_COUNT (0)
+    /* @brief LPUART availability on the SoC. */
+    #define FSL_FEATURE_SOC_LPUART_COUNT (0)
+    /* @brief LTC availability on the SoC. */
+    #define FSL_FEATURE_SOC_LTC_COUNT (0)
+    /* @brief MC availability on the SoC. */
+    #define FSL_FEATURE_SOC_MC_COUNT (0)
+    /* @brief MCG availability on the SoC. */
+    #define FSL_FEATURE_SOC_MCG_COUNT (1)
+    /* @brief MCGLITE availability on the SoC. */
+    #define FSL_FEATURE_SOC_MCGLITE_COUNT (0)
+    /* @brief MCM availability on the SoC. */
+    #define FSL_FEATURE_SOC_MCM_COUNT (1)
+    /* @brief MMAU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MMAU_COUNT (0)
+    /* @brief MMDVSQ availability on the SoC. */
+    #define FSL_FEATURE_SOC_MMDVSQ_COUNT (0)
+    /* @brief MPU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MPU_COUNT (1)
+    /* @brief MSCAN availability on the SoC. */
+    #define FSL_FEATURE_SOC_MSCAN_COUNT (0)
+    /* @brief MSCM availability on the SoC. */
+    #define FSL_FEATURE_SOC_MSCM_COUNT (0)
+    /* @brief MTB availability on the SoC. */
+    #define FSL_FEATURE_SOC_MTB_COUNT (0)
+    /* @brief MTBDWT availability on the SoC. */
+    #define FSL_FEATURE_SOC_MTBDWT_COUNT (0)
+    /* @brief MU availability on the SoC. */
+    #define FSL_FEATURE_SOC_MU_COUNT (0)
+    /* @brief NFC availability on the SoC. */
+    #define FSL_FEATURE_SOC_NFC_COUNT (0)
+    /* @brief OPAMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_OPAMP_COUNT (0)
+    /* @brief OSC availability on the SoC. */
+    #define FSL_FEATURE_SOC_OSC_COUNT (1)
+    /* @brief OSC32 availability on the SoC. */
+    #define FSL_FEATURE_SOC_OSC32_COUNT (0)
+    /* @brief OTFAD availability on the SoC. */
+    #define FSL_FEATURE_SOC_OTFAD_COUNT (0)
+    /* @brief PDB availability on the SoC. */
+    #define FSL_FEATURE_SOC_PDB_COUNT (1)
+    /* @brief PCC availability on the SoC. */
+    #define FSL_FEATURE_SOC_PCC_COUNT (0)
+    /* @brief PGA availability on the SoC. */
+    #define FSL_FEATURE_SOC_PGA_COUNT (0)
+    /* @brief PIT availability on the SoC. */
+    #define FSL_FEATURE_SOC_PIT_COUNT (1)
+    /* @brief PMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_PMC_COUNT (1)
+    /* @brief PORT availability on the SoC. */
+    #define FSL_FEATURE_SOC_PORT_COUNT (5)
+    /* @brief PWM availability on the SoC. */
+    #define FSL_FEATURE_SOC_PWM_COUNT (0)
+    /* @brief PWT availability on the SoC. */
+    #define FSL_FEATURE_SOC_PWT_COUNT (0)
+    /* @brief QuadSPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_QuadSPI_COUNT (0)
+    /* @brief RCM availability on the SoC. */
+    #define FSL_FEATURE_SOC_RCM_COUNT (1)
+    /* @brief RFSYS availability on the SoC. */
+    #define FSL_FEATURE_SOC_RFSYS_COUNT (1)
+    /* @brief RFVBAT availability on the SoC. */
+    #define FSL_FEATURE_SOC_RFVBAT_COUNT (1)
+    /* @brief RNG availability on the SoC. */
+    #define FSL_FEATURE_SOC_RNG_COUNT (1)
+    /* @brief RNGB availability on the SoC. */
+    #define FSL_FEATURE_SOC_RNGB_COUNT (0)
+    /* @brief ROM availability on the SoC. */
+    #define FSL_FEATURE_SOC_ROM_COUNT (0)
+    /* @brief RSIM availability on the SoC. */
+    #define FSL_FEATURE_SOC_RSIM_COUNT (0)
+    /* @brief RTC availability on the SoC. */
+    #define FSL_FEATURE_SOC_RTC_COUNT (1)
+    /* @brief SCG availability on the SoC. */
+    #define FSL_FEATURE_SOC_SCG_COUNT (0)
+    /* @brief SCI availability on the SoC. */
+    #define FSL_FEATURE_SOC_SCI_COUNT (0)
+    /* @brief SDHC availability on the SoC. */
+    #define FSL_FEATURE_SOC_SDHC_COUNT (1)
+    /* @brief SDRAM availability on the SoC. */
+    #define FSL_FEATURE_SOC_SDRAM_COUNT (0)
+    /* @brief SEMA42 availability on the SoC. */
+    #define FSL_FEATURE_SOC_SEMA42_COUNT (0)
+    /* @brief SIM availability on the SoC. */
+    #define FSL_FEATURE_SOC_SIM_COUNT (1)
+    /* @brief SMC availability on the SoC. */
+    #define FSL_FEATURE_SOC_SMC_COUNT (1)
+    /* @brief SPI availability on the SoC. */
+    #define FSL_FEATURE_SOC_SPI_COUNT (0)
+    /* @brief TMR availability on the SoC. */
+    #define FSL_FEATURE_SOC_TMR_COUNT (0)
+    /* @brief TPM availability on the SoC. */
+    #define FSL_FEATURE_SOC_TPM_COUNT (0)
+    /* @brief TRGMUX availability on the SoC. */
+    #define FSL_FEATURE_SOC_TRGMUX_COUNT (0)
+    /* @brief TRIAMP availability on the SoC. */
+    #define FSL_FEATURE_SOC_TRIAMP_COUNT (0)
+    /* @brief TRNG availability on the SoC. */
+    #define FSL_FEATURE_SOC_TRNG_COUNT (0)
+    /* @brief TSI availability on the SoC. */
+    #define FSL_FEATURE_SOC_TSI_COUNT (0)
+    /* @brief TSTMR availability on the SoC. */
+    #define FSL_FEATURE_SOC_TSTMR_COUNT (0)
+    /* @brief UART availability on the SoC. */
+    #define FSL_FEATURE_SOC_UART_COUNT (6)
+    /* @brief USB availability on the SoC. */
+    #define FSL_FEATURE_SOC_USB_COUNT (1)
+    /* @brief USBDCD availability on the SoC. */
+    #define FSL_FEATURE_SOC_USBDCD_COUNT (1)
+    /* @brief USBHSDCD availability on the SoC. */
+    #define FSL_FEATURE_SOC_USBHSDCD_COUNT (0)
+    /* @brief USBPHY availability on the SoC. */
+    #define FSL_FEATURE_SOC_USBPHY_COUNT (0)
+    /* @brief VREF availability on the SoC. */
+    #define FSL_FEATURE_SOC_VREF_COUNT (1)
+    /* @brief WDOG availability on the SoC. */
+    #define FSL_FEATURE_SOC_WDOG_COUNT (1)
+    /* @brief XBAR availability on the SoC. */
+    #define FSL_FEATURE_SOC_XBAR_COUNT (0)
+    /* @brief XBARA availability on the SoC. */
+    #define FSL_FEATURE_SOC_XBARA_COUNT (0)
+    /* @brief XBARB availability on the SoC. */
+    #define FSL_FEATURE_SOC_XBARB_COUNT (0)
+    /* @brief XCVR availability on the SoC. */
+    #define FSL_FEATURE_SOC_XCVR_COUNT (0)
+    /* @brief XRDC availability on the SoC. */
+    #define FSL_FEATURE_SOC_XRDC_COUNT (0)
+    /* @brief ZLL availability on the SoC. */
+    #define FSL_FEATURE_SOC_ZLL_COUNT (0)
+#endif
+
+/* ADC16 module features */
+
+/* @brief Has Programmable Gain Amplifier (PGA) in ADC (register PGA). */
+#define FSL_FEATURE_ADC16_HAS_PGA (0)
+/* @brief Has PGA chopping control in ADC (bit PGA[PGACHPb] or PGA[PGACHP]). */
+#define FSL_FEATURE_ADC16_HAS_PGA_CHOPPING (0)
+/* @brief Has PGA offset measurement mode in ADC (bit PGA[PGAOFSM]). */
+#define FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT (0)
+/* @brief Has DMA support (bit SC2[DMAEN] or SC4[DMAEN]). */
+#define FSL_FEATURE_ADC16_HAS_DMA (1)
+/* @brief Has differential mode (bitfield SC1x[DIFF]). */
+#define FSL_FEATURE_ADC16_HAS_DIFF_MODE (1)
+/* @brief Has FIFO (bit SC4[AFDEP]). */
+#define FSL_FEATURE_ADC16_HAS_FIFO (0)
+/* @brief FIFO size if available (bitfield SC4[AFDEP]). */
+#define FSL_FEATURE_ADC16_FIFO_SIZE (0)
+/* @brief Has channel set a/b multiplexor (bitfield CFG2[MUXSEL]). */
+#define FSL_FEATURE_ADC16_HAS_MUX_SELECT (1)
+/* @brief Has HW trigger masking (bitfield SC5[HTRGMASKE]. */
+#define FSL_FEATURE_ADC16_HAS_HW_TRIGGER_MASK (0)
+/* @brief Has calibration feature (bit SC3[CAL] and registers CLPx, CLMx). */
+#define FSL_FEATURE_ADC16_HAS_CALIBRATION (1)
+/* @brief Has HW averaging (bit SC3[AVGE]). */
+#define FSL_FEATURE_ADC16_HAS_HW_AVERAGE (1)
+/* @brief Has offset correction (register OFS). */
+#define FSL_FEATURE_ADC16_HAS_OFFSET_CORRECTION (1)
+/* @brief Maximum ADC resolution. */
+#define FSL_FEATURE_ADC16_MAX_RESOLUTION (16)
+/* @brief Number of SC1x and Rx register pairs (conversion control and result registers). */
+#define FSL_FEATURE_ADC16_CONVERSION_CONTROL_COUNT (2)
+
+/* FLEXCAN module features */
+
+/* @brief Message buffer size */
+#define FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(x) (16)
+/* @brief Has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT (0)
+/* @brief Has a glitch filter on the receive pin (register bit field MCR[WAKSRC]). */
+#define FSL_FEATURE_FLEXCAN_HAS_GLITCH_FILTER (1)
+/* @brief Has extended interrupt mask and flag register (register IMASK2, IFLAG2). */
+#define FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER (0)
+/* @brief Has extended bit timing register (register CBT). */
+#define FSL_FEATURE_FLEXCAN_HAS_EXTENDED_TIMING_REGISTER (0)
+/* @brief Has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA (0)
+/* @brief Has separate message buffer 0 interrupt flag (register bit field IFLAG1[BUF0I]). */
+#define FSL_FEATURE_FLEXCAN_HAS_SEPARATE_BUFFER_0_FLAG (1)
+/* @brief Has bitfield name BUF31TO0M. */
+#define FSL_FEATURE_FLEXCAN_HAS_BUF31TO0M (0)
+/* @brief Number of interrupt vectors. */
+#define FSL_FEATURE_FLEXCAN_INTERRUPT_COUNT (6)
+/* @brief Is affected by errata with ID 5641 (Module does not transmit a message that is enabled to be transmitted at a specific moment during the arbitration process). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_5641 (0)
+
+/* CMP module features */
+
+/* @brief Has Trigger mode in CMP (register bit field CR1[TRIGM]). */
+#define FSL_FEATURE_CMP_HAS_TRIGGER_MODE (0)
+/* @brief Has Window mode in CMP (register bit field CR1[WE]). */
+#define FSL_FEATURE_CMP_HAS_WINDOW_MODE (1)
+/* @brief Has External sample supported in CMP (register bit field CR1[SE]). */
+#define FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT (1)
+/* @brief Has DMA support in CMP (register bit field SCR[DMAEN]). */
+#define FSL_FEATURE_CMP_HAS_DMA (1)
+/* @brief Has Pass Through mode in CMP (register bit field MUXCR[PSTM]). */
+#define FSL_FEATURE_CMP_HAS_PASS_THROUGH_MODE (1)
+/* @brief Has DAC Test function in CMP (register DACTEST). */
+#define FSL_FEATURE_CMP_HAS_DAC_TEST (0)
+
+/* CRC module features */
+
+/* @brief Has data register with name CRC */
+#define FSL_FEATURE_CRC_HAS_CRC_REG (0)
+
+/* DAC module features */
+
+/* @brief Define the size of hardware buffer */
+#define FSL_FEATURE_DAC_BUFFER_SIZE (16)
+/* @brief Define whether the buffer supports watermark event detection or not. */
+#define FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION (1)
+/* @brief Define whether the buffer supports watermark selection detection or not. */
+#define FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION (1)
+/* @brief Define whether the buffer supports watermark event 1 word before buffer upper limit. */
+#define FSL_FEATURE_DAC_HAS_WATERMARK_1_WORD (1)
+/* @brief Define whether the buffer supports watermark event 2 words before buffer upper limit. */
+#define FSL_FEATURE_DAC_HAS_WATERMARK_2_WORDS (1)
+/* @brief Define whether the buffer supports watermark event 3 words before buffer upper limit. */
+#define FSL_FEATURE_DAC_HAS_WATERMARK_3_WORDS (1)
+/* @brief Define whether the buffer supports watermark event 4 words before buffer upper limit. */
+#define FSL_FEATURE_DAC_HAS_WATERMARK_4_WORDS (1)
+/* @brief Define whether FIFO buffer mode is available or not. */
+#define FSL_FEATURE_DAC_HAS_BUFFER_FIFO_MODE (0)
+/* @brief Define whether swing buffer mode is available or not.. */
+#define FSL_FEATURE_DAC_HAS_BUFFER_SWING_MODE (1)
+
+/* EDMA module features */
+
+/* @brief Number of DMA channels (related to number of registers TCD, DCHPRI, bit fields ERQ[ERQn], EEI[EEIn], INT[INTn], ERR[ERRn], HRS[HRSn] and bit field widths ES[ERRCHN], CEEI[CEEI], SEEI[SEEI], CERQ[CERQ], SERQ[SERQ], CDNE[CDNE], SSRT[SSRT], CERR[CERR], CINT[CINT], TCDn_CITER_ELINKYES[LINKCH], TCDn_CSR[MAJORLINKCH], TCDn_BITER_ELINKYES[LINKCH]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL (16)
+/* @brief Total number of DMA channels on all modules. */
+#define FSL_FEATURE_EDMA_DMAMUX_CHANNELS (FSL_FEATURE_SOC_EDMA_COUNT * 16)
+/* @brief Number of DMA channel groups (register bit fields CR[ERGA], CR[GRPnPRI], ES[GPE], DCHPRIn[GRPPRI]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT (1)
+/* @brief Has DMA_Error interrupt vector. */
+#define FSL_FEATURE_EDMA_HAS_ERROR_IRQ (1)
+/* @brief Number of DMA channels with asynchronous request capability (register EARS). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT (0)
+
+/* DMAMUX module features */
+
+/* @brief Number of DMA channels (related to number of register CHCFGn). */
+#define FSL_FEATURE_DMAMUX_MODULE_CHANNEL (16)
+/* @brief Total number of DMA channels on all modules. */
+#define FSL_FEATURE_DMAMUX_DMAMUX_CHANNELS (FSL_FEATURE_SOC_DMAMUX_COUNT * 16)
+/* @brief Has the periodic trigger capability for the triggered DMA channel (register bit CHCFG0[TRIG]). */
+#define FSL_FEATURE_DMAMUX_HAS_TRIG (1)
+
+/* ENET module features */
+
+/* @brief Has buffer descriptor byte swapping (register bit field ECR[DBSWP]). */
+#define FSL_FEATURE_ENET_DMA_BIG_ENDIAN_ONLY (0)
+/* @brief Has precision time protocol (IEEE 1588) support (register bit field ECR[EN1588], registers ATCR, ATVR, ATOFF, ATPER, ATCOR, ATINC, ATSTMP). */
+#define FSL_FEATURE_ENET_SUPPORT_PTP (1)
+/* @brief Number of associated interrupt vectors. */
+#define FSL_FEATURE_ENET_INTERRUPT_COUNT (4)
+/* @brief Has threshold for the number of frames in the receive FIFO (register bit field RSEM[STAT_SECTION_EMPTY]). */
+#define FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD (1)
+
+/* EWM module features */
+
+/* @brief Has clock select (register CLKCTRL). */
+#define FSL_FEATURE_EWM_HAS_CLOCK_SELECT  (0)
+/* @brief Has clock prescaler (register CLKPRESCALER). */
+#define FSL_FEATURE_EWM_HAS_PRESCALER  (0)
+
+/* FLEXBUS module features */
+
+/* No feature definitions */
+
+/* FLASH module features */
+
+#if defined(CPU_MK64FN1M0CAJ12) || defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLL12) || defined(CPU_MK64FN1M0VLQ12) || \
+    defined(CPU_MK64FN1M0VMD12)
+    /* @brief Is of type FTFA. */
+    #define FSL_FEATURE_FLASH_IS_FTFA (0)
+    /* @brief Is of type FTFE. */
+    #define FSL_FEATURE_FLASH_IS_FTFE (1)
+    /* @brief Is of type FTFL. */
+    #define FSL_FEATURE_FLASH_IS_FTFL (0)
+    /* @brief Has flags indicating the status of the FlexRAM (register bits FCNFG[EEERDY], FCNFG[RAMRDY] and FCNFG[PFLSH]). */
+    #define FSL_FEATURE_FLASH_HAS_FLEX_RAM_FLAGS (1)
+    /* @brief Has program flash swapping status flag (register bit FCNFG[SWAP]). */
+    #define FSL_FEATURE_FLASH_HAS_PFLASH_SWAPPING_STATUS_FLAG (1)
+    /* @brief Has EEPROM region protection (register FEPROT). */
+    #define FSL_FEATURE_FLASH_HAS_EEROM_REGION_PROTECTION (1)
+    /* @brief Has data flash region protection (register FDPROT). */
+    #define FSL_FEATURE_FLASH_HAS_DATA_FLASH_REGION_PROTECTION (1)
+    /* @brief Has flash access control (registers XACCHn, SACCHn, where n is a number, FACSS and FACSN). */
+    #define FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL (0)
+    /* @brief Has flash cache control in FMC module. */
+    #define FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS (1)
+    /* @brief Has flash cache control in MCM module. */
+    #define FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS (0)
+    /* @brief Has flash cache control in MSCM module. */
+    #define FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS (0)
+    /* @brief P-Flash start address. */
+    #define FSL_FEATURE_FLASH_PFLASH_START_ADDRESS (0x00000000)
+    /* @brief P-Flash block count. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT (2)
+    /* @brief P-Flash block size. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE (524288)
+    /* @brief P-Flash sector size. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE (4096)
+    /* @brief P-Flash write unit size. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE (8)
+    /* @brief P-Flash data path width. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (16)
+    /* @brief P-Flash block swap feature. */
+    #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (1)
+    /* @brief Has FlexNVM memory. */
+    #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (0)
+    /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_START_ADDRESS (0x00000000)
+    /* @brief FlexNVM block count. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT (0)
+    /* @brief FlexNVM block size. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SIZE (0)
+    /* @brief FlexNVM sector size. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE (0)
+    /* @brief FlexNVM write unit size. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_WRITE_UNIT_SIZE (0)
+    /* @brief FlexNVM data path width. */
+    #define FSL_FEATURE_FLASH_FLEX_BLOCK_DATA_PATH_WIDTH (0)
+    /* @brief Has FlexRAM memory. */
+    #define FSL_FEATURE_FLASH_HAS_FLEX_RAM (1)
+    /* @brief FlexRAM start address. (Valid only if FlexRAM is available.) */
+    #define FSL_FEATURE_FLASH_FLEX_RAM_START_ADDRESS (0x14000000)
+    /* @brief FlexRAM size. */
+    #define FSL_FEATURE_FLASH_FLEX_RAM_SIZE (4096)
+    /* @brief Has 0x00 Read 1s Block command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_BLOCK_CMD (1)
+    /* @brief Has 0x01 Read 1s Section command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_SECTION_CMD (1)
+    /* @brief Has 0x02 Program Check command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_CHECK_CMD (1)
+    /* @brief Has 0x03 Read Resource command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD (1)
+    /* @brief Has 0x06 Program Longword command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_LONGWORD_CMD (0)
+    /* @brief Has 0x07 Program Phrase command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_PHRASE_CMD (1)
+    /* @brief Has 0x08 Erase Flash Block command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_FLASH_BLOCK_CMD (1)
+    /* @brief Has 0x09 Erase Flash Sector command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_FLASH_SECTOR_CMD (1)
+    /* @brief Has 0x0B Program Section command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD (1)
+    /* @brief Has 0x40 Read 1s All Blocks command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_ALL_BLOCKS_CMD (1)
+    /* @brief Has 0x41 Read Once command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_ONCE_CMD (1)
+    /* @brief Has 0x43 Program Once command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_ONCE_CMD (1)
+    /* @brief Has 0x44 Erase All Blocks command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_CMD (1)
+    /* @brief Has 0x45 Verify Backdoor Access Key command. */
+    #define FSL_FEATURE_FLASH_HAS_VERIFY_BACKDOOR_ACCESS_KEY_CMD (1)
+    /* @brief Has 0x46 Swap Control command. */
+    #define FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD (1)
+    /* @brief Has 0x49 Erase All Blocks Unsecure command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD (0)
+    /* @brief Has 0x4A Read 1s All Execute-only Segments command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_ALL_EXECUTE_ONLY_SEGMENTS_CMD (0)
+    /* @brief Has 0x4B Erase All Execute-only Segments command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_ALL_EXECUTE_ONLY_SEGMENTS_CMD (0)
+    /* @brief Has 0x80 Program Partition command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD (0)
+    /* @brief Has 0x81 Set FlexRAM Function command. */
+    #define FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD (0)
+    /* @brief P-Flash Erase/Read 1st all block command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief P-Flash Erase sector command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief P-Flash Rrogram/Verify section command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief P-Flash Read resource command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT (8)
+    /* @brief P-Flash Program check command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_CHECK_CMD_ADDRESS_ALIGMENT (4)
+    /* @brief P-Flash Program check command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief FlexNVM Erase/Read 1st all block command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_CMD_ADDRESS_ALIGMENT (0)
+    /* @brief FlexNVM Erase sector command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_SECTOR_CMD_ADDRESS_ALIGMENT (0)
+    /* @brief FlexNVM Rrogram/Verify section command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_SECTION_CMD_ADDRESS_ALIGMENT (0)
+    /* @brief FlexNVM Read resource command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_RESOURCE_CMD_ADDRESS_ALIGMENT (0)
+    /* @brief FlexNVM Program check command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_CHECK_CMD_ADDRESS_ALIGMENT (0)
+    /* @brief FlexNVM partition code 0000 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0000 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0001 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0001 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0010 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0010 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0011 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0011 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0100 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0100 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0101 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0101 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0110 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0110 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0111 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0111 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1000 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1000 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1001 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1001 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1010 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1010 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1011 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1011 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1100 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1100 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1101 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1101 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1110 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1110 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1111 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1111 (0xFFFFFFFF)
+    /* @brief Emulated eeprom size code 0000 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0000 (0xFFFF)
+    /* @brief Emulated eeprom size code 0001 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0001 (0xFFFF)
+    /* @brief Emulated eeprom size code 0010 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0010 (0x1000)
+    /* @brief Emulated eeprom size code 0011 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0011 (0x0800)
+    /* @brief Emulated eeprom size code 0100 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0100 (0x0400)
+    /* @brief Emulated eeprom size code 0101 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0101 (0x0200)
+    /* @brief Emulated eeprom size code 0110 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0110 (0x0100)
+    /* @brief Emulated eeprom size code 0111 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0111 (0x0080)
+    /* @brief Emulated eeprom size code 1000 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1000 (0x0040)
+    /* @brief Emulated eeprom size code 1001 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1001 (0x0020)
+    /* @brief Emulated eeprom size code 1010 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1010 (0xFFFF)
+    /* @brief Emulated eeprom size code 1011 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1011 (0xFFFF)
+    /* @brief Emulated eeprom size code 1100 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1100 (0xFFFF)
+    /* @brief Emulated eeprom size code 1101 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1101 (0xFFFF)
+    /* @brief Emulated eeprom size code 1110 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1110 (0xFFFF)
+    /* @brief Emulated eeprom size code 1111 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1111 (0x0000)
+#elif defined(CPU_MK64FX512VDC12) || defined(CPU_MK64FX512VLL12) || defined(CPU_MK64FX512VLQ12) || defined(CPU_MK64FX512VMD12)
+    /* @brief Is of type FTFA. */
+    #define FSL_FEATURE_FLASH_IS_FTFA (0)
+    /* @brief Is of type FTFE. */
+    #define FSL_FEATURE_FLASH_IS_FTFE (1)
+    /* @brief Is of type FTFL. */
+    #define FSL_FEATURE_FLASH_IS_FTFL (0)
+    /* @brief Has flags indicating the status of the FlexRAM (register bits FCNFG[EEERDY], FCNFG[RAMRDY] and FCNFG[PFLSH]). */
+    #define FSL_FEATURE_FLASH_HAS_FLEX_RAM_FLAGS (1)
+    /* @brief Has program flash swapping status flag (register bit FCNFG[SWAP]). */
+    #define FSL_FEATURE_FLASH_HAS_PFLASH_SWAPPING_STATUS_FLAG (1)
+    /* @brief Has EEPROM region protection (register FEPROT). */
+    #define FSL_FEATURE_FLASH_HAS_EEROM_REGION_PROTECTION (1)
+    /* @brief Has data flash region protection (register FDPROT). */
+    #define FSL_FEATURE_FLASH_HAS_DATA_FLASH_REGION_PROTECTION (1)
+    /* @brief Has flash access control (registers XACCHn, SACCHn, where n is a number, FACSS and FACSN). */
+    #define FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL (0)
+    /* @brief Has flash cache control in FMC module. */
+    #define FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS (1)
+    /* @brief Has flash cache control in MCM module. */
+    #define FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS (0)
+    /* @brief Has flash cache control in MSCM module. */
+    #define FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS (0)
+    /* @brief P-Flash start address. */
+    #define FSL_FEATURE_FLASH_PFLASH_START_ADDRESS (0x00000000)
+    /* @brief P-Flash block count. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT (1)
+    /* @brief P-Flash block size. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE (524288)
+    /* @brief P-Flash sector size. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE (4096)
+    /* @brief P-Flash write unit size. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE (8)
+    /* @brief P-Flash data path width. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (16)
+    /* @brief P-Flash block swap feature. */
+    #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (0)
+    /* @brief Has FlexNVM memory. */
+    #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (1)
+    /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_START_ADDRESS (0x10000000)
+    /* @brief FlexNVM block count. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT (1)
+    /* @brief FlexNVM block size. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SIZE (131072)
+    /* @brief FlexNVM sector size. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE (4096)
+    /* @brief FlexNVM write unit size. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_WRITE_UNIT_SIZE (8)
+    /* @brief FlexNVM data path width. */
+    #define FSL_FEATURE_FLASH_FLEX_BLOCK_DATA_PATH_WIDTH (16)
+    /* @brief Has FlexRAM memory. */
+    #define FSL_FEATURE_FLASH_HAS_FLEX_RAM (1)
+    /* @brief FlexRAM start address. (Valid only if FlexRAM is available.) */
+    #define FSL_FEATURE_FLASH_FLEX_RAM_START_ADDRESS (0x14000000)
+    /* @brief FlexRAM size. */
+    #define FSL_FEATURE_FLASH_FLEX_RAM_SIZE (4096)
+    /* @brief Has 0x00 Read 1s Block command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_BLOCK_CMD (0)
+    /* @brief Has 0x01 Read 1s Section command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_SECTION_CMD (1)
+    /* @brief Has 0x02 Program Check command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_CHECK_CMD (1)
+    /* @brief Has 0x03 Read Resource command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD (1)
+    /* @brief Has 0x06 Program Longword command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_LONGWORD_CMD (0)
+    /* @brief Has 0x07 Program Phrase command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_PHRASE_CMD (1)
+    /* @brief Has 0x08 Erase Flash Block command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_FLASH_BLOCK_CMD (0)
+    /* @brief Has 0x09 Erase Flash Sector command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_FLASH_SECTOR_CMD (1)
+    /* @brief Has 0x0B Program Section command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD (1)
+    /* @brief Has 0x40 Read 1s All Blocks command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_ALL_BLOCKS_CMD (1)
+    /* @brief Has 0x41 Read Once command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_ONCE_CMD (1)
+    /* @brief Has 0x43 Program Once command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_ONCE_CMD (1)
+    /* @brief Has 0x44 Erase All Blocks command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_CMD (1)
+    /* @brief Has 0x45 Verify Backdoor Access Key command. */
+    #define FSL_FEATURE_FLASH_HAS_VERIFY_BACKDOOR_ACCESS_KEY_CMD (1)
+    /* @brief Has 0x46 Swap Control command. */
+    #define FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD (0)
+    /* @brief Has 0x49 Erase All Blocks Unsecure command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD (0)
+    /* @brief Has 0x4A Read 1s All Execute-only Segments command. */
+    #define FSL_FEATURE_FLASH_HAS_READ_1S_ALL_EXECUTE_ONLY_SEGMENTS_CMD (0)
+    /* @brief Has 0x4B Erase All Execute-only Segments command. */
+    #define FSL_FEATURE_FLASH_HAS_ERASE_ALL_EXECUTE_ONLY_SEGMENTS_CMD (0)
+    /* @brief Has 0x80 Program Partition command. */
+    #define FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD (1)
+    /* @brief Has 0x81 Set FlexRAM Function command. */
+    #define FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD (1)
+    /* @brief P-Flash Erase/Read 1st all block command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_BLOCK_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief P-Flash Erase sector command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief P-Flash Rrogram/Verify section command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief P-Flash Read resource command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT (8)
+    /* @brief P-Flash Program check command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_CHECK_CMD_ADDRESS_ALIGMENT (4)
+    /* @brief P-Flash Program check command address alignment. */
+    #define FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT (0)
+    /* @brief FlexNVM Erase/Read 1st all block command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief FlexNVM Erase sector command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_SECTOR_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief FlexNVM Rrogram/Verify section command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_SECTION_CMD_ADDRESS_ALIGMENT (16)
+    /* @brief FlexNVM Read resource command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_RESOURCE_CMD_ADDRESS_ALIGMENT (8)
+    /* @brief FlexNVM Program check command address alignment. */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_CHECK_CMD_ADDRESS_ALIGMENT (4)
+    /* @brief FlexNVM partition code 0000 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0000 (0x00020000)
+    /* @brief FlexNVM partition code 0001 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0001 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0010 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0010 (0x0001C000)
+    /* @brief FlexNVM partition code 0011 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0011 (0x00018000)
+    /* @brief FlexNVM partition code 0100 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0100 (0x00010000)
+    /* @brief FlexNVM partition code 0101 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0101 (0x00000000)
+    /* @brief FlexNVM partition code 0110 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0110 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 0111 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0111 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1000 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1000 (0x00000000)
+    /* @brief FlexNVM partition code 1001 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1001 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1010 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1010 (0x00004000)
+    /* @brief FlexNVM partition code 1011 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1011 (0x00008000)
+    /* @brief FlexNVM partition code 1100 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1100 (0x00010000)
+    /* @brief FlexNVM partition code 1101 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1101 (0x00020000)
+    /* @brief FlexNVM partition code 1110 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1110 (0xFFFFFFFF)
+    /* @brief FlexNVM partition code 1111 mapping to data flash size in bytes (0xFFFFFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1111 (0x00020000)
+    /* @brief Emulated eeprom size code 0000 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0000 (0xFFFF)
+    /* @brief Emulated eeprom size code 0001 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0001 (0xFFFF)
+    /* @brief Emulated eeprom size code 0010 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0010 (0x1000)
+    /* @brief Emulated eeprom size code 0011 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0011 (0x0800)
+    /* @brief Emulated eeprom size code 0100 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0100 (0x0400)
+    /* @brief Emulated eeprom size code 0101 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0101 (0x0200)
+    /* @brief Emulated eeprom size code 0110 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0110 (0x0100)
+    /* @brief Emulated eeprom size code 0111 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0111 (0x0080)
+    /* @brief Emulated eeprom size code 1000 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1000 (0x0040)
+    /* @brief Emulated eeprom size code 1001 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1001 (0x0020)
+    /* @brief Emulated eeprom size code 1010 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1010 (0xFFFF)
+    /* @brief Emulated eeprom size code 1011 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1011 (0xFFFF)
+    /* @brief Emulated eeprom size code 1100 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1100 (0xFFFF)
+    /* @brief Emulated eeprom size code 1101 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1101 (0xFFFF)
+    /* @brief Emulated eeprom size code 1110 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1110 (0xFFFF)
+    /* @brief Emulated eeprom size code 1111 mapping to emulated eeprom size in bytes (0xFFFF = reserved). */
+    #define FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1111 (0x0000)
+#endif /* defined(CPU_MK64FN1M0CAJ12) || defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLL12) || defined(CPU_MK64FN1M0VLQ12) || \
+    defined(CPU_MK64FN1M0VMD12) */
+
+/* FTM module features */
+
+/* @brief Number of channels. */
+#define FSL_FEATURE_FTM_CHANNEL_COUNTn(x) \
+    ((x) == FTM0 ? (8) : \
+    ((x) == FTM1 ? (2) : \
+    ((x) == FTM2 ? (2) : \
+    ((x) == FTM3 ? (8) : (-1)))))
+/* @brief Has counter reset by the selected input capture event (register bits C0SC[ICRST], C1SC[ICRST], ...). */
+#define FSL_FEATURE_FTM_HAS_COUNTER_RESET_BY_CAPTURE_EVENT (0)
+/* @brief Enable pwm output for the module. */
+#define FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT (0)
+/* @brief Has half-cycle reload for the module. */
+#define FSL_FEATURE_FTM_HAS_HALFCYCLE_RELOAD (0)
+/* @brief Has reload interrupt. */
+#define FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT (0)
+/* @brief Has reload initialization trigger. */
+#define FSL_FEATURE_FTM_HAS_RELOAD_INITIALIZATION_TRIGGER (0)
+
+/* GPIO module features */
+
+/* @brief Has fast (single cycle) access capability via a dedicated memory region. */
+#define FSL_FEATURE_GPIO_HAS_FAST_GPIO (0)
+/* @brief Has port input disable register (PIDR). */
+#define FSL_FEATURE_GPIO_HAS_INPUT_DISABLE (0)
+/* @brief Has dedicated interrupt vector. */
+#define FSL_FEATURE_GPIO_HAS_PORT_INTERRUPT_VECTOR (1)
+
+/* I2C module features */
+
+/* @brief Has System Management Bus support (registers SMB, A2, SLTL and SLTH). */
+#define FSL_FEATURE_I2C_HAS_SMBUS (1)
+/* @brief Maximum supported baud rate in kilobit per second. */
+#define FSL_FEATURE_I2C_MAX_BAUD_KBPS (400)
+/* @brief Is affected by errata with ID 6070 (repeat start cannot be generated if the F[MULT] bit field is set to a non-zero value). */
+#define FSL_FEATURE_I2C_HAS_ERRATA_6070 (0)
+/* @brief Has DMA support (register bit C1[DMAEN]). */
+#define FSL_FEATURE_I2C_HAS_DMA_SUPPORT (1)
+/* @brief Has I2C bus start and stop detection (register bits FLT[SSIE], FLT[STARTF] and FLT[STOPF]). */
+#define FSL_FEATURE_I2C_HAS_START_STOP_DETECT (1)
+/* @brief Has I2C bus stop detection (register bits FLT[STOPIE] and FLT[STOPF]). */
+#define FSL_FEATURE_I2C_HAS_STOP_DETECT (0)
+/* @brief Has I2C bus stop hold off (register bit FLT[SHEN]). */
+#define FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF (1)
+/* @brief Maximum width of the glitch filter in number of bus clocks. */
+#define FSL_FEATURE_I2C_MAX_GLITCH_FILTER_WIDTH (15)
+/* @brief Has control of the drive capability of the I2C pins. */
+#define FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION (1)
+/* @brief Has double buffering support (register S2). */
+#define FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING (0)
+/* @brief Has double buffer enable. */
+#define FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE (0)
+
+/* SAI module features */
+
+/* @brief Receive/transmit FIFO size in item count (register bit fields TCSR[FRDE], TCSR[FRIE], TCSR[FRF], TCR1[TFW], RCSR[FRDE], RCSR[FRIE], RCSR[FRF], RCR1[RFW], registers TFRn, RFRn). */
+#define FSL_FEATURE_SAI_FIFO_COUNT (8)
+/* @brief Receive/transmit channel number (register bit fields TCR3[TCE], RCR3[RCE], registers TDRn and RDRn). */
+#define FSL_FEATURE_SAI_CHANNEL_COUNT (2)
+/* @brief Maximum words per frame (register bit fields TCR3[WDFL], TCR4[FRSZ], TMR[TWM], RCR3[WDFL], RCR4[FRSZ], RMR[RWM]). */
+#define FSL_FEATURE_SAI_MAX_WORDS_PER_FRAME (32)
+/* @brief Has support of combining multiple data channel FIFOs into single channel FIFO (register bit fields TCR3[CFR], TCR4[FCOMB], TFR0[WCP], TFR1[WCP], RCR3[CFR], RCR4[FCOMB], RFR0[RCP], RFR1[RCP]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE (0)
+/* @brief Has packing of 8-bit and 16-bit data into each 32-bit FIFO word (register bit fields TCR4[FPACK], RCR4[FPACK]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_PACKING (0)
+/* @brief Configures when the SAI will continue transmitting after a FIFO error has been detected (register bit fields TCR4[FCONT], RCR4[FCONT]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR (0)
+/* @brief Configures if the frame sync is generated internally, a frame sync is only generated when the FIFO warning flag is clear or continuously (register bit fields TCR4[ONDEM], RCR4[ONDEM]). */
+#define FSL_FEATURE_SAI_HAS_ON_DEMAND_MODE (0)
+/* @brief Simplified bit clock source and asynchronous/synchronous mode selection (register bit fields TCR2[CLKMODE], RCR2[CLKMODE]), in comparison with the exclusively implemented TCR2[SYNC,BCS,BCI,MSEL], RCR2[SYNC,BCS,BCI,MSEL]. */
+#define FSL_FEATURE_SAI_HAS_CLOCKING_MODE (0)
+/* @brief Has register for configuration of the MCLK divide ratio (register bit fields MDR[FRACT], MDR[DIVIDE]). */
+#define FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER (1)
+/* @brief Ihe interrupt source number */
+#define FSL_FEATURE_SAI_INT_SOURCE_NUM (2)
+/* @brief Has register of MCR. */
+#define FSL_FEATURE_SAI_HAS_MCR (1)
+/* @brief Has register of MDR */
+#define FSL_FEATURE_SAI_HAS_MDR (1)
+
+/* LLWU module features */
+
+#if defined(CPU_MK64FN1M0CAJ12)
+    /* @brief Maximum number of pins (maximal index plus one) connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN (16)
+    /* @brief Has pins 8-15 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_EXTERNAL_PIN_GROUP2 (1)
+    /* @brief Maximum number of internal modules connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE (8)
+    /* @brief Number of digital filters. */
+    #define FSL_FEATURE_LLWU_HAS_PIN_FILTER (2)
+    /* @brief Has MF register. */
+    #define FSL_FEATURE_LLWU_HAS_MF (0)
+    /* @brief Has PF register. */
+    #define FSL_FEATURE_LLWU_HAS_PF (0)
+    /* @brief Has possibility to enable reset in low leakage power mode and enable digital filter for RESET pin (register LLWU_RST). */
+    #define FSL_FEATURE_LLWU_HAS_RESET_ENABLE (1)
+    /* @brief Has external pin 0 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN0 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN0_GPIO_IDX (GPIOE_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN0_GPIO_PIN (1)
+    /* @brief Has external pin 1 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN1 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN1_GPIO_IDX (GPIOE_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN1_GPIO_PIN (2)
+    /* @brief Has external pin 2 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN2 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN2_GPIO_IDX (GPIOE_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN2_GPIO_PIN (4)
+    /* @brief Has external pin 3 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN3 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN3_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN3_GPIO_PIN (0)
+    /* @brief Has external pin 4 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN4 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN4_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN4_GPIO_PIN (0)
+    /* @brief Has external pin 5 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN5 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN5_GPIO_IDX (GPIOB_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN5_GPIO_PIN (0)
+    /* @brief Has external pin 6 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN6 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN6_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN6_GPIO_PIN (1)
+    /* @brief Has external pin 7 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN7 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN7_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN7_GPIO_PIN (3)
+    /* @brief Has external pin 8 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN8 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN8_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN8_GPIO_PIN (4)
+    /* @brief Has external pin 9 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN9 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN9_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN9_GPIO_PIN (5)
+    /* @brief Has external pin 10 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN10 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN10_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN10_GPIO_PIN (6)
+    /* @brief Has external pin 11 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN11 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN11_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN11_GPIO_PIN (11)
+    /* @brief Has external pin 12 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN12 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN12_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN12_GPIO_PIN (0)
+    /* @brief Has external pin 13 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN13 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN13_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN13_GPIO_PIN (2)
+    /* @brief Has external pin 14 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN14 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN14_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN14_GPIO_PIN (4)
+    /* @brief Has external pin 15 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN15 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN15_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN15_GPIO_PIN (6)
+    /* @brief Has external pin 16 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN16 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN16_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN16_GPIO_PIN (0)
+    /* @brief Has external pin 17 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN17 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN17_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN17_GPIO_PIN (0)
+    /* @brief Has external pin 18 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN18 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN18_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN18_GPIO_PIN (0)
+    /* @brief Has external pin 19 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN19 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN19_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN19_GPIO_PIN (0)
+    /* @brief Has external pin 20 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN20 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN20_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN20_GPIO_PIN (0)
+    /* @brief Has external pin 21 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN21 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN21_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN21_GPIO_PIN (0)
+    /* @brief Has external pin 22 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN22 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN22_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN22_GPIO_PIN (0)
+    /* @brief Has external pin 23 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN23 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN23_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN23_GPIO_PIN (0)
+    /* @brief Has external pin 24 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN24 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN24_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN24_GPIO_PIN (0)
+    /* @brief Has external pin 25 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN25 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN25_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN25_GPIO_PIN (0)
+    /* @brief Has external pin 26 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN26 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN26_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN26_GPIO_PIN (0)
+    /* @brief Has external pin 27 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN27 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN27_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN27_GPIO_PIN (0)
+    /* @brief Has external pin 28 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN28 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN28_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN28_GPIO_PIN (0)
+    /* @brief Has external pin 29 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN29 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN29_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN29_GPIO_PIN (0)
+    /* @brief Has external pin 30 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN30 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN30_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN30_GPIO_PIN (0)
+    /* @brief Has external pin 31 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN31 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN31_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN31_GPIO_PIN (0)
+    /* @brief Has internal module 0 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE0 (1)
+    /* @brief Has internal module 1 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE1 (1)
+    /* @brief Has internal module 2 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE2 (1)
+    /* @brief Has internal module 3 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE3 (1)
+    /* @brief Has internal module 4 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE4 (0)
+    /* @brief Has internal module 5 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE5 (1)
+    /* @brief Has internal module 6 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE6 (0)
+    /* @brief Has internal module 7 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE7 (1)
+    /* @brief Has Version ID Register (LLWU_VERID). */
+    #define FSL_FEATURE_LLWU_HAS_VERID (0)
+    /* @brief Has Parameter Register (LLWU_PARAM). */
+    #define FSL_FEATURE_LLWU_HAS_PARAM (0)
+    /* @brief Width of registers of the LLWU. */
+    #define FSL_FEATURE_LLWU_REG_BITWIDTH (8)
+    /* @brief Has DMA Enable register (LLWU_DE). */
+    #define FSL_FEATURE_LLWU_HAS_DMA_ENABLE_REG (0)
+#elif defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLL12) || defined(CPU_MK64FN1M0VLQ12) || defined(CPU_MK64FN1M0VMD12) || \
+    defined(CPU_MK64FX512VDC12) || defined(CPU_MK64FX512VLL12) || defined(CPU_MK64FX512VLQ12) || defined(CPU_MK64FX512VMD12)
+    /* @brief Maximum number of pins (maximal index plus one) connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN (16)
+    /* @brief Has pins 8-15 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_EXTERNAL_PIN_GROUP2 (1)
+    /* @brief Maximum number of internal modules connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE (8)
+    /* @brief Number of digital filters. */
+    #define FSL_FEATURE_LLWU_HAS_PIN_FILTER (2)
+    /* @brief Has MF register. */
+    #define FSL_FEATURE_LLWU_HAS_MF (0)
+    /* @brief Has PF register. */
+    #define FSL_FEATURE_LLWU_HAS_PF (0)
+    /* @brief Has possibility to enable reset in low leakage power mode and enable digital filter for RESET pin (register LLWU_RST). */
+    #define FSL_FEATURE_LLWU_HAS_RESET_ENABLE (1)
+    /* @brief Has external pin 0 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN0 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN0_GPIO_IDX (GPIOE_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN0_GPIO_PIN (1)
+    /* @brief Has external pin 1 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN1 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN1_GPIO_IDX (GPIOE_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN1_GPIO_PIN (2)
+    /* @brief Has external pin 2 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN2 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN2_GPIO_IDX (GPIOE_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN2_GPIO_PIN (4)
+    /* @brief Has external pin 3 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN3 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN3_GPIO_IDX (GPIOA_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN3_GPIO_PIN (4)
+    /* @brief Has external pin 4 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN4 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN4_GPIO_IDX (GPIOA_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN4_GPIO_PIN (13)
+    /* @brief Has external pin 5 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN5 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN5_GPIO_IDX (GPIOB_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN5_GPIO_PIN (0)
+    /* @brief Has external pin 6 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN6 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN6_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN6_GPIO_PIN (1)
+    /* @brief Has external pin 7 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN7 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN7_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN7_GPIO_PIN (3)
+    /* @brief Has external pin 8 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN8 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN8_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN8_GPIO_PIN (4)
+    /* @brief Has external pin 9 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN9 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN9_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN9_GPIO_PIN (5)
+    /* @brief Has external pin 10 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN10 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN10_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN10_GPIO_PIN (6)
+    /* @brief Has external pin 11 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN11 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN11_GPIO_IDX (GPIOC_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN11_GPIO_PIN (11)
+    /* @brief Has external pin 12 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN12 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN12_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN12_GPIO_PIN (0)
+    /* @brief Has external pin 13 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN13 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN13_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN13_GPIO_PIN (2)
+    /* @brief Has external pin 14 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN14 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN14_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN14_GPIO_PIN (4)
+    /* @brief Has external pin 15 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN15 (1)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN15_GPIO_IDX (GPIOD_IDX)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN15_GPIO_PIN (6)
+    /* @brief Has external pin 16 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN16 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN16_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN16_GPIO_PIN (0)
+    /* @brief Has external pin 17 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN17 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN17_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN17_GPIO_PIN (0)
+    /* @brief Has external pin 18 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN18 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN18_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN18_GPIO_PIN (0)
+    /* @brief Has external pin 19 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN19 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN19_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN19_GPIO_PIN (0)
+    /* @brief Has external pin 20 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN20 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN20_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN20_GPIO_PIN (0)
+    /* @brief Has external pin 21 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN21 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN21_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN21_GPIO_PIN (0)
+    /* @brief Has external pin 22 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN22 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN22_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN22_GPIO_PIN (0)
+    /* @brief Has external pin 23 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN23 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN23_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN23_GPIO_PIN (0)
+    /* @brief Has external pin 24 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN24 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN24_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN24_GPIO_PIN (0)
+    /* @brief Has external pin 25 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN25 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN25_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN25_GPIO_PIN (0)
+    /* @brief Has external pin 26 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN26 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN26_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN26_GPIO_PIN (0)
+    /* @brief Has external pin 27 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN27 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN27_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN27_GPIO_PIN (0)
+    /* @brief Has external pin 28 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN28 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN28_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN28_GPIO_PIN (0)
+    /* @brief Has external pin 29 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN29 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN29_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN29_GPIO_PIN (0)
+    /* @brief Has external pin 30 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN30 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN30_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN30_GPIO_PIN (0)
+    /* @brief Has external pin 31 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN31 (0)
+    /* @brief Index of port of external pin. */
+    #define FSL_FEATURE_LLWU_PIN31_GPIO_IDX (0)
+    /* @brief Number of external pin port on specified port. */
+    #define FSL_FEATURE_LLWU_PIN31_GPIO_PIN (0)
+    /* @brief Has internal module 0 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE0 (1)
+    /* @brief Has internal module 1 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE1 (1)
+    /* @brief Has internal module 2 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE2 (1)
+    /* @brief Has internal module 3 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE3 (1)
+    /* @brief Has internal module 4 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE4 (0)
+    /* @brief Has internal module 5 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE5 (1)
+    /* @brief Has internal module 6 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE6 (0)
+    /* @brief Has internal module 7 connected to LLWU device. */
+    #define FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE7 (1)
+    /* @brief Has Version ID Register (LLWU_VERID). */
+    #define FSL_FEATURE_LLWU_HAS_VERID (0)
+    /* @brief Has Parameter Register (LLWU_PARAM). */
+    #define FSL_FEATURE_LLWU_HAS_PARAM (0)
+    /* @brief Width of registers of the LLWU. */
+    #define FSL_FEATURE_LLWU_REG_BITWIDTH (8)
+    /* @brief Has DMA Enable register (LLWU_DE). */
+    #define FSL_FEATURE_LLWU_HAS_DMA_ENABLE_REG (0)
+#endif /* defined(CPU_MK64FN1M0CAJ12) */
+
+/* LPTMR module features */
+
+/* @brief Has shared interrupt handler with another LPTMR module. */
+#define FSL_FEATURE_LPTMR_HAS_SHARED_IRQ_HANDLER (0)
+
+/* MCG module features */
+
+/* @brief PRDIV base value (divider of register bit field [PRDIV] zero value). */
+#define FSL_FEATURE_MCG_PLL_PRDIV_BASE (1)
+/* @brief Maximum PLL external reference divider value (max. value of register bit field C5[PRVDIV]). */
+#define FSL_FEATURE_MCG_PLL_PRDIV_MAX (24)
+/* @brief VCO divider base value (multiply factor of register bit field C6[VDIV] zero value). */
+#define FSL_FEATURE_MCG_PLL_VDIV_BASE (24)
+/* @brief PLL reference clock low range. OSCCLK/PLL_R. */
+#define FSL_FEATURE_MCG_PLL_REF_MIN (2000000)
+/* @brief PLL reference clock high range. OSCCLK/PLL_R. */
+#define FSL_FEATURE_MCG_PLL_REF_MAX (4000000)
+/* @brief The PLL clock is divided by 2 before VCO divider. */
+#define FSL_FEATURE_MCG_HAS_PLL_INTERNAL_DIV (0)
+/* @brief FRDIV supports 1280. */
+#define FSL_FEATURE_MCG_FRDIV_SUPPORT_1280 (1)
+/* @brief FRDIV supports 1536. */
+#define FSL_FEATURE_MCG_FRDIV_SUPPORT_1536 (1)
+/* @brief MCGFFCLK divider. */
+#define FSL_FEATURE_MCG_FFCLK_DIV (1)
+/* @brief Is PLL clock divided by 2 before MCG PLL/FLL clock selection in the SIM module. */
+#define FSL_FEATURE_MCG_HAS_PLL_EXTRA_DIV (0)
+/* @brief Has 32kHz RTC external reference clock (register bits C8[LOCS1], C8[CME1], C8[LOCRE1] and RTC module are present). */
+#define FSL_FEATURE_MCG_HAS_RTC_32K (1)
+/* @brief Has PLL1 external reference clock (registers C10, C11, C12, S2). */
+#define FSL_FEATURE_MCG_HAS_PLL1 (0)
+/* @brief Has 48MHz internal oscillator. */
+#define FSL_FEATURE_MCG_HAS_IRC_48M (1)
+/* @brief Has OSC1 external oscillator (registers C10, C11, C12, S2). */
+#define FSL_FEATURE_MCG_HAS_OSC1 (0)
+/* @brief Has fast internal reference clock fine trim (register bit C2[FCFTRIM]). */
+#define FSL_FEATURE_MCG_HAS_FCFTRIM (1)
+/* @brief Has PLL loss of lock reset (register bit C8[LOLRE]). */
+#define FSL_FEATURE_MCG_HAS_LOLRE (1)
+/* @brief Has MCG OSC clock selection (register bit C7[OSCSEL]). */
+#define FSL_FEATURE_MCG_USE_OSCSEL (1)
+/* @brief Has PLL external reference selection (register bits C5[PLLREFSEL0] and C11[PLLREFSEL1]). */
+#define FSL_FEATURE_MCG_USE_PLLREFSEL (0)
+/* @brief TBD */
+#define FSL_FEATURE_MCG_USE_SYSTEM_CLOCK (0)
+/* @brief Has phase-locked loop (PLL) (register C5 and bits C6[VDIV], C6[PLLS], C6[LOLIE0], S[PLLST], S[LOCK0], S[LOLS]). */
+#define FSL_FEATURE_MCG_HAS_PLL (1)
+/* @brief Has phase-locked loop (PLL) PRDIV (register C5[PRDIV]. */
+#define FSL_FEATURE_MCG_HAS_PLL_PRDIV (1)
+/* @brief Has phase-locked loop (PLL) VDIV (register C6[VDIV]. */
+#define FSL_FEATURE_MCG_HAS_PLL_VDIV (1)
+/* @brief PLL/OSC related register bit fields have PLL/OSC index in their name. */
+#define FSL_FEATURE_MCG_HAS_PLL_OSC_INDEX (0)
+/* @brief Has frequency-locked loop (FLL) (register ATCVH, ATCVL and bits C1[IREFS], C1[FRDIV]). */
+#define FSL_FEATURE_MCG_HAS_FLL (1)
+/* @brief Has PLL external to MCG (C9[PLL_CME], C9[PLL_LOCRE], C9[EXT_PLL_LOCS]). */
+#define FSL_FEATURE_MCG_HAS_EXTERNAL_PLL (0)
+/* @brief Has crystal oscillator or external reference clock low power controls (register bits C2[HGO], C2[RANGE]). */
+#define FSL_FEATURE_MCG_HAS_EXT_REF_LOW_POWER_CONTROL (1)
+/* @brief Has PLL/FLL selection as MCG output (register bit C6[PLLS]). */
+#define FSL_FEATURE_MCG_HAS_PLL_FLL_SELECTION (1)
+/* @brief Has PLL output selection (PLL0/PLL1, PLL/external PLL) (register bit C11[PLLCS]). */
+#define FSL_FEATURE_MCG_HAS_PLL_OUTPUT_SELECTION (0)
+/* @brief Has automatic trim machine (registers ATCVH, ATCVL and bits SC[ATMF], SC[ATMS], SC[ATME]). */
+#define FSL_FEATURE_MCG_HAS_AUTO_TRIM_MACHINE (1)
+/* @brief Has external clock monitor (register bit C6[CME]). */
+#define FSL_FEATURE_MCG_HAS_EXTERNAL_CLOCK_MONITOR (1)
+/* @brief Has low frequency internal reference clock (IRC) (registers LTRIMRNG, LFRIM, LSTRIM and bit MC[LIRC_DIV2]). */
+#define FSL_FEATURE_MCG_HAS_LOW_FREQ_IRC (0)
+/* @brief Has high frequency internal reference clock (IRC) (registers HCTRIM, HTTRIM, HFTRIM and bit MC[HIRCEN]). */
+#define FSL_FEATURE_MCG_HAS_HIGH_FREQ_IRC (0)
+/* @brief Has PEI mode or PBI mode. */
+#define FSL_FEATURE_MCG_HAS_PLL_INTERNAL_MODE (0)
+/* @brief Reset clock mode is BLPI. */
+#define FSL_FEATURE_MCG_RESET_IS_BLPI (0)
+
+/* MPU module features */
+
+/* @brief Specifies number of descriptors available. */
+#define FSL_FEATURE_MPU_DESCRIPTOR_COUNT (12)
+/* @brief Has process identifier support. */
+#define FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER (1)
+/* @brief Total number of MPU master. */
+#define FSL_FEATURE_MPU_MASTER_COUNT (8)
+/* @brief Total number of MPU master with privileged rights */
+#define FSL_FEATURE_MPU_PRIVILEGED_RIGHTS_MASTER_COUNT (4)
+/* @brief Max index of used MPU master. */
+#define FSL_FEATURE_MPU_MASTER_MAX_INDEX (5)
+/* @brief Max index of used MPU master with privileged rights */
+#define FSL_FEATURE_MPU_PRIVILEGED_RIGHTS_MASTER_MAX_INDEX (3)
+/* @brief Has master 0. */
+#define FSL_FEATURE_MPU_HAS_MASTER0 (1)
+/* @brief Has master 1. */
+#define FSL_FEATURE_MPU_HAS_MASTER1 (1)
+/* @brief Has master 2. */
+#define FSL_FEATURE_MPU_HAS_MASTER2 (1)
+/* @brief Has master 3. */
+#define FSL_FEATURE_MPU_HAS_MASTER3 (1)
+/* @brief Has master 4. */
+#define FSL_FEATURE_MPU_HAS_MASTER4 (1)
+/* @brief Has master 5. */
+#define FSL_FEATURE_MPU_HAS_MASTER5 (1)
+/* @brief Has master 6. */
+#define FSL_FEATURE_MPU_HAS_MASTER6 (0)
+/* @brief Has master 7. */
+#define FSL_FEATURE_MPU_HAS_MASTER7 (0)
+
+/* interrupt module features */
+
+/* @brief Lowest interrupt request number. */
+#define FSL_FEATURE_INTERRUPT_IRQ_MIN (-14)
+/* @brief Highest interrupt request number. */
+#define FSL_FEATURE_INTERRUPT_IRQ_MAX (85)
+
+/* OSC module features */
+
+/* @brief Has OSC1 external oscillator. */
+#define FSL_FEATURE_OSC_HAS_OSC1 (0)
+/* @brief Has OSC0 external oscillator. */
+#define FSL_FEATURE_OSC_HAS_OSC0 (0)
+/* @brief Has OSC external oscillator (without index). */
+#define FSL_FEATURE_OSC_HAS_OSC (1)
+/* @brief Number of OSC external oscillators. */
+#define FSL_FEATURE_OSC_OSC_COUNT (1)
+/* @brief Has external reference clock divider (register bit field DIV[ERPS]). */
+#define FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER (0)
+
+/* PDB module features */
+
+/* @brief Define the count of supporting ADC pre-trigger for each channel. */
+#define FSL_FEATURE_PDB_ADC_PRE_CHANNEL_COUNT (2)
+/* @brief Has DAC support. */
+#define FSL_FEATURE_PDB_HAS_DAC (1)
+/* @brief Has shared interrupt handler (has not individual interrupt handler for each channel). */
+#define FSL_FEATURE_PDB_HAS_SHARED_IRQ_HANDLER (0)
+
+/* PIT module features */
+
+/* @brief Number of channels (related to number of registers LDVALn, CVALn, TCTRLn, TFLGn). */
+#define FSL_FEATURE_PIT_TIMER_COUNT (4)
+/* @brief Has lifetime timer (related to existence of registers LTMR64L and LTMR64H). */
+#define FSL_FEATURE_PIT_HAS_LIFETIME_TIMER (0)
+/* @brief Has chain mode (related to existence of register bit field TCTRLn[CHN]). */
+#define FSL_FEATURE_PIT_HAS_CHAIN_MODE (1)
+/* @brief Has shared interrupt handler (has not individual interrupt handler for each channel). */
+#define FSL_FEATURE_PIT_HAS_SHARED_IRQ_HANDLER (0)
+
+/* PMC module features */
+
+/* @brief Has Bandgap Enable In VLPx Operation support. */
+#define FSL_FEATURE_PMC_HAS_BGEN (1)
+/* @brief Has Bandgap Buffer Enable. */
+#define FSL_FEATURE_PMC_HAS_BGBE (1)
+/* @brief Has Bandgap Buffer Drive Select. */
+#define FSL_FEATURE_PMC_HAS_BGBDS (0)
+/* @brief Has Low-Voltage Detect Voltage Select support. */
+#define FSL_FEATURE_PMC_HAS_LVDV (1)
+/* @brief Has Low-Voltage Warning Voltage Select support. */
+#define FSL_FEATURE_PMC_HAS_LVWV (1)
+/* @brief Has LPO. */
+#define FSL_FEATURE_PMC_HAS_LPO (0)
+/* @brief Has VLPx option PMC_REGSC[VLPO]. */
+#define FSL_FEATURE_PMC_HAS_VLPO (0)
+/* @brief Has acknowledge isolation support. */
+#define FSL_FEATURE_PMC_HAS_ACKISO (1)
+/* @brief Has Regulator In Full Performance Mode Status Bit PMC_REGSC[REGFPM]. */
+#define FSL_FEATURE_PMC_HAS_REGFPM (0)
+/* @brief Has Regulator In Run Regulation Status Bit PMC_REGSC[REGONS]. */
+#define FSL_FEATURE_PMC_HAS_REGONS (1)
+/* @brief Has PMC_HVDSC1. */
+#define FSL_FEATURE_PMC_HAS_HVDSC1 (0)
+/* @brief Has PMC_PARAM. */
+#define FSL_FEATURE_PMC_HAS_PARAM (0)
+/* @brief Has PMC_VERID. */
+#define FSL_FEATURE_PMC_HAS_VERID (0)
+
+/* PORT module features */
+
+/* @brief Has control lock (register bit PCR[LK]). */
+#define FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK (1)
+/* @brief Has open drain control (register bit PCR[ODE]). */
+#define FSL_FEATURE_PORT_HAS_OPEN_DRAIN (1)
+/* @brief Has digital filter (registers DFER, DFCR and DFWR). */
+#define FSL_FEATURE_PORT_HAS_DIGITAL_FILTER (1)
+/* @brief Has DMA request (register bit field PCR[IRQC] values). */
+#define FSL_FEATURE_PORT_HAS_DMA_REQUEST (1)
+/* @brief Has pull resistor selection available. */
+#define FSL_FEATURE_PORT_HAS_PULL_SELECTION (1)
+/* @brief Has pull resistor enable (register bit PCR[PE]). */
+#define FSL_FEATURE_PORT_HAS_PULL_ENABLE (1)
+/* @brief Has slew rate control (register bit PCR[SRE]). */
+#define FSL_FEATURE_PORT_HAS_SLEW_RATE (1)
+/* @brief Has passive filter (register bit field PCR[PFE]). */
+#define FSL_FEATURE_PORT_HAS_PASSIVE_FILTER (1)
+/* @brief Has drive strength control (register bit PCR[DSE]). */
+#define FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH (1)
+/* @brief Has separate drive strength register (HDRVE). */
+#define FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH_REGISTER (0)
+/* @brief Has glitch filter (register IOFLT). */
+#define FSL_FEATURE_PORT_HAS_GLITCH_FILTER (0)
+/* @brief Defines width of PCR[MUX] field. */
+#define FSL_FEATURE_PORT_PCR_MUX_WIDTH (3)
+/* @brief Has dedicated interrupt vector. */
+#define FSL_FEATURE_PORT_HAS_INTERRUPT_VECTOR (1)
+/* @brief Defines whether PCR[IRQC] bit-field has flag states. */
+#define FSL_FEATURE_PORT_HAS_IRQC_FLAG (0)
+/* @brief Defines whether PCR[IRQC] bit-field has trigger states. */
+#define FSL_FEATURE_PORT_HAS_IRQC_TRIGGER (0)
+
+/* RCM module features */
+
+/* @brief Has Loss-of-Lock Reset support. */
+#define FSL_FEATURE_RCM_HAS_LOL (1)
+/* @brief Has Loss-of-Clock Reset support. */
+#define FSL_FEATURE_RCM_HAS_LOC (1)
+/* @brief Has JTAG generated Reset support. */
+#define FSL_FEATURE_RCM_HAS_JTAG (1)
+/* @brief Has EzPort generated Reset support. */
+#define FSL_FEATURE_RCM_HAS_EZPORT (1)
+/* @brief Has bit-field indicating EZP_MS_B pin state during last reset. */
+#define FSL_FEATURE_RCM_HAS_EZPMS (1)
+/* @brief Has boot ROM configuration, MR[BOOTROM], FM[FORCEROM] */
+#define FSL_FEATURE_RCM_HAS_BOOTROM (0)
+/* @brief Has sticky system reset status register RCM_SSRS0 and RCM_SSRS1. */
+#define FSL_FEATURE_RCM_HAS_SSRS (0)
+/* @brief Has Version ID Register (RCM_VERID). */
+#define FSL_FEATURE_RCM_HAS_VERID (0)
+/* @brief Has Parameter Register (RCM_PARAM). */
+#define FSL_FEATURE_RCM_HAS_PARAM (0)
+/* @brief Has Reset Interrupt Enable Register RCM_SRIE. */
+#define FSL_FEATURE_RCM_HAS_SRIE (0)
+/* @brief Width of registers of the RCM. */
+#define FSL_FEATURE_RCM_REG_WIDTH (8)
+/* @brief Has Core 1 generated Reset support RCM_SRS[CORE1] */
+#define FSL_FEATURE_RCM_HAS_CORE1 (0)
+/* @brief Has MDM-AP system reset support RCM_SRS1[MDM_AP] */
+#define FSL_FEATURE_RCM_HAS_MDM_AP (1)
+/* @brief Has wakeup reset feature. Register bit SRS[WAKEUP]. */
+#define FSL_FEATURE_RCM_HAS_WAKEUP (1)
+
+/* RTC module features */
+
+#if defined(CPU_MK64FN1M0CAJ12) || defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLL12) || defined(CPU_MK64FN1M0VLQ12) || \
+    defined(CPU_MK64FX512VDC12) || defined(CPU_MK64FX512VLL12) || defined(CPU_MK64FX512VLQ12)
+    /* @brief Has wakeup pin. */
+    #define FSL_FEATURE_RTC_HAS_WAKEUP_PIN (1)
+    /* @brief Has wakeup pin selection (bit field CR[WPS]). */
+    #define FSL_FEATURE_RTC_HAS_WAKEUP_PIN_SELECTION (1)
+    /* @brief Has low power features (registers MER, MCLR and MCHR). */
+    #define FSL_FEATURE_RTC_HAS_MONOTONIC (0)
+    /* @brief Has read/write access control (registers WAR and RAR). */
+    #define FSL_FEATURE_RTC_HAS_ACCESS_CONTROL (1)
+    /* @brief Has security features (registers TTSR, MER, MCLR and MCHR). */
+    #define FSL_FEATURE_RTC_HAS_SECURITY (1)
+    /* @brief Has RTC_CLKIN available. */
+    #define FSL_FEATURE_RTC_HAS_RTC_CLKIN (0)
+    /* @brief Has prescaler adjust for LPO. */
+    #define FSL_FEATURE_RTC_HAS_LPO_ADJUST (0)
+    /* @brief Has Clock Pin Enable field. */
+    #define FSL_FEATURE_RTC_HAS_CPE (0)
+    /* @brief Has Timer Seconds Interrupt Configuration field. */
+    #define FSL_FEATURE_RTC_HAS_TSIC (0)
+    /* @brief Has OSC capacitor setting RTC_CR[SC2P ~ SC16P] */
+    #define FSL_FEATURE_RTC_HAS_OSC_SCXP (1)
+#elif defined(CPU_MK64FN1M0VMD12) || defined(CPU_MK64FX512VMD12)
+    /* @brief Has wakeup pin. */
+    #define FSL_FEATURE_RTC_HAS_WAKEUP_PIN (1)
+    /* @brief Has wakeup pin selection (bit field CR[WPS]). */
+    #define FSL_FEATURE_RTC_HAS_WAKEUP_PIN_SELECTION (1)
+    /* @brief Has low power features (registers MER, MCLR and MCHR). */
+    #define FSL_FEATURE_RTC_HAS_MONOTONIC (0)
+    /* @brief Has read/write access control (registers WAR and RAR). */
+    #define FSL_FEATURE_RTC_HAS_ACCESS_CONTROL (1)
+    /* @brief Has security features (registers TTSR, MER, MCLR and MCHR). */
+    #define FSL_FEATURE_RTC_HAS_SECURITY (0)
+    /* @brief Has RTC_CLKIN available. */
+    #define FSL_FEATURE_RTC_HAS_RTC_CLKIN (0)
+    /* @brief Has prescaler adjust for LPO. */
+    #define FSL_FEATURE_RTC_HAS_LPO_ADJUST (0)
+    /* @brief Has Clock Pin Enable field. */
+    #define FSL_FEATURE_RTC_HAS_CPE (0)
+    /* @brief Has Timer Seconds Interrupt Configuration field. */
+    #define FSL_FEATURE_RTC_HAS_TSIC (0)
+    /* @brief Has OSC capacitor setting RTC_CR[SC2P ~ SC16P] */
+    #define FSL_FEATURE_RTC_HAS_OSC_SCXP (1)
+#endif /* defined(CPU_MK64FN1M0CAJ12) || defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLL12) || defined(CPU_MK64FN1M0VLQ12) || \
+    defined(CPU_MK64FX512VDC12) || defined(CPU_MK64FX512VLL12) || defined(CPU_MK64FX512VLQ12) */
+
+/* SDHC module features */
+
+/* @brief Has external DMA support (register bit VENDOR[EXTDMAEN]). */
+#define FSL_FEATURE_SDHC_HAS_EXTERNAL_DMA_SUPPORT (1)
+/* @brief Has support of 3.0V voltage (register bit HTCAPBLT[VS30]). */
+#define FSL_FEATURE_SDHC_HAS_V300_SUPPORT (0)
+/* @brief Has support of 1.8V voltage (register bit HTCAPBLT[VS18]). */
+#define FSL_FEATURE_SDHC_HAS_V180_SUPPORT (0)
+
+/* SIM module features */
+
+/* @brief Has USB FS divider. */
+#define FSL_FEATURE_SIM_USBFS_USE_SPECIAL_DIVIDER (0)
+/* @brief Is PLL clock divided by 2 before MCG PLL/FLL clock selection. */
+#define FSL_FEATURE_SIM_PLLCLK_USE_SPECIAL_DIVIDER (0)
+/* @brief Has RAM size specification (register bit field SOPT1[RAMSIZE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_RAMSIZE (1)
+/* @brief Has 32k oscillator clock output (register bit SOPT1[OSC32KOUT]). */
+#define FSL_FEATURE_SIM_OPT_HAS_OSC32K_OUT (0)
+/* @brief Has 32k oscillator clock selection (register bit field SOPT1[OSC32KSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_OSC32K_SELECTION (1)
+/* @brief 32k oscillator clock selection width (width of register bit field SOPT1[OSC32KSEL]). */
+#define FSL_FEATURE_SIM_OPT_OSC32K_SELECTION_WIDTH (2)
+/* @brief Has RTC clock output selection (register bit SOPT2[RTCCLKOUTSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_RTC_CLOCK_OUT_SELECTION (1)
+/* @brief Has USB voltage regulator (register bits SOPT1[USBVSTBY], SOPT1[USBSSTBY], SOPT1[USBREGEN], SOPT1CFG[URWE], SOPT1CFG[UVSWE], SOPT1CFG[USSWE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR (1)
+/* @brief USB has integrated PHY (register bits USBPHYCTL[USBVREGSEL], USBPHYCTL[USBVREGPD], USBPHYCTL[USB3VOUTTRG], USBPHYCTL[USBDISILIM], SOPT2[USBSLSRC], SOPT2[USBREGEN]). */
+#define FSL_FEATURE_SIM_OPT_HAS_USB_PHY (0)
+/* @brief Has PTD7 pad drive strength control (register bit SOPT2[PTD7PAD]). */
+#define FSL_FEATURE_SIM_OPT_HAS_PTD7PAD (1)
+/* @brief Has FlexBus security level selection (register bit SOPT2[FBSL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_FBSL (1)
+/* @brief Has number of FlexBus hold cycle before FlexBus can release bus (register bit SOPT6[PCR]). */
+#define FSL_FEATURE_SIM_OPT_HAS_PCR (0)
+/* @brief Has number of NFC hold cycle in case of FlexBus request (register bit SOPT6[MCC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_MCC (0)
+/* @brief Has UART open drain enable (register bits UARTnODE, where n is a number, in register SOPT5). */
+#define FSL_FEATURE_SIM_OPT_HAS_ODE (0)
+/* @brief Number of LPUART modules (number of register bits LPUARTn, where n is a number, in register SCGC5). */
+#define FSL_FEATURE_SIM_OPT_LPUART_COUNT (0)
+/* @brief Number of UART modules (number of register bits UARTn, where n is a number, in register SCGC4). */
+#define FSL_FEATURE_SIM_OPT_UART_COUNT (4)
+/* @brief Has UART0 open drain enable (register bit SOPT5[UART0ODE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART0_ODE (0)
+/* @brief Has UART1 open drain enable (register bit SOPT5[UART1ODE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART1_ODE (0)
+/* @brief Has UART2 open drain enable (register bit SOPT5[UART2ODE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART2_ODE (0)
+/* @brief Has LPUART0 open drain enable (register bit SOPT5[LPUART0ODE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART0_ODE (0)
+/* @brief Has LPUART1 open drain enable (register bit SOPT5[LPUART1ODE]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART1_ODE (0)
+/* @brief Has CMT/UART pad drive strength control (register bit SOPT2[CMTUARTPAD]). */
+#define FSL_FEATURE_SIM_OPT_HAS_CMTUARTPAD (0)
+/* @brief Has LPUART0 transmit data source selection (register bit SOPT5[LPUART0TXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART0_TX_SRC (0)
+/* @brief Has LPUART0 receive data source selection (register bit SOPT5[LPUART0RXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART0_RX_SRC (0)
+/* @brief Has LPUART1 transmit data source selection (register bit SOPT5[LPUART1TXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART1_TX_SRC (0)
+/* @brief Has LPUART1 receive data source selection (register bit SOPT5[LPUART1RXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART1_RX_SRC (0)
+/* @brief Has UART0 transmit data source selection (register bit SOPT5[UART0TXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART0_TX_SRC (1)
+/* @brief UART0 transmit data source selection width (width of register bit SOPT5[UART0TXSRC]). */
+#define FSL_FEATURE_SIM_OPT_UART0_TX_SRC_WIDTH (2)
+/* @brief Has UART0 receive data source selection (register bit SOPT5[UART0RXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART0_RX_SRC (1)
+/* @brief UART0 receive data source selection width (width of register bit SOPT5[UART0RXSRC]). */
+#define FSL_FEATURE_SIM_OPT_UART0_RX_SRC_WIDTH (2)
+/* @brief Has UART1 transmit data source selection (register bit SOPT5[UART1TXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART1_TX_SRC (1)
+/* @brief Has UART1 receive data source selection (register bit SOPT5[UART1RXSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART1_RX_SRC (1)
+/* @brief UART1 receive data source selection width (width of register bit SOPT5[UART1RXSRC]). */
+#define FSL_FEATURE_SIM_OPT_UART1_RX_SRC_WIDTH (2)
+/* @brief Has FTM module(s) configuration. */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM (1)
+/* @brief Number of FTM modules. */
+#define FSL_FEATURE_SIM_OPT_FTM_COUNT (4)
+/* @brief Number of FTM triggers with selectable source. */
+#define FSL_FEATURE_SIM_OPT_FTM_TRIGGER_COUNT (2)
+/* @brief Has FTM0 triggers source selection (register bits SOPT4[FTM0TRGnSRC], where n is a number). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM0_TRIGGER (1)
+/* @brief Has FTM3 triggers source selection (register bits SOPT4[FTM3TRGnSRC], where n is a number). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM3_TRIGGER (1)
+/* @brief Has FTM1 channel 0 input capture source selection (register bit SOPT4[FTM1CH0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM1_CHANNELS (1)
+/* @brief Has FTM2 channel 0 input capture source selection (register bit SOPT4[FTM2CH0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM2_CHANNELS (1)
+/* @brief Has FTM3 channel 0 input capture source selection (register bit SOPT4[FTM3CH0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM3_CHANNELS (0)
+/* @brief Has FTM2 channel 1 input capture source selection (register bit SOPT4[FTM2CH1SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM2_CHANNEL1 (0)
+/* @brief Number of configurable FTM0 fault detection input (number of register bits SOPT4[FTM0FLTn], where n is a number starting from zero). */
+#define FSL_FEATURE_SIM_OPT_FTM0_FAULT_COUNT (3)
+/* @brief Number of configurable FTM1 fault detection input (number of register bits SOPT4[FTM1FLTn], where n is a number starting from zero). */
+#define FSL_FEATURE_SIM_OPT_FTM1_FAULT_COUNT (1)
+/* @brief Number of configurable FTM2 fault detection input (number of register bits SOPT4[FTM2FLTn], where n is a number starting from zero). */
+#define FSL_FEATURE_SIM_OPT_FTM2_FAULT_COUNT (1)
+/* @brief Number of configurable FTM3 fault detection input (number of register bits SOPT4[FTM3FLTn], where n is a number starting from zero). */
+#define FSL_FEATURE_SIM_OPT_FTM3_FAULT_COUNT (1)
+/* @brief Has FTM hardware trigger 0 software synchronization (register bit SOPT8[FTMnSYNCBIT], where n is a module instance index). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM_TRIGGER_SYNC (0)
+/* @brief Has FTM channels output source selection (register bit SOPT8[FTMxOCHnSRC], where x is a module instance index and n is a channel index). */
+#define FSL_FEATURE_SIM_OPT_HAS_FTM_CHANNELS_OUTPUT_SRC (0)
+/* @brief Has TPM module(s) configuration. */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM (0)
+/* @brief The highest TPM module index. */
+#define FSL_FEATURE_SIM_OPT_MAX_TPM_INDEX (0)
+/* @brief Has TPM module with index 0. */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM0 (0)
+/* @brief Has TPM0 clock selection (register bit field SOPT4[TPM0CLKSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM0_CLK_SEL (0)
+/* @brief Is TPM channels configuration in the SOPT4 (not SOPT9) register (register bits TPMnCH0SRC, TPMnCLKSEL, where n is a module instance index). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM_CHANNELS_CONFIG_IN_SOPT4_REG (0)
+/* @brief Has TPM1 channel 0 input capture source selection (register bit field SOPT4[TPM1CH0SRC] or SOPT9[TPM1CH0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM1_CH0_SRC_SELECTION (0)
+/* @brief Has TPM1 clock selection (register bit field SOPT4[TPM1CLKSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM1_CLK_SEL (0)
+/* @brief TPM1 channel 0 input capture source selection width (width of register bit field SOPT4[TPM1CH0SRC] or SOPT9[TPM1CH0SRC]). */
+#define FSL_FEATURE_SIM_OPT_TPM1_CH0_SRC_SELECTION_WIDTH (0)
+/* @brief Has TPM2 channel 0 input capture source selection (register bit field SOPT4[TPM2CH0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM2_CH0_SRC_SELECTION (0)
+/* @brief Has TPM2 clock selection (register bit field SOPT4[TPM2CLKSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPM2_CLK_SEL (0)
+/* @brief Has PLL/FLL clock selection (register bit field SOPT2[PLLFLLSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_PLL_FLL_SELECTION (1)
+/* @brief PLL/FLL clock selection width (width of register bit field SOPT2[PLLFLLSEL]). */
+#define FSL_FEATURE_SIM_OPT_PLL_FLL_SELECTION_WIDTH (1)
+/* @brief Has NFC clock source selection (register bit SOPT2[NFCSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_NFCSRC (0)
+/* @brief Has eSDHC clock source selection (register bit SOPT2[ESDHCSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_ESDHCSRC (0)
+/* @brief Has SDHC clock source selection (register bit SOPT2[SDHCSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_SDHCSRC (1)
+/* @brief Has LCDC clock source selection (register bits SOPT2[LCDCSRC], SOPT2[LCDC_CLKSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LCDCSRC (0)
+/* @brief Has ENET timestamp clock source selection (register bit SOPT2[TIMESRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TIMESRC (1)
+/* @brief Has ENET RMII clock source selection (register bit SOPT2[RMIISRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_RMIISRC (1)
+/* @brief Has USB clock source selection (register bit SOPT2[USBSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_USBSRC (1)
+/* @brief Has USB FS clock source selection (register bit SOPT2[USBFSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_USBFSRC (0)
+/* @brief Has USB HS clock source selection (register bit SOPT2[USBHSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_USBHSRC (0)
+/* @brief Has LPUART clock source selection (register bit SOPT2[LPUARTSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUARTSRC (0)
+/* @brief Has LPUART0 clock source selection (register bit SOPT2[LPUART0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART0SRC (0)
+/* @brief Has LPUART1 clock source selection (register bit SOPT2[LPUART1SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_LPUART1SRC (0)
+/* @brief Has FLEXIOSRC clock source selection (register bit SOPT2[FLEXIOSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_FLEXIOSRC (0)
+/* @brief Has UART0 clock source selection (register bit SOPT2[UART0SRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_UART0SRC (0)
+/* @brief Has TPM clock source selection (register bit SOPT2[TPMSRC]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TPMSRC (0)
+/* @brief Has debug trace clock selection (register bit SOPT2[TRACECLKSEL]). */
+#define FSL_FEATURE_SIM_OPT_HAS_TRACE_CLKSEL (1)
+/* @brief Number of ADC modules (register bits SOPT7[ADCnTRGSEL], SOPT7[ADCnPRETRGSEL], SOPT7[ADCnALTTRGSEL], where n is a module instance index). */
+#define FSL_FEATURE_SIM_OPT_ADC_COUNT (2)
+/* @brief ADC0 alternate trigger enable width (width of bit field ADC0ALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_ADC0ALTTRGEN_WIDTH (1)
+/* @brief ADC1 alternate trigger enable width (width of bit field ADC1ALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_ADC1ALTTRGEN_WIDTH (1)
+/* @brief ADC2 alternate trigger enable width (width of bit field ADC2ALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_ADC2ALTTRGEN_WIDTH (0)
+/* @brief ADC3 alternate trigger enable width (width of bit field ADC3ALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_ADC3ALTTRGEN_WIDTH (0)
+/* @brief HSADC0 converter A alternate trigger enable width (width of bit field HSADC0AALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_HSADC0AALTTRGEN_WIDTH (0)
+/* @brief HSADC1 converter A alternate trigger enable width (width of bit field HSADC1AALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_HSADC1AALTTRGEN_WIDTH (0)
+/* @brief ADC converter A alternate trigger enable width (width of bit field ADCAALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_ADCAALTTRGEN_WIDTH (0)
+/* @brief HSADC0 converter B alternate trigger enable width (width of bit field HSADC0BALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_HSADC0BALTTRGEN_WIDTH (0)
+/* @brief HSADC1 converter B alternate trigger enable width (width of bit field HSADC1BALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_HSADC1BALTTRGEN_WIDTH (0)
+/* @brief ADC converter B alternate trigger enable width (width of bit field ADCBALTTRGEN of register SOPT7). */
+#define FSL_FEATURE_SIM_OPT_ADCBALTTRGEN_WIDTH (0)
+/* @brief Has clock 2 output divider (register bit field CLKDIV1[OUTDIV2]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_OUTDIV2 (1)
+/* @brief Has clock 3 output divider (register bit field CLKDIV1[OUTDIV3]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_OUTDIV3 (1)
+/* @brief Has clock 4 output divider (register bit field CLKDIV1[OUTDIV4]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_OUTDIV4 (1)
+/* @brief Clock 4 output divider width (width of register bit field CLKDIV1[OUTDIV4]). */
+#define FSL_FEATURE_SIM_DIVIDER_OUTDIV4_WIDTH (4)
+/* @brief Has clock 5 output divider (register bit field CLKDIV1[OUTDIV5]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_OUTDIV5 (0)
+/* @brief Has USB clock divider (register bit field CLKDIV2[USBDIV] and CLKDIV2[USBFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_USBDIV (1)
+/* @brief Has USB FS clock divider (register bit field CLKDIV2[USBFSDIV] and CLKDIV2[USBFSFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_USBFSDIV (0)
+/* @brief Has USB HS clock divider (register bit field CLKDIV2[USBHSDIV] and CLKDIV2[USBHSFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_USBHSDIV (0)
+/* @brief Has PLL/FLL clock divider (register bit field CLKDIV3[PLLFLLDIV] and CLKDIV3[PLLFLLFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_PLLFLLDIV (0)
+/* @brief Has LCDC clock divider (register bit field CLKDIV3[LCDCDIV] and CLKDIV3[LCDCFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_LCDCDIV (0)
+/* @brief Has trace clock divider (register bit field CLKDIV4[TRACEDIV] and CLKDIV4[TRACEFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_TRACEDIV (0)
+/* @brief Has NFC clock divider (register bit field CLKDIV4[NFCDIV] and CLKDIV4[NFCFRAC]). */
+#define FSL_FEATURE_SIM_DIVIDER_HAS_NFCDIV (0)
+/* @brief Has Kinetis family ID (register bit field SDID[FAMILYID]). */
+#define FSL_FEATURE_SIM_SDID_HAS_FAMILYID (1)
+/* @brief Has Kinetis family ID (register bit field SDID[FAMID]). */
+#define FSL_FEATURE_SIM_SDID_HAS_FAMID (1)
+/* @brief Has Kinetis sub-family ID (register bit field SDID[SUBFAMID]). */
+#define FSL_FEATURE_SIM_SDID_HAS_SUBFAMID (1)
+/* @brief Has Kinetis series ID (register bit field SDID[SERIESID]). */
+#define FSL_FEATURE_SIM_SDID_HAS_SERIESID (1)
+/* @brief Has device die ID (register bit field SDID[DIEID]). */
+#define FSL_FEATURE_SIM_SDID_HAS_DIEID (1)
+/* @brief Has system SRAM size specifier (register bit field SDID[SRAMSIZE]). */
+#define FSL_FEATURE_SIM_SDID_HAS_SRAMSIZE (0)
+/* @brief Has flash mode (register bit FCFG1[FLASHDOZE]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_FLASHDOZE (1)
+/* @brief Has flash disable (register bit FCFG1[FLASHDIS]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_FLASHDIS (1)
+/* @brief Has FTFE disable (register bit FCFG1[FTFDIS]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_FTFDIS (0)
+/* @brief Has FlexNVM size specifier (register bit field FCFG1[NVMSIZE]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_NVMSIZE (1)
+/* @brief Has EEPROM size specifier (register bit field FCFG1[EESIZE]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_EESIZE (1)
+/* @brief Has FlexNVM partition (register bit field FCFG1[DEPART]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_DEPART (1)
+/* @brief Maximum flash address block 0 address specifier (register bit field FCFG2[MAXADDR0]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_MAXADDR0 (1)
+/* @brief Maximum flash address block 1 address specifier (register bit field FCFG2[MAXADDR1]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_MAXADDR1 (1)
+/* @brief Maximum flash address block 0 or 1 address specifier (register bit field FCFG2[MAXADDR01]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_MAXADDR01 (0)
+/* @brief Maximum flash address block 2 or 3 address specifier (register bit field FCFG2[MAXADDR23]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_MAXADDR23 (0)
+/* @brief Has program flash availability specifier (register bit FCFG2[PFLSH]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_PFLSH (1)
+/* @brief Has program flash swapping (register bit FCFG2[SWAPPFLSH]). */
+#define FSL_FEATURE_SIM_FCFG_HAS_PFLSH_SWAP (0)
+/* @brief Has miscellanious control register (register MCR). */
+#define FSL_FEATURE_SIM_HAS_MISC_CONTROLS (0)
+/* @brief Has COP watchdog (registers COPC and SRVCOP). */
+#define FSL_FEATURE_SIM_HAS_COP_WATCHDOG (0)
+/* @brief Has COP watchdog stop (register bits COPC[COPSTPEN], COPC[COPDBGEN] and COPC[COPCLKSEL]). */
+#define FSL_FEATURE_SIM_HAS_COP_STOP (0)
+/* @brief Has LLWU clock gate bit (e.g SIM_SCGC4). */
+#define FSL_FEATURE_SIM_HAS_SCGC_LLWU (0)
+
+/* SMC module features */
+
+/* @brief Has partial stop option (register bit STOPCTRL[PSTOPO]). */
+#define FSL_FEATURE_SMC_HAS_PSTOPO (0)
+/* @brief Has LPO power option (register bit STOPCTRL[LPOPO]). */
+#define FSL_FEATURE_SMC_HAS_LPOPO (0)
+/* @brief Has POR power option (register bit STOPCTRL[PORPO] or VLLSCTRL[PORPO]). */
+#define FSL_FEATURE_SMC_HAS_PORPO (1)
+/* @brief Has low power wakeup on interrupt (register bit PMCTRL[LPWUI]). */
+#define FSL_FEATURE_SMC_HAS_LPWUI (1)
+/* @brief Has LLS or VLLS mode control (register bit STOPCTRL[LLSM]). */
+#define FSL_FEATURE_SMC_HAS_LLS_SUBMODE (0)
+/* @brief Has VLLS mode control (register bit VLLSCTRL[VLLSM]). */
+#define FSL_FEATURE_SMC_USE_VLLSCTRL_REG (1)
+/* @brief Has VLLS mode control (register bit STOPCTRL[VLLSM]). */
+#define FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM (0)
+/* @brief Has RAM partition 2 power option (register bit STOPCTRL[RAM2PO]). */
+#define FSL_FEATURE_SMC_HAS_RAM2_POWER_OPTION (0)
+/* @brief Has high speed run mode (register bit PMPROT[AHSRUN]). */
+#define FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE (0)
+/* @brief Has low leakage stop mode (register bit PMPROT[ALLS]). */
+#define FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE (1)
+/* @brief Has very low leakage stop mode (register bit PMPROT[AVLLS]). */
+#define FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE (1)
+/* @brief Has stop submode. */
+#define FSL_FEATURE_SMC_HAS_SUB_STOP_MODE (1)
+/* @brief Has stop submode 0(VLLS0). */
+#define FSL_FEATURE_SMC_HAS_STOP_SUBMODE0 (1)
+/* @brief Has stop submode 2(VLLS2). */
+#define FSL_FEATURE_SMC_HAS_STOP_SUBMODE2 (1)
+/* @brief Has SMC_PARAM. */
+#define FSL_FEATURE_SMC_HAS_PARAM (0)
+/* @brief Has SMC_VERID. */
+#define FSL_FEATURE_SMC_HAS_VERID (0)
+
+/* DSPI module features */
+
+/* @brief Receive/transmit FIFO size in number of items. */
+#define FSL_FEATURE_DSPI_FIFO_SIZEn(x) \
+    ((x) == DSPI0 ? (4) : \
+    ((x) == DSPI1 ? (1) : \
+    ((x) == DSPI2 ? (1) : (-1))))
+/* @brief Maximum transfer data width in bits. */
+#define FSL_FEATURE_DSPI_MAX_DATA_WIDTH (16)
+/* @brief Maximum number of chip select pins. (Reflects the width of register bit field PUSHR[PCS].) */
+#define FSL_FEATURE_DSPI_MAX_CHIP_SELECT_COUNT (6)
+/* @brief Number of chip select pins. */
+#define FSL_FEATURE_DSPI_CHIP_SELECT_COUNT (6)
+/* @brief Has chip select strobe capability on the PCS5 pin. */
+#define FSL_FEATURE_DSPI_HAS_CHIP_SELECT_STROBE (1)
+/* @brief Has separated TXDATA and CMD FIFOs (register SREX). */
+#define FSL_FEATURE_DSPI_HAS_SEPARATE_TXDATA_CMD_FIFO (0)
+/* @brief Has 16-bit data transfer support. */
+#define FSL_FEATURE_DSPI_16BIT_TRANSFERS (1)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) \
+    ((x) == DSPI0 ? (1) : \
+    ((x) == DSPI1 ? (0) : \
+    ((x) == DSPI2 ? (0) : (-1))))
+
+/* SysTick module features */
+
+/* @brief Systick has external reference clock. */
+#define FSL_FEATURE_SYSTICK_HAS_EXT_REF (0)
+/* @brief Systick external reference clock is core clock divided by this value. */
+#define FSL_FEATURE_SYSTICK_EXT_REF_CORE_DIV (0)
+
+/* UART module features */
+
+/* @brief Has receive FIFO overflow detection (bit field CFIFO[RXOFE]). */
+#define FSL_FEATURE_UART_HAS_IRQ_EXTENDED_FUNCTIONS (1)
+/* @brief Has low power features (can be enabled in wait mode via register bit C1[DOZEEN] or CTRL[DOZEEN] if the registers are 32-bit wide). */
+#define FSL_FEATURE_UART_HAS_LOW_POWER_UART_SUPPORT (0)
+/* @brief Has extended data register ED (or extra flags in the DATA register if the registers are 32-bit wide). */
+#define FSL_FEATURE_UART_HAS_EXTENDED_DATA_REGISTER_FLAGS (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_UART_HAS_FIFO (1)
+/* @brief Hardware flow control (RTS, CTS) is supported. */
+#define FSL_FEATURE_UART_HAS_MODEM_SUPPORT (1)
+/* @brief Infrared (modulation) is supported. */
+#define FSL_FEATURE_UART_HAS_IR_SUPPORT (1)
+/* @brief 2 bits long stop bit is available. */
+#define FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT (1)
+/* @brief If 10-bit mode is supported. */
+#define FSL_FEATURE_UART_HAS_10BIT_DATA_SUPPORT (1)
+/* @brief Baud rate fine adjustment is available. */
+#define FSL_FEATURE_UART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT (1)
+/* @brief Baud rate oversampling is available (has bit fields C4[OSR], C5[BOTHEDGE], C5[RESYNCDIS] or BAUD[OSR], BAUD[BOTHEDGE], BAUD[RESYNCDIS] if the registers are 32-bit wide). */
+#define FSL_FEATURE_UART_HAS_BAUD_RATE_OVER_SAMPLING_SUPPORT (0)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_UART_HAS_RX_RESYNC_SUPPORT (0)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_UART_HAS_BOTH_EDGE_SAMPLING_SUPPORT (0)
+/* @brief Peripheral type. */
+#define FSL_FEATURE_UART_IS_SCI (0)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_UART_FIFO_SIZEn(x) \
+    ((x) == UART0 ? (8) : \
+    ((x) == UART1 ? (8) : \
+    ((x) == UART2 ? (1) : \
+    ((x) == UART3 ? (1) : \
+    ((x) == UART4 ? (1) : \
+    ((x) == UART5 ? (1) : (-1)))))))
+/* @brief Maximal data width without parity bit. */
+#define FSL_FEATURE_UART_MAX_DATA_WIDTH_WITH_NO_PARITY (9)
+/* @brief Maximal data width with parity bit. */
+#define FSL_FEATURE_UART_MAX_DATA_WIDTH_WITH_PARITY (10)
+/* @brief Supports two match addresses to filter incoming frames. */
+#define FSL_FEATURE_UART_HAS_ADDRESS_MATCHING (1)
+/* @brief Has transmitter/receiver DMA enable bits C5[TDMAE]/C5[RDMAE] (or BAUD[TDMAE]/BAUD[RDMAE] if the registers are 32-bit wide). */
+#define FSL_FEATURE_UART_HAS_DMA_ENABLE (0)
+/* @brief Has transmitter/receiver DMA select bits C4[TDMAS]/C4[RDMAS], resp. C5[TDMAS]/C5[RDMAS] if IS_SCI = 0. */
+#define FSL_FEATURE_UART_HAS_DMA_SELECT (1)
+/* @brief Data character bit order selection is supported (bit field S2[MSBF] or STAT[MSBF] if the registers are 32-bit wide). */
+#define FSL_FEATURE_UART_HAS_BIT_ORDER_SELECT (1)
+/* @brief Has smart card (ISO7816 protocol) support and no improved smart card support. */
+#define FSL_FEATURE_UART_HAS_SMART_CARD_SUPPORT (1)
+/* @brief Has improved smart card (ISO7816 protocol) support. */
+#define FSL_FEATURE_UART_HAS_IMPROVED_SMART_CARD_SUPPORT (0)
+/* @brief Has local operation network (CEA709.1-B protocol) support. */
+#define FSL_FEATURE_UART_HAS_LOCAL_OPERATION_NETWORK_SUPPORT (0)
+/* @brief Has 32-bit registers (BAUD, STAT, CTRL, DATA, MATCH, MODIR) instead of 8-bit (BDH, BDL, C1, S1, D, etc.). */
+#define FSL_FEATURE_UART_HAS_32BIT_REGISTERS (0)
+/* @brief Lin break detect available (has bit BDH[LBKDIE]). */
+#define FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT (1)
+/* @brief UART stops in Wait mode available (has bit C1[UARTSWAI]). */
+#define FSL_FEATURE_UART_HAS_WAIT_MODE_OPERATION (1)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_UART_HAS_SEPARATE_DMA_RX_TX_REQn(x) \
+    ((x) == UART0 ? (1) : \
+    ((x) == UART1 ? (1) : \
+    ((x) == UART2 ? (1) : \
+    ((x) == UART3 ? (1) : \
+    ((x) == UART4 ? (0) : \
+    ((x) == UART5 ? (0) : (-1)))))))
+
+/* USB module features */
+
+/* @brief HOST mode enabled */
+#define FSL_FEATURE_USB_KHCI_HOST_ENABLED (1)
+/* @brief OTG mode enabled */
+#define FSL_FEATURE_USB_KHCI_OTG_ENABLED (1)
+/* @brief Size of the USB dedicated RAM */
+#define FSL_FEATURE_USB_KHCI_USB_RAM (0)
+/* @brief Has KEEP_ALIVE_CTRL register */
+#define FSL_FEATURE_USB_KHCI_KEEP_ALIVE_ENABLED (0)
+/* @brief Has the Dynamic SOF threshold compare support */
+#define FSL_FEATURE_USB_KHCI_DYNAMIC_SOF_THRESHOLD_COMPARE_ENABLED (0)
+/* @brief Has the VBUS detect support */
+#define FSL_FEATURE_USB_KHCI_VBUS_DETECT_ENABLED (0)
+/* @brief Has the IRC48M module clock support */
+#define FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED (1)
+/* @brief Number of endpoints supported */
+#define FSL_FEATURE_USB_ENDPT_COUNT (16)
+
+/* VREF module features */
+
+/* @brief Has chop oscillator (bit TRM[CHOPEN]) */
+#define FSL_FEATURE_VREF_HAS_CHOP_OSC (1)
+/* @brief Has second order curvature compensation (bit SC[ICOMPEN]) */
+#define FSL_FEATURE_VREF_HAS_COMPENSATION (1)
+/* @brief If high/low buffer mode supported */
+#define FSL_FEATURE_VREF_MODE_LV_TYPE (1)
+/* @brief Module has also low reference (registers VREFL/VREFH) */
+#define FSL_FEATURE_VREF_HAS_LOW_REFERENCE (0)
+/* @brief Has VREF_TRM4. */
+#define FSL_FEATURE_VREF_HAS_TRM4 (0)
+
+/* WDOG module features */
+
+/* @brief Watchdog is available. */
+#define FSL_FEATURE_WDOG_HAS_WATCHDOG (1)
+/* @brief Has Wait mode support. */
+#define FSL_FEATURE_WDOG_HAS_WAITEN (1)
+
+#endif /* _MK64F12_FEATURES_H_ */
+

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_adc16.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_adc16.c
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_adc16.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get instance number for ADC16 module.
+ *
+ * @param base ADC16 peripheral base address
+ */
+static uint32_t ADC16_GetInstance(ADC_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to ADC16 bases for each instance. */
+static ADC_Type *const s_adc16Bases[] = ADC_BASE_PTRS;
+
+/*! @brief Pointers to ADC16 clocks for each instance. */
+const clock_ip_name_t s_adc16Clocks[] = ADC16_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t ADC16_GetInstance(ADC_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_ADC16_COUNT; instance++)
+    {
+        if (s_adc16Bases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_ADC16_COUNT);
+
+    return instance;
+}
+
+void ADC16_Init(ADC_Type *base, const adc16_config_t *config)
+{
+    assert(NULL != config);
+
+    uint32_t tmp32;
+
+    /* Enable the clock. */
+    CLOCK_EnableClock(s_adc16Clocks[ADC16_GetInstance(base)]);
+
+    /* ADCx_CFG1. */
+    tmp32 = ADC_CFG1_ADICLK(config->clockSource) | ADC_CFG1_MODE(config->resolution);
+    if (kADC16_LongSampleDisabled != config->longSampleMode)
+    {
+        tmp32 |= ADC_CFG1_ADLSMP_MASK;
+    }
+    tmp32 |= ADC_CFG1_ADIV(config->clockDivider);
+    if (config->enableLowPower)
+    {
+        tmp32 |= ADC_CFG1_ADLPC_MASK;
+    }
+    base->CFG1 = tmp32;
+
+    /* ADCx_CFG2. */
+    tmp32 = base->CFG2 & ~(ADC_CFG2_ADACKEN_MASK | ADC_CFG2_ADHSC_MASK | ADC_CFG2_ADLSTS_MASK);
+    if (kADC16_LongSampleDisabled != config->longSampleMode)
+    {
+        tmp32 |= ADC_CFG2_ADLSTS(config->longSampleMode);
+    }
+    if (config->enableHighSpeed)
+    {
+        tmp32 |= ADC_CFG2_ADHSC_MASK;
+    }
+    if (config->enableAsynchronousClock)
+    {
+        tmp32 |= ADC_CFG2_ADACKEN_MASK;
+    }
+    base->CFG2 = tmp32;
+
+    /* ADCx_SC2. */
+    tmp32 = base->SC2 & ~(ADC_SC2_REFSEL_MASK);
+    tmp32 |= ADC_SC2_REFSEL(config->referenceVoltageSource);
+    base->SC2 = tmp32;
+
+    /* ADCx_SC3. */
+    if (config->enableContinuousConversion)
+    {
+        base->SC3 |= ADC_SC3_ADCO_MASK;
+    }
+    else
+    {
+        base->SC3 &= ~ADC_SC3_ADCO_MASK;
+    }
+}
+
+void ADC16_Deinit(ADC_Type *base)
+{
+    /* Disable the clock. */
+    CLOCK_DisableClock(s_adc16Clocks[ADC16_GetInstance(base)]);
+}
+
+void ADC16_GetDefaultConfig(adc16_config_t *config)
+{
+    assert(NULL != config);
+
+    config->referenceVoltageSource = kADC16_ReferenceVoltageSourceVref;
+    config->clockSource = kADC16_ClockSourceAsynchronousClock;
+    config->enableAsynchronousClock = true;
+    config->clockDivider = kADC16_ClockDivider8;
+    config->resolution = kADC16_ResolutionSE12Bit;
+    config->longSampleMode = kADC16_LongSampleDisabled;
+    config->enableHighSpeed = false;
+    config->enableLowPower = false;
+    config->enableContinuousConversion = false;
+}
+
+#if defined(FSL_FEATURE_ADC16_HAS_CALIBRATION) && FSL_FEATURE_ADC16_HAS_CALIBRATION
+status_t ADC16_DoAutoCalibration(ADC_Type *base)
+{
+    bool bHWTrigger = false;
+    uint32_t tmp32;
+    status_t status = kStatus_Success;
+
+    /* The calibration would be failed when in hardwar mode.
+     * Remember the hardware trigger state here and restore it later if the hardware trigger is enabled.*/
+    if (0U != (ADC_SC2_ADTRG_MASK & base->SC2))
+    {
+        bHWTrigger = true;
+        base->SC2 &= ~ADC_SC2_ADTRG_MASK;
+    }
+
+    /* Clear the CALF and launch the calibration. */
+    base->SC3 |= ADC_SC3_CAL_MASK | ADC_SC3_CALF_MASK;
+    while (0U == (kADC16_ChannelConversionDoneFlag & ADC16_GetChannelStatusFlags(base, 0U)))
+    {
+        /* Check the CALF when the calibration is active. */
+        if (0U != (kADC16_CalibrationFailedFlag & ADC16_GetStatusFlags(base)))
+        {
+            status = kStatus_Fail;
+            break;
+        }
+    }
+
+    /* Restore the hardware trigger setting if it was enabled before. */
+    if (bHWTrigger)
+    {
+        base->SC2 |= ADC_SC2_ADTRG_MASK;
+    }
+    /* Check the CALF at the end of calibration. */
+    if (0U != (kADC16_CalibrationFailedFlag & ADC16_GetStatusFlags(base)))
+    {
+        status = kStatus_Fail;
+    }
+    if (kStatus_Success != status) /* Check if the calibration process is succeed. */
+    {
+        return status;
+    }
+
+    /* Calculate the calibration values. */
+    tmp32 = base->CLP0 + base->CLP1 + base->CLP2 + base->CLP3 + base->CLP4 + base->CLPS;
+    tmp32 = 0x8000U | (tmp32 >> 1U);
+    base->PG = tmp32;
+
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+    tmp32 = base->CLM0 + base->CLM1 + base->CLM2 + base->CLM3 + base->CLM4 + base->CLMS;
+    tmp32 = 0x8000U | (tmp32 >> 1U);
+    base->MG = tmp32;
+#endif /* FSL_FEATURE_ADC16_HAS_DIFF_MODE */
+
+    return kStatus_Success;
+}
+#endif /* FSL_FEATURE_ADC16_HAS_CALIBRATION */
+
+#if defined(FSL_FEATURE_ADC16_HAS_MUX_SELECT) && FSL_FEATURE_ADC16_HAS_MUX_SELECT
+void ADC16_SetChannelMuxMode(ADC_Type *base, adc16_channel_mux_mode_t mode)
+{
+    if (kADC16_ChannelMuxA == mode)
+    {
+        base->CFG2 &= ~ADC_CFG2_MUXSEL_MASK;
+    }
+    else /* kADC16_ChannelMuxB. */
+    {
+        base->CFG2 |= ADC_CFG2_MUXSEL_MASK;
+    }
+}
+#endif /* FSL_FEATURE_ADC16_HAS_MUX_SELECT */
+
+void ADC16_SetHardwareCompareConfig(ADC_Type *base, const adc16_hardware_compare_config_t *config)
+{
+    uint32_t tmp32 = base->SC2 & ~(ADC_SC2_ACFE_MASK | ADC_SC2_ACFGT_MASK | ADC_SC2_ACREN_MASK);
+
+    if (!config) /* Pass "NULL" to disable the feature. */
+    {
+        base->SC2 = tmp32;
+        return;
+    }
+    /* Enable the feature. */
+    tmp32 |= ADC_SC2_ACFE_MASK;
+
+    /* Select the hardware compare working mode. */
+    switch (config->hardwareCompareMode)
+    {
+        case kADC16_HardwareCompareMode0:
+            break;
+        case kADC16_HardwareCompareMode1:
+            tmp32 |= ADC_SC2_ACFGT_MASK;
+            break;
+        case kADC16_HardwareCompareMode2:
+            tmp32 |= ADC_SC2_ACREN_MASK;
+            break;
+        case kADC16_HardwareCompareMode3:
+            tmp32 |= ADC_SC2_ACFGT_MASK | ADC_SC2_ACREN_MASK;
+            break;
+        default:
+            break;
+    }
+    base->SC2 = tmp32;
+
+    /* Load the compare values. */
+    base->CV1 = ADC_CV1_CV(config->value1);
+    base->CV2 = ADC_CV2_CV(config->value2);
+}
+
+#if defined(FSL_FEATURE_ADC16_HAS_HW_AVERAGE) && FSL_FEATURE_ADC16_HAS_HW_AVERAGE
+void ADC16_SetHardwareAverage(ADC_Type *base, adc16_hardware_average_mode_t mode)
+{
+    uint32_t tmp32 = base->SC3 & ~(ADC_SC3_AVGE_MASK | ADC_SC3_AVGS_MASK);
+
+    if (kADC16_HardwareAverageDisabled != mode)
+    {
+        tmp32 |= ADC_SC3_AVGE_MASK | ADC_SC3_AVGS(mode);
+    }
+    base->SC3 = tmp32;
+}
+#endif /* FSL_FEATURE_ADC16_HAS_HW_AVERAGE */
+
+#if defined(FSL_FEATURE_ADC16_HAS_PGA) && FSL_FEATURE_ADC16_HAS_PGA
+void ADC16_SetPGAConfig(ADC_Type *base, const adc16_pga_config_t *config)
+{
+    uint32_t tmp32;
+
+    if (!config) /* Passing "NULL" is to disable the feature. */
+    {
+        base->PGA = 0U;
+        return;
+    }
+
+    /* Enable the PGA and set the gain value. */
+    tmp32 = ADC_PGA_PGAEN_MASK | ADC_PGA_PGAG(config->pgaGain);
+
+    /* Configure the misc features for PGA. */
+    if (config->enableRunInNormalMode)
+    {
+        tmp32 |= ADC_PGA_PGALPb_MASK;
+    }
+#if defined(FSL_FEATURE_ADC16_HAS_PGA_CHOPPING) && FSL_FEATURE_ADC16_HAS_PGA_CHOPPING
+    if (config->disablePgaChopping)
+    {
+        tmp32 |= ADC_PGA_PGACHPb_MASK;
+    }
+#endif /* FSL_FEATURE_ADC16_HAS_PGA_CHOPPING */
+#if defined(FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT) && FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT
+    if (config->enableRunInOffsetMeasurement)
+    {
+        tmp32 |= ADC_PGA_PGAOFSM_MASK;
+    }
+#endif /* FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT */
+    base->PGA = tmp32;
+}
+#endif /* FSL_FEATURE_ADC16_HAS_PGA */
+
+uint32_t ADC16_GetStatusFlags(ADC_Type *base)
+{
+    uint32_t ret = 0;
+
+    if (0U != (base->SC2 & ADC_SC2_ADACT_MASK))
+    {
+        ret |= kADC16_ActiveFlag;
+    }
+#if defined(FSL_FEATURE_ADC16_HAS_CALIBRATION) && FSL_FEATURE_ADC16_HAS_CALIBRATION
+    if (0U != (base->SC3 & ADC_SC3_CALF_MASK))
+    {
+        ret |= kADC16_CalibrationFailedFlag;
+    }
+#endif /* FSL_FEATURE_ADC16_HAS_CALIBRATION */
+    return ret;
+}
+
+void ADC16_ClearStatusFlags(ADC_Type *base, uint32_t mask)
+{
+#if defined(FSL_FEATURE_ADC16_HAS_CALIBRATION) && FSL_FEATURE_ADC16_HAS_CALIBRATION
+    if (0U != (mask & kADC16_CalibrationFailedFlag))
+    {
+        base->SC3 |= ADC_SC3_CALF_MASK;
+    }
+#endif /* FSL_FEATURE_ADC16_HAS_CALIBRATION */
+}
+
+void ADC16_SetChannelConfig(ADC_Type *base, uint32_t channelGroup, const adc16_channel_config_t *config)
+{
+    assert(channelGroup < ADC_SC1_COUNT);
+    assert(NULL != config);
+
+    uint32_t sc1 = ADC_SC1_ADCH(config->channelNumber); /* Set the channel number. */
+
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+    /* Enable the differential conversion. */
+    if (config->enableDifferentialConversion)
+    {
+        sc1 |= ADC_SC1_DIFF_MASK;
+    }
+#endif /* FSL_FEATURE_ADC16_HAS_DIFF_MODE */
+    /* Enable the interrupt when the conversion is done. */
+    if (config->enableInterruptOnConversionCompleted)
+    {
+        sc1 |= ADC_SC1_AIEN_MASK;
+    }
+    base->SC1[channelGroup] = sc1;
+}
+
+uint32_t ADC16_GetChannelStatusFlags(ADC_Type *base, uint32_t channelGroup)
+{
+    assert(channelGroup < ADC_SC1_COUNT);
+
+    uint32_t ret = 0U;
+
+    if (0U != (base->SC1[channelGroup] & ADC_SC1_COCO_MASK))
+    {
+        ret |= kADC16_ChannelConversionDoneFlag;
+    }
+    return ret;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_adc16.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_adc16.h
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_ADC16_H_
+#define _FSL_ADC16_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup adc16
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief ADC16 driver version 2.0.0. */
+#define FSL_ADC16_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*!
+ * @brief Channel status flags.
+ */
+enum _adc16_channel_status_flags
+{
+    kADC16_ChannelConversionDoneFlag = ADC_SC1_COCO_MASK, /*!< Conversion done. */
+};
+
+/*!
+ * @brief Converter status flags.
+ */
+enum _adc16_status_flags
+{
+    kADC16_ActiveFlag = ADC_SC2_ADACT_MASK, /*!< Converter is active. */
+#if defined(FSL_FEATURE_ADC16_HAS_CALIBRATION) && FSL_FEATURE_ADC16_HAS_CALIBRATION
+    kADC16_CalibrationFailedFlag = ADC_SC3_CALF_MASK, /*!< Calibration is failed. */
+#endif                                                /* FSL_FEATURE_ADC16_HAS_CALIBRATION */
+};
+
+#if defined(FSL_FEATURE_ADC16_HAS_MUX_SELECT) && FSL_FEATURE_ADC16_HAS_MUX_SELECT
+/*!
+ * @brief Channel multiplexer mode for each channel.
+ *
+ * For some ADC16 channels, there are two pin selections in channel multiplexer. For example, ADC0_SE4a and ADC0_SE4b
+ * are the different channels but share the same channel number.
+ */
+typedef enum _adc_channel_mux_mode
+{
+    kADC16_ChannelMuxA = 0U, /*!< For channel with channel mux a. */
+    kADC16_ChannelMuxB = 1U, /*!< For channel with channel mux b. */
+} adc16_channel_mux_mode_t;
+#endif /* FSL_FEATURE_ADC16_HAS_MUX_SELECT */
+
+/*!
+ * @brief Clock divider for the converter.
+ */
+typedef enum _adc16_clock_divider
+{
+    kADC16_ClockDivider1 = 0U, /*!< For divider 1 from the input clock to the module. */
+    kADC16_ClockDivider2 = 1U, /*!< For divider 2 from the input clock to the module. */
+    kADC16_ClockDivider4 = 2U, /*!< For divider 4 from the input clock to the module. */
+    kADC16_ClockDivider8 = 3U, /*!< For divider 8 from the input clock to the module. */
+} adc16_clock_divider_t;
+
+/*!
+ *@brief Converter's resolution.
+ */
+typedef enum _adc16_resolution
+{
+    /* This group of enumeration is for internal use which is related to register setting. */
+    kADC16_Resolution8or9Bit = 0U,   /*!< Single End 8-bit or Differential Sample 9-bit. */
+    kADC16_Resolution12or13Bit = 1U, /*!< Single End 12-bit or Differential Sample 13-bit. */
+    kADC16_Resolution10or11Bit = 2U, /*!< Single End 10-bit or Differential Sample 11-bit. */
+
+    /* This group of enumeration is for public user. */
+    kADC16_ResolutionSE8Bit = kADC16_Resolution8or9Bit,    /*!< Single End 8-bit. */
+    kADC16_ResolutionSE12Bit = kADC16_Resolution12or13Bit, /*!< Single End 12-bit. */
+    kADC16_ResolutionSE10Bit = kADC16_Resolution10or11Bit, /*!< Single End 10-bit. */
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+    kADC16_ResolutionDF9Bit = kADC16_Resolution8or9Bit,    /*!< Differential Sample 9-bit. */
+    kADC16_ResolutionDF13Bit = kADC16_Resolution12or13Bit, /*!< Differential Sample 13-bit. */
+    kADC16_ResolutionDF11Bit = kADC16_Resolution10or11Bit, /*!< Differential Sample 11-bit. */
+#endif                                                     /* FSL_FEATURE_ADC16_HAS_DIFF_MODE */
+
+#if defined(FSL_FEATURE_ADC16_MAX_RESOLUTION) && (FSL_FEATURE_ADC16_MAX_RESOLUTION >= 16U)
+    /* 16-bit is supported by default. */
+    kADC16_Resolution16Bit = 3U,                       /*!< Single End 16-bit or Differential Sample 16-bit. */
+    kADC16_ResolutionSE16Bit = kADC16_Resolution16Bit, /*!< Single End 16-bit. */
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+    kADC16_ResolutionDF16Bit = kADC16_Resolution16Bit, /*!< Differential Sample 16-bit. */
+#endif                                                 /* FSL_FEATURE_ADC16_HAS_DIFF_MODE */
+#endif                                                 /* FSL_FEATURE_ADC16_MAX_RESOLUTION >= 16U */
+} adc16_resolution_t;
+
+/*!
+ * @brief Clock source.
+ */
+typedef enum _adc16_clock_source
+{
+    kADC16_ClockSourceAlt0 = 0U, /*!< Selection 0 of the clock source. */
+    kADC16_ClockSourceAlt1 = 1U, /*!< Selection 1 of the clock source. */
+    kADC16_ClockSourceAlt2 = 2U, /*!< Selection 2 of the clock source. */
+    kADC16_ClockSourceAlt3 = 3U, /*!< Selection 3 of the clock source. */
+
+    /* Chip defined clock source */
+    kADC16_ClockSourceAsynchronousClock = kADC16_ClockSourceAlt3, /*!< Using internal asynchronous clock. */
+} adc16_clock_source_t;
+
+/*!
+ * @brief Long sample mode.
+ */
+typedef enum _adc16_long_sample_mode
+{
+    kADC16_LongSampleCycle24 = 0U,  /*!< 20 extra ADCK cycles, 24 ADCK cycles total. */
+    kADC16_LongSampleCycle16 = 1U,  /*!< 12 extra ADCK cycles, 16 ADCK cycles total. */
+    kADC16_LongSampleCycle10 = 2U,  /*!< 6 extra ADCK cycles, 10 ADCK cycles total. */
+    kADC16_LongSampleCycle6 = 3U,   /*!< 2 extra ADCK cycles, 6 ADCK cycles total. */
+    kADC16_LongSampleDisabled = 4U, /*!< Disable the long sample feature. */
+} adc16_long_sample_mode_t;
+
+/*!
+ * @brief Reference voltage source.
+ */
+typedef enum _adc16_reference_voltage_source
+{
+    kADC16_ReferenceVoltageSourceVref = 0U, /*!< For external pins pair of VrefH and VrefL. */
+    kADC16_ReferenceVoltageSourceValt = 1U, /*!< For alternate reference pair of ValtH and ValtL. */
+} adc16_reference_voltage_source_t;
+
+#if defined(FSL_FEATURE_ADC16_HAS_HW_AVERAGE) && FSL_FEATURE_ADC16_HAS_HW_AVERAGE
+/*!
+ * @brief Hardware average mode.
+ */
+typedef enum _adc16_hardware_average_mode
+{
+    kADC16_HardwareAverageCount4 = 0U,   /*!< For hardware average with 4 samples. */
+    kADC16_HardwareAverageCount8 = 1U,   /*!< For hardware average with 8 samples. */
+    kADC16_HardwareAverageCount16 = 2U,  /*!< For hardware average with 16 samples. */
+    kADC16_HardwareAverageCount32 = 3U,  /*!< For hardware average with 32 samples. */
+    kADC16_HardwareAverageDisabled = 4U, /*!< Disable the hardware average feature.*/
+} adc16_hardware_average_mode_t;
+#endif /* FSL_FEATURE_ADC16_HAS_HW_AVERAGE */
+
+/*!
+ * @brief Hardware compare mode.
+ */
+typedef enum _adc16_hardware_compare_mode
+{
+    kADC16_HardwareCompareMode0 = 0U, /*!< x < value1. */
+    kADC16_HardwareCompareMode1 = 1U, /*!< x > value1. */
+    kADC16_HardwareCompareMode2 = 2U, /*!< if value1 <= value2, then x < value1 || x > value2;
+                                           else, value1 > x > value2. */
+    kADC16_HardwareCompareMode3 = 3U, /*!< if value1 <= value2, then value1 <= x <= value2;
+                                           else x >= value1 || x <= value2. */
+} adc16_hardware_compare_mode_t;
+
+#if defined(FSL_FEATURE_ADC16_HAS_PGA) && FSL_FEATURE_ADC16_HAS_PGA
+/*!
+ * @brief PGA's Gain mode.
+ */
+typedef enum _adc16_pga_gain
+{
+    kADC16_PGAGainValueOf1 = 0U,  /*!< For amplifier gain of 1.  */
+    kADC16_PGAGainValueOf2 = 1U,  /*!< For amplifier gain of 2.  */
+    kADC16_PGAGainValueOf4 = 2U,  /*!< For amplifier gain of 4.  */
+    kADC16_PGAGainValueOf8 = 3U,  /*!< For amplifier gain of 8.  */
+    kADC16_PGAGainValueOf16 = 4U, /*!< For amplifier gain of 16. */
+    kADC16_PGAGainValueOf32 = 5U, /*!< For amplifier gain of 32. */
+    kADC16_PGAGainValueOf64 = 6U, /*!< For amplifier gain of 64. */
+} adc16_pga_gain_t;
+#endif /* FSL_FEATURE_ADC16_HAS_PGA */
+
+/*!
+ * @brief ADC16 converter configuration .
+ */
+typedef struct _adc16_config
+{
+    adc16_reference_voltage_source_t referenceVoltageSource; /*!< Select the reference voltage source. */
+    adc16_clock_source_t clockSource;                        /*!< Select the input clock source to converter. */
+    bool enableAsynchronousClock;                            /*!< Enable the asynchronous clock output. */
+    adc16_clock_divider_t clockDivider;                      /*!< Select the divider of input clock source. */
+    adc16_resolution_t resolution;                           /*!< Select the sample resolution mode. */
+    adc16_long_sample_mode_t longSampleMode;                 /*!< Select the long sample mode. */
+    bool enableHighSpeed;                                    /*!< Enable the high-speed mode. */
+    bool enableLowPower;                                     /*!< Enable low power. */
+    bool enableContinuousConversion;                         /*!< Enable continuous conversion mode. */
+} adc16_config_t;
+
+/*!
+ * @brief ADC16 Hardware compare configuration.
+ */
+typedef struct _adc16_hardware_compare_config
+{
+    adc16_hardware_compare_mode_t hardwareCompareMode; /*!< Select the hardware compare mode.
+                                                            See "adc16_hardware_compare_mode_t". */
+    int16_t value1;                                    /*!< Setting value1 for hardware compare mode. */
+    int16_t value2;                                    /*!< Setting value2 for hardware compare mode. */
+} adc16_hardware_compare_config_t;
+
+/*!
+ * @brief ADC16 channel conversion configuration.
+ */
+typedef struct _adc16_channel_config
+{
+    uint32_t channelNumber;                    /*!< Setting the conversion channel number. The available range is 0-31.
+                                                    See channel connection information for each chip in Reference
+                                                    Manual document. */
+    bool enableInterruptOnConversionCompleted; /*!< Generate a interrupt request once the conversion is completed. */
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+    bool enableDifferentialConversion; /*!< Using Differential sample mode. */
+#endif                                 /* FSL_FEATURE_ADC16_HAS_DIFF_MODE */
+} adc16_channel_config_t;
+
+#if defined(FSL_FEATURE_ADC16_HAS_PGA) && FSL_FEATURE_ADC16_HAS_PGA
+/*!
+ * @brief ADC16 programmable gain amplifier configuration.
+ */
+typedef struct _adc16_pga_config
+{
+    adc16_pga_gain_t pgaGain;   /*!< Setting PGA gain. */
+    bool enableRunInNormalMode; /*!< Enable PGA working in normal mode, or low power mode by default. */
+#if defined(FSL_FEATURE_ADC16_HAS_PGA_CHOPPING) && FSL_FEATURE_ADC16_HAS_PGA_CHOPPING
+    bool disablePgaChopping; /*!< Disable the PGA chopping function.
+                                  The PGA employs chopping to remove/reduce offset and 1/f noise and offers
+                                  an offset measurement configuration that aids the offset calibration. */
+#endif                       /* FSL_FEATURE_ADC16_HAS_PGA_CHOPPING */
+#if defined(FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT) && FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT
+    bool enableRunInOffsetMeasurement; /*!< Enable the PGA working in offset measurement mode.
+                                            When this feature is enabled, the PGA disconnects itself from the external
+                                            inputs and auto-configures into offset measurement mode. With this field
+                                            set, run the ADC in the recommended settings and enable the maximum hardware
+                                            averaging to get the PGA offset number. The output is the
+                                            (PGA offset * (64+1)) for the given PGA setting. */
+#endif                                 /* FSL_FEATURE_ADC16_HAS_PGA_OFFSET_MEASUREMENT */
+} adc16_pga_config_t;
+#endif /* FSL_FEATURE_ADC16_HAS_PGA */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+/*!
+ * @name Initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the ADC16 module.
+ *
+ * @param base   ADC16 peripheral base address.
+ * @param config Pointer to configuration structure. See "adc16_config_t".
+ */
+void ADC16_Init(ADC_Type *base, const adc16_config_t *config);
+
+/*!
+ * @brief De-initializes the ADC16 module.
+ *
+ * @param base ADC16 peripheral base address.
+ */
+void ADC16_Deinit(ADC_Type *base);
+
+/*!
+ * @brief Gets an available pre-defined settings for converter's configuration.
+ *
+ * This function initializes the converter configuration structure with an available settings. The default values are:
+ * @code
+ *   config->referenceVoltageSource     = kADC16_ReferenceVoltageSourceVref;
+ *   config->clockSource                = kADC16_ClockSourceAsynchronousClock;
+ *   config->enableAsynchronousClock    = true;
+ *   config->clockDivider               = kADC16_ClockDivider8;
+ *   config->resolution                 = kADC16_ResolutionSE12Bit;
+ *   config->longSampleMode             = kADC16_LongSampleDisabled;
+ *   config->enableHighSpeed            = false;
+ *   config->enableLowPower             = false;
+ *   config->enableContinuousConversion = false;
+ * @endcode
+ * @param config Pointer to configuration structure.
+ */
+void ADC16_GetDefaultConfig(adc16_config_t *config);
+
+#if defined(FSL_FEATURE_ADC16_HAS_CALIBRATION) && FSL_FEATURE_ADC16_HAS_CALIBRATION
+/*!
+ * @brief  Automates the hardware calibration.
+ *
+ * This auto calibration helps to adjust the plus/minus side gain automatically on the converter's working situation.
+ * Execute the calibration before using the converter. Note that the hardware trigger should be used
+ * during calibration.
+ *
+ * @param  base ADC16 peripheral base address.
+ *
+ * @return                 Execution status.
+ * @retval kStatus_Success Calibration is done successfully.
+ * @retval kStatus_Fail    Calibration is failed.
+ */
+status_t ADC16_DoAutoCalibration(ADC_Type *base);
+#endif /* FSL_FEATURE_ADC16_HAS_CALIBRATION */
+
+#if defined(FSL_FEATURE_ADC16_HAS_OFFSET_CORRECTION) && FSL_FEATURE_ADC16_HAS_OFFSET_CORRECTION
+/*!
+ * @brief Sets the offset value for the conversion result.
+ *
+ * This offset value takes effect on the conversion result. If the offset value is not zero, the reading result
+ * is subtracted by it. Note, the hardware calibration fills the offset value automatically.
+ *
+ * @param base  ADC16 peripheral base address.
+ * @param value Setting offset value.
+ */
+static inline void ADC16_SetOffsetValue(ADC_Type *base, int16_t value)
+{
+    base->OFS = (uint32_t)(value);
+}
+#endif /* FSL_FEATURE_ADC16_HAS_OFFSET_CORRECTION */
+
+/* @} */
+
+/*!
+ * @name Advanced Feature
+ * @{
+ */
+
+#if defined(FSL_FEATURE_ADC16_HAS_DMA) && FSL_FEATURE_ADC16_HAS_DMA
+/*!
+ * @brief Enables generating the DMA trigger when conversion is completed.
+ *
+ * @param base   ADC16 peripheral base address.
+ * @param enable Switcher of DMA feature. "true" means to enable, "false" means not.
+ */
+static inline void ADC16_EnableDMA(ADC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->SC2 |= ADC_SC2_DMAEN_MASK;
+    }
+    else
+    {
+        base->SC2 &= ~ADC_SC2_DMAEN_MASK;
+    }
+}
+#endif /* FSL_FEATURE_ADC16_HAS_DMA */
+
+/*!
+ * @brief Enables the hardware trigger mode.
+ *
+ * @param base   ADC16 peripheral base address.
+ * @param enable Switcher of hardware trigger feature. "true" means to enable, "false" means not.
+ */
+static inline void ADC16_EnableHardwareTrigger(ADC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->SC2 |= ADC_SC2_ADTRG_MASK;
+    }
+    else
+    {
+        base->SC2 &= ~ADC_SC2_ADTRG_MASK;
+    }
+}
+
+#if defined(FSL_FEATURE_ADC16_HAS_MUX_SELECT) && FSL_FEATURE_ADC16_HAS_MUX_SELECT
+/*!
+ * @brief Sets the channel mux mode.
+ *
+ * Some sample pins share the same channel index. The channel mux mode decides which pin is used for an
+ * indicated channel.
+ *
+ * @param base ADC16 peripheral base address.
+ * @param mode Setting channel mux mode. See "adc16_channel_mux_mode_t".
+ */
+void ADC16_SetChannelMuxMode(ADC_Type *base, adc16_channel_mux_mode_t mode);
+#endif /* FSL_FEATURE_ADC16_HAS_MUX_SELECT */
+
+/*!
+ * @brief Configures the hardware compare mode.
+ *
+ * The hardware compare mode provides a way to process the conversion result automatically by hardware. Only the result
+ * in
+ * compare range is available. To compare the range, see "adc16_hardware_compare_mode_t", or the reference
+ * manual document for more detailed information.
+ *
+ * @param base     ADC16 peripheral base address.
+ * @param config   Pointer to "adc16_hardware_compare_config_t" structure. Passing "NULL" is to disable the feature.
+ */
+void ADC16_SetHardwareCompareConfig(ADC_Type *base, const adc16_hardware_compare_config_t *config);
+
+#if defined(FSL_FEATURE_ADC16_HAS_HW_AVERAGE) && FSL_FEATURE_ADC16_HAS_HW_AVERAGE
+/*!
+ * @brief Sets the hardware average mode.
+ *
+ * Hardware average mode provides a way to process the conversion result automatically by hardware. The multiple
+ * conversion results are accumulated and averaged internally. This aids  reading results.
+ *
+ * @param base  ADC16 peripheral base address.
+ * @param mode  Setting hardware average mode. See "adc16_hardware_average_mode_t".
+ */
+void ADC16_SetHardwareAverage(ADC_Type *base, adc16_hardware_average_mode_t mode);
+#endif /* FSL_FEATURE_ADC16_HAS_HW_AVERAGE */
+
+#if defined(FSL_FEATURE_ADC16_HAS_PGA) && FSL_FEATURE_ADC16_HAS_PGA
+/*!
+ * @brief Configures the PGA for converter's front end.
+ *
+ * @param base    ADC16 peripheral base address.
+ * @param config  Pointer to "adc16_pga_config_t" structure. Passing "NULL" is to disable the feature.
+ */
+void ADC16_SetPGAConfig(ADC_Type *base, const adc16_pga_config_t *config);
+#endif /* FSL_FEATURE_ADC16_HAS_PGA */
+
+/*!
+ * @brief  Gets the status flags of the converter.
+ *
+ * @param  base ADC16 peripheral base address.
+ *
+ * @return      Flags' mask if indicated flags are asserted. See "_adc16_status_flags".
+ */
+uint32_t ADC16_GetStatusFlags(ADC_Type *base);
+
+/*!
+ * @brief  Clears the status flags of the converter.
+ *
+ * @param  base ADC16 peripheral base address.
+ * @param  mask Mask value for the cleared flags. See "_adc16_status_flags".
+ */
+void ADC16_ClearStatusFlags(ADC_Type *base, uint32_t mask);
+
+/* @} */
+
+/*!
+ * @name Conversion Channel
+ * @{
+ */
+
+/*!
+ * @brief Configures the conversion channel.
+ *
+ * This operation triggers the conversion if in software trigger mode. When in hardware trigger mode, this API
+ * configures the channel while the external trigger source helps to trigger the conversion.
+ *
+ * Note that the "Channel Group" has a detailed description.
+ * To allow sequential conversions of the ADC to be triggered by internal peripherals, the ADC can have more than one
+ * group of status and control register, one for each conversion. The channel group parameter indicates which group of
+ * registers are used channel group 0 is for Group A registers and channel group 1 is for Group B registers.  The
+ * channel groups are used in a "ping-pong" approach to control the ADC operation.  At any point, only one of
+ * the channel groups is actively controlling ADC conversions. Channel group 0 is used for both software and hardware
+ * trigger modes of operation. Channel groups 1 and greater indicate potentially multiple channel group registers for
+ * use only in hardware trigger mode. See the chip configuration information in the MCU reference manual about the
+ * number of SC1n registers (channel groups) specific to this device.  None of the channel groups 1 or greater are used
+ * for software trigger operation and therefore writes to these channel groups do not initiate a new conversion.
+ * Updating channel group 0 while a different channel group is actively controlling a conversion is allowed and
+ * vice versa. Writing any of the channel group registers while that specific channel group is actively controlling a
+ * conversion aborts the current conversion.
+ *
+ * @param base          ADC16 peripheral base address.
+ * @param channelGroup  Channel group index.
+ * @param config        Pointer to "adc16_channel_config_t" structure for conversion channel.
+ */
+void ADC16_SetChannelConfig(ADC_Type *base, uint32_t channelGroup, const adc16_channel_config_t *config);
+
+/*!
+ * @brief  Gets the conversion value.
+ *
+ * @param  base         ADC16 peripheral base address.
+ * @param  channelGroup Channel group index.
+ *
+ * @return              Conversion value.
+ */
+static inline uint32_t ADC16_GetChannelConversionValue(ADC_Type *base, uint32_t channelGroup)
+{
+    assert(channelGroup < ADC_R_COUNT);
+
+    return base->R[channelGroup];
+}
+
+/*!
+ * @brief  Gets the status flags of channel.
+ *
+ * @param  base         ADC16 peripheral base address.
+ * @param  channelGroup Channel group index.
+ *
+ * @return              Flags' mask if indicated flags are asserted. See "_adc16_channel_status_flags".
+ */
+uint32_t ADC16_GetChannelStatusFlags(ADC_Type *base, uint32_t channelGroup);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+/*!
+ * @}
+ */
+#endif /* _FSL_ADC16_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_clock.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_clock.c
@@ -1,0 +1,1760 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_common.h"
+#include "fsl_clock.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Macro definition remap workaround. */
+#if (defined(MCG_C2_EREFS_MASK) && !(defined(MCG_C2_EREFS0_MASK)))
+#define MCG_C2_EREFS0_MASK MCG_C2_EREFS_MASK
+#endif
+#if (defined(MCG_C2_HGO_MASK) && !(defined(MCG_C2_HGO0_MASK)))
+#define MCG_C2_HGO0_MASK MCG_C2_HGO_MASK
+#endif
+#if (defined(MCG_C2_RANGE_MASK) && !(defined(MCG_C2_RANGE0_MASK)))
+#define MCG_C2_RANGE0_MASK MCG_C2_RANGE_MASK
+#endif
+#if (defined(MCG_C6_CME_MASK) && !(defined(MCG_C6_CME0_MASK)))
+#define MCG_C6_CME0_MASK MCG_C6_CME_MASK
+#endif
+
+/* PLL fixed multiplier when there is not PRDIV and VDIV. */
+#define PLL_FIXED_MULT (375U)
+/* Max frequency of the reference clock used for internal clock trim. */
+#define TRIM_REF_CLK_MIN (8000000U)
+/* Min frequency of the reference clock used for internal clock trim. */
+#define TRIM_REF_CLK_MAX (16000000U)
+/* Max trim value of fast internal reference clock. */
+#define TRIM_FIRC_MAX (5000000U)
+/* Min trim value of fast internal reference clock. */
+#define TRIM_FIRC_MIN (3000000U)
+/* Max trim value of fast internal reference clock. */
+#define TRIM_SIRC_MAX (39063U)
+/* Min trim value of fast internal reference clock. */
+#define TRIM_SIRC_MIN (31250U)
+
+#define MCG_S_IRCST_VAL ((MCG->S & MCG_S_IRCST_MASK) >> MCG_S_IRCST_SHIFT)
+#define MCG_S_CLKST_VAL ((MCG->S & MCG_S_CLKST_MASK) >> MCG_S_CLKST_SHIFT)
+#define MCG_S_IREFST_VAL ((MCG->S & MCG_S_IREFST_MASK) >> MCG_S_IREFST_SHIFT)
+#define MCG_S_PLLST_VAL ((MCG->S & MCG_S_PLLST_MASK) >> MCG_S_PLLST_SHIFT)
+#define MCG_C1_FRDIV_VAL ((MCG->C1 & MCG_C1_FRDIV_MASK) >> MCG_C1_FRDIV_SHIFT)
+#define MCG_C2_LP_VAL ((MCG->C2 & MCG_C2_LP_MASK) >> MCG_C2_LP_SHIFT)
+#define MCG_C2_RANGE_VAL ((MCG->C2 & MCG_C2_RANGE_MASK) >> MCG_C2_RANGE_SHIFT)
+#define MCG_SC_FCRDIV_VAL ((MCG->SC & MCG_SC_FCRDIV_MASK) >> MCG_SC_FCRDIV_SHIFT)
+#define MCG_S2_PLLCST_VAL ((MCG->S2 & MCG_S2_PLLCST_MASK) >> MCG_S2_PLLCST_SHIFT)
+#define MCG_C7_OSCSEL_VAL ((MCG->C7 & MCG_C7_OSCSEL_MASK) >> MCG_C7_OSCSEL_SHIFT)
+#define MCG_C4_DMX32_VAL ((MCG->C4 & MCG_C4_DMX32_MASK) >> MCG_C4_DMX32_SHIFT)
+#define MCG_C4_DRST_DRS_VAL ((MCG->C4 & MCG_C4_DRST_DRS_MASK) >> MCG_C4_DRST_DRS_SHIFT)
+#define MCG_C7_PLL32KREFSEL_VAL ((MCG->C7 & MCG_C7_PLL32KREFSEL_MASK) >> MCG_C7_PLL32KREFSEL_SHIFT)
+#define MCG_C5_PLLREFSEL0_VAL ((MCG->C5 & MCG_C5_PLLREFSEL0_MASK) >> MCG_C5_PLLREFSEL0_SHIFT)
+#define MCG_C11_PLLREFSEL1_VAL ((MCG->C11 & MCG_C11_PLLREFSEL1_MASK) >> MCG_C11_PLLREFSEL1_SHIFT)
+#define MCG_C11_PRDIV1_VAL ((MCG->C11 & MCG_C11_PRDIV1_MASK) >> MCG_C11_PRDIV1_SHIFT)
+#define MCG_C12_VDIV1_VAL ((MCG->C12 & MCG_C12_VDIV1_MASK) >> MCG_C12_VDIV1_SHIFT)
+#define MCG_C5_PRDIV0_VAL ((MCG->C5 & MCG_C5_PRDIV0_MASK) >> MCG_C5_PRDIV0_SHIFT)
+#define MCG_C6_VDIV0_VAL ((MCG->C6 & MCG_C6_VDIV0_MASK) >> MCG_C6_VDIV0_SHIFT)
+
+#define OSC_MODE_MASK (MCG_C2_EREFS0_MASK | MCG_C2_HGO0_MASK | MCG_C2_RANGE0_MASK)
+
+#define SIM_CLKDIV1_OUTDIV1_VAL ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV1_MASK) >> SIM_CLKDIV1_OUTDIV1_SHIFT)
+#define SIM_CLKDIV1_OUTDIV2_VAL ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV2_MASK) >> SIM_CLKDIV1_OUTDIV2_SHIFT)
+#define SIM_CLKDIV1_OUTDIV3_VAL ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV3_MASK) >> SIM_CLKDIV1_OUTDIV3_SHIFT)
+#define SIM_CLKDIV1_OUTDIV4_VAL ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV4_MASK) >> SIM_CLKDIV1_OUTDIV4_SHIFT)
+#define SIM_SOPT1_OSC32KSEL_VAL ((SIM->SOPT1 & SIM_SOPT1_OSC32KSEL_MASK) >> SIM_SOPT1_OSC32KSEL_SHIFT)
+#define SIM_SOPT2_PLLFLLSEL_VAL ((SIM->SOPT2 & SIM_SOPT2_PLLFLLSEL_MASK) >> SIM_SOPT2_PLLFLLSEL_SHIFT)
+
+/* MCG_S_CLKST definition. */
+enum _mcg_clkout_stat
+{
+    kMCG_ClkOutStatFll, /* FLL.            */
+    kMCG_ClkOutStatInt, /* Internal clock. */
+    kMCG_ClkOutStatExt, /* External clock. */
+    kMCG_ClkOutStatPll  /* PLL.            */
+};
+
+/* MCG_S_PLLST definition. */
+enum _mcg_pllst
+{
+    kMCG_PllstFll, /* FLL is used. */
+    kMCG_PllstPll  /* PLL is used. */
+};
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/* Slow internal reference clock frequency. */
+static uint32_t s_slowIrcFreq = 32768U;
+/* Fast internal reference clock frequency. */
+static uint32_t s_fastIrcFreq = 4000000U;
+
+/* External XTAL0 (OSC0) clock frequency. */
+uint32_t g_xtal0Freq;
+
+/* External XTAL32K clock frequency. */
+uint32_t g_xtal32Freq;
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get the MCG external reference clock frequency.
+ *
+ * Get the current MCG external reference clock frequency in Hz. It is
+ * the frequency select by MCG_C7[OSCSEL]. This is an internal function.
+ *
+ * @return MCG external reference clock frequency in Hz.
+ */
+static uint32_t CLOCK_GetMcgExtClkFreq(void);
+
+/*!
+ * @brief Get the MCG FLL external reference clock frequency.
+ *
+ * Get the current MCG FLL external reference clock frequency in Hz. It is
+ * the frequency after by MCG_C1[FRDIV]. This is an internal function.
+ *
+ * @return MCG FLL external reference clock frequency in Hz.
+ */
+static uint32_t CLOCK_GetFllExtRefClkFreq(void);
+
+/*!
+ * @brief Get the MCG FLL reference clock frequency.
+ *
+ * Get the current MCG FLL reference clock frequency in Hz. It is
+ * the frequency select by MCG_C1[IREFS]. This is an internal function.
+ *
+ * @return MCG FLL reference clock frequency in Hz.
+ */
+static uint32_t CLOCK_GetFllRefClkFreq(void);
+
+/*!
+ * @brief Get the frequency of clock selected by MCG_C2[IRCS].
+ *
+ * This clock's two output:
+ *  1. MCGOUTCLK when MCG_S[CLKST]=0.
+ *  2. MCGIRCLK when MCG_C1[IRCLKEN]=1.
+ *
+ * @return The frequency in Hz.
+ */
+static uint32_t CLOCK_GetInternalRefClkSelectFreq(void);
+
+/*!
+ * @brief Get the MCG PLL/PLL0 reference clock frequency.
+ *
+ * Get the current MCG PLL/PLL0 reference clock frequency in Hz.
+ * This is an internal function.
+ *
+ * @return MCG PLL/PLL0 reference clock frequency in Hz.
+ */
+static uint32_t CLOCK_GetPll0RefFreq(void);
+
+/*!
+ * @brief Calculate the RANGE value base on crystal frequency.
+ *
+ * To setup external crystal oscillator, must set the register bits RANGE
+ * base on the crystal frequency. This function returns the RANGE base on the
+ * input frequency. This is an internal function.
+ *
+ * @param freq Crystal frequency in Hz.
+ * @return The RANGE value.
+ */
+static uint8_t CLOCK_GetOscRangeFromFreq(uint32_t freq);
+
+/*!
+ * @brief Delay function to wait FLL stable.
+ *
+ * Delay function to wait FLL stable in FEI mode or FEE mode, should wait at least
+ * 1ms. Every time changes FLL setting, should wait this time for FLL stable.
+ */
+static void CLOCK_FllStableDelay(void);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t CLOCK_GetMcgExtClkFreq(void)
+{
+    uint32_t freq;
+
+    switch (MCG_C7_OSCSEL_VAL)
+    {
+        case 0U:
+            /* Please call CLOCK_SetXtal0Freq base on board setting before using OSC0 clock. */
+            assert(g_xtal0Freq);
+            freq = g_xtal0Freq;
+            break;
+        case 1U:
+            /* Please call CLOCK_SetXtal32Freq base on board setting before using XTAL32K/RTC_CLKIN clock. */
+            assert(g_xtal32Freq);
+            freq = g_xtal32Freq;
+            break;
+        case 2U:
+            freq = MCG_INTERNAL_IRC_48M;
+            break;
+        default:
+            freq = 0U;
+            break;
+    }
+
+    return freq;
+}
+
+static uint32_t CLOCK_GetFllExtRefClkFreq(void)
+{
+    /* FllExtRef = McgExtRef / FllExtRefDiv */
+    uint8_t frdiv;
+    uint8_t range;
+    uint8_t oscsel;
+
+    uint32_t freq = CLOCK_GetMcgExtClkFreq();
+
+    if (!freq)
+    {
+        return freq;
+    }
+
+    frdiv = MCG_C1_FRDIV_VAL;
+    freq >>= frdiv;
+
+    range = MCG_C2_RANGE_VAL;
+    oscsel = MCG_C7_OSCSEL_VAL;
+
+    /*
+       When should use divider 32, 64, 128, 256, 512, 1024, 1280, 1536.
+       1. MCG_C7[OSCSEL] selects IRC48M.
+       2. MCG_C7[OSCSEL] selects OSC0 and MCG_C2[RANGE] is not 0.
+    */
+    if (((0U != range) && (kMCG_OscselOsc == oscsel)) || (kMCG_OscselIrc == oscsel))
+    {
+        switch (frdiv)
+        {
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+                freq >>= 5u;
+                break;
+            case 6:
+                /* 64*20=1280 */
+                freq /= 20u;
+                break;
+            case 7:
+                /* 128*12=1536 */
+                freq /= 12u;
+                break;
+            default:
+                freq = 0u;
+                break;
+        }
+    }
+
+    return freq;
+}
+
+static uint32_t CLOCK_GetInternalRefClkSelectFreq(void)
+{
+    if (kMCG_IrcSlow == MCG_S_IRCST_VAL)
+    {
+        /* Slow internal reference clock selected*/
+        return s_slowIrcFreq;
+    }
+    else
+    {
+        /* Fast internal reference clock selected*/
+        return s_fastIrcFreq >> MCG_SC_FCRDIV_VAL;
+    }
+}
+
+static uint32_t CLOCK_GetFllRefClkFreq(void)
+{
+    /* If use external reference clock. */
+    if (kMCG_FllSrcExternal == MCG_S_IREFST_VAL)
+    {
+        return CLOCK_GetFllExtRefClkFreq();
+    }
+    /* If use internal reference clock. */
+    else
+    {
+        return s_slowIrcFreq;
+    }
+}
+
+static uint32_t CLOCK_GetPll0RefFreq(void)
+{
+    /* MCG external reference clock. */
+    return CLOCK_GetMcgExtClkFreq();
+}
+
+static uint8_t CLOCK_GetOscRangeFromFreq(uint32_t freq)
+{
+    uint8_t range;
+
+    if (freq <= 39063U)
+    {
+        range = 0U;
+    }
+    else if (freq <= 8000000U)
+    {
+        range = 1U;
+    }
+    else
+    {
+        range = 2U;
+    }
+
+    return range;
+}
+
+static void CLOCK_FllStableDelay(void)
+{
+    /*
+       Should wait at least 1ms. Because in these modes, the core clock is 100MHz
+       at most, so this function could obtain the 1ms delay.
+     */
+    volatile uint32_t i = 30000U;
+    while (i--)
+    {
+        __NOP();
+    }
+}
+
+uint32_t CLOCK_GetOsc0ErClkFreq(void)
+{
+    if (OSC0->CR & OSC_CR_ERCLKEN_MASK)
+    {
+        /* Please call CLOCK_SetXtal0Freq base on board setting before using OSC0 clock. */
+        assert(g_xtal0Freq);
+        return g_xtal0Freq;
+    }
+    else
+    {
+        return 0U;
+    }
+}
+
+uint32_t CLOCK_GetEr32kClkFreq(void)
+{
+    uint32_t freq;
+
+    switch (SIM_SOPT1_OSC32KSEL_VAL)
+    {
+        case 0U: /* OSC 32k clock  */
+            freq = (CLOCK_GetOsc0ErClkFreq() == 32768U) ? 32768U : 0U;
+            break;
+        case 2U: /* RTC 32k clock  */
+            /* Please call CLOCK_SetXtal32Freq base on board setting before using XTAL32K/RTC_CLKIN clock. */
+            assert(g_xtal32Freq);
+            freq = g_xtal32Freq;
+            break;
+        case 3U: /* LPO clock      */
+            freq = LPO_CLK_FREQ;
+            break;
+        default:
+            freq = 0U;
+            break;
+    }
+    return freq;
+}
+
+uint32_t CLOCK_GetPllFllSelClkFreq(void)
+{
+    uint32_t freq;
+
+    switch (SIM_SOPT2_PLLFLLSEL_VAL)
+    {
+        case 0U: /* FLL. */
+            freq = CLOCK_GetFllFreq();
+            break;
+        case 1U: /* PLL. */
+            freq = CLOCK_GetPll0Freq();
+            break;
+        case 3U: /* MCG IRC48M. */
+            freq = MCG_INTERNAL_IRC_48M;
+            break;
+        default:
+            freq = 0U;
+            break;
+    }
+
+    return freq;
+}
+
+uint32_t CLOCK_GetPlatClkFreq(void)
+{
+    return CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV1_VAL + 1);
+}
+
+uint32_t CLOCK_GetFlashClkFreq(void)
+{
+    return CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV4_VAL + 1);
+}
+
+uint32_t CLOCK_GetFlexBusClkFreq(void)
+{
+    return CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV3_VAL + 1);
+}
+
+uint32_t CLOCK_GetBusClkFreq(void)
+{
+    return CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV2_VAL + 1);
+}
+
+uint32_t CLOCK_GetCoreSysClkFreq(void)
+{
+    return CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV1_VAL + 1);
+}
+
+uint32_t CLOCK_GetFreq(clock_name_t clockName)
+{
+    uint32_t freq;
+
+    switch (clockName)
+    {
+        case kCLOCK_CoreSysClk:
+        case kCLOCK_PlatClk:
+            freq = CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV1_VAL + 1);
+            break;
+        case kCLOCK_BusClk:
+            freq = CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV2_VAL + 1);
+            break;
+        case kCLOCK_FlexBusClk:
+            freq = CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV3_VAL + 1);
+            break;
+        case kCLOCK_FlashClk:
+            freq = CLOCK_GetOutClkFreq() / (SIM_CLKDIV1_OUTDIV4_VAL + 1);
+            break;
+        case kCLOCK_PllFllSelClk:
+            freq = CLOCK_GetPllFllSelClkFreq();
+            break;
+        case kCLOCK_Er32kClk:
+            freq = CLOCK_GetEr32kClkFreq();
+            break;
+        case kCLOCK_Osc0ErClk:
+            freq = CLOCK_GetOsc0ErClkFreq();
+            break;
+        case kCLOCK_McgFixedFreqClk:
+            freq = CLOCK_GetFixedFreqClkFreq();
+            break;
+        case kCLOCK_McgInternalRefClk:
+            freq = CLOCK_GetInternalRefClkFreq();
+            break;
+        case kCLOCK_McgFllClk:
+            freq = CLOCK_GetFllFreq();
+            break;
+        case kCLOCK_McgPll0Clk:
+            freq = CLOCK_GetPll0Freq();
+            break;
+        case kCLOCK_McgIrc48MClk:
+            freq = MCG_INTERNAL_IRC_48M;
+            break;
+        case kCLOCK_LpoClk:
+            freq = LPO_CLK_FREQ;
+            break;
+        default:
+            freq = 0U;
+            break;
+    }
+
+    return freq;
+}
+
+void CLOCK_SetSimConfig(sim_clock_config_t const *config)
+{
+    SIM->CLKDIV1 = config->clkdiv1;
+    CLOCK_SetPllFllSelClock(config->pllFllSel);
+    CLOCK_SetEr32kClock(config->er32kSrc);
+}
+
+bool CLOCK_EnableUsbfs0Clock(clock_usb_src_t src, uint32_t freq)
+{
+    bool ret = true;
+
+    CLOCK_DisableClock(kCLOCK_Usbfs0);
+
+    if (kCLOCK_UsbSrcExt == src)
+    {
+        SIM->SOPT2 &= ~SIM_SOPT2_USBSRC_MASK;
+    }
+    else
+    {
+        switch (freq)
+        {
+            case 120000000U:
+                SIM->CLKDIV2 = SIM_CLKDIV2_USBDIV(4) | SIM_CLKDIV2_USBFRAC(1);
+                break;
+            case 96000000U:
+                SIM->CLKDIV2 = SIM_CLKDIV2_USBDIV(1) | SIM_CLKDIV2_USBFRAC(0);
+                break;
+            case 72000000U:
+                SIM->CLKDIV2 = SIM_CLKDIV2_USBDIV(2) | SIM_CLKDIV2_USBFRAC(1);
+                break;
+            case 48000000U:
+                SIM->CLKDIV2 = SIM_CLKDIV2_USBDIV(0) | SIM_CLKDIV2_USBFRAC(0);
+                break;
+            default:
+                ret = false;
+                break;
+        }
+
+        SIM->SOPT2 = ((SIM->SOPT2 & ~(SIM_SOPT2_PLLFLLSEL_MASK | SIM_SOPT2_USBSRC_MASK)) | (uint32_t)src);
+    }
+
+    CLOCK_EnableClock(kCLOCK_Usbfs0);
+
+    if (kCLOCK_UsbSrcIrc48M == src)
+    {
+        USB0->CLK_RECOVER_IRC_EN = 0x03U;
+        USB0->CLK_RECOVER_CTRL |= USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_MASK;
+    }
+    return ret;
+}
+
+uint32_t CLOCK_GetOutClkFreq(void)
+{
+    uint32_t mcgoutclk;
+    uint32_t clkst = MCG_S_CLKST_VAL;
+
+    switch (clkst)
+    {
+        case kMCG_ClkOutStatPll:
+            mcgoutclk = CLOCK_GetPll0Freq();
+            break;
+        case kMCG_ClkOutStatFll:
+            mcgoutclk = CLOCK_GetFllFreq();
+            break;
+        case kMCG_ClkOutStatInt:
+            mcgoutclk = CLOCK_GetInternalRefClkSelectFreq();
+            break;
+        case kMCG_ClkOutStatExt:
+            mcgoutclk = CLOCK_GetMcgExtClkFreq();
+            break;
+        default:
+            mcgoutclk = 0U;
+            break;
+    }
+    return mcgoutclk;
+}
+
+uint32_t CLOCK_GetFllFreq(void)
+{
+    static const uint16_t fllFactorTable[4][2] = {{640, 732}, {1280, 1464}, {1920, 2197}, {2560, 2929}};
+
+    uint8_t drs, dmx32;
+    uint32_t freq;
+
+    /* If FLL is not enabled currently, then return 0U. */
+    if ((MCG->C2 & MCG_C2_LP_MASK) || (MCG->S & MCG_S_PLLST_MASK))
+    {
+        return 0U;
+    }
+
+    /* Get FLL reference clock frequency. */
+    freq = CLOCK_GetFllRefClkFreq();
+    if (!freq)
+    {
+        return freq;
+    }
+
+    drs = MCG_C4_DRST_DRS_VAL;
+    dmx32 = MCG_C4_DMX32_VAL;
+
+    return freq * fllFactorTable[drs][dmx32];
+}
+
+uint32_t CLOCK_GetInternalRefClkFreq(void)
+{
+    /* If MCGIRCLK is gated. */
+    if (!(MCG->C1 & MCG_C1_IRCLKEN_MASK))
+    {
+        return 0U;
+    }
+
+    return CLOCK_GetInternalRefClkSelectFreq();
+}
+
+uint32_t CLOCK_GetFixedFreqClkFreq(void)
+{
+    uint32_t freq = CLOCK_GetFllRefClkFreq();
+
+    /* MCGFFCLK must be no more than MCGOUTCLK/8. */
+    if ((freq) && (freq <= (CLOCK_GetOutClkFreq() / 8U)))
+    {
+        return freq;
+    }
+    else
+    {
+        return 0U;
+    }
+}
+
+uint32_t CLOCK_GetPll0Freq(void)
+{
+    uint32_t mcgpll0clk;
+
+    /* If PLL0 is not enabled, return 0. */
+    if (!(MCG->S & MCG_S_LOCK0_MASK))
+    {
+        return 0U;
+    }
+
+    mcgpll0clk = CLOCK_GetPll0RefFreq();
+
+    mcgpll0clk /= (FSL_FEATURE_MCG_PLL_PRDIV_BASE + MCG_C5_PRDIV0_VAL);
+    mcgpll0clk *= (FSL_FEATURE_MCG_PLL_VDIV_BASE + MCG_C6_VDIV0_VAL);
+
+    return mcgpll0clk;
+}
+
+status_t CLOCK_SetExternalRefClkConfig(mcg_oscsel_t oscsel)
+{
+    bool needDelay;
+    uint32_t i;
+
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    /* If change MCG_C7[OSCSEL] and external reference clock is system clock source, return error. */
+    if ((MCG_C7_OSCSEL_VAL != oscsel) && (!(MCG->S & MCG_S_IREFST_MASK)))
+    {
+        return kStatus_MCG_SourceUsed;
+    }
+#endif /* MCG_CONFIG_CHECK_PARAM */
+
+    if (MCG_C7_OSCSEL_VAL != oscsel)
+    {
+        /* If change OSCSEL, need to delay, ERR009878. */
+        needDelay = true;
+    }
+    else
+    {
+        needDelay = false;
+    }
+
+    MCG->C7 = (MCG->C7 & ~MCG_C7_OSCSEL_MASK) | MCG_C7_OSCSEL(oscsel);
+    if (kMCG_OscselOsc == oscsel)
+    {
+        if (MCG->C2 & MCG_C2_EREFS_MASK)
+        {
+            while (!(MCG->S & MCG_S_OSCINIT0_MASK))
+            {
+            }
+        }
+    }
+
+    if (needDelay)
+    {
+        /* ERR009878 Delay at least 50 micro-seconds for external clock change valid. */
+        i = 1500U;
+        while (i--)
+        {
+            __NOP();
+        }
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetInternalRefClkConfig(uint8_t enableMode, mcg_irc_mode_t ircs, uint8_t fcrdiv)
+{
+    uint32_t mcgOutClkState = MCG_S_CLKST_VAL;
+    mcg_irc_mode_t curIrcs = (mcg_irc_mode_t)MCG_S_IRCST_VAL;
+    uint8_t curFcrdiv = MCG_SC_FCRDIV_VAL;
+
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    /* If MCGIRCLK is used as system clock source. */
+    if (kMCG_ClkOutStatInt == mcgOutClkState)
+    {
+        /* If need to change MCGIRCLK source or driver, return error. */
+        if (((kMCG_IrcFast == curIrcs) && (fcrdiv != curFcrdiv)) || (ircs != curIrcs))
+        {
+            return kStatus_MCG_SourceUsed;
+        }
+    }
+#endif
+
+    /* If need to update the FCRDIV. */
+    if (fcrdiv != curFcrdiv)
+    {
+        /* If fast IRC is in use currently, change to slow IRC. */
+        if ((kMCG_IrcFast == curIrcs) && ((mcgOutClkState == kMCG_ClkOutStatInt) || (MCG->C1 & MCG_C1_IRCLKEN_MASK)))
+        {
+            MCG->C2 = ((MCG->C2 & ~MCG_C2_IRCS_MASK) | (MCG_C2_IRCS(kMCG_IrcSlow)));
+            while (MCG_S_IRCST_VAL != kMCG_IrcSlow)
+            {
+            }
+        }
+        /* Update FCRDIV. */
+        MCG->SC = (MCG->SC & ~(MCG_SC_FCRDIV_MASK | MCG_SC_ATMF_MASK | MCG_SC_LOCS0_MASK)) | MCG_SC_FCRDIV(fcrdiv);
+    }
+
+    /* Set internal reference clock selection. */
+    MCG->C2 = (MCG->C2 & ~MCG_C2_IRCS_MASK) | (MCG_C2_IRCS(ircs));
+    MCG->C1 = (MCG->C1 & ~(MCG_C1_IRCLKEN_MASK | MCG_C1_IREFSTEN_MASK)) | (uint8_t)enableMode;
+
+    /* If MCGIRCLK is used, need to wait for MCG_S_IRCST. */
+    if ((mcgOutClkState == kMCG_ClkOutStatInt) || (enableMode & kMCG_IrclkEnable))
+    {
+        while (MCG_S_IRCST_VAL != ircs)
+        {
+        }
+    }
+
+    return kStatus_Success;
+}
+
+uint32_t CLOCK_CalcPllDiv(uint32_t refFreq, uint32_t desireFreq, uint8_t *prdiv, uint8_t *vdiv)
+{
+    uint8_t ret_prdiv;           /* PRDIV to return. */
+    uint8_t ret_vdiv;            /* VDIV to return.  */
+    uint8_t prdiv_min;           /* Min PRDIV value to make reference clock in allowed range. */
+    uint8_t prdiv_max;           /* Max PRDIV value to make reference clock in allowed range. */
+    uint8_t prdiv_cur;           /* PRDIV value for iteration.    */
+    uint8_t vdiv_cur;            /* VDIV value for iteration.     */
+    uint32_t ret_freq = 0U;      /* PLL output fequency to return. */
+    uint32_t diff = 0xFFFFFFFFU; /* Difference between desireFreq and return frequency. */
+    uint32_t ref_div;            /* Reference frequency after PRDIV. */
+
+    /*
+       Steps:
+       1. Get allowed prdiv with such rules:
+          1). refFreq / prdiv >= FSL_FEATURE_MCG_PLL_REF_MIN.
+          2). refFreq / prdiv <= FSL_FEATURE_MCG_PLL_REF_MAX.
+       2. For each allowed prdiv, there are two candidate vdiv values:
+          1). (desireFreq / (refFreq / prdiv)).
+          2). (desireFreq / (refFreq / prdiv)) + 1.
+          If could get the precise desired frequency, return current prdiv and
+          vdiv directly. Otherwise choose the one which is closer to desired
+          frequency.
+     */
+
+    /* Reference frequency is out of range. */
+    if ((refFreq < FSL_FEATURE_MCG_PLL_REF_MIN) ||
+        (refFreq > (FSL_FEATURE_MCG_PLL_REF_MAX * (FSL_FEATURE_MCG_PLL_PRDIV_MAX + FSL_FEATURE_MCG_PLL_PRDIV_BASE))))
+    {
+        return 0U;
+    }
+
+    /* refFreq/PRDIV must in a range. First get the allowed PRDIV range. */
+    prdiv_max = refFreq / FSL_FEATURE_MCG_PLL_REF_MIN;
+    prdiv_min = (refFreq + FSL_FEATURE_MCG_PLL_REF_MAX - 1U) / FSL_FEATURE_MCG_PLL_REF_MAX;
+
+    /* PRDIV traversal. */
+    for (prdiv_cur = prdiv_max; prdiv_cur >= prdiv_min; prdiv_cur--)
+    {
+        /* Reference frequency after PRDIV. */
+        ref_div = refFreq / prdiv_cur;
+
+        vdiv_cur = desireFreq / ref_div;
+
+        if ((vdiv_cur < FSL_FEATURE_MCG_PLL_VDIV_BASE - 1U) || (vdiv_cur > FSL_FEATURE_MCG_PLL_VDIV_BASE + 31U))
+        {
+            /* No VDIV is available with this PRDIV. */
+            continue;
+        }
+
+        ret_freq = vdiv_cur * ref_div;
+
+        if (vdiv_cur >= FSL_FEATURE_MCG_PLL_VDIV_BASE)
+        {
+            if (ret_freq == desireFreq) /* If desire frequency is got. */
+            {
+                *prdiv = prdiv_cur - FSL_FEATURE_MCG_PLL_PRDIV_BASE;
+                *vdiv = vdiv_cur - FSL_FEATURE_MCG_PLL_VDIV_BASE;
+                return ret_freq;
+            }
+            /* New PRDIV/VDIV is closer. */
+            if (diff > desireFreq - ret_freq)
+            {
+                diff = desireFreq - ret_freq;
+                ret_prdiv = prdiv_cur;
+                ret_vdiv = vdiv_cur;
+            }
+        }
+        vdiv_cur++;
+        if (vdiv_cur <= (FSL_FEATURE_MCG_PLL_VDIV_BASE + 31U))
+        {
+            ret_freq += ref_div;
+            /* New PRDIV/VDIV is closer. */
+            if (diff > ret_freq - desireFreq)
+            {
+                diff = ret_freq - desireFreq;
+                ret_prdiv = prdiv_cur;
+                ret_vdiv = vdiv_cur;
+            }
+        }
+    }
+
+    if (0xFFFFFFFFU != diff)
+    {
+        /* PRDIV/VDIV found. */
+        *prdiv = ret_prdiv - FSL_FEATURE_MCG_PLL_PRDIV_BASE;
+        *vdiv = ret_vdiv - FSL_FEATURE_MCG_PLL_VDIV_BASE;
+        ret_freq = (refFreq / ret_prdiv) * ret_vdiv;
+        return ret_freq;
+    }
+    else
+    {
+        /* No proper PRDIV/VDIV found. */
+        return 0U;
+    }
+}
+
+void CLOCK_EnablePll0(mcg_pll_config_t const *config)
+{
+    assert(config);
+
+    uint8_t mcg_c5 = 0U;
+
+    mcg_c5 |= MCG_C5_PRDIV0(config->prdiv);
+    MCG->C5 = mcg_c5; /* Disable the PLL first. */
+
+    MCG->C6 = (MCG->C6 & ~MCG_C6_VDIV0_MASK) | MCG_C6_VDIV0(config->vdiv);
+
+    /* Set enable mode. */
+    MCG->C5 |= ((uint32_t)kMCG_PllEnableIndependent | (uint32_t)config->enableMode);
+
+    /* Wait for PLL lock. */
+    while (!(MCG->S & MCG_S_LOCK0_MASK))
+    {
+    }
+}
+
+void CLOCK_SetOsc0MonitorMode(mcg_monitor_mode_t mode)
+{
+    /* Clear the previous flag, MCG_SC[LOCS0]. */
+    MCG->SC &= ~MCG_SC_ATMF_MASK;
+
+    if (kMCG_MonitorNone == mode)
+    {
+        MCG->C6 &= ~MCG_C6_CME0_MASK;
+    }
+    else
+    {
+        if (kMCG_MonitorInt == mode)
+        {
+            MCG->C2 &= ~MCG_C2_LOCRE0_MASK;
+        }
+        else
+        {
+            MCG->C2 |= MCG_C2_LOCRE0_MASK;
+        }
+        MCG->C6 |= MCG_C6_CME0_MASK;
+    }
+}
+
+void CLOCK_SetRtcOscMonitorMode(mcg_monitor_mode_t mode)
+{
+    uint8_t mcg_c8 = MCG->C8;
+
+    mcg_c8 &= ~(MCG_C8_CME1_MASK | MCG_C8_LOCRE1_MASK);
+
+    if (kMCG_MonitorNone != mode)
+    {
+        if (kMCG_MonitorReset == mode)
+        {
+            mcg_c8 |= MCG_C8_LOCRE1_MASK;
+        }
+        mcg_c8 |= MCG_C8_CME1_MASK;
+    }
+    MCG->C8 = mcg_c8;
+}
+
+void CLOCK_SetPll0MonitorMode(mcg_monitor_mode_t mode)
+{
+    uint8_t mcg_c8;
+
+    /* Clear previous flag. */
+    MCG->S = MCG_S_LOLS0_MASK;
+
+    if (kMCG_MonitorNone == mode)
+    {
+        MCG->C6 &= ~MCG_C6_LOLIE0_MASK;
+    }
+    else
+    {
+        mcg_c8 = MCG->C8;
+
+        mcg_c8 &= ~MCG_C8_LOCS1_MASK;
+
+        if (kMCG_MonitorInt == mode)
+        {
+            mcg_c8 &= ~MCG_C8_LOLRE_MASK;
+        }
+        else
+        {
+            mcg_c8 |= MCG_C8_LOLRE_MASK;
+        }
+        MCG->C8 = mcg_c8;
+        MCG->C6 |= MCG_C6_LOLIE0_MASK;
+    }
+}
+
+uint32_t CLOCK_GetStatusFlags(void)
+{
+    uint32_t ret = 0U;
+    uint8_t mcg_s = MCG->S;
+
+    if (MCG->SC & MCG_SC_LOCS0_MASK)
+    {
+        ret |= kMCG_Osc0LostFlag;
+    }
+    if (mcg_s & MCG_S_OSCINIT0_MASK)
+    {
+        ret |= kMCG_Osc0InitFlag;
+    }
+    if (MCG->C8 & MCG_C8_LOCS1_MASK)
+    {
+        ret |= kMCG_RtcOscLostFlag;
+    }
+    if (mcg_s & MCG_S_LOLS0_MASK)
+    {
+        ret |= kMCG_Pll0LostFlag;
+    }
+    if (mcg_s & MCG_S_LOCK0_MASK)
+    {
+        ret |= kMCG_Pll0LockFlag;
+    }
+    return ret;
+}
+
+void CLOCK_ClearStatusFlags(uint32_t mask)
+{
+    uint8_t reg;
+
+    if (mask & kMCG_Osc0LostFlag)
+    {
+        MCG->SC &= ~MCG_SC_ATMF_MASK;
+    }
+    if (mask & kMCG_RtcOscLostFlag)
+    {
+        reg = MCG->C8;
+        MCG->C8 = reg;
+    }
+    if (mask & kMCG_Pll0LostFlag)
+    {
+        MCG->S = MCG_S_LOLS0_MASK;
+    }
+}
+
+void CLOCK_InitOsc0(osc_config_t const *config)
+{
+    uint8_t range = CLOCK_GetOscRangeFromFreq(config->freq);
+
+    OSC_SetCapLoad(OSC0, config->capLoad);
+    OSC_SetExtRefClkConfig(OSC0, &config->oscerConfig);
+
+    MCG->C2 = ((MCG->C2 & ~OSC_MODE_MASK) | MCG_C2_RANGE(range) | (uint8_t)config->workMode);
+
+    if ((kOSC_ModeExt != config->workMode) && (OSC0->CR & OSC_CR_ERCLKEN_MASK))
+    {
+        /* Wait for stable. */
+        while (!(MCG->S & MCG_S_OSCINIT0_MASK))
+        {
+        }
+    }
+}
+
+void CLOCK_DeinitOsc0(void)
+{
+    OSC0->CR = 0U;
+    MCG->C2 &= ~OSC_MODE_MASK;
+}
+
+status_t CLOCK_TrimInternalRefClk(uint32_t extFreq, uint32_t desireFreq, uint32_t *actualFreq, mcg_atm_select_t atms)
+{
+    uint32_t multi; /* extFreq / desireFreq */
+    uint32_t actv;  /* Auto trim value. */
+    uint8_t mcg_sc;
+
+    static const uint32_t trimRange[2][2] = {
+        /*     Min           Max      */
+        {TRIM_SIRC_MIN, TRIM_SIRC_MAX}, /* Slow IRC. */
+        {TRIM_FIRC_MIN, TRIM_FIRC_MAX}  /* Fast IRC. */
+    };
+
+    if ((extFreq > TRIM_REF_CLK_MAX) || (extFreq < TRIM_REF_CLK_MIN))
+    {
+        return kStatus_MCG_AtmBusClockInvalid;
+    }
+
+    /* Check desired frequency range. */
+    if ((desireFreq < trimRange[atms][0]) || (desireFreq > trimRange[atms][1]))
+    {
+        return kStatus_MCG_AtmDesiredFreqInvalid;
+    }
+
+    /*
+       Make sure internal reference clock is not used to generate bus clock.
+       Here only need to check (MCG_S_IREFST == 1).
+     */
+    if (MCG_S_IREFST(kMCG_FllSrcInternal) == (MCG->S & MCG_S_IREFST_MASK))
+    {
+        return kStatus_MCG_AtmIrcUsed;
+    }
+
+    multi = extFreq / desireFreq;
+    actv = multi * 21U;
+
+    if (kMCG_AtmSel4m == atms)
+    {
+        actv *= 128U;
+    }
+
+    /* Now begin to start trim. */
+    MCG->ATCVL = (uint8_t)actv;
+    MCG->ATCVH = (uint8_t)(actv >> 8U);
+
+    mcg_sc = MCG->SC;
+    mcg_sc &= ~(MCG_SC_ATMS_MASK | MCG_SC_LOCS0_MASK);
+    mcg_sc |= (MCG_SC_ATMF_MASK | MCG_SC_ATMS(atms));
+    MCG->SC = (mcg_sc | MCG_SC_ATME_MASK);
+
+    /* Wait for finished. */
+    while (MCG->SC & MCG_SC_ATME_MASK)
+    {
+    }
+
+    /* Error occurs? */
+    if (MCG->SC & MCG_SC_ATMF_MASK)
+    {
+        /* Clear the failed flag. */
+        MCG->SC = mcg_sc;
+        return kStatus_MCG_AtmHardwareFail;
+    }
+
+    *actualFreq = extFreq / multi;
+
+    if (kMCG_AtmSel4m == atms)
+    {
+        s_fastIrcFreq = *actualFreq;
+    }
+    else
+    {
+        s_slowIrcFreq = *actualFreq;
+    }
+
+    return kStatus_Success;
+}
+
+mcg_mode_t CLOCK_GetMode(void)
+{
+    mcg_mode_t mode = kMCG_ModeError;
+    uint32_t clkst = MCG_S_CLKST_VAL;
+    uint32_t irefst = MCG_S_IREFST_VAL;
+    uint32_t lp = MCG_C2_LP_VAL;
+    uint32_t pllst = MCG_S_PLLST_VAL;
+
+    /*------------------------------------------------------------------
+                           Mode and Registers
+    ____________________________________________________________________
+
+      Mode   |   CLKST    |   IREFST   |   PLLST   |      LP
+    ____________________________________________________________________
+
+      FEI    |  00(FLL)   |   1(INT)   |   0(FLL)  |      X
+    ____________________________________________________________________
+
+      FEE    |  00(FLL)   |   0(EXT)   |   0(FLL)  |      X
+    ____________________________________________________________________
+
+      FBE    |  10(EXT)   |   0(EXT)   |   0(FLL)  |   0(NORMAL)
+    ____________________________________________________________________
+
+      FBI    |  01(INT)   |   1(INT)   |   0(FLL)  |   0(NORMAL)
+    ____________________________________________________________________
+
+      BLPI   |  01(INT)   |   1(INT)   |   0(FLL)  |   1(LOW POWER)
+    ____________________________________________________________________
+
+      BLPE   |  10(EXT)   |   0(EXT)   |     X     |   1(LOW POWER)
+    ____________________________________________________________________
+
+      PEE    |  11(PLL)   |   0(EXT)   |   1(PLL)  |      X
+    ____________________________________________________________________
+
+      PBE    |  10(EXT)   |   0(EXT)   |   1(PLL)  |   O(NORMAL)
+    ____________________________________________________________________
+
+      PBI    |  01(INT)   |   1(INT)   |   1(PLL)  |   0(NORMAL)
+    ____________________________________________________________________
+
+      PEI    |  11(PLL)   |   1(INT)   |   1(PLL)  |      X
+    ____________________________________________________________________
+
+    ----------------------------------------------------------------------*/
+
+    switch (clkst)
+    {
+        case kMCG_ClkOutStatFll:
+            if (kMCG_FllSrcExternal == irefst)
+            {
+                mode = kMCG_ModeFEE;
+            }
+            else
+            {
+                mode = kMCG_ModeFEI;
+            }
+            break;
+        case kMCG_ClkOutStatInt:
+            if (lp)
+            {
+                mode = kMCG_ModeBLPI;
+            }
+            else
+            {
+                {
+                    mode = kMCG_ModeFBI;
+                }
+            }
+            break;
+        case kMCG_ClkOutStatExt:
+            if (lp)
+            {
+                mode = kMCG_ModeBLPE;
+            }
+            else
+            {
+                if (kMCG_PllstPll == pllst)
+                {
+                    mode = kMCG_ModePBE;
+                }
+                else
+                {
+                    mode = kMCG_ModeFBE;
+                }
+            }
+            break;
+        case kMCG_ClkOutStatPll:
+        {
+            mode = kMCG_ModePEE;
+        }
+        break;
+        default:
+            break;
+    }
+
+    return mode;
+}
+
+status_t CLOCK_SetFeiMode(mcg_drs_t drs, void (*fllStableDelay)(void))
+{
+    uint8_t mcg_c4;
+    bool change_drs = false;
+
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    mcg_mode_t mode = CLOCK_GetMode();
+    if (!((kMCG_ModeFEI == mode) || (kMCG_ModeFBI == mode) || (kMCG_ModeFBE == mode) || (kMCG_ModeFEE == mode)))
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif
+    mcg_c4 = MCG->C4;
+
+    /*
+       Errata: ERR007993
+       Workaround: Invert MCG_C4[DMX32] or change MCG_C4[DRST_DRS] before
+       reference clock source changes, then reset to previous value after
+       reference clock changes.
+     */
+    if (kMCG_FllSrcExternal == MCG_S_IREFST_VAL)
+    {
+        change_drs = true;
+        /* Change the LSB of DRST_DRS. */
+        MCG->C4 ^= (1U << MCG_C4_DRST_DRS_SHIFT);
+    }
+
+    /* Set CLKS and IREFS. */
+    MCG->C1 =
+        ((MCG->C1 & ~(MCG_C1_CLKS_MASK | MCG_C1_IREFS_MASK))) | (MCG_C1_CLKS(kMCG_ClkOutSrcOut)        /* CLKS = 0 */
+                                                                 | MCG_C1_IREFS(kMCG_FllSrcInternal)); /* IREFS = 1 */
+
+    /* Wait and check status. */
+    while (kMCG_FllSrcInternal != MCG_S_IREFST_VAL)
+    {
+    }
+
+    /* Errata: ERR007993 */
+    if (change_drs)
+    {
+        MCG->C4 = mcg_c4;
+    }
+
+    /* In FEI mode, the MCG_C4[DMX32] is set to 0U. */
+    MCG->C4 = (mcg_c4 & ~(MCG_C4_DMX32_MASK | MCG_C4_DRST_DRS_MASK)) | (MCG_C4_DRST_DRS(drs));
+
+    /* Check MCG_S[CLKST] */
+    while (kMCG_ClkOutStatFll != MCG_S_CLKST_VAL)
+    {
+    }
+
+    /* Wait for FLL stable time. */
+    if (fllStableDelay)
+    {
+        fllStableDelay();
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetFeeMode(uint8_t frdiv, mcg_dmx32_t dmx32, mcg_drs_t drs, void (*fllStableDelay)(void))
+{
+    uint8_t mcg_c4;
+    bool change_drs = false;
+
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    mcg_mode_t mode = CLOCK_GetMode();
+    if (!((kMCG_ModeFEE == mode) || (kMCG_ModeFBI == mode) || (kMCG_ModeFBE == mode) || (kMCG_ModeFEI == mode)))
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif
+    mcg_c4 = MCG->C4;
+
+    /*
+       Errata: ERR007993
+       Workaround: Invert MCG_C4[DMX32] or change MCG_C4[DRST_DRS] before
+       reference clock source changes, then reset to previous value after
+       reference clock changes.
+     */
+    if (kMCG_FllSrcInternal == MCG_S_IREFST_VAL)
+    {
+        change_drs = true;
+        /* Change the LSB of DRST_DRS. */
+        MCG->C4 ^= (1U << MCG_C4_DRST_DRS_SHIFT);
+    }
+
+    /* Set CLKS and IREFS. */
+    MCG->C1 = ((MCG->C1 & ~(MCG_C1_CLKS_MASK | MCG_C1_FRDIV_MASK | MCG_C1_IREFS_MASK)) |
+               (MCG_C1_CLKS(kMCG_ClkOutSrcOut)         /* CLKS = 0 */
+                | MCG_C1_FRDIV(frdiv)                  /* FRDIV */
+                | MCG_C1_IREFS(kMCG_FllSrcExternal))); /* IREFS = 0 */
+
+    /* Wait and check status. */
+    while (kMCG_FllSrcExternal != MCG_S_IREFST_VAL)
+    {
+    }
+
+    /* Errata: ERR007993 */
+    if (change_drs)
+    {
+        MCG->C4 = mcg_c4;
+    }
+
+    /* Set DRS and DMX32. */
+    mcg_c4 = ((mcg_c4 & ~(MCG_C4_DMX32_MASK | MCG_C4_DRST_DRS_MASK)) | (MCG_C4_DMX32(dmx32) | MCG_C4_DRST_DRS(drs)));
+    MCG->C4 = mcg_c4;
+
+    /* Wait for DRST_DRS update. */
+    while (MCG->C4 != mcg_c4)
+    {
+    }
+
+    /* Check MCG_S[CLKST] */
+    while (kMCG_ClkOutStatFll != MCG_S_CLKST_VAL)
+    {
+    }
+
+    /* Wait for FLL stable time. */
+    if (fllStableDelay)
+    {
+        fllStableDelay();
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetFbiMode(mcg_drs_t drs, void (*fllStableDelay)(void))
+{
+    uint8_t mcg_c4;
+    bool change_drs = false;
+
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    mcg_mode_t mode = CLOCK_GetMode();
+
+    if (!((kMCG_ModeFEE == mode) || (kMCG_ModeFBI == mode) || (kMCG_ModeFBE == mode) || (kMCG_ModeFEI == mode) ||
+          (kMCG_ModeBLPI == mode)))
+
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif
+
+    mcg_c4 = MCG->C4;
+
+    MCG->C2 &= ~MCG_C2_LP_MASK; /* Disable lowpower. */
+
+    /*
+       Errata: ERR007993
+       Workaround: Invert MCG_C4[DMX32] or change MCG_C4[DRST_DRS] before
+       reference clock source changes, then reset to previous value after
+       reference clock changes.
+     */
+    if (kMCG_FllSrcExternal == MCG_S_IREFST_VAL)
+    {
+        change_drs = true;
+        /* Change the LSB of DRST_DRS. */
+        MCG->C4 ^= (1U << MCG_C4_DRST_DRS_SHIFT);
+    }
+
+    /* Set CLKS and IREFS. */
+    MCG->C1 =
+        ((MCG->C1 & ~(MCG_C1_CLKS_MASK | MCG_C1_IREFS_MASK)) | (MCG_C1_CLKS(kMCG_ClkOutSrcInternal)    /* CLKS = 1 */
+                                                                | MCG_C1_IREFS(kMCG_FllSrcInternal))); /* IREFS = 1 */
+
+    /* Wait and check status. */
+    while (kMCG_FllSrcInternal != MCG_S_IREFST_VAL)
+    {
+    }
+
+    /* Errata: ERR007993 */
+    if (change_drs)
+    {
+        MCG->C4 = mcg_c4;
+    }
+
+    while (kMCG_ClkOutStatInt != MCG_S_CLKST_VAL)
+    {
+    }
+
+    MCG->C4 = (mcg_c4 & ~(MCG_C4_DMX32_MASK | MCG_C4_DRST_DRS_MASK)) | (MCG_C4_DRST_DRS(drs));
+
+    /* Wait for FLL stable time. */
+    if (fllStableDelay)
+    {
+        fllStableDelay();
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetFbeMode(uint8_t frdiv, mcg_dmx32_t dmx32, mcg_drs_t drs, void (*fllStableDelay)(void))
+{
+    uint8_t mcg_c4;
+    bool change_drs = false;
+
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    mcg_mode_t mode = CLOCK_GetMode();
+    if (!((kMCG_ModeFEE == mode) || (kMCG_ModeFBI == mode) || (kMCG_ModeFBE == mode) || (kMCG_ModeFEI == mode) ||
+          (kMCG_ModePBE == mode) || (kMCG_ModeBLPE == mode)))
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif
+
+    /* Change to FLL mode. */
+    MCG->C6 &= ~MCG_C6_PLLS_MASK;
+    while (MCG->S & MCG_S_PLLST_MASK)
+    {
+    }
+
+    /* Set LP bit to enable the FLL */
+    MCG->C2 &= ~MCG_C2_LP_MASK;
+
+    mcg_c4 = MCG->C4;
+
+    /*
+       Errata: ERR007993
+       Workaround: Invert MCG_C4[DMX32] or change MCG_C4[DRST_DRS] before
+       reference clock source changes, then reset to previous value after
+       reference clock changes.
+     */
+    if (kMCG_FllSrcInternal == MCG_S_IREFST_VAL)
+    {
+        change_drs = true;
+        /* Change the LSB of DRST_DRS. */
+        MCG->C4 ^= (1U << MCG_C4_DRST_DRS_SHIFT);
+    }
+
+    /* Set CLKS and IREFS. */
+    MCG->C1 = ((MCG->C1 & ~(MCG_C1_CLKS_MASK | MCG_C1_FRDIV_MASK | MCG_C1_IREFS_MASK)) |
+               (MCG_C1_CLKS(kMCG_ClkOutSrcExternal)    /* CLKS = 2 */
+                | MCG_C1_FRDIV(frdiv)                  /* FRDIV = frdiv */
+                | MCG_C1_IREFS(kMCG_FllSrcExternal))); /* IREFS = 0 */
+
+    /* Wait for Reference clock Status bit to clear */
+    while (kMCG_FllSrcExternal != MCG_S_IREFST_VAL)
+    {
+    }
+
+    /* Errata: ERR007993 */
+    if (change_drs)
+    {
+        MCG->C4 = mcg_c4;
+    }
+
+    /* Set DRST_DRS and DMX32. */
+    mcg_c4 = ((mcg_c4 & ~(MCG_C4_DMX32_MASK | MCG_C4_DRST_DRS_MASK)) | (MCG_C4_DMX32(dmx32) | MCG_C4_DRST_DRS(drs)));
+
+    /* Wait for clock status bits to show clock source is ext ref clk */
+    while (kMCG_ClkOutStatExt != MCG_S_CLKST_VAL)
+    {
+    }
+
+    /* Wait for fll stable time. */
+    if (fllStableDelay)
+    {
+        fllStableDelay();
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetBlpiMode(void)
+{
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    if (MCG_S_CLKST_VAL != kMCG_ClkOutStatInt)
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif /* MCG_CONFIG_CHECK_PARAM */
+
+    /* Set LP. */
+    MCG->C2 |= MCG_C2_LP_MASK;
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetBlpeMode(void)
+{
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    if (MCG_S_CLKST_VAL != kMCG_ClkOutStatExt)
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif
+
+    /* Set LP bit to enter BLPE mode. */
+    MCG->C2 |= MCG_C2_LP_MASK;
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetPbeMode(mcg_pll_clk_select_t pllcs, mcg_pll_config_t const *config)
+{
+    /*
+       This function is designed to change MCG to PBE mode from PEE/BLPE/FBE,
+       but with this workflow, the source mode could be all modes except PEI/PBI.
+     */
+    MCG->C2 &= ~MCG_C2_LP_MASK; /* Disable lowpower. */
+
+    /* Change to use external clock first. */
+    MCG->C1 = ((MCG->C1 & ~(MCG_C1_CLKS_MASK | MCG_C1_IREFS_MASK)) | MCG_C1_CLKS(kMCG_ClkOutSrcExternal));
+
+    /* Wait for CLKST clock status bits to show clock source is ext ref clk */
+    while ((MCG->S & (MCG_S_IREFST_MASK | MCG_S_CLKST_MASK)) !=
+           (MCG_S_IREFST(kMCG_FllSrcExternal) | MCG_S_CLKST(kMCG_ClkOutStatExt)))
+    {
+    }
+
+    /* Disable PLL first, then configure PLL. */
+    MCG->C6 &= ~MCG_C6_PLLS_MASK;
+    while (MCG->S & MCG_S_PLLST_MASK)
+    {
+    }
+
+    /* Configure the PLL. */
+    {
+        CLOCK_EnablePll0(config);
+    }
+
+    /* Change to PLL mode. */
+    MCG->C6 |= MCG_C6_PLLS_MASK;
+    while (!(MCG->S & MCG_S_PLLST_MASK))
+    {
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_SetPeeMode(void)
+{
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    mcg_mode_t mode = CLOCK_GetMode();
+    if (kMCG_ModePBE != mode)
+    {
+        return kStatus_MCG_ModeUnreachable;
+    }
+#endif
+
+    /* Change to use PLL/FLL output clock first. */
+    MCG->C1 = (MCG->C1 & ~MCG_C1_CLKS_MASK) | MCG_C1_CLKS(kMCG_ClkOutSrcOut);
+
+    /* Wait for clock status bits to update */
+    while (MCG_S_CLKST_VAL != kMCG_ClkOutStatPll)
+    {
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_ExternalModeToFbeModeQuick(void)
+{
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    if (MCG->S & MCG_S_IREFST_MASK)
+    {
+        return kStatus_MCG_ModeInvalid;
+    }
+#endif /* MCG_CONFIG_CHECK_PARAM */
+
+    /* Disable low power */
+    MCG->C2 &= ~MCG_C2_LP_MASK;
+
+    MCG->C1 = ((MCG->C1 & ~MCG_C1_CLKS_MASK) | MCG_C1_CLKS(kMCG_ClkOutSrcExternal));
+    while (MCG_S_CLKST_VAL != kMCG_ClkOutStatExt)
+    {
+    }
+
+    /* Disable PLL. */
+    MCG->C6 &= ~MCG_C6_PLLS_MASK;
+    while (MCG->S & MCG_S_PLLST_MASK)
+    {
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_InternalModeToFbiModeQuick(void)
+{
+#if (defined(MCG_CONFIG_CHECK_PARAM) && MCG_CONFIG_CHECK_PARAM)
+    if (!(MCG->S & MCG_S_IREFST_MASK))
+    {
+        return kStatus_MCG_ModeInvalid;
+    }
+#endif
+
+    /* Disable low power */
+    MCG->C2 &= ~MCG_C2_LP_MASK;
+
+    MCG->C1 = ((MCG->C1 & ~MCG_C1_CLKS_MASK) | MCG_C1_CLKS(kMCG_ClkOutSrcInternal));
+    while (MCG_S_CLKST_VAL != kMCG_ClkOutStatInt)
+    {
+    }
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_BootToFeiMode(mcg_drs_t drs, void (*fllStableDelay)(void))
+{
+    return CLOCK_SetFeiMode(drs, fllStableDelay);
+}
+
+status_t CLOCK_BootToFeeMode(
+    mcg_oscsel_t oscsel, uint8_t frdiv, mcg_dmx32_t dmx32, mcg_drs_t drs, void (*fllStableDelay)(void))
+{
+    CLOCK_SetExternalRefClkConfig(oscsel);
+
+    return CLOCK_SetFeeMode(frdiv, dmx32, drs, fllStableDelay);
+}
+
+status_t CLOCK_BootToBlpiMode(uint8_t fcrdiv, mcg_irc_mode_t ircs, uint8_t ircEnableMode)
+{
+    /* If reset mode is FEI mode, set MCGIRCLK and always success. */
+    CLOCK_SetInternalRefClkConfig(ircEnableMode, ircs, fcrdiv);
+
+    /* If reset mode is not BLPI, first enter FBI mode. */
+    MCG->C1 = (MCG->C1 & ~MCG_C1_CLKS_MASK) | MCG_C1_CLKS(kMCG_ClkOutSrcInternal);
+    while (MCG_S_CLKST_VAL != kMCG_ClkOutStatInt)
+    {
+    }
+
+    /* Enter BLPI mode. */
+    MCG->C2 |= MCG_C2_LP_MASK;
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_BootToBlpeMode(mcg_oscsel_t oscsel)
+{
+    CLOCK_SetExternalRefClkConfig(oscsel);
+
+    /* Set to FBE mode. */
+    MCG->C1 =
+        ((MCG->C1 & ~(MCG_C1_CLKS_MASK | MCG_C1_IREFS_MASK)) | (MCG_C1_CLKS(kMCG_ClkOutSrcExternal)    /* CLKS = 2 */
+                                                                | MCG_C1_IREFS(kMCG_FllSrcExternal))); /* IREFS = 0 */
+
+    /* Wait for MCG_S[CLKST] and MCG_S[IREFST]. */
+    while ((MCG->S & (MCG_S_IREFST_MASK | MCG_S_CLKST_MASK)) !=
+           (MCG_S_IREFST(kMCG_FllSrcExternal) | MCG_S_CLKST(kMCG_ClkOutStatExt)))
+    {
+    }
+
+    /* In FBE now, start to enter BLPE. */
+    MCG->C2 |= MCG_C2_LP_MASK;
+
+    return kStatus_Success;
+}
+
+status_t CLOCK_BootToPeeMode(mcg_oscsel_t oscsel, mcg_pll_clk_select_t pllcs, mcg_pll_config_t const *config)
+{
+    assert(config);
+
+    CLOCK_SetExternalRefClkConfig(oscsel);
+
+    CLOCK_SetPbeMode(pllcs, config);
+
+    /* Change to use PLL output clock. */
+    MCG->C1 = (MCG->C1 & ~MCG_C1_CLKS_MASK) | MCG_C1_CLKS(kMCG_ClkOutSrcOut);
+    while (MCG_S_CLKST_VAL != kMCG_ClkOutStatPll)
+    {
+    }
+
+    return kStatus_Success;
+}
+
+/*
+   The transaction matrix. It defines the path for mode switch, the row is for
+   current mode and the column is target mode.
+   For example, switch from FEI to PEE:
+   1. Current mode FEI, next mode is mcgModeMatrix[FEI][PEE] = FBE, so swith to FBE.
+   2. Current mode FBE, next mode is mcgModeMatrix[FBE][PEE] = PBE, so swith to PBE.
+   3. Current mode PBE, next mode is mcgModeMatrix[PBE][PEE] = PEE, so swith to PEE.
+   Thus the MCG mode has changed from FEI to PEE.
+ */
+static const mcg_mode_t mcgModeMatrix[8][8] = {
+    {kMCG_ModeFEI, kMCG_ModeFBI, kMCG_ModeFBI, kMCG_ModeFEE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE,
+     kMCG_ModeFBE}, /* FEI */
+    {kMCG_ModeFEI, kMCG_ModeFBI, kMCG_ModeBLPI, kMCG_ModeFEE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE,
+     kMCG_ModeFBE}, /* FBI */
+    {kMCG_ModeFBI, kMCG_ModeFBI, kMCG_ModeBLPI, kMCG_ModeFBI, kMCG_ModeFBI, kMCG_ModeFBI, kMCG_ModeFBI,
+     kMCG_ModeFBI}, /* BLPI */
+    {kMCG_ModeFEI, kMCG_ModeFBI, kMCG_ModeFBI, kMCG_ModeFEE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE,
+     kMCG_ModeFBE}, /* FEE */
+    {kMCG_ModeFEI, kMCG_ModeFBI, kMCG_ModeFBI, kMCG_ModeFEE, kMCG_ModeFBE, kMCG_ModeBLPE, kMCG_ModePBE,
+     kMCG_ModePBE}, /* FBE */
+    {kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeBLPE, kMCG_ModePBE,
+     kMCG_ModePBE}, /* BLPE */
+    {kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeFBE, kMCG_ModeBLPE, kMCG_ModePBE,
+     kMCG_ModePEE}, /* PBE */
+    {kMCG_ModePBE, kMCG_ModePBE, kMCG_ModePBE, kMCG_ModePBE, kMCG_ModePBE, kMCG_ModePBE, kMCG_ModePBE,
+     kMCG_ModePBE} /* PEE */
+    /*    FEI           FBI           BLPI           FEE           FBE           BLPE           PBE           PEE */
+};
+
+status_t CLOCK_SetMcgConfig(const mcg_config_t *config)
+{
+    mcg_mode_t next_mode;
+    status_t status = kStatus_Success;
+
+    mcg_pll_clk_select_t pllcs = kMCG_PllClkSelPll0;
+
+    /* If need to change external clock, MCG_C7[OSCSEL]. */
+    if (MCG_C7_OSCSEL_VAL != config->oscsel)
+    {
+        /* If external clock is in use, change to FEI first. */
+        if (!(MCG->S & MCG_S_IRCST_MASK))
+        {
+            CLOCK_ExternalModeToFbeModeQuick();
+            CLOCK_SetFeiMode(config->drs, (void (*)(void))0);
+        }
+
+        CLOCK_SetExternalRefClkConfig(config->oscsel);
+    }
+
+    /* Re-configure MCGIRCLK, if MCGIRCLK is used as system clock source, then change to FEI/PEI first. */
+    if (MCG_S_CLKST_VAL == kMCG_ClkOutStatInt)
+    {
+        MCG->C2 &= ~MCG_C2_LP_MASK; /* Disable lowpower. */
+
+        {
+            CLOCK_SetFeiMode(config->drs, CLOCK_FllStableDelay);
+        }
+    }
+
+    /* Configure MCGIRCLK. */
+    CLOCK_SetInternalRefClkConfig(config->irclkEnableMode, config->ircs, config->fcrdiv);
+
+    next_mode = CLOCK_GetMode();
+
+    do
+    {
+        next_mode = mcgModeMatrix[next_mode][config->mcgMode];
+
+        switch (next_mode)
+        {
+            case kMCG_ModeFEI:
+                status = CLOCK_SetFeiMode(config->drs, CLOCK_FllStableDelay);
+                break;
+            case kMCG_ModeFEE:
+                status = CLOCK_SetFeeMode(config->frdiv, config->dmx32, config->drs, CLOCK_FllStableDelay);
+                break;
+            case kMCG_ModeFBI:
+                status = CLOCK_SetFbiMode(config->drs, (void (*)(void))0);
+                break;
+            case kMCG_ModeFBE:
+                status = CLOCK_SetFbeMode(config->frdiv, config->dmx32, config->drs, (void (*)(void))0);
+                break;
+            case kMCG_ModeBLPI:
+                status = CLOCK_SetBlpiMode();
+                break;
+            case kMCG_ModeBLPE:
+                status = CLOCK_SetBlpeMode();
+                break;
+            case kMCG_ModePBE:
+                /* If target mode is not PBE or PEE, then only need to set CLKS = EXT here. */
+                if ((kMCG_ModePEE == config->mcgMode) || (kMCG_ModePBE == config->mcgMode))
+                {
+                    {
+                        status = CLOCK_SetPbeMode(pllcs, &config->pll0Config);
+                    }
+                }
+                else
+                {
+                    MCG->C1 = ((MCG->C1 & ~MCG_C1_CLKS_MASK) | MCG_C1_CLKS(kMCG_ClkOutSrcExternal));
+                    while (MCG_S_CLKST_VAL != kMCG_ClkOutStatExt)
+                    {
+                    }
+                }
+                break;
+            case kMCG_ModePEE:
+                status = CLOCK_SetPeeMode();
+                break;
+            default:
+                break;
+        }
+        if (kStatus_Success != status)
+        {
+            return status;
+        }
+    } while (next_mode != config->mcgMode);
+
+    if (config->pll0Config.enableMode & kMCG_PllEnableIndependent)
+    {
+        CLOCK_EnablePll0(&config->pll0Config);
+    }
+    else
+    {
+        MCG->C5 &= ~(uint32_t)kMCG_PllEnableIndependent;
+    }
+    return kStatus_Success;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_clock.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_clock.h
@@ -1,0 +1,1510 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_CLOCK_H_
+#define _FSL_CLOCK_H_
+
+#include "fsl_device_registers.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+
+/*! @addtogroup clock */
+/*! @{ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief Clock driver version. */
+#define FSL_CLOCK_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+
+/*! @brief External XTAL0 (OSC0) clock frequency.
+ *
+ * The XTAL0/EXTAL0 (OSC0) clock frequency in Hz, when the clock is setup, use the
+ * function CLOCK_SetXtal0Freq to set the value in to clock driver. For example,
+ * if XTAL0 is 8MHz,
+ * @code
+ * CLOCK_InitOsc0(...); // Setup the OSC0
+ * CLOCK_SetXtal0Freq(80000000); // Set the XTAL0 value to clock driver.
+ * @endcode
+ *
+ * This is important for the multicore platforms, only one core needs to setup
+ * OSC0 using CLOCK_InitOsc0, all other cores need to call CLOCK_SetXtal0Freq
+ * to get valid clock frequency.
+ */
+extern uint32_t g_xtal0Freq;
+
+/*! @brief External XTAL32/EXTAL32/RTC_CLKIN clock frequency.
+ *
+ * The XTAL32/EXTAL32/RTC_CLKIN clock frequency in Hz, when the clock is setup, use the
+ * function CLOCK_SetXtal32Freq to set the value in to clock driver.
+ *
+ * This is important for the multicore platforms, only one core needs to setup
+ * the clock, all other cores need to call CLOCK_SetXtal32Freq
+ * to get valid clock frequency.
+ */
+extern uint32_t g_xtal32Freq;
+
+/*! @brief IRC48M clock frequency in Hz. */
+#define MCG_INTERNAL_IRC_48M 48000000U
+
+#if (defined(OSC) && !(defined(OSC0)))
+#define OSC0 OSC
+#endif
+
+/*! @brief Clock ip name array for DMAMUX. */
+#define DMAMUX_CLOCKS  \
+    {                  \
+        kCLOCK_Dmamux0 \
+    }
+
+/*! @brief Clock ip name array for RTC. */
+#define RTC_CLOCKS  \
+    {               \
+        kCLOCK_Rtc0 \
+    }
+
+/*! @brief Clock ip name array for ENET. */
+#define ENET_CLOCKS  \
+    {                \
+        kCLOCK_Enet0 \
+    }
+
+/*! @brief Clock ip name array for PORT. */
+#define PORT_CLOCKS                                                          \
+    {                                                                        \
+        kCLOCK_PortA, kCLOCK_PortB, kCLOCK_PortC, kCLOCK_PortD, kCLOCK_PortE \
+    }
+
+/*! @brief Clock ip name array for SAI. */
+#define SAI_CLOCKS  \
+    {               \
+        kCLOCK_Sai0 \
+    }
+
+/*! @brief Clock ip name array for FLEXBUS. */
+#define FLEXBUS_CLOCKS  \
+    {                   \
+        kCLOCK_Flexbus0 \
+    }
+
+/*! @brief Clock ip name array for EWM. */
+#define EWM_CLOCKS  \
+    {               \
+        kCLOCK_Ewm0 \
+    }
+
+/*! @brief Clock ip name array for PIT. */
+#define PIT_CLOCKS  \
+    {               \
+        kCLOCK_Pit0 \
+    }
+
+/*! @brief Clock ip name array for DSPI. */
+#define DSPI_CLOCKS                           \
+    {                                         \
+        kCLOCK_Spi0, kCLOCK_Spi1, kCLOCK_Spi2 \
+    }
+
+/*! @brief Clock ip name array for LPTMR. */
+#define LPTMR_CLOCKS  \
+    {                 \
+        kCLOCK_Lptmr0 \
+    }
+
+/*! @brief Clock ip name array for SDHC. */
+#define SDHC_CLOCKS  \
+    {                \
+        kCLOCK_Sdhc0 \
+    }
+
+/*! @brief Clock ip name array for FTM. */
+#define FTM_CLOCKS                                         \
+    {                                                      \
+        kCLOCK_Ftm0, kCLOCK_Ftm1, kCLOCK_Ftm2, kCLOCK_Ftm3 \
+    }
+
+/*! @brief Clock ip name array for EDMA. */
+#define EDMA_CLOCKS \
+    {               \
+        kCLOCK_Dma0 \
+    }
+
+/*! @brief Clock ip name array for FLEXCAN. */
+#define FLEXCAN_CLOCKS  \
+    {                   \
+        kCLOCK_Flexcan0 \
+    }
+
+/*! @brief Clock ip name array for DAC. */
+#define DAC_CLOCKS               \
+    {                            \
+        kCLOCK_Dac0, kCLOCK_Dac1 \
+    }
+
+/*! @brief Clock ip name array for ADC16. */
+#define ADC16_CLOCKS             \
+    {                            \
+        kCLOCK_Adc0, kCLOCK_Adc1 \
+    }
+
+/*! @brief Clock ip name array for MMCAU. */
+#define MMCAU_CLOCKS  \
+    {                 \
+        kCLOCK_Mmcau0 \
+    }
+
+/*! @brief Clock ip name array for MPU. */
+#define MPU_CLOCKS  \
+    {               \
+        kCLOCK_Mpu0 \
+    }
+
+/*! @brief Clock ip name array for VREF. */
+#define VREF_CLOCKS  \
+    {                \
+        kCLOCK_Vref0 \
+    }
+
+/*! @brief Clock ip name array for CMT. */
+#define CMT_CLOCKS  \
+    {               \
+        kCLOCK_Cmt0 \
+    }
+
+/*! @brief Clock ip name array for UART. */
+#define UART_CLOCKS                                                                        \
+    {                                                                                      \
+        kCLOCK_Uart0, kCLOCK_Uart1, kCLOCK_Uart2, kCLOCK_Uart3, kCLOCK_Uart4, kCLOCK_Uart5 \
+    }
+
+/*! @brief Clock ip name array for RNGA. */
+#define RNGA_CLOCKS  \
+    {                \
+        kCLOCK_Rnga0 \
+    }
+
+/*! @brief Clock ip name array for CRC. */
+#define CRC_CLOCKS  \
+    {               \
+        kCLOCK_Crc0 \
+    }
+
+/*! @brief Clock ip name array for I2C. */
+#define I2C_CLOCKS                            \
+    {                                         \
+        kCLOCK_I2c0, kCLOCK_I2c1, kCLOCK_I2c2 \
+    }
+
+/*! @brief Clock ip name array for PDB. */
+#define PDB_CLOCKS  \
+    {               \
+        kCLOCK_Pdb0 \
+    }
+
+/*! @brief Clock ip name array for FTF. */
+#define FTF_CLOCKS  \
+    {               \
+        kCLOCK_Ftf0 \
+    }
+
+/*! @brief Clock ip name array for CMP. */
+#define CMP_CLOCKS                            \
+    {                                         \
+        kCLOCK_Cmp0, kCLOCK_Cmp1, kCLOCK_Cmp2 \
+    }
+
+/*!
+ * @brief LPO clock frequency.
+ */
+#define LPO_CLK_FREQ 1000U
+
+/*! @brief Peripherals clock source definition. */
+#define SYS_CLK kCLOCK_CoreSysClk
+#define BUS_CLK kCLOCK_BusClk
+
+#define I2C0_CLK_SRC BUS_CLK
+#define I2C1_CLK_SRC BUS_CLK
+#define I2C2_CLK_SRC BUS_CLK
+#define DSPI0_CLK_SRC BUS_CLK
+#define DSPI1_CLK_SRC BUS_CLK
+#define DSPI2_CLK_SRC BUS_CLK
+#define UART0_CLK_SRC SYS_CLK
+#define UART1_CLK_SRC SYS_CLK
+#define UART2_CLK_SRC BUS_CLK
+#define UART3_CLK_SRC BUS_CLK
+#define UART4_CLK_SRC BUS_CLK
+#define UART5_CLK_SRC BUS_CLK
+
+/*! @brief Clock name used to get clock frequency. */
+typedef enum _clock_name
+{
+
+    /* ----------------------------- System layer clock -------------------------------*/
+    kCLOCK_CoreSysClk,    /*!< Core/system clock                                         */
+    kCLOCK_PlatClk,       /*!< Platform clock                                            */
+    kCLOCK_BusClk,        /*!< Bus clock                                                 */
+    kCLOCK_FlexBusClk,    /*!< FlexBus clock                                             */
+    kCLOCK_FlashClk,      /*!< Flash clock                                               */
+    kCLOCK_FastPeriphClk, /*!< Fast peripheral clock                                     */
+    kCLOCK_PllFllSelClk,  /*!< The clock after SIM[PLLFLLSEL].                           */
+
+    /* ---------------------------------- OSC clock -----------------------------------*/
+    kCLOCK_Er32kClk,       /*!< External reference 32K clock (ERCLK32K)                   */
+    kCLOCK_Osc0ErClk,      /*!< OSC0 external reference clock (OSC0ERCLK)                 */
+    kCLOCK_Osc1ErClk,      /*!< OSC1 external reference clock (OSC1ERCLK)                 */
+    kCLOCK_Osc0ErClkUndiv, /*!< OSC0 external reference undivided clock(OSC0ERCLK_UNDIV). */
+
+    /* ----------------------------- MCG and MCG-Lite clock ---------------------------*/
+    kCLOCK_McgFixedFreqClk,   /*!< MCG fixed frequency clock (MCGFFCLK)                      */
+    kCLOCK_McgInternalRefClk, /*!< MCG internal reference clock (MCGIRCLK)                   */
+    kCLOCK_McgFllClk,         /*!< MCGFLLCLK                                                 */
+    kCLOCK_McgPll0Clk,        /*!< MCGPLL0CLK                                                */
+    kCLOCK_McgPll1Clk,        /*!< MCGPLL1CLK                                                */
+    kCLOCK_McgExtPllClk,      /*!< EXT_PLLCLK                                                */
+    kCLOCK_McgPeriphClk,      /*!< MCG peripheral clock (MCGPCLK)                            */
+    kCLOCK_McgIrc48MClk,      /*!< MCG IRC48M clock                                          */
+
+    /* --------------------------------- Other clock ----------------------------------*/
+    kCLOCK_LpoClk, /*!< LPO clock                                                 */
+
+} clock_name_t;
+
+/*! @brief USB clock source definition. */
+typedef enum _clock_usb_src
+{
+    kCLOCK_UsbSrcPll0 = SIM_SOPT2_USBSRC(1U) | SIM_SOPT2_PLLFLLSEL(1U),   /*!< Use PLL0.      */
+    kCLOCK_UsbSrcIrc48M = SIM_SOPT2_USBSRC(1U) | SIM_SOPT2_PLLFLLSEL(3U), /*!< Use IRC48M.    */
+    kCLOCK_UsbSrcExt = SIM_SOPT2_USBSRC(0U)                               /*!< Use USB_CLKIN. */
+} clock_usb_src_t;
+
+/*------------------------------------------------------------------------------
+
+ clock_gate_t definition:
+
+ 31                              16                              0
+ -----------------------------------------------------------------
+ | SIM_SCGC register offset       |   control bit offset in SCGC |
+ -----------------------------------------------------------------
+
+ For example, the SDHC clock gate is controlled by SIM_SCGC3[17], the
+ SIM_SCGC3 offset in SIM is 0x1030, then kCLOCK_GateSdhc0 is defined as
+
+              kCLOCK_GateSdhc0 = (0x1030 << 16) | 17;
+
+------------------------------------------------------------------------------*/
+
+#define CLK_GATE_REG_OFFSET_SHIFT 16U
+#define CLK_GATE_REG_OFFSET_MASK 0xFFFF0000U
+#define CLK_GATE_BIT_SHIFT_SHIFT 0U
+#define CLK_GATE_BIT_SHIFT_MASK 0x0000FFFFU
+
+#define CLK_GATE_DEFINE(reg_offset, bit_shift)                                  \
+    ((((reg_offset) << CLK_GATE_REG_OFFSET_SHIFT) & CLK_GATE_REG_OFFSET_MASK) | \
+     (((bit_shift) << CLK_GATE_BIT_SHIFT_SHIFT) & CLK_GATE_BIT_SHIFT_MASK))
+
+#define CLK_GATE_ABSTRACT_REG_OFFSET(x) (((x)&CLK_GATE_REG_OFFSET_MASK) >> CLK_GATE_REG_OFFSET_SHIFT)
+#define CLK_GATE_ABSTRACT_BITS_SHIFT(x) (((x)&CLK_GATE_BIT_SHIFT_MASK) >> CLK_GATE_BIT_SHIFT_SHIFT)
+
+/*! @brief Clock gate name used for CLOCK_EnableClock/CLOCK_DisableClock. */
+typedef enum _clock_ip_name
+{
+    kCLOCK_IpInvalid = 0U,
+    kCLOCK_I2c2 = CLK_GATE_DEFINE(0x1028U, 6U),
+    kCLOCK_Uart4 = CLK_GATE_DEFINE(0x1028U, 10U),
+    kCLOCK_Uart5 = CLK_GATE_DEFINE(0x1028U, 11U),
+
+    kCLOCK_Enet0 = CLK_GATE_DEFINE(0x102CU, 0U),
+    kCLOCK_Dac0 = CLK_GATE_DEFINE(0x102CU, 12U),
+    kCLOCK_Dac1 = CLK_GATE_DEFINE(0x102CU, 13U),
+
+    kCLOCK_Spi2 = CLK_GATE_DEFINE(0x1030U, 12U),
+    kCLOCK_Sdhc0 = CLK_GATE_DEFINE(0x1030U, 17U),
+    kCLOCK_Ftm3 = CLK_GATE_DEFINE(0x1030U, 25U),
+    kCLOCK_Adc1 = CLK_GATE_DEFINE(0x1030U, 27U),
+
+    kCLOCK_Ewm0 = CLK_GATE_DEFINE(0x1034U, 1U),
+    kCLOCK_Cmt0 = CLK_GATE_DEFINE(0x1034U, 2U),
+    kCLOCK_I2c0 = CLK_GATE_DEFINE(0x1034U, 6U),
+    kCLOCK_I2c1 = CLK_GATE_DEFINE(0x1034U, 7U),
+    kCLOCK_Uart0 = CLK_GATE_DEFINE(0x1034U, 10U),
+    kCLOCK_Uart1 = CLK_GATE_DEFINE(0x1034U, 11U),
+    kCLOCK_Uart2 = CLK_GATE_DEFINE(0x1034U, 12U),
+    kCLOCK_Uart3 = CLK_GATE_DEFINE(0x1034U, 13U),
+    kCLOCK_Usbfs0 = CLK_GATE_DEFINE(0x1034U, 18U),
+    kCLOCK_Cmp0 = CLK_GATE_DEFINE(0x1034U, 19U),
+    kCLOCK_Cmp1 = CLK_GATE_DEFINE(0x1034U, 19U),
+    kCLOCK_Cmp2 = CLK_GATE_DEFINE(0x1034U, 19U),
+    kCLOCK_Vref0 = CLK_GATE_DEFINE(0x1034U, 20U),
+
+    kCLOCK_Lptmr0 = CLK_GATE_DEFINE(0x1038U, 0U),
+    kCLOCK_PortA = CLK_GATE_DEFINE(0x1038U, 9U),
+    kCLOCK_PortB = CLK_GATE_DEFINE(0x1038U, 10U),
+    kCLOCK_PortC = CLK_GATE_DEFINE(0x1038U, 11U),
+    kCLOCK_PortD = CLK_GATE_DEFINE(0x1038U, 12U),
+    kCLOCK_PortE = CLK_GATE_DEFINE(0x1038U, 13U),
+
+    kCLOCK_Ftf0 = CLK_GATE_DEFINE(0x103CU, 0U),
+    kCLOCK_Dmamux0 = CLK_GATE_DEFINE(0x103CU, 1U),
+    kCLOCK_Flexcan0 = CLK_GATE_DEFINE(0x103CU, 4U),
+    kCLOCK_Rnga0 = CLK_GATE_DEFINE(0x103CU, 9U),
+    kCLOCK_Spi0 = CLK_GATE_DEFINE(0x103CU, 12U),
+    kCLOCK_Spi1 = CLK_GATE_DEFINE(0x103CU, 13U),
+    kCLOCK_Sai0 = CLK_GATE_DEFINE(0x103CU, 15U),
+    kCLOCK_Crc0 = CLK_GATE_DEFINE(0x103CU, 18U),
+    kCLOCK_Usbdcd0 = CLK_GATE_DEFINE(0x103CU, 21U),
+    kCLOCK_Pdb0 = CLK_GATE_DEFINE(0x103CU, 22U),
+    kCLOCK_Pit0 = CLK_GATE_DEFINE(0x103CU, 23U),
+    kCLOCK_Ftm0 = CLK_GATE_DEFINE(0x103CU, 24U),
+    kCLOCK_Ftm1 = CLK_GATE_DEFINE(0x103CU, 25U),
+    kCLOCK_Ftm2 = CLK_GATE_DEFINE(0x103CU, 26U),
+    kCLOCK_Adc0 = CLK_GATE_DEFINE(0x103CU, 27U),
+    kCLOCK_Rtc0 = CLK_GATE_DEFINE(0x103CU, 29U),
+
+    kCLOCK_Flexbus0 = CLK_GATE_DEFINE(0x1040U, 0U),
+    kCLOCK_Dma0 = CLK_GATE_DEFINE(0x1040U, 1U),
+    kCLOCK_Mpu0 = CLK_GATE_DEFINE(0x1040U, 2U),
+} clock_ip_name_t;
+
+/*!@brief SIM configuration structure for clock setting. */
+typedef struct _sim_clock_config
+{
+    uint8_t pllFllSel; /*!< PLL/FLL/IRC48M selection.    */
+    uint8_t er32kSrc;  /*!< ERCLK32K source selection.   */
+    uint32_t clkdiv1;  /*!< SIM_CLKDIV1.                 */
+} sim_clock_config_t;
+
+/*! @brief OSC work mode. */
+typedef enum _osc_mode
+{
+    kOSC_ModeExt = 0U, /*!< Use external clock.   */
+#if (defined(MCG_C2_EREFS_MASK) && !(defined(MCG_C2_EREFS0_MASK)))
+    kOSC_ModeOscLowPower = MCG_C2_EREFS_MASK, /*!< Oscillator low power. */
+#else
+    kOSC_ModeOscLowPower = MCG_C2_EREFS0_MASK, /*!< Oscillator low power. */
+#endif
+    kOSC_ModeOscHighGain = 0U
+#if (defined(MCG_C2_EREFS_MASK) && !(defined(MCG_C2_EREFS0_MASK)))
+                           |
+                           MCG_C2_EREFS_MASK
+#else
+                           |
+                           MCG_C2_EREFS0_MASK
+#endif
+#if (defined(MCG_C2_HGO_MASK) && !(defined(MCG_C2_HGO0_MASK)))
+                           |
+                           MCG_C2_HGO_MASK, /*!< Oscillator high gain. */
+#else
+                           |
+                           MCG_C2_HGO0_MASK, /*!< Oscillator high gain. */
+#endif
+} osc_mode_t;
+
+/*! @brief Oscillator capacitor load setting.*/
+enum _osc_cap_load
+{
+    kOSC_Cap2P = OSC_CR_SC2P_MASK,  /*!< 2  pF capacitor load */
+    kOSC_Cap4P = OSC_CR_SC4P_MASK,  /*!< 4  pF capacitor load */
+    kOSC_Cap8P = OSC_CR_SC8P_MASK,  /*!< 8  pF capacitor load */
+    kOSC_Cap16P = OSC_CR_SC16P_MASK /*!< 16 pF capacitor load */
+};
+
+/*! @brief OSCERCLK enable mode. */
+enum _oscer_enable_mode
+{
+    kOSC_ErClkEnable = OSC_CR_ERCLKEN_MASK,       /*!< Enable.              */
+    kOSC_ErClkEnableInStop = OSC_CR_EREFSTEN_MASK /*!< Enable in stop mode. */
+};
+
+/*! @brief OSC configuration for OSCERCLK. */
+typedef struct _oscer_config
+{
+    uint8_t enableMode; /*!< OSCERCLK enable mode. OR'ed value of @ref _oscer_enable_mode. */
+
+} oscer_config_t;
+
+/*!
+ * @brief OSC Initialization Configuration Structure
+ *
+ * Defines the configuration data structure to initialize the OSC.
+ * When porting to a new board, please set the following members
+ * according to board setting:
+ * 1. freq: The external frequency.
+ * 2. workMode: The OSC module mode.
+ */
+typedef struct _osc_config
+{
+    uint32_t freq;              /*!< External clock frequency.    */
+    uint8_t capLoad;            /*!< Capacitor load setting.      */
+    osc_mode_t workMode;        /*!< OSC work mode setting.       */
+    oscer_config_t oscerConfig; /*!< Configuration for OSCERCLK.  */
+} osc_config_t;
+
+/*! @brief MCG FLL reference clock source select. */
+typedef enum _mcg_fll_src
+{
+    kMCG_FllSrcExternal, /*!< External reference clock is selected          */
+    kMCG_FllSrcInternal  /*!< The slow internal reference clock is selected */
+} mcg_fll_src_t;
+
+/*! @brief MCG internal reference clock select */
+typedef enum _mcg_irc_mode
+{
+    kMCG_IrcSlow, /*!< Slow internal reference clock selected */
+    kMCG_IrcFast  /*!< Fast internal reference clock selected */
+} mcg_irc_mode_t;
+
+/*! @brief MCG DCO Maximum Frequency with 32.768 kHz Reference */
+typedef enum _mcg_dmx32
+{
+    kMCG_Dmx32Default, /*!< DCO has a default range of 25% */
+    kMCG_Dmx32Fine     /*!< DCO is fine-tuned for maximum frequency with 32.768 kHz reference */
+} mcg_dmx32_t;
+
+/*! @brief MCG DCO range select */
+typedef enum _mcg_drs
+{
+    kMCG_DrsLow,     /*!< Low frequency range       */
+    kMCG_DrsMid,     /*!< Mid frequency range       */
+    kMCG_DrsMidHigh, /*!< Mid-High frequency range  */
+    kMCG_DrsHigh     /*!< High frequency range      */
+} mcg_drs_t;
+
+/*! @brief MCG PLL reference clock select */
+typedef enum _mcg_pll_ref_src
+{
+    kMCG_PllRefOsc0, /*!< Selects OSC0 as PLL reference clock                 */
+    kMCG_PllRefOsc1  /*!< Selects OSC1 as PLL reference clock                 */
+} mcg_pll_ref_src_t;
+
+/*! @brief MCGOUT clock source. */
+typedef enum _mcg_clkout_src
+{
+    kMCG_ClkOutSrcOut,      /*!< Output of the FLL is selected (reset default)  */
+    kMCG_ClkOutSrcInternal, /*!< Internal reference clock is selected           */
+    kMCG_ClkOutSrcExternal, /*!< External reference clock is selected           */
+} mcg_clkout_src_t;
+
+/*! @brief MCG Automatic Trim Machine Select */
+typedef enum _mcg_atm_select
+{
+    kMCG_AtmSel32k, /*!< 32 kHz Internal Reference Clock selected  */
+    kMCG_AtmSel4m   /*!< 4 MHz Internal Reference Clock selected   */
+} mcg_atm_select_t;
+
+/*! @brief MCG OSC Clock Select */
+typedef enum _mcg_oscsel
+{
+    kMCG_OscselOsc, /*!< Selects System Oscillator (OSCCLK) */
+    kMCG_OscselRtc, /*!< Selects 32 kHz RTC Oscillator      */
+    kMCG_OscselIrc  /*!< Selects 48 MHz IRC Oscillator      */
+} mcg_oscsel_t;
+
+/*! @brief MCG PLLCS select */
+typedef enum _mcg_pll_clk_select
+{
+    kMCG_PllClkSelPll0, /*!< PLL0 output clock is selected  */
+    kMCG_PllClkSelPll1  /* PLL1 output clock is selected    */
+} mcg_pll_clk_select_t;
+
+/*! @brief MCG clock monitor mode. */
+typedef enum _mcg_monitor_mode
+{
+    kMCG_MonitorNone, /*!< Clock monitor is disabled.         */
+    kMCG_MonitorInt,  /*!< Trigger interrupt when clock lost. */
+    kMCG_MonitorReset /*!< System reset when clock lost.      */
+} mcg_monitor_mode_t;
+
+/*! @brief MCG status. */
+enum _mcg_status
+{
+    kStatus_MCG_ModeUnreachable = MAKE_STATUS(kStatusGroup_MCG, 0),       /*!< Can't switch to target mode. */
+    kStatus_MCG_ModeInvalid = MAKE_STATUS(kStatusGroup_MCG, 1),           /*!< Current mode invalid for the specific
+                                                                               function. */
+    kStatus_MCG_AtmBusClockInvalid = MAKE_STATUS(kStatusGroup_MCG, 2),    /*!< Invalid bus clock for ATM. */
+    kStatus_MCG_AtmDesiredFreqInvalid = MAKE_STATUS(kStatusGroup_MCG, 3), /*!< Invalid desired frequency for ATM. */
+    kStatus_MCG_AtmIrcUsed = MAKE_STATUS(kStatusGroup_MCG, 4),            /*!< IRC is used when using ATM. */
+    kStatus_MCG_AtmHardwareFail = MAKE_STATUS(kStatusGroup_MCG, 5),       /*!< Hardware fail occurs during ATM. */
+    kStatus_MCG_SourceUsed = MAKE_STATUS(kStatusGroup_MCG, 6)             /*!< Could not change clock source because
+                                                                               it is used currently. */
+};
+
+/*! @brief MCG status flags. */
+enum _mcg_status_flags_t
+{
+    kMCG_Osc0LostFlag = (1U << 0U),   /*!< OSC0 lost.         */
+    kMCG_Osc0InitFlag = (1U << 1U),   /*!< OSC0 crystal initialized. */
+    kMCG_RtcOscLostFlag = (1U << 4U), /*!< RTC OSC lost.      */
+    kMCG_Pll0LostFlag = (1U << 5U),   /*!< PLL0 lost.         */
+    kMCG_Pll0LockFlag = (1U << 6U),   /*!< PLL0 locked.       */
+};
+
+/*! @brief MCG internal reference clock (MCGIRCLK) enable mode definition. */
+enum _mcg_irclk_enable_mode
+{
+    kMCG_IrclkEnable = MCG_C1_IRCLKEN_MASK,       /*!< MCGIRCLK enable.              */
+    kMCG_IrclkEnableInStop = MCG_C1_IREFSTEN_MASK /*!< MCGIRCLK enable in stop mode. */
+};
+
+/*! @brief MCG PLL clock enable mode definition. */
+enum _mcg_pll_enable_mode
+{
+    kMCG_PllEnableIndependent = MCG_C5_PLLCLKEN0_MASK, /*!< MCGPLLCLK enable indepencent of
+                                                           MCG clock mode. Generally, PLL
+                                                           is disabled in FLL modes
+                                                           (FEI/FBI/FEE/FBE), set PLL clock
+                                                           enable independent will enable
+                                                           PLL in the FLL modes.          */
+    kMCG_PllEnableInStop = MCG_C5_PLLSTEN0_MASK        /*!< MCGPLLCLK enable in STOP mode. */
+};
+
+/*! @brief MCG mode definitions */
+typedef enum _mcg_mode
+{
+    kMCG_ModeFEI = 0U, /*!< FEI   - FLL Engaged Internal         */
+    kMCG_ModeFBI,      /*!< FBI   - FLL Bypassed Internal        */
+    kMCG_ModeBLPI,     /*!< BLPI  - Bypassed Low Power Internal  */
+    kMCG_ModeFEE,      /*!< FEE   - FLL Engaged External         */
+    kMCG_ModeFBE,      /*!< FBE   - FLL Bypassed External        */
+    kMCG_ModeBLPE,     /*!< BLPE  - Bypassed Low Power External  */
+    kMCG_ModePBE,      /*!< PBE   - PLL Bypassed External        */
+    kMCG_ModePEE,      /*!< PEE   - PLL Engaged External         */
+    kMCG_ModeError     /*!< Unknown mode                         */
+} mcg_mode_t;
+
+/*! @brief MCG PLL configuration. */
+typedef struct _mcg_pll_config
+{
+    uint8_t enableMode; /*!< Enable mode. OR'ed value of @ref _mcg_pll_enable_mode. */
+    uint8_t prdiv;      /*!< Reference divider PRDIV.    */
+    uint8_t vdiv;       /*!< VCO divider VDIV.           */
+} mcg_pll_config_t;
+
+/*! @brief MCG configure structure for mode change.
+ *
+ * When porting to a new board, please set the following members
+ * according to board setting:
+ * 1. frdiv: If FLL uses the external reference clock, please set this
+ *    value to make sure external reference clock divided by frdiv is
+ *    in the range 31.25kHz to 39.0625kHz.
+ * 2. The PLL reference clock divider PRDIV: PLL reference clock frequency after
+ *    PRDIV should be in the range of FSL_FEATURE_MCG_PLL_REF_MIN to
+ *    FSL_FEATURE_MCG_PLL_REF_MAX.
+ */
+typedef struct _mcg_config
+{
+    mcg_mode_t mcgMode; /*!< MCG mode.                   */
+
+    /* ----------------------- MCGIRCCLK settings ------------------------ */
+    uint8_t irclkEnableMode; /*!< MCGIRCLK enable mode.       */
+    mcg_irc_mode_t ircs;     /*!< Source, MCG_C2[IRCS].       */
+    uint8_t fcrdiv;          /*!< Divider, MCG_SC[FCRDIV].    */
+
+    /* ------------------------ MCG FLL settings ------------------------- */
+    uint8_t frdiv;       /*!< Divider MCG_C1[FRDIV].      */
+    mcg_drs_t drs;       /*!< DCO range MCG_C4[DRST_DRS]. */
+    mcg_dmx32_t dmx32;   /*!< MCG_C4[DMX32].              */
+    mcg_oscsel_t oscsel; /*!< OSC select MCG_C7[OSCSEL].  */
+
+    /* ------------------------ MCG PLL settings ------------------------- */
+    mcg_pll_config_t pll0Config; /*!< MCGPLL0CLK configuration.   */
+
+} mcg_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @brief Set the XTAL0 frequency based on board setting.
+ *
+ * @param freq The XTAL0/EXTAL0 input clock frequency in Hz.
+ */
+static inline void CLOCK_SetXtal0Freq(uint32_t freq)
+{
+    g_xtal0Freq = freq;
+}
+
+/*!
+ * @brief Set the XTAL32/RTC_CLKIN frequency based on board setting.
+ *
+ * @param freq The XTAL32/EXTAL32/RTC_CLKIN input clock frequency in Hz.
+ */
+static inline void CLOCK_SetXtal32Freq(uint32_t freq)
+{
+    g_xtal32Freq = freq;
+}
+
+/*!
+ * @brief Enable the clock for specific IP.
+ *
+ * @param name  Which clock to enable, see \ref clock_ip_name_t.
+ */
+static inline void CLOCK_EnableClock(clock_ip_name_t name)
+{
+    uint32_t regAddr = SIM_BASE + CLK_GATE_ABSTRACT_REG_OFFSET((uint32_t)name);
+    (*(volatile uint32_t *)regAddr) |= (1U << CLK_GATE_ABSTRACT_BITS_SHIFT((uint32_t)name));
+}
+
+/*!
+ * @brief Disable the clock for specific IP.
+ *
+ * @param name  Which clock to disable, see \ref clock_ip_name_t.
+ */
+static inline void CLOCK_DisableClock(clock_ip_name_t name)
+{
+    uint32_t regAddr = SIM_BASE + CLK_GATE_ABSTRACT_REG_OFFSET((uint32_t)name);
+    (*(volatile uint32_t *)regAddr) &= ~(1U << CLK_GATE_ABSTRACT_BITS_SHIFT((uint32_t)name));
+}
+
+/*!
+ * @brief Set ERCLK32K source.
+ *
+ * @param src The value to set ERCLK32K clock source.
+ */
+static inline void CLOCK_SetEr32kClock(uint32_t src)
+{
+    SIM->SOPT1 = ((SIM->SOPT1 & ~SIM_SOPT1_OSC32KSEL_MASK) | SIM_SOPT1_OSC32KSEL(src));
+}
+
+/*!
+ * @brief Set SDHC0 clock source.
+ *
+ * @param src The value to set SDHC0 clock source.
+ */
+static inline void CLOCK_SetSdhc0Clock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_SDHCSRC_MASK) | SIM_SOPT2_SDHCSRC(src));
+}
+
+/*!
+ * @brief Set enet timestamp clock source.
+ *
+ * @param src The value to set enet timestamp clock source.
+ */
+static inline void CLOCK_SetEnetTime0Clock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_TIMESRC_MASK) | SIM_SOPT2_TIMESRC(src));
+}
+
+/*!
+ * @brief Set RMII clock source.
+ *
+ * @param src The value to set RMII clock source.
+ */
+static inline void CLOCK_SetRmii0Clock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_RMIISRC_MASK) | SIM_SOPT2_RMIISRC(src));
+}
+
+/*!
+ * @brief Set debug trace clock source.
+ *
+ * @param src The value to set debug trace clock source.
+ */
+static inline void CLOCK_SetTraceClock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_TRACECLKSEL_MASK) | SIM_SOPT2_TRACECLKSEL(src));
+}
+
+/*!
+ * @brief Set PLLFLLSEL clock source.
+ *
+ * @param src The value to set PLLFLLSEL clock source.
+ */
+static inline void CLOCK_SetPllFllSelClock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_PLLFLLSEL_MASK) | SIM_SOPT2_PLLFLLSEL(src));
+}
+
+/*!
+ * @brief Set CLKOUT source.
+ *
+ * @param src The value to set CLKOUT source.
+ */
+static inline void CLOCK_SetClkOutClock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_CLKOUTSEL_MASK) | SIM_SOPT2_CLKOUTSEL(src));
+}
+
+/*!
+ * @brief Set RTC_CLKOUT source.
+ *
+ * @param src The value to set RTC_CLKOUT source.
+ */
+static inline void CLOCK_SetRtcClkOutClock(uint32_t src)
+{
+    SIM->SOPT2 = ((SIM->SOPT2 & ~SIM_SOPT2_RTCCLKOUTSEL_MASK) | SIM_SOPT2_RTCCLKOUTSEL(src));
+}
+
+/*! @brief Enable USB FS clock.
+ *
+ * @param src  USB FS clock source.
+ * @param freq The frequency specified by src.
+ * @retval true The clock is set successfully.
+ * @retval false The clock source is invalid to get proper USB FS clock.
+ */
+bool CLOCK_EnableUsbfs0Clock(clock_usb_src_t src, uint32_t freq);
+
+/*! @brief Disable USB FS clock.
+ *
+ * Disable USB FS clock.
+ */
+static inline void CLOCK_DisableUsbfs0Clock(void)
+{
+    CLOCK_DisableClock(kCLOCK_Usbfs0);
+}
+
+/*!
+ * @brief System clock divider
+ *
+ * Set the SIM_CLKDIV1[OUTDIV1], SIM_CLKDIV1[OUTDIV2], SIM_CLKDIV1[OUTDIV3], SIM_CLKDIV1[OUTDIV4].
+ *
+ * @param outdiv1 Clock 1 output divider value.
+ *
+ * @param outdiv2 Clock 2 output divider value.
+ *
+ * @param outdiv3 Clock 3 output divider value.
+ *
+ * @param outdiv4 Clock 4 output divider value.
+ */
+static inline void CLOCK_SetOutDiv(uint32_t outdiv1, uint32_t outdiv2, uint32_t outdiv3, uint32_t outdiv4)
+{
+    SIM->CLKDIV1 = SIM_CLKDIV1_OUTDIV1(outdiv1) | SIM_CLKDIV1_OUTDIV2(outdiv2) | SIM_CLKDIV1_OUTDIV3(outdiv3) |
+                   SIM_CLKDIV1_OUTDIV4(outdiv4);
+}
+
+/*!
+ * @brief Gets the clock frequency for a specific clock name.
+ *
+ * This function checks the current clock configurations and then calculates
+ * the clock frequency for a specific clock name defined in clock_name_t.
+ * The MCG must be properly configured before using this function.
+ *
+ * @param clockName Clock names defined in clock_name_t
+ * @return Clock frequency value in Hertz
+ */
+uint32_t CLOCK_GetFreq(clock_name_t clockName);
+
+/*!
+ * @brief Get the core clock or system clock frequency.
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetCoreSysClkFreq(void);
+
+/*!
+ * @brief Get the platform clock frequency.
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetPlatClkFreq(void);
+
+/*!
+ * @brief Get the bus clock frequency.
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetBusClkFreq(void);
+
+/*!
+ * @brief Get the flexbus clock frequency.
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetFlexBusClkFreq(void);
+
+/*!
+ * @brief Get the flash clock frequency.
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetFlashClkFreq(void);
+
+/*!
+ * @brief Get the output clock frequency selected by SIM[PLLFLLSEL].
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetPllFllSelClkFreq(void);
+
+/*!
+ * @brief Get the external reference 32K clock frequency (ERCLK32K).
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetEr32kClkFreq(void);
+
+/*!
+ * @brief Get the OSC0 external reference clock frequency (OSC0ERCLK).
+ *
+ * @return Clock frequency in Hz.
+ */
+uint32_t CLOCK_GetOsc0ErClkFreq(void);
+
+/*!
+ * @brief Set the clock configure in SIM module.
+ *
+ * This function sets system layer clock settings in SIM module.
+ *
+ * @param config Pointer to the configure structure.
+ */
+void CLOCK_SetSimConfig(sim_clock_config_t const *config);
+
+/*!
+ * @brief Set the system clock dividers in SIM to safe value.
+ *
+ * The system level clocks (core clock, bus clock, flexbus clock and flash clock)
+ * must be in allowed ranges. During MCG clock mode switch, the MCG output clock
+ * changes then the system level clocks may be out of range. This function could
+ * be used before MCG mode change, to make sure system level clocks are in allowed
+ * range.
+ *
+ * @param config Pointer to the configure structure.
+ */
+static inline void CLOCK_SetSimSafeDivs(void)
+{
+    SIM->CLKDIV1 = 0x01240000U;
+}
+
+/*! @name MCG frequency functions. */
+/*@{*/
+
+/*!
+ * @brief Get the MCG output clock(MCGOUTCLK) frequency.
+ *
+ * This function gets the MCG output clock frequency (Hz) based on current MCG
+ * register value.
+ *
+ * @return The frequency of MCGOUTCLK.
+ */
+uint32_t CLOCK_GetOutClkFreq(void);
+
+/*!
+ * @brief Get the MCG FLL clock(MCGFLLCLK) frequency.
+ *
+ * This function gets the MCG FLL clock frequency (Hz) based on current MCG
+ * register value. The FLL is only enabled in FEI/FBI/FEE/FBE mode, in other
+ * modes, FLL is disabled in low power state.
+ *
+ * @return The frequency of MCGFLLCLK.
+ */
+uint32_t CLOCK_GetFllFreq(void);
+
+/*!
+ * @brief Get the MCG internal reference clock(MCGIRCLK) frequency.
+ *
+ * This function gets the MCG internal reference clock frequency (Hz) based
+ * on current MCG register value.
+ *
+ * @return The frequency of MCGIRCLK.
+ */
+uint32_t CLOCK_GetInternalRefClkFreq(void);
+
+/*!
+ * @brief Get the MCG fixed frequency clock(MCGFFCLK) frequency.
+ *
+ * This function gets the MCG fixed frequency clock frequency (Hz) based
+ * on current MCG register value.
+ *
+ * @return The frequency of MCGFFCLK.
+ */
+uint32_t CLOCK_GetFixedFreqClkFreq(void);
+
+/*!
+ * @brief Get the MCG PLL0 clock(MCGPLL0CLK) frequency.
+ *
+ * This function gets the MCG PLL0 clock frequency (Hz) based on current MCG
+ * register value.
+ *
+ * @return The frequency of MCGPLL0CLK.
+ */
+uint32_t CLOCK_GetPll0Freq(void);
+
+/*@}*/
+
+/*! @name MCG clock configuration. */
+/*@{*/
+
+/*!
+ * @brief Enable or disable MCG low power.
+ *
+ * Enable MCG low power will disable the PLL and FLL in bypass modes. That is,
+ * in FBE and PBE modes, enable low power will set MCG to BLPE mode, in FBI and
+ * PBI mode, enable low power will set MCG to BLPI mode.
+ * When disable MCG low power, the PLL or FLL will be enabled based on MCG setting.
+ *
+ * @param enable True to enable MCG low power, false to disable MCG low power.
+ */
+static inline void CLOCK_SetLowPowerEnable(bool enable)
+{
+    if (enable)
+    {
+        MCG->C2 |= MCG_C2_LP_MASK;
+    }
+    else
+    {
+        MCG->C2 &= ~MCG_C2_LP_MASK;
+    }
+}
+
+/*!
+ * @brief Configure the Internal Reference clock (MCGIRCLK)
+ *
+ * This function setups the \c MCGIRCLK base on parameters. It selects the IRC
+ * source, if fast IRC is used, this function also sets the fast IRC divider.
+ * This function also sets whether enable \c MCGIRCLK in stop mode.
+ * Calling this function in FBI/PBI/BLPI modes may change the system clock, so
+ * it is not allowed to use this in these modes.
+ *
+ * @param enableMode MCGIRCLK enable mode, OR'ed value of @ref _mcg_irclk_enable_mode.
+ * @param ircs       MCGIRCLK clock source, choose fast or slow.
+ * @param fcrdiv     Fast IRC divider setting (\c FCRDIV).
+ * @retval kStatus_MCG_SourceUsed MCGIRCLK is used as system clock, should not configure MCGIRCLK.
+ * @retval kStatus_Success MCGIRCLK configuration finished successfully.
+ */
+status_t CLOCK_SetInternalRefClkConfig(uint8_t enableMode, mcg_irc_mode_t ircs, uint8_t fcrdiv);
+
+/*!
+ * @brief Select the MCG external reference clock.
+ *
+ * Select the MCG external reference clock source, it changes the MCG_C7[OSCSEL]
+ * and wait for the clock source stable. Should not change external reference
+ * clock in FEE/FBE/BLPE/PBE/PEE mdes, so don't call this function in these modes.
+ *
+ * @param oscsel MCG external reference clock source, MCG_C7[OSCSEL].
+ * @retval kStatus_MCG_SourceUsed External reference clock is used, should not change.
+ * @retval kStatus_Success External reference clock set successfully.
+ */
+status_t CLOCK_SetExternalRefClkConfig(mcg_oscsel_t oscsel);
+
+/*!
+ * @brief Enables the PLL0 in FLL mode.
+ *
+ * This function setups the PLL0 in FLL mode, make sure the PLL reference
+ * clock is enabled before calling this function. This function reconfigures
+ * the PLL0, make sure the PLL0 is not used as a clock source while calling
+ * this function. The function CLOCK_CalcPllDiv can help to get the proper PLL
+ * divider values.
+ *
+ * @param config Pointer to the configuration structure.
+ */
+void CLOCK_EnablePll0(mcg_pll_config_t const *config);
+
+/*!
+ * @brief Disables the PLL0 in FLL mode.
+ *
+ * This function disables the PLL0 in FLL mode, it should be used together with
+ * @ref CLOCK_EnablePll0.
+ */
+static inline void CLOCK_DisablePll0(void)
+{
+    MCG->C5 &= ~(MCG_C5_PLLCLKEN0_MASK | MCG_C5_PLLSTEN0_MASK);
+}
+
+/*!
+ * @brief Calculates the PLL divider setting for desired output frequency.
+ *
+ * This function calculates the proper reference clock divider (\c PRDIV) and
+ * VCO divider (\c VDIV) to generate desired PLL output frequency. It returns the
+ * closest frequency PLL could generate, the corresponding \c PRDIV/VDIV are
+ * returned from parameters. If desired frequency is not valid, this function
+ * returns 0.
+ *
+ * @param refFreq    PLL reference clock frequency.
+ * @param desireFreq Desired PLL output frequency.
+ * @param prdiv      PRDIV value to generate desired PLL frequency.
+ * @param vdiv       VDIV value to generate desired PLL frequency.
+ * @return Closest frequency PLL could generate.
+ */
+uint32_t CLOCK_CalcPllDiv(uint32_t refFreq, uint32_t desireFreq, uint8_t *prdiv, uint8_t *vdiv);
+
+/*@}*/
+
+/*! @name MCG clock lock monitor functions. */
+/*@{*/
+
+/*!
+ * @brief Set the OSC0 clock monitor mode.
+ *
+ * Set the OSC0 clock monitor mode, see @ref mcg_monitor_mode_t for details.
+ *
+ * @param mode The monitor mode to set.
+ */
+void CLOCK_SetOsc0MonitorMode(mcg_monitor_mode_t mode);
+
+/*!
+ * @brief Set the RTC OSC clock monitor mode.
+ *
+ * Set the RTC OSC clock monitor mode, see @ref mcg_monitor_mode_t for details.
+ *
+ * @param mode The monitor mode to set.
+ */
+void CLOCK_SetRtcOscMonitorMode(mcg_monitor_mode_t mode);
+
+/*!
+ * @brief Set the PLL0 clock monitor mode.
+ *
+ * Set the PLL0 clock monitor mode, see @ref mcg_monitor_mode_t for details.
+ *
+ * @param mode The monitor mode to set.
+ */
+void CLOCK_SetPll0MonitorMode(mcg_monitor_mode_t mode);
+
+/*!
+ * @brief Get the MCG status flags.
+ *
+ * This function gets the MCG clock status flags, all the status flags are
+ * returned as a logical OR of the enumeration @ref _mcg_status_flags_t. To
+ * check specific flags, compare the return value with the flags.
+ *
+ * Example:
+ * @code
+   // To check the clock lost lock status of OSC0 and PLL0.
+   uint32_t mcgFlags;
+
+   mcgFlags = CLOCK_GetStatusFlags();
+
+   if (mcgFlags & kMCG_Osc0LostFlag)
+   {
+       // OSC0 clock lock lost. Do something.
+   }
+   if (mcgFlags & kMCG_Pll0LostFlag)
+   {
+       // PLL0 clock lock lost. Do something.
+   }
+   @endcode
+ *
+ * @return  Logical OR value of the @ref _mcg_status_flags_t.
+ */
+uint32_t CLOCK_GetStatusFlags(void);
+
+/*!
+ * @brief Clears the MCG status flags.
+ *
+ * This function clears the MCG clock lock lost status. The parameter is logical
+ * OR value of the flags to clear, see @ref _mcg_status_flags_t.
+ *
+ * Example:
+ * @code
+   // To clear the clock lost lock status flags of OSC0 and PLL0.
+
+   CLOCK_ClearStatusFlags(kMCG_Osc0LostFlag | kMCG_Pll0LostFlag);
+   @endcode
+ *
+ * @param mask The status flags to clear. This is a logical OR of members of the
+ *             enumeration @ref _mcg_status_flags_t.
+ */
+void CLOCK_ClearStatusFlags(uint32_t mask);
+
+/*@}*/
+
+/*!
+ * @name OSC configuration
+ * @{
+ */
+
+/*!
+ * @brief Configures the OSC external reference clock (OSCERCLK).
+ *
+ * This function configures the OSC external reference clock (OSCERCLK).
+ * For example, to enable the OSCERCLK in normal mode and stop mode, and also set
+ * the output divider to 1, as follows:
+ *
+   @code
+   oscer_config_t config =
+   {
+       .enableMode = kOSC_ErClkEnable | kOSC_ErClkEnableInStop,
+       .erclkDiv   = 1U,
+   };
+
+   OSC_SetExtRefClkConfig(OSC, &config);
+   @endcode
+ *
+ * @param base   OSC peripheral address.
+ * @param config Pointer to the configuration structure.
+ */
+static inline void OSC_SetExtRefClkConfig(OSC_Type *base, oscer_config_t const *config)
+{
+    uint8_t reg = base->CR;
+
+    reg &= ~(OSC_CR_ERCLKEN_MASK | OSC_CR_EREFSTEN_MASK);
+    reg |= config->enableMode;
+
+    base->CR = reg;
+}
+
+/*!
+ * @brief Sets the capacitor load configuration for the oscillator.
+ *
+ * This function sets the specified capacitors configuration for the oscillator.
+ * This should be done in the early system level initialization function call
+ * based on the system configuration.
+ *
+ * @param base   OSC peripheral address.
+ * @param capLoad OR'ed value for the capacitor load option, see \ref _osc_cap_load.
+ *
+ * Example:
+   @code
+   // To enable only 2 pF and 8 pF capacitor load, please use like this.
+   OSC_SetCapLoad(OSC, kOSC_Cap2P | kOSC_Cap8P);
+   @endcode
+ */
+static inline void OSC_SetCapLoad(OSC_Type *base, uint8_t capLoad)
+{
+    uint8_t reg = base->CR;
+
+    reg &= ~(OSC_CR_SC2P_MASK | OSC_CR_SC4P_MASK | OSC_CR_SC8P_MASK | OSC_CR_SC16P_MASK);
+    reg |= capLoad;
+
+    base->CR = reg;
+}
+
+/*!
+ * @brief Initialize OSC0.
+ *
+ * This function initializes OSC0 according to board configuration.
+ *
+ * @param  config Pointer to the OSC0 configuration structure.
+ */
+void CLOCK_InitOsc0(osc_config_t const *config);
+
+/*!
+ * @brief Deinitialize OSC0.
+ *
+ * This function deinitializes OSC0.
+ */
+void CLOCK_DeinitOsc0(void);
+
+/* @} */
+
+/*!
+ * @name MCG auto-trim machine.
+ * @{
+ */
+
+/*!
+ * @brief Auto trim the internal reference clock.
+ *
+ * This function trims the internal reference clock using external clock. If
+ * successful, it returns the kStatus_Success and the frequency after
+ * trimming is received in the parameter @p actualFreq. If an error occurs,
+ * the error code is returned.
+ *
+ * @param extFreq      External clock frequency, should be bus clock.
+ * @param desireFreq   Frequency want to trim to.
+ * @param actualFreq   Actual frequency after trim.
+ * @param atms         Trim fast or slow internal reference clock.
+ * @retval kStatus_Success ATM success.
+ * @retval kStatus_MCG_AtmBusClockInvalid The bus clock is not in allowed range for ATM.
+ * @retval kStatus_MCG_AtmDesiredFreqInvalid MCGIRCLK could not be trimmed to the desired frequency.
+ * @retval kStatus_MCG_AtmIrcUsed Could not trim because MCGIRCLK is used as bus clock source.
+ * @retval kStatus_MCG_AtmHardwareFail Hardware fails during trim.
+ */
+status_t CLOCK_TrimInternalRefClk(uint32_t extFreq, uint32_t desireFreq, uint32_t *actualFreq, mcg_atm_select_t atms);
+/* @} */
+
+/*! @name MCG mode functions. */
+/*@{*/
+
+/*!
+ * @brief Gets the current MCG mode.
+ *
+ * This function checks the MCG registers and determine current MCG mode.
+ *
+ * @return Current MCG mode or error code, see @ref mcg_mode_t.
+ */
+mcg_mode_t CLOCK_GetMode(void);
+
+/*!
+ * @brief Set MCG to FEI mode.
+ *
+ * This function sets MCG to FEI mode. If could not set to FEI mode directly
+ * from current mode, this function returns error. @ref kMCG_Dmx32Default is used in this
+ * mode because using kMCG_Dmx32Fine with internal reference clock source
+ * might damage hardware.
+ *
+ * @param       drs The DCO range selection.
+ * @param       fllStableDelay Delay function to make sure FLL is stable, if pass
+ *              in NULL, then does not delay.
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_SetFeiMode(mcg_drs_t drs, void (*fllStableDelay)(void));
+
+/*!
+ * @brief Set MCG to FEE mode.
+ *
+ * This function sets MCG to FEE mode. If could not set to FEE mode directly
+ * from current mode, this function returns error.
+ *
+ * @param   frdiv  FLL reference clock divider setting, FRDIV.
+ * @param   dmx32  DMX32 in FEE mode.
+ * @param   drs    The DCO range selection.
+ * @param   fllStableDelay Delay function to make sure FLL is stable, if pass
+ *          in NULL, then does not delay.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_SetFeeMode(uint8_t frdiv, mcg_dmx32_t dmx32, mcg_drs_t drs, void (*fllStableDelay)(void));
+
+/*!
+ * @brief Set MCG to FBI mode.
+ *
+ * This function sets MCG to FBI mode. If could not set to FBI mode directly
+ * from current mode, this function returns error.
+ *
+ * @param  drs  The DCO range selection.
+ * @param  fllStableDelay Delay function to make sure FLL is stable. If FLL
+ *         is not used in FBI mode, this parameter could be NULL. Pass in
+ *         NULL does not delay.
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_SetFbiMode(mcg_drs_t drs, void (*fllStableDelay)(void));
+
+/*!
+ * @brief Set MCG to FBE mode.
+ *
+ * This function sets MCG to FBE mode. If could not set to FBE mode directly
+ * from current mode, this function returns error.
+ *
+ * @param   frdiv  FLL reference clock divider setting, FRDIV.
+ * @param   dmx32  DMX32 in FBE mode.
+ * @param   drs    The DCO range selection.
+ * @param   fllStableDelay Delay function to make sure FLL is stable. If FLL
+ *          is not used in FBE mode, this parameter could be NULL. Pass in NULL
+ *          does not delay.
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_SetFbeMode(uint8_t frdiv, mcg_dmx32_t dmx32, mcg_drs_t drs, void (*fllStableDelay)(void));
+
+/*!
+ * @brief Set MCG to BLPI mode.
+ *
+ * This function sets MCG to BLPI mode. If could not set to BLPI mode directly
+ * from current mode, this function returns error.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_SetBlpiMode(void);
+
+/*!
+ * @brief Set MCG to BLPE mode.
+ *
+ * This function sets MCG to BLPE mode. If could not set to BLPE mode directly
+ * from current mode, this function returns error.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_SetBlpeMode(void);
+
+/*!
+ * @brief Set MCG to PBE mode.
+ *
+ * This function sets MCG to PBE mode. If could not set to PBE mode directly
+ * from current mode, this function returns error.
+ *
+ * @param   pllcs  The PLL selection, PLLCS.
+ * @param   config Pointer to the PLL configuration.
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ *
+ * @note
+ * 1. The parameter \c pllcs selects the PLL, for some platforms, there is
+ * only one PLL, the parameter pllcs is kept for interface compatible.
+ * 2. The parameter \c config is the PLL configuration structure, on some
+ * platforms, could choose the external PLL directly. This means that the
+ * configuration structure is not necessary, pass in NULL for this case.
+ * For example: CLOCK_SetPbeMode(kMCG_OscselOsc, kMCG_PllClkSelExtPll, NULL);
+ */
+status_t CLOCK_SetPbeMode(mcg_pll_clk_select_t pllcs, mcg_pll_config_t const *config);
+
+/*!
+ * @brief Set MCG to PEE mode.
+ *
+ * This function sets MCG to PEE mode.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ *
+ * @note This function only change CLKS to use PLL/FLL output. If the
+ *       PRDIV/VDIV are different from PBE mode, please setup these
+ *       settings in PBE mode and wait for stable then switch to PEE mode.
+ */
+status_t CLOCK_SetPeeMode(void);
+
+/*!
+ * @brief Switch MCG to FBE mode quickly from external mode.
+ *
+ * This function changes MCG from external modes (PEE/PBE/BLPE/FEE) to FBE mode quickly.
+ * It only changes to use external clock as the system clock souce and disable PLL, but does not
+ * configure FLL settings. This is a lite function with small code size, it is useful
+ * during mode switch. For example, to switch from PEE mode to FEI mode:
+ *
+ * @code
+ * CLOCK_ExternalModeToFbeModeQuick();
+ * CLOCK_SetFeiMode(...);
+ * @endcode
+ *
+ * @retval kStatus_Success Change successfully.
+ * @retval kStatus_MCG_ModeInvalid Current mode is not external modes, should not call this function.
+ */
+status_t CLOCK_ExternalModeToFbeModeQuick(void);
+
+/*!
+ * @brief Switch MCG to FBI mode quickly from internal modes.
+ *
+ * This function changes MCG from internal modes (PEI/PBI/BLPI/FEI) to FBI mode quickly.
+ * It only changes to use MCGIRCLK as the system clock souce and disable PLL, but does not
+ * configure FLL settings. This is a lite function with small code size, it is useful
+ * during mode switch. For example, to switch from PEI mode to FEE mode:
+ *
+ * @code
+ * CLOCK_InternalModeToFbiModeQuick();
+ * CLOCK_SetFeeMode(...);
+ * @endcode
+ *
+ * @retval kStatus_Success Change successfully.
+ * @retval kStatus_MCG_ModeInvalid Current mode is not internal mode, should not call this function.
+ */
+status_t CLOCK_InternalModeToFbiModeQuick(void);
+
+/*!
+ * @brief Set MCG to FEI mode during system boot up.
+ *
+ * This function sets MCG to FEI mode from reset mode, it could be used to
+ * set up MCG during system boot up. @ref kMCG_Dmx32Default is used in this
+ * mode because using kMCG_Dmx32Fine with internal reference clock source
+ * might damage hardware.
+ *
+ * @param  drs The DCO range selection.
+ * @param  fllStableDelay Delay function to make sure FLL is stable.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_BootToFeiMode(mcg_drs_t drs, void (*fllStableDelay)(void));
+
+/*!
+ * @brief Set MCG to FEE mode during system bootup.
+ *
+ * This function sets MCG to FEE mode from reset mode, it could be used to
+ * set up MCG during system boot up.
+ *
+ * @param   oscsel OSC clock select, OSCSEL.
+ * @param   frdiv  FLL reference clock divider setting, FRDIV.
+ * @param   dmx32  DMX32 in FEE mode.
+ * @param   drs    The DCO range selection.
+ * @param   fllStableDelay Delay function to make sure FLL is stable.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_BootToFeeMode(
+    mcg_oscsel_t oscsel, uint8_t frdiv, mcg_dmx32_t dmx32, mcg_drs_t drs, void (*fllStableDelay)(void));
+
+/*!
+ * @brief Set MCG to BLPI mode during system boot up.
+ *
+ * This function sets MCG to BLPI mode from reset mode, it could be used to
+ * setup MCG during sytem boot up.
+ *
+ * @param  fcrdiv Fast IRC divider, FCRDIV.
+ * @param  ircs   The internal reference clock to select, IRCS.
+ * @param  ircEnableMode  The MCGIRCLK enable mode, OR'ed value of @ref _mcg_irclk_enable_mode.
+ *
+ * @retval kStatus_MCG_SourceUsed Could not change MCGIRCLK setting.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_BootToBlpiMode(uint8_t fcrdiv, mcg_irc_mode_t ircs, uint8_t ircEnableMode);
+
+/*!
+ * @brief Set MCG to BLPE mode during sytem boot up.
+ *
+ * This function sets MCG to BLPE mode from reset mode, it could be used to
+ * setup MCG during sytem boot up.
+ *
+ * @param  oscsel OSC clock select, MCG_C7[OSCSEL].
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_BootToBlpeMode(mcg_oscsel_t oscsel);
+
+/*!
+ * @brief Set MCG to PEE mode during system boot up.
+ *
+ * This function sets MCG to PEE mode from reset mode, it could be used to
+ * setup MCG during system boot up.
+ *
+ * @param   oscsel OSC clock select, MCG_C7[OSCSEL].
+ * @param   pllcs  The PLL selection, PLLCS.
+ * @param   config Pointer to the PLL configuration.
+ *
+ * @retval kStatus_MCG_ModeUnreachable Could not switch to the target mode.
+ * @retval kStatus_Success Switch to target mode successfully.
+ */
+status_t CLOCK_BootToPeeMode(mcg_oscsel_t oscsel, mcg_pll_clk_select_t pllcs, mcg_pll_config_t const *config);
+
+/*!
+ * @brief Set MCG to some target mode.
+ *
+ * This function sets MCG to some target mode defined by the configure
+ * structure, if cannot switch to target mode directly, this function will
+ * choose the proper path.
+ *
+ * @param  config Pointer to the target MCG mode configuration structure.
+ * @return Return kStatus_Success if switch successfully, otherwise return error code #_mcg_status.
+ *
+ * @note If external clock is used in the target mode, please make sure it is
+ * enabled, for example, if the OSC0 is used, please setup OSC0 correctly before
+ * this funciton.
+ */
+status_t CLOCK_SetMcgConfig(mcg_config_t const *config);
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @} */
+
+#endif /* _FSL_CLOCK_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmp.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmp.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_cmp.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get instance number for CMP module.
+ *
+ * @param base CMP peripheral base address
+ */
+static uint32_t CMP_GetInstance(CMP_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to CMP bases for each instance. */
+static CMP_Type *const s_cmpBases[] = CMP_BASE_PTRS;
+/*! @brief Pointers to CMP clocks for each instance. */
+const clock_ip_name_t s_cmpClocks[] = CMP_CLOCKS;
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+static uint32_t CMP_GetInstance(CMP_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_CMP_COUNT; instance++)
+    {
+        if (s_cmpBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_CMP_COUNT);
+
+    return instance;
+}
+
+void CMP_Init(CMP_Type *base, const cmp_config_t *config)
+{
+    assert(NULL != config);
+
+    uint8_t tmp8;
+
+    /* Enable the clock. */
+    CLOCK_EnableClock(s_cmpClocks[CMP_GetInstance(base)]);
+
+    /* Configure. */
+    CMP_Enable(base, false); /* Disable the CMP module during configuring. */
+    /* CMPx_CR1. */
+    tmp8 = base->CR1 & ~(CMP_CR1_PMODE_MASK | CMP_CR1_INV_MASK | CMP_CR1_COS_MASK | CMP_CR1_OPE_MASK);
+    if (config->enableHighSpeed)
+    {
+        tmp8 |= CMP_CR1_PMODE_MASK;
+    }
+    if (config->enableInvertOutput)
+    {
+        tmp8 |= CMP_CR1_INV_MASK;
+    }
+    if (config->useUnfilteredOutput)
+    {
+        tmp8 |= CMP_CR1_COS_MASK;
+    }
+    if (config->enablePinOut)
+    {
+        tmp8 |= CMP_CR1_OPE_MASK;
+    }
+#if defined(FSL_FEATURE_CMP_HAS_TRIGGER_MODE) && FSL_FEATURE_CMP_HAS_TRIGGER_MODE
+    if (config->enableTriggerMode)
+    {
+        tmp8 |= CMP_CR1_TRIGM_MASK;
+    }
+    else
+    {
+        tmp8 &= ~CMP_CR1_TRIGM_MASK;
+    }
+#endif /* FSL_FEATURE_CMP_HAS_TRIGGER_MODE */
+    base->CR1 = tmp8;
+
+    /* CMPx_CR0. */
+    tmp8 = base->CR0 & ~CMP_CR0_HYSTCTR_MASK;
+    tmp8 |= CMP_CR0_HYSTCTR(config->hysteresisMode);
+    base->CR0 = tmp8;
+
+    CMP_Enable(base, config->enableCmp); /* Enable the CMP module after configured or not. */
+}
+
+void CMP_Deinit(CMP_Type *base)
+{
+    /* Disable the CMP module. */
+    CMP_Enable(base, false);
+
+    /* Disable the clock. */
+    CLOCK_DisableClock(s_cmpClocks[CMP_GetInstance(base)]);
+}
+
+void CMP_GetDefaultConfig(cmp_config_t *config)
+{
+    assert(NULL != config);
+
+    config->enableCmp = true; /* Enable the CMP module after initialization. */
+    config->hysteresisMode = kCMP_HysteresisLevel0;
+    config->enableHighSpeed = false;
+    config->enableInvertOutput = false;
+    config->useUnfilteredOutput = false;
+    config->enablePinOut = false;
+#if defined(FSL_FEATURE_CMP_HAS_TRIGGER_MODE) && FSL_FEATURE_CMP_HAS_TRIGGER_MODE
+    config->enableTriggerMode = false;
+#endif /* FSL_FEATURE_CMP_HAS_TRIGGER_MODE */
+}
+
+void CMP_SetInputChannels(CMP_Type *base, uint8_t positiveChannel, uint8_t negativeChannel)
+{
+    uint8_t tmp8 = base->MUXCR;
+
+    tmp8 &= ~(CMP_MUXCR_PSEL_MASK | CMP_MUXCR_MSEL_MASK);
+    tmp8 |= CMP_MUXCR_PSEL(positiveChannel) | CMP_MUXCR_MSEL(negativeChannel);
+    base->MUXCR = tmp8;
+}
+
+#if defined(FSL_FEATURE_CMP_HAS_DMA) && FSL_FEATURE_CMP_HAS_DMA
+void CMP_EnableDMA(CMP_Type *base, bool enable)
+{
+    uint8_t tmp8 = base->SCR & ~(CMP_SCR_CFR_MASK | CMP_SCR_CFF_MASK); /* To avoid change the w1c bits. */
+
+    if (enable)
+    {
+        tmp8 |= CMP_SCR_DMAEN_MASK;
+    }
+    else
+    {
+        tmp8 &= ~CMP_SCR_DMAEN_MASK;
+    }
+    base->SCR = tmp8;
+}
+#endif /* FSL_FEATURE_CMP_HAS_DMA */
+
+void CMP_SetFilterConfig(CMP_Type *base, const cmp_filter_config_t *config)
+{
+    assert(NULL != config);
+
+    uint8_t tmp8;
+
+#if defined(FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT) && FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT
+    /* Choose the clock source for sampling. */
+    if (config->enableSample)
+    {
+        base->CR1 |= CMP_CR1_SE_MASK; /* Choose the external SAMPLE clock. */
+    }
+    else
+    {
+        base->CR1 &= ~CMP_CR1_SE_MASK; /* Choose the internal divided bus clock. */
+    }
+#endif /* FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT */
+    /* Set the filter count. */
+    tmp8 = base->CR0 & ~CMP_CR0_FILTER_CNT_MASK;
+    tmp8 |= CMP_CR0_FILTER_CNT(config->filterCount);
+    base->CR0 = tmp8;
+    /* Set the filter period. It is used as the divider to bus clock. */
+    base->FPR = CMP_FPR_FILT_PER(config->filterPeriod);
+}
+
+void CMP_SetDACConfig(CMP_Type *base, const cmp_dac_config_t *config)
+{
+    uint8_t tmp8 = 0U;
+
+    if (NULL == config)
+    {
+        /* Passing "NULL" as input parameter means no available configuration. So the DAC feature is disabled.*/
+        base->DACCR = 0U;
+        return;
+    }
+    /* CMPx_DACCR. */
+    tmp8 |= CMP_DACCR_DACEN_MASK; /* Enable the internal DAC. */
+    if (kCMP_VrefSourceVin2 == config->referenceVoltageSource)
+    {
+        tmp8 |= CMP_DACCR_VRSEL_MASK;
+    }
+    tmp8 |= CMP_DACCR_VOSEL(config->DACValue);
+
+    base->DACCR = tmp8;
+}
+
+void CMP_EnableInterrupts(CMP_Type *base, uint32_t mask)
+{
+    uint8_t tmp8 = base->SCR & ~(CMP_SCR_CFR_MASK | CMP_SCR_CFF_MASK); /* To avoid change the w1c bits. */
+
+    if (0U != (kCMP_OutputRisingInterruptEnable & mask))
+    {
+        tmp8 |= CMP_SCR_IER_MASK;
+    }
+    if (0U != (kCMP_OutputFallingInterruptEnable & mask))
+    {
+        tmp8 |= CMP_SCR_IEF_MASK;
+    }
+    base->SCR = tmp8;
+}
+
+void CMP_DisableInterrupts(CMP_Type *base, uint32_t mask)
+{
+    uint8_t tmp8 = base->SCR & ~(CMP_SCR_CFR_MASK | CMP_SCR_CFF_MASK); /* To avoid change the w1c bits. */
+
+    if (0U != (kCMP_OutputRisingInterruptEnable & mask))
+    {
+        tmp8 &= ~CMP_SCR_IER_MASK;
+    }
+    if (0U != (kCMP_OutputFallingInterruptEnable & mask))
+    {
+        tmp8 &= ~CMP_SCR_IEF_MASK;
+    }
+    base->SCR = tmp8;
+}
+
+uint32_t CMP_GetStatusFlags(CMP_Type *base)
+{
+    uint32_t ret32 = 0U;
+
+    if (0U != (CMP_SCR_CFR_MASK & base->SCR))
+    {
+        ret32 |= kCMP_OutputRisingEventFlag;
+    }
+    if (0U != (CMP_SCR_CFF_MASK & base->SCR))
+    {
+        ret32 |= kCMP_OutputFallingEventFlag;
+    }
+    if (0U != (CMP_SCR_COUT_MASK & base->SCR))
+    {
+        ret32 |= kCMP_OutputAssertEventFlag;
+    }
+    return ret32;
+}
+
+void CMP_ClearStatusFlags(CMP_Type *base, uint32_t mask)
+{
+    uint8_t tmp8 = base->SCR & ~(CMP_SCR_CFR_MASK | CMP_SCR_CFF_MASK); /* To avoid change the w1c bits. */
+
+    if (0U != (kCMP_OutputRisingEventFlag & mask))
+    {
+        tmp8 |= CMP_SCR_CFR_MASK;
+    }
+    if (0U != (kCMP_OutputFallingEventFlag & mask))
+    {
+        tmp8 |= CMP_SCR_CFF_MASK;
+    }
+    base->SCR = tmp8;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmp.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmp.h
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_CMP_H_
+#define _FSL_CMP_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup cmp
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief CMP driver version 2.0.0. */
+#define FSL_CMP_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*!
+* @brief Interrupt enable/disable mask.
+*/
+enum _cmp_interrupt_enable
+{
+    kCMP_OutputRisingInterruptEnable = CMP_SCR_IER_MASK,  /*!< Comparator interrupt enable rising. */
+    kCMP_OutputFallingInterruptEnable = CMP_SCR_IEF_MASK, /*!< Comparator interrupt enable falling. */
+};
+
+/*!
+ * @brief Status flags' mask.
+ */
+enum _cmp_status_flags
+{
+    kCMP_OutputRisingEventFlag = CMP_SCR_CFR_MASK,  /*!< Rising-edge on compare output has occurred. */
+    kCMP_OutputFallingEventFlag = CMP_SCR_CFF_MASK, /*!< Falling-edge on compare output has occurred. */
+    kCMP_OutputAssertEventFlag = CMP_SCR_COUT_MASK, /*!< Return the current value of the analog comparator output. */
+};
+
+/*!
+ * @brief CMP Hysteresis mode.
+ */
+typedef enum _cmp_hysteresis_mode
+{
+    kCMP_HysteresisLevel0 = 0U, /*!< Hysteresis level 0. */
+    kCMP_HysteresisLevel1 = 1U, /*!< Hysteresis level 1. */
+    kCMP_HysteresisLevel2 = 2U, /*!< Hysteresis level 2. */
+    kCMP_HysteresisLevel3 = 3U, /*!< Hysteresis level 3. */
+} cmp_hysteresis_mode_t;
+
+/*!
+ * @brief CMP Voltage Reference source.
+ */
+typedef enum _cmp_reference_voltage_source
+{
+    kCMP_VrefSourceVin1 = 0U, /*!< Vin1 is selected as resistor ladder network supply reference Vin. */
+    kCMP_VrefSourceVin2 = 1U, /*!< Vin2 is selected as resistor ladder network supply reference Vin. */
+} cmp_reference_voltage_source_t;
+
+/*!
+ * @brief Configure the comparator.
+ */
+typedef struct _cmp_config
+{
+    bool enableCmp;                       /*!< Enable the CMP module. */
+    cmp_hysteresis_mode_t hysteresisMode; /*!< CMP Hysteresis mode. */
+    bool enableHighSpeed;                 /*!< Enable High Speed (HS) comparison mode. */
+    bool enableInvertOutput;              /*!< Enable inverted comparator output. */
+    bool useUnfilteredOutput;             /*!< Set compare output(COUT) to equal COUTA(true) or COUT(false). */
+    bool enablePinOut;                    /*!< The comparator output is available on the associated pin. */
+#if defined(FSL_FEATURE_CMP_HAS_TRIGGER_MODE) && FSL_FEATURE_CMP_HAS_TRIGGER_MODE
+    bool enableTriggerMode; /*!< Enable the trigger mode. */
+#endif                      /* FSL_FEATURE_CMP_HAS_TRIGGER_MODE */
+} cmp_config_t;
+
+/*!
+ * @brief Configure the filter.
+ */
+typedef struct _cmp_filter_config
+{
+#if defined(FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT) && FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT
+    bool enableSample;    /*!< Using external SAMPLE as sampling clock input, or using divided bus clock. */
+#endif                    /* FSL_FEATURE_CMP_HAS_EXTERNAL_SAMPLE_SUPPORT */
+    uint8_t filterCount;  /*!< Filter Sample Count. Available range is 1-7, 0 would cause the filter disabled.*/
+    uint8_t filterPeriod; /*!< Filter Sample Period. The divider to bus clock. Available range is 0-255. */
+} cmp_filter_config_t;
+
+/*!
+ * @brief Configure the internal DAC.
+ */
+typedef struct _cmp_dac_config
+{
+    cmp_reference_voltage_source_t referenceVoltageSource; /*!< Supply voltage reference source. */
+    uint8_t DACValue;                                      /*!< Value for DAC Output Voltage. Available range is 0-63.*/
+} cmp_dac_config_t;
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+/*!
+ * @name Initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the CMP.
+ *
+ * This function initializes the CMP module. The operations included are:
+ * - Enabling the clock for CMP module.
+ * - Configuring the comparator.
+ * - Enabling the CMP module.
+ * Note: For some devices, multiple CMP instance share the same clock gate. In this case, to enable the clock for
+ * any instance enables all the CMPs. Check the chip reference manual for the clock assignment of the CMP.
+ *
+ * @param base   CMP peripheral base address.
+ * @param config Pointer to configuration structure.
+ */
+void CMP_Init(CMP_Type *base, const cmp_config_t *config);
+
+/*!
+ * @brief De-initializes the CMP module.
+ *
+ * This function de-initializes the CMP module. The operations included are:
+ * - Disabling the CMP module.
+ * - Disabling the clock for CMP module.
+ *
+ * This function disables the clock for the CMP.
+ * Note: For some devices, multiple CMP instance shares the same clock gate. In this case, before disabling the
+ * clock for the CMP,  ensure that all the CMP instances are not used.
+ *
+ * @param base CMP peripheral base address.
+ */
+void CMP_Deinit(CMP_Type *base);
+
+/*!
+ * @brief Enables/disables the CMP module.
+ *
+ * @param base CMP peripheral base address.
+ * @param enable Enable the module or not.
+ */
+static inline void CMP_Enable(CMP_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->CR1 |= CMP_CR1_EN_MASK;
+    }
+    else
+    {
+        base->CR1 &= ~CMP_CR1_EN_MASK;
+    }
+}
+
+/*!
+* @brief Initializes the CMP user configuration structure.
+*
+* This function initializes the user configure structure to these default values:
+* @code
+*   config->enableCmp           = true;
+*   config->hysteresisMode      = kCMP_HysteresisLevel0;
+*   config->enableHighSpeed     = false;
+*   config->enableInvertOutput  = false;
+*   config->useUnfilteredOutput = false;
+*   config->enablePinOut        = false;
+*   config->enableTriggerMode   = false;
+* @endcode
+* @param config Pointer to the configuration structure.
+*/
+void CMP_GetDefaultConfig(cmp_config_t *config);
+
+/*!
+ * @brief  Sets the input channels for the comparator.
+ *
+ * This function sets the input channels for the comparator.
+ * Note that two input channels cannot be set as same in the application. When the user selects the same input
+ * from the analog mux to the positive and negative port, the comparator is disabled automatically.
+ *
+ * @param  base            CMP peripheral base address.
+ * @param  positiveChannel Positive side input channel number. Available range is 0-7.
+ * @param  negativeChannel Negative side input channel number. Available range is 0-7.
+ */
+void CMP_SetInputChannels(CMP_Type *base, uint8_t positiveChannel, uint8_t negativeChannel);
+
+/* @} */
+
+/*!
+ * @name Advanced Features
+ * @{
+ */
+
+#if defined(FSL_FEATURE_CMP_HAS_DMA) && FSL_FEATURE_CMP_HAS_DMA
+/*!
+ * @brief Enables/disables the DMA request for rising/falling events.
+ *
+ * This function enables/disables the DMA request for rising/falling events. Either event triggers the generation of
+ * the DMA
+ * request from CMP if the DMA feature is enabled. Both events are ignored for generating the DMA request from the CMP
+ * if the
+ * DMA is disabled.
+ *
+ * @param base CMP peripheral base address.
+ * @param enable Enable the feature or not.
+ */
+void CMP_EnableDMA(CMP_Type *base, bool enable);
+#endif /* FSL_FEATURE_CMP_HAS_DMA */
+
+#if defined(FSL_FEATURE_CMP_HAS_WINDOW_MODE) && FSL_FEATURE_CMP_HAS_WINDOW_MODE
+/*!
+ * @brief Enables/disables the window mode.
+ *
+ * @param base CMP peripheral base address.
+ * @param enable Enable the feature or not.
+ */
+static inline void CMP_EnableWindowMode(CMP_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->CR1 |= CMP_CR1_WE_MASK;
+    }
+    else
+    {
+        base->CR1 &= ~CMP_CR1_WE_MASK;
+    }
+}
+#endif /* FSL_FEATURE_CMP_HAS_WINDOW_MODE */
+
+#if defined(FSL_FEATURE_CMP_HAS_PASS_THROUGH_MODE) && FSL_FEATURE_CMP_HAS_PASS_THROUGH_MODE
+/*!
+ * @brief Enables/disables the pass through mode.
+ *
+ * @param base CMP peripheral base address.
+ * @param enable Enable the feature or not.
+ */
+static inline void CMP_EnablePassThroughMode(CMP_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->MUXCR |= CMP_MUXCR_PSTM_MASK;
+    }
+    else
+    {
+        base->MUXCR &= ~CMP_MUXCR_PSTM_MASK;
+    }
+}
+#endif /* FSL_FEATURE_CMP_HAS_PASS_THROUGH_MODE */
+
+/*!
+ * @brief  Configures the filter.
+ *
+ * @param  base   CMP peripheral base address.
+ * @param  config Pointer to configuration structure.
+ */
+void CMP_SetFilterConfig(CMP_Type *base, const cmp_filter_config_t *config);
+
+/*!
+ * @brief Configures the internal DAC.
+ *
+ * @param base   CMP peripheral base address.
+ * @param config Pointer to configuration structure. "NULL" is for disabling the feature.
+ */
+void CMP_SetDACConfig(CMP_Type *base, const cmp_dac_config_t *config);
+
+/*!
+ * @brief Enables the interrupts.
+ *
+ * @param base    CMP peripheral base address.
+ * @param mask    Mask value for interrupts. See "_cmp_interrupt_enable".
+ */
+void CMP_EnableInterrupts(CMP_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables the interrupts.
+ *
+ * @param base    CMP peripheral base address.
+ * @param mask    Mask value for interrupts. See "_cmp_interrupt_enable".
+ */
+void CMP_DisableInterrupts(CMP_Type *base, uint32_t mask);
+
+/* @} */
+
+/*!
+ * @name Results
+ * @{
+ */
+
+/*!
+ * @brief  Gets the status flags.
+ *
+ * @param  base     CMP peripheral base address.
+ *
+ * @return          Mask value for the asserted flags. See "_cmp_status_flags".
+ */
+uint32_t CMP_GetStatusFlags(CMP_Type *base);
+
+/*!
+ * @brief Clears the status flags.
+ *
+ * @param base     CMP peripheral base address.
+ * @param mask     Mask value for the flags. See "_cmp_status_flags".
+ */
+void CMP_ClearStatusFlags(CMP_Type *base, uint32_t mask);
+
+/* @} */
+#if defined(__cplusplus)
+}
+#endif
+/*!
+ * @}
+ */
+#endif /* _FSL_CMP_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmt.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmt.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_cmt.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* The standard intermediate frequency (IF). */
+#define CMT_INTERMEDIATEFREQUENCY_8MHZ (8000000U)
+/* CMT data modulate mask. */
+#define CMT_MODULATE_COUNT_WIDTH (8U)
+/* CMT diver 1. */
+#define CMT_CMTDIV_ONE (1)
+/* CMT diver 2. */
+#define CMT_CMTDIV_TWO (2)
+/* CMT diver 4. */
+#define CMT_CMTDIV_FOUR (4)
+/* CMT diver 8. */
+#define CMT_CMTDIV_EIGHT (8)
+/* CMT mode bit mask. */
+#define CMT_MODE_BIT_MASK (CMT_MSC_MCGEN_MASK | CMT_MSC_FSK_MASK | CMT_MSC_BASE_MASK)
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get instance number for CMT module.
+ *
+ * @param base CMT peripheral base address.
+ */
+static uint32_t CMT_GetInstance(CMT_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to cmt clocks for each instance. */
+const clock_ip_name_t s_cmtClock[FSL_FEATURE_SOC_CMT_COUNT] = CMT_CLOCKS;
+
+/*! @brief Pointers to cmt bases for each instance. */
+static CMT_Type *const s_cmtBases[] = CMT_BASE_PTRS;
+
+/*! @brief Pointers to cmt IRQ number for each instance. */
+const IRQn_Type s_cmtIrqs[] = CMT_IRQS;
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+
+static uint32_t CMT_GetInstance(CMT_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_CMT_COUNT; instance++)
+    {
+        if (s_cmtBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_CMT_COUNT);
+
+    return instance;
+}
+
+void CMT_GetDefaultConfig(cmt_config_t *config)
+{
+    assert(config);
+
+    /* Default infrared output is enabled and set with high active, the divider is set to 1. */
+    config->isInterruptEnabled = false;
+    config->isIroEnabled = true;
+    config->iroPolarity = kCMT_IROActiveHigh;
+    config->divider = kCMT_SecondClkDiv1;
+}
+
+void CMT_Init(CMT_Type *base, const cmt_config_t *config, uint32_t busClock_Hz)
+{
+    assert(config);
+    assert(busClock_Hz >= CMT_INTERMEDIATEFREQUENCY_8MHZ);
+
+    uint8_t divider;
+
+    /* Ungate clock. */
+    CLOCK_EnableClock(s_cmtClock[CMT_GetInstance(base)]);
+
+    /* Sets clock divider. The divider set in pps should be set
+       to make sycClock_Hz/divder = 8MHz */
+    base->PPS = CMT_PPS_PPSDIV(busClock_Hz / CMT_INTERMEDIATEFREQUENCY_8MHZ - 1);
+    divider = base->MSC;
+    divider &= ~CMT_MSC_CMTDIV_MASK;
+    divider |= CMT_MSC_CMTDIV(config->divider);
+    base->MSC = divider;
+
+    /* Set the IRO signal. */
+    base->OC = CMT_OC_CMTPOL(config->iroPolarity) | CMT_OC_IROPEN(config->isIroEnabled);
+
+    /* Set interrupt. */
+    if (config->isInterruptEnabled)
+    {
+        CMT_EnableInterrupts(base, kCMT_EndOfCycleInterruptEnable);
+        EnableIRQ(s_cmtIrqs[CMT_GetInstance(base)]);
+    }
+}
+
+void CMT_Deinit(CMT_Type *base)
+{
+    /*Disable the CMT modulator. */
+    base->MSC = 0;
+
+    /* Disable the interrupt. */
+    CMT_DisableInterrupts(base, kCMT_EndOfCycleInterruptEnable);
+    DisableIRQ(s_cmtIrqs[CMT_GetInstance(base)]);
+
+    /* Gate the clock. */
+    CLOCK_DisableClock(s_cmtClock[CMT_GetInstance(base)]);
+}
+
+void CMT_SetMode(CMT_Type *base, cmt_mode_t mode, cmt_modulate_config_t *modulateConfig)
+{
+    uint8_t mscReg;
+
+    /* Set the mode. */
+    if (mode != kCMT_DirectIROCtl)
+    {
+        assert(modulateConfig);
+
+        /* Set carrier generator. */
+        CMT_SetCarrirGenerateCountOne(base, modulateConfig->highCount1, modulateConfig->lowCount1);
+        if (mode == kCMT_FSKMode)
+        {
+            CMT_SetCarrirGenerateCountTwo(base, modulateConfig->highCount2, modulateConfig->lowCount2);
+        }
+
+        /* Set carrier modulator. */
+        CMT_SetModulateMarkSpace(base, modulateConfig->markCount, modulateConfig->spaceCount);
+    }
+
+    /* Set the CMT mode. */
+    mscReg = base->MSC;
+    mscReg &= ~CMT_MODE_BIT_MASK;
+    mscReg |= mode;
+
+    base->MSC = mscReg;
+}
+
+cmt_mode_t CMT_GetMode(CMT_Type *base)
+{
+    uint8_t mode = base->MSC;
+
+    if (!(mode & CMT_MSC_MCGEN_MASK))
+    { /* Carrier modulator disabled and the IRO signal is in direct software control. */
+        return kCMT_DirectIROCtl;
+    }
+    else
+    {
+        /* Carrier modulator is enabled. */
+        if (mode & CMT_MSC_BASE_MASK)
+        {
+            /* Base band mode. */
+            return kCMT_BasebandMode;
+        }
+        else if (mode & CMT_MSC_FSK_MASK)
+        {
+            /* FSK mode. */
+            return kCMT_FSKMode;
+        }
+        else
+        {
+            /* Time mode. */
+            return kCMT_TimeMode;
+        }
+    }
+}
+
+uint32_t CMT_GetCMTFrequency(CMT_Type *base, uint32_t busClock_Hz)
+{
+    uint32_t frequency;
+    uint32_t divider;
+
+    /* Get intermediate frequency. */
+    frequency = busClock_Hz / ((base->PPS & CMT_PPS_PPSDIV_MASK) + 1);
+
+    /* Get the second divider. */
+    divider = ((base->MSC & CMT_MSC_CMTDIV_MASK) >> CMT_MSC_CMTDIV_SHIFT);
+    /* Get CMT frequency. */
+    switch ((cmt_second_clkdiv_t)divider)
+    {
+        case kCMT_SecondClkDiv1:
+            frequency = frequency / CMT_CMTDIV_ONE;
+            break;
+        case kCMT_SecondClkDiv2:
+            frequency = frequency / CMT_CMTDIV_TWO;
+            break;
+        case kCMT_SecondClkDiv4:
+            frequency = frequency / CMT_CMTDIV_FOUR;
+            break;
+        case kCMT_SecondClkDiv8:
+            frequency = frequency / CMT_CMTDIV_EIGHT;
+            break;
+        default:
+            frequency = frequency / CMT_CMTDIV_ONE;
+            break;
+    }
+
+    return frequency;
+}
+
+void CMT_SetModulateMarkSpace(CMT_Type *base, uint32_t markCount, uint32_t spaceCount)
+{
+    /* Set modulate mark. */
+    base->CMD1 = (markCount >> CMT_MODULATE_COUNT_WIDTH) & CMT_CMD1_MB_MASK;
+    base->CMD2 = (markCount & CMT_CMD2_MB_MASK);
+    /* Set modulate space. */
+    base->CMD3 = (spaceCount >> CMT_MODULATE_COUNT_WIDTH) & CMT_CMD3_SB_MASK;
+    base->CMD4 = spaceCount & CMT_CMD4_SB_MASK;
+}
+
+void CMT_SetIroState(CMT_Type *base, cmt_infrared_output_state_t state)
+{
+    uint8_t ocReg = base->OC;
+
+    ocReg &= ~CMT_OC_IROL_MASK;
+    ocReg |= CMT_OC_IROL(state);
+
+    /* Set the infrared output signal control. */
+    base->OC = ocReg;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmt.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_cmt.h
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_CMT_H_
+#define _FSL_CMT_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup cmt
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief CMT driver version 2.0.0. */
+#define FSL_CMT_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*!
+ * @brief The modes of CMT.
+ */
+typedef enum _cmt_mode
+{
+    kCMT_DirectIROCtl = 0x00U, /*!< Carrier modulator is disabled and the IRO signal is directly in software control */
+    kCMT_TimeMode = 0x01U,     /*!< Carrier modulator is enabled in time mode. */
+    kCMT_FSKMode = 0x05U,      /*!< Carrier modulator is enabled in FSK mode. */
+    kCMT_BasebandMode = 0x09U  /*!< Carrier modulator is enabled in baseband mode. */
+} cmt_mode_t;
+
+/*!
+ * @brief The CMT clock divide primary prescaler.
+ * The primary clock divider is used to divider the bus clock to
+ * get the intermediate frequency to approximately equal to 8 MHZ.
+ * When the bus clock is 8 MHZ, set primary prescaler to "kCMT_PrimaryClkDiv1".
+ */
+typedef enum _cmt_primary_clkdiv
+{
+    kCMT_PrimaryClkDiv1 = 0U,   /*!< The intermediate frequency is the bus clock divided by 1. */
+    kCMT_PrimaryClkDiv2 = 1U,   /*!< The intermediate frequency is the bus clock divided by 2. */
+    kCMT_PrimaryClkDiv3 = 2U,   /*!< The intermediate frequency is the bus clock divided by 3. */
+    kCMT_PrimaryClkDiv4 = 3U,   /*!< The intermediate frequency is the bus clock divided by 4. */
+    kCMT_PrimaryClkDiv5 = 4U,   /*!< The intermediate frequency is the bus clock divided by 5. */
+    kCMT_PrimaryClkDiv6 = 5U,   /*!< The intermediate frequency is the bus clock divided by 6. */
+    kCMT_PrimaryClkDiv7 = 6U,   /*!< The intermediate frequency is the bus clock divided by 7. */
+    kCMT_PrimaryClkDiv8 = 7U,   /*!< The intermediate frequency is the bus clock divided by 8. */
+    kCMT_PrimaryClkDiv9 = 8U,   /*!< The intermediate frequency is the bus clock divided by 9. */
+    kCMT_PrimaryClkDiv10 = 9U,  /*!< The intermediate frequency is the bus clock divided by 10. */
+    kCMT_PrimaryClkDiv11 = 10U, /*!< The intermediate frequency is the bus clock divided by 11. */
+    kCMT_PrimaryClkDiv12 = 11U, /*!< The intermediate frequency is the bus clock divided by 12. */
+    kCMT_PrimaryClkDiv13 = 12U, /*!< The intermediate frequency is the bus clock divided by 13. */
+    kCMT_PrimaryClkDiv14 = 13U, /*!< The intermediate frequency is the bus clock divided by 14. */
+    kCMT_PrimaryClkDiv15 = 14U, /*!< The intermediate frequency is the bus clock divided by 15. */
+    kCMT_PrimaryClkDiv16 = 15U  /*!< The intermediate frequency is the bus clock divided by 16. */
+} cmt_primary_clkdiv_t;
+
+/*!
+ * @brief The CMT clock divide secondary prescaler.
+ * The second prescaler can be used to divide the 8 MHZ CMT clock
+ * by 1, 2, 4, or 8 according to the specification.
+ */
+typedef enum _cmt_second_clkdiv
+{
+    kCMT_SecondClkDiv1 = 0U, /*!< The CMT clock is the intermediate frequency frequency divided by 1. */
+    kCMT_SecondClkDiv2 = 1U, /*!< The CMT clock is the intermediate frequency frequency divided by 2. */
+    kCMT_SecondClkDiv4 = 2U, /*!< The CMT clock is the intermediate frequency frequency divided by 4. */
+    kCMT_SecondClkDiv8 = 3U  /*!< The CMT clock is the intermediate frequency frequency divided by 8. */
+} cmt_second_clkdiv_t;
+
+/*!
+ * @brief The CMT infrared output polarity.
+ */
+typedef enum _cmt_infrared_output_polarity
+{
+    kCMT_IROActiveLow = 0U, /*!< The CMT infrared output signal polarity is active-low. */
+    kCMT_IROActiveHigh = 1U /*!< The CMT infrared output signal polarity is active-high. */
+} cmt_infrared_output_polarity_t;
+
+/*!
+ * @brief The CMT infrared output signal state control.
+ */
+typedef enum _cmt_infrared_output_state
+{
+    kCMT_IROCtlLow = 0U, /*!< The CMT Infrared output signal state is controlled to low. */
+    kCMT_IROCtlHigh = 1U /*!< The CMT Infrared output signal state is controlled to high. */
+} cmt_infrared_output_state_t;
+
+/*!
+ * @brief CMT interrupt configuration structure, default settings all disabled.
+ *
+ * This structure contains the settings for all of the CMT interrupt configurations.
+ */
+enum _cmt_interrupt_enable
+{
+    kCMT_EndOfCycleInterruptEnable = CMT_MSC_EOCIE_MASK, /*!< CMT end of cycle interrupt. */
+};
+
+/*!
+ * @brief CMT carrier generator and modulator configure structure
+ *
+ */
+typedef struct _cmt_modulate_config
+{
+    uint8_t highCount1;  /*!< The high time for carrier generator first register. */
+    uint8_t lowCount1;   /*!< The low time for carrier generator first register. */
+    uint8_t highCount2;  /*!< The high time for carrier generator second register for FSK mode. */
+    uint8_t lowCount2;   /*!< The low time for carrier generator second register for FSK mode. */
+    uint16_t markCount;  /*!< The mark time for the modulator gate. */
+    uint16_t spaceCount; /*!< The space time for the modulator gate. */
+} cmt_modulate_config_t;
+
+/*! @brief CMT basic configuration structure. */
+typedef struct _cmt_config
+{
+    bool isInterruptEnabled;                    /*!< Timer interrupt 0-disable, 1-enable. */
+    bool isIroEnabled;                          /*!< The IRO output 0-disabled, 1-enabled. */
+    cmt_infrared_output_polarity_t iroPolarity; /*!< The IRO polarity. */
+    cmt_second_clkdiv_t divider;                /*!< The CMT clock divide prescaler. */
+} cmt_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Gets the CMT default configuration structure. The purpose
+ * of this API is to get the default configuration structure for the CMT_Init().
+ * Use the initialized structure unchanged in CMT_Init(), or modify
+ * some fields of the structure before calling the CMT_Init().
+ *
+ * @param config The CMT configuration structure pointer.
+ */
+void CMT_GetDefaultConfig(cmt_config_t *config);
+
+/*!
+ * @brief Initializes the CMT module.
+ *
+ * This function ungates the module clock and sets the CMT internal clock,
+ * interrupt, and infrared output signal for the CMT module.
+ *
+ * @param base            CMT peripheral base address.
+ * @param config          The CMT basic configuration structure.
+ * @param busClock_Hz     The CMT module input clock - bus clock frequency.
+ */
+void CMT_Init(CMT_Type *base, const cmt_config_t *config, uint32_t busClock_Hz);
+
+/*!
+ * @brief Disables the CMT module and gate control.
+ *
+ * This function disables CMT modulator, interrupts, and gates the
+ * CMT clock control. CMT_Init must be called  to use the CMT again.
+ *
+ * @param base   CMT peripheral base address.
+ */
+void CMT_Deinit(CMT_Type *base);
+
+/*! @}*/
+
+/*!
+ * @name Basic Control Operations
+ * @{
+ */
+
+/*!
+ * @brief Selects the mode for CMT.
+ *
+ * @param base   CMT peripheral base address.
+ * @param mode   The CMT feature mode enumeration. See "cmt_mode_t".
+ * @param modulateConfig  The carrier generation and modulator configuration.
+ */
+void CMT_SetMode(CMT_Type *base, cmt_mode_t mode, cmt_modulate_config_t *modulateConfig);
+
+/*!
+ * @brief Gets the mode of the CMT module.
+ *
+ * @param base   CMT peripheral base address.
+ * @return The CMT mode.
+ *     kCMT_DirectIROCtl     Carrier modulator is disabled, the IRO signal is directly in software control.
+ *     kCMT_TimeMode         Carrier modulator is enabled in time mode.
+ *     kCMT_FSKMode          Carrier modulator is enabled in FSK mode.
+ *     kCMT_BasebandMode     Carrier modulator is enabled in baseband mode.
+ */
+cmt_mode_t CMT_GetMode(CMT_Type *base);
+
+/*!
+ * @brief Gets the actual CMT clock frequency.
+ *
+ * @param base        CMT peripheral base address.
+ * @param busClock_Hz CMT module input clock - bus clock frequency.
+ * @return The CMT clock frequency.
+ */
+uint32_t CMT_GetCMTFrequency(CMT_Type *base, uint32_t busClock_Hz);
+
+/*!
+ * @brief Sets the primary data set for the CMT carrier generator counter.
+ *
+ * This function sets the high time and low time of the primary data set for the
+ * CMT carrier generator counter to control the period and the duty cycle of the
+ * output carrier signal.
+ * If the CMT clock period is Tcmt, The period of the carrier generator signal equals
+ * (highCount + lowCount) * Tcmt. The duty cycle equals  highCount / (highCount + lowCount).
+ *
+ * @param base      CMT peripheral base address.
+ * @param highCount The number of CMT clocks for carrier generator signal high time,
+ *                  integer in the range of 1 ~ 0xFF.
+ * @param lowCount  The number of CMT clocks for carrier generator signal low time,
+ *                  integer in the range of 1 ~ 0xFF.
+ */
+static inline void CMT_SetCarrirGenerateCountOne(CMT_Type *base, uint32_t highCount, uint32_t lowCount)
+{
+    assert(highCount <= CMT_CGH1_PH_MASK);
+    assert(highCount);
+    assert(lowCount <= CMT_CGL1_PL_MASK);
+    assert(lowCount);
+
+    base->CGH1 = highCount;
+    base->CGL1 = lowCount;
+}
+
+/*!
+ * @brief Sets the secondary data set for the CMT carrier generator counter.
+ *
+ * This function is used for FSK mode setting the high time and low time of the secondary
+ * data set CMT carrier generator counter to control the period and the duty cycle
+ * of the output carrier signal.
+ * If the CMT clock period is Tcmt, The period of the carrier generator signal equals
+ * (highCount + lowCount) * Tcmt. The duty cycle equals  highCount / (highCount + lowCount).
+ *
+ * @param base      CMT peripheral base address.
+ * @param highCount The number of CMT clocks for carrier generator signal high time,
+ *                  integer in the range of 1 ~ 0xFF.
+ * @param lowCount  The number of CMT clocks for carrier generator signal low time,
+ *                  integer in the range of 1 ~ 0xFF.
+ */
+static inline void CMT_SetCarrirGenerateCountTwo(CMT_Type *base, uint32_t highCount, uint32_t lowCount)
+{
+    assert(highCount <= CMT_CGH2_SH_MASK);
+    assert(highCount);
+    assert(lowCount <= CMT_CGL2_SL_MASK);
+    assert(lowCount);
+
+    base->CGH2 = highCount;
+    base->CGL2 = lowCount;
+}
+
+/*!
+ * @brief Sets the modulation mark and space time period for the CMT modulator.
+ *
+ * This function sets the mark time period of the CMT modulator counter
+ * to control the mark time of the output modulated signal from the carrier generator output signal.
+ * If the CMT clock frequency is Fcmt and the carrier out signal frequency is fcg:
+ *      - In Time and Baseband mode: The mark period of the generated signal equals (markCount + 1) / (Fcmt/8).
+ *                                   The space period of the generated signal equals spaceCount / (Fcmt/8).
+ *      - In FSK mode: The mark period of the generated signal equals (markCount + 1)/fcg.
+ *                     The space period of the generated signal equals spaceCount / fcg.
+ *
+ * @param base Base address for current CMT instance.
+ * @param markCount The number of clock period for CMT modulator signal mark period,
+ *                   in the range of 0 ~ 0xFFFF.
+ * @param spaceCount The number of clock period for CMT modulator signal space period,
+ *                   in the range of the 0 ~ 0xFFFF.
+ */
+void CMT_SetModulateMarkSpace(CMT_Type *base, uint32_t markCount, uint32_t spaceCount);
+
+/*!
+ * @brief Enables or disables the extended space operation.
+ *
+ * This function is used to make the space period longer
+ * for time, baseband, and FSK modes.
+ *
+ * @param base   CMT peripheral base address.
+ * @param enable True enable the extended space, false disable the extended space.
+ */
+static inline void CMT_EnableExtendedSpace(CMT_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->MSC |= CMT_MSC_EXSPC_MASK;
+    }
+    else
+    {
+        base->MSC &= ~CMT_MSC_EXSPC_MASK;
+    }
+}
+
+/*!
+ * @brief Sets IRO - infrared output signal state.
+ *
+ * Changes the states of the IRO signal when the kCMT_DirectIROMode mode is set
+ * and the IRO signal is enabled.
+ *
+ * @param base   CMT peripheral base address.
+ * @param state  The control of the IRO signal. See "cmt_infrared_output_state_t"
+ */
+void CMT_SetIroState(CMT_Type *base, cmt_infrared_output_state_t state);
+
+/*!
+ * @brief Enables the CMT interrupt.
+ *
+ * This function enables the CMT interrupts according to the provided maskIf enabled.
+ * The CMT only has the end of the cycle interrupt - an interrupt occurs at the end
+ * of the modulator cycle. This interrupt provides a means for the user
+ * to reload the new mark/space values into the CMT modulator data registers
+ * and verify the modulator mark and space.
+ * For example, to enable the end of cycle, do the following:
+ * @code
+ *     CMT_EnableInterrupts(CMT, kCMT_EndOfCycleInterruptEnable);
+ * @endcode
+ * @param base   CMT peripheral base address.
+ * @param mask The interrupts to enable. Logical OR of @ref _cmt_interrupt_enable.
+ */
+static inline void CMT_EnableInterrupts(CMT_Type *base, uint32_t mask)
+{
+    base->MSC |= mask;
+}
+
+/*!
+ * @brief Disables the CMT interrupt.
+ *
+ * This function disables the CMT interrupts according to the provided maskIf enabled.
+ * The CMT only has the end of the cycle interrupt.
+ * For example, to disable the end of cycle, do the following:
+ * @code
+ *     CMT_DisableInterrupts(CMT, kCMT_EndOfCycleInterruptEnable);
+ * @endcode
+ *
+ * @param base   CMT peripheral base address.
+ * @param mask The interrupts to enable. Logical OR of @ref _cmt_interrupt_enable.
+ */
+static inline void CMT_DisableInterrupts(CMT_Type *base, uint32_t mask)
+{
+    base->MSC &= ~mask;
+}
+
+/*!
+ * @brief Gets the end of the cycle status flag.
+ *
+ * The flag is set:
+ *           - When the modulator is not currently active and carrier and modulator
+ *             are set to start the initial CMT transmission.
+ *           - At the end of each modulation cycle when the counter is reloaded and
+ *             the carrier and modulator are enabled.
+ * @param base   CMT peripheral base address.
+ * @return Current status of the end of cycle status flag
+ *         @arg non-zero:  End-of-cycle has occurred.
+ *         @arg zero: End-of-cycle has not yet occurred since the flag last cleared.
+ */
+static inline uint32_t CMT_GetStatusFlags(CMT_Type *base)
+{
+    return base->MSC & CMT_MSC_EOCF_MASK;
+}
+
+/*! @}*/
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_CMT_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_common.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_common.c
@@ -1,0 +1,95 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fsl_common.h"
+#include "fsl_debug_console.h"
+
+#ifndef NDEBUG
+#if (defined(__CC_ARM)) || (defined(__ICCARM__))
+void __aeabi_assert(const char *failedExpr, const char *file, int line)
+{
+    PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" \n", failedExpr, file, line);
+    for (;;)
+    {
+        __asm("bkpt #0");
+    }
+}
+#elif(defined(__GNUC__))
+void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
+{
+    PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
+    for (;;)
+    {
+        __asm("bkpt #0");
+    }
+}
+#endif /* (defined(__CC_ARM)) ||  (defined (__ICCARM__)) */
+#endif /* NDEBUG */
+
+void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler)
+{
+/* Addresses for VECTOR_TABLE and VECTOR_RAM come from the linker file */
+#if defined(__CC_ARM)
+    extern uint32_t Image$$VECTOR_ROM$$Base[];
+    extern uint32_t Image$$VECTOR_RAM$$Base[];
+    extern uint32_t Image$$RW_m_data$$Base[];
+
+#define __VECTOR_TABLE Image$$VECTOR_ROM$$Base
+#define __VECTOR_RAM Image$$VECTOR_RAM$$Base
+#define __RAM_VECTOR_TABLE_SIZE (((uint32_t)Image$$RW_m_data$$Base - (uint32_t)Image$$VECTOR_RAM$$Base))
+#elif defined(__ICCARM__)
+    extern uint32_t __RAM_VECTOR_TABLE_SIZE[];
+    extern uint32_t __VECTOR_TABLE[];
+    extern uint32_t __VECTOR_RAM[];
+#elif defined(__GNUC__)
+    extern uint32_t __VECTOR_TABLE[];
+    extern uint32_t __VECTOR_RAM[];
+    extern uint32_t __RAM_VECTOR_TABLE_SIZE_BYTES[];
+    uint32_t __RAM_VECTOR_TABLE_SIZE = (uint32_t)(__RAM_VECTOR_TABLE_SIZE_BYTES);
+#endif /* defined(__CC_ARM) */
+    uint32_t n;
+
+    __disable_irq();
+    if (SCB->VTOR != (uint32_t)__VECTOR_RAM)
+    {
+        /* Copy the vector table from ROM to RAM */
+        for (n = 0; n < ((uint32_t)__RAM_VECTOR_TABLE_SIZE) / sizeof(uint32_t); n++)
+        {
+            __VECTOR_RAM[n] = __VECTOR_TABLE[n];
+        }
+        /* Point the VTOR to the position of vector table */
+        SCB->VTOR = (uint32_t)__VECTOR_RAM;
+    }
+
+    /* make sure the __VECTOR_RAM is noncachable */
+    __VECTOR_RAM[irq + 16] = irqHandler;
+
+    __enable_irq();
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_common.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_common.h
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_COMMON_H_
+#define _FSL_COMMON_H_
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "fsl_device_registers.h"
+
+/*!
+ * @addtogroup ksdk_common
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief Construct a status code value from a group and code number. */
+#define MAKE_STATUS(group, code) ((((group)*100) + (code)))
+
+/*! @brief Construct the version number for drivers. */
+#define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
+
+/* Debug console type definition. */
+#define DEBUG_CONSOLE_DEVICE_TYPE_NONE 0U   /*!< No debug console.             */
+#define DEBUG_CONSOLE_DEVICE_TYPE_UART 1U   /*!< Debug console base on UART.   */
+#define DEBUG_CONSOLE_DEVICE_TYPE_LPUART 2U /*!< Debug console base on LPUART. */
+#define DEBUG_CONSOLE_DEVICE_TYPE_LPSCI 3U  /*!< Debug console base on LPSCI.  */
+#define DEBUG_CONSOLE_DEVICE_TYPE_USBCDC 4U /*!< Debug console base on USBCDC. */
+
+/*! @brief Status group numbers. */
+enum _status_groups
+{
+    kStatusGroup_Generic = 0,                 /*!< Group number for generic status codes. */
+    kStatusGroup_FLASH = 1,                   /*!< Group number for FLASH status codes. */
+    kStatusGroup_LPSPI = 4,                   /*!< Group number for LPSPI status codes. */
+    kStatusGroup_FLEXIO_SPI = 5,              /*!< Group number for FLEXIO SPI status codes. */
+    kStatusGroup_DSPI = 6,                    /*!< Group number for DSPI status codes. */
+    kStatusGroup_FLEXIO_UART = 7,             /*!< Group number for FLEXIO UART status codes. */
+    kStatusGroup_FLEXIO_I2C = 8,              /*!< Group number for FLEXIO I2C status codes. */
+    kStatusGroup_LPI2C = 9,                   /*!< Group number for LPI2C status codes. */
+    kStatusGroup_UART = 10,                   /*!< Group number for UART status codes. */
+    kStatusGroup_I2C = 11,                    /*!< Group number for UART status codes. */
+    kStatusGroup_LPSCI = 12,                  /*!< Group number for LPSCI status codes. */
+    kStatusGroup_LPUART = 13,                 /*!< Group number for LPUART status codes. */
+    kStatusGroup_SPI = 14,                    /*!< Group number for SPI status code.*/
+    kStatusGroup_XRDC = 15,                   /*!< Group number for XRDC status code.*/
+    kStatusGroup_SEMA42 = 16,                 /*!< Group number for SEMA42 status code.*/
+    kStatusGroup_SDHC = 17,                   /*!< Group number for SDHC status code */
+    kStatusGroup_SDMMC = 18,                  /*!< Group number for SDMMC status code */
+    kStatusGroup_SAI = 19,                    /*!< Group number for SAI status code */
+    kStatusGroup_MCG = 20,                    /*!< Group number for MCG status codes. */
+    kStatusGroup_SCG = 21,                    /*!< Group number for SCG status codes. */
+    kStatusGroup_SDSPI = 22,                  /*!< Group number for SDSPI status codes. */
+    kStatusGroup_FLEXIO_I2S = 23,             /*!< Group number for FLEXIO I2S status codes */
+    kStatusGroup_SDRAMC = 35,                 /*!< Group number for SDRAMC status codes. */
+    kStatusGroup_POWER = 39,                  /*!< Group number for POWER status codes. */
+    kStatusGroup_ENET = 40,                   /*!< Group number for ENET status codes. */
+    kStatusGroup_PHY = 41,                    /*!< Group number for PHY status codes. */
+    kStatusGroup_TRGMUX = 42,                 /*!< Group number for TRGMUX status codes. */
+    kStatusGroup_SMARTCARD = 43,              /*!< Group number for SMARTCARD status codes. */
+    kStatusGroup_LMEM = 44,                   /*!< Group number for LMEM status codes. */
+    kStatusGroup_QSPI = 45,                   /*!< Group number for QSPI status codes. */
+    kStatusGroup_DMA = 50,                    /*!< Group number for DMA status codes. */
+    kStatusGroup_EDMA = 51,                   /*!< Group number for EDMA status codes. */
+    kStatusGroup_DMAMGR = 52,                 /*!< Group number for DMAMGR status codes. */
+    kStatusGroup_FLEXCAN = 53,                /*!< Group number for FlexCAN status codes. */
+    kStatusGroup_LTC = 54,                    /*!< Group number for LTC status codes. */
+    kStatusGroup_FLEXIO_CAMERA = 55,          /*!< Group number for FLEXIO CAMERA status codes. */
+    kStatusGroup_NOTIFIER = 98,               /*!< Group number for NOTIFIER status codes. */
+    kStatusGroup_DebugConsole = 99,           /*!< Group number for debug console status codes. */
+    kStatusGroup_ApplicationRangeStart = 100, /*!< Starting number for application groups. */
+};
+
+/*! @brief Generic status return codes. */
+enum _generic_status
+{
+    kStatus_Success = MAKE_STATUS(kStatusGroup_Generic, 0),
+    kStatus_Fail = MAKE_STATUS(kStatusGroup_Generic, 1),
+    kStatus_ReadOnly = MAKE_STATUS(kStatusGroup_Generic, 2),
+    kStatus_OutOfRange = MAKE_STATUS(kStatusGroup_Generic, 3),
+    kStatus_InvalidArgument = MAKE_STATUS(kStatusGroup_Generic, 4),
+    kStatus_Timeout = MAKE_STATUS(kStatusGroup_Generic, 5),
+    kStatus_NoTransferInProgress = MAKE_STATUS(kStatusGroup_Generic, 6),
+};
+
+/*! @brief Type used for all status and error return values. */
+typedef int32_t status_t;
+
+/*
+ * The fsl_clock.h is included here because it needs MAKE_VERSION/MAKE_STATUS/status_t
+ * defined in previous of this file.
+ */
+#include "fsl_clock.h"
+
+/*! @name Min/max macros */
+/* @{ */
+#if !defined(MIN)
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#if !defined(MAX)
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+/* @} */
+
+/*! @brief Computes the number of elements in an array. */
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+/*! @name UINT16_MAX/UINT32_MAX value */
+/* @{ */
+#if !defined(UINT16_MAX)
+#define UINT16_MAX ((uint16_t)-1)
+#endif
+
+#if !defined(UINT32_MAX)
+#define UINT32_MAX ((uint32_t)-1)
+#endif
+/* @} */
+
+/*! @name Timer utilities */
+/* @{ */
+/*! Macro to convert a microsecond period to raw count value */
+#define USEC_TO_COUNT(us, clockFreqInHz) (uint64_t)((uint64_t)us * clockFreqInHz / 1000000U)
+/*! Macro to convert a raw count value to microsecond */
+#define COUNT_TO_USEC(count, clockFreqInHz) (uint64_t)((uint64_t)count * 1000000U / clockFreqInHz)
+
+/*! Macro to convert a millisecond period to raw count value */
+#define MSEC_TO_COUNT(ms, clockFreqInHz) (uint64_t)((uint64_t)ms * clockFreqInHz / 1000U)
+/*! Macro to convert a raw count value to millisecond */
+#define COUNT_TO_MSEC(count, clockFreqInHz) (uint64_t)((uint64_t)count * 1000U / clockFreqInHz)
+/* @} */
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @brief Enable specific interrupt.
+ *
+ * Enable the interrupt not routed from intmux.
+ *
+ * @param interrupt The IRQ number.
+ */
+static inline void EnableIRQ(IRQn_Type interrupt)
+{
+#if defined(FSL_FEATURE_SOC_INTMUX_COUNT) && (FSL_FEATURE_SOC_INTMUX_COUNT > 0)
+    if (interrupt < FSL_FEATURE_INTMUX_IRQ_START_INDEX)
+#endif
+    {
+        NVIC_EnableIRQ(interrupt);
+    }
+}
+
+/*!
+ * @brief Disable specific interrupt.
+ *
+ * Disable the interrupt not routed from intmux.
+ *
+ * @param interrupt The IRQ number.
+ */
+static inline void DisableIRQ(IRQn_Type interrupt)
+{
+#if defined(FSL_FEATURE_SOC_INTMUX_COUNT) && (FSL_FEATURE_SOC_INTMUX_COUNT > 0)
+    if (interrupt < FSL_FEATURE_INTMUX_IRQ_START_INDEX)
+#endif
+    {
+        NVIC_DisableIRQ(interrupt);
+    }
+}
+
+/*!
+ * @brief Disable the global IRQ
+ *
+ * Disable the global interrupt and return the current primask register. User is required to provided the primask
+ * register for the EnableGlobalIRQ().
+ *
+ * @return Current primask value.
+ */
+static inline uint32_t DisableGlobalIRQ(void)
+{
+    uint32_t regPrimask = __get_PRIMASK();
+
+    __disable_irq();
+
+    return regPrimask;
+}
+
+/*!
+ * @brief Enaable the global IRQ
+ *
+ * Set the primask register with the provided primask value but not just enable the primask. The idea is for the
+ * convinience of integration of RTOS. some RTOS get its own management mechanism of primask. User is required to
+ * use the EnableGlobalIRQ() and DisableGlobalIRQ() in pair.
+ *
+ * @param primask value of primask register to be restored. The primask value is supposed to be provided by the
+ * DisableGlobalIRQ().
+ */
+static inline void EnableGlobalIRQ(uint32_t primask)
+{
+    __set_PRIMASK(primask);
+}
+
+/*!
+ * @brief install IRQ handler
+ *
+ * @param irq IRQ number
+ * @param irqHandler IRQ handler address
+ */
+void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler);
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @} */
+
+#endif /* _FSL_COMMON_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_crc.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_crc.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "fsl_crc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+#if defined(CRC_DRIVER_USE_CRC16_CCIT_FALSE_AS_DEFAULT) && CRC_DRIVER_USE_CRC16_CCIT_FALSE_AS_DEFAULT
+/* @brief Default user configuration structure for CRC-16-CCITT */
+#define CRC_DRIVER_DEFAULT_POLYNOMIAL 0x1021U
+/*< CRC-16-CCIT polynomial x**16 + x**12 + x**5 + x**0 */
+#define CRC_DRIVER_DEFAULT_SEED 0xFFFFU
+/*< Default initial checksum */
+#define CRC_DRIVER_DEFAULT_REFLECT_IN false
+/*< Default is no transpose */
+#define CRC_DRIVER_DEFAULT_REFLECT_OUT false
+/*< Default is transpose bytes */
+#define CRC_DRIVER_DEFAULT_COMPLEMENT_CHECKSUM false
+/*< Default is without complement of CRC data register read data */
+#define CRC_DRIVER_DEFAULT_CRC_BITS kCrcBits16
+/*< Default is 16-bit CRC protocol */
+#define CRC_DRIVER_DEFAULT_CRC_RESULT kCrcFinalChecksum
+/*< Default is resutl type is final checksum */
+#endif /* CRC_DRIVER_USE_CRC16_CCIT_FALSE_AS_DEFAULT */
+
+/*! @brief CRC type of transpose of read write data */
+typedef enum _crc_transpose_type
+{
+    kCrcTransposeNone = 0U,         /*! No transpose  */
+    kCrcTransposeBits = 1U,         /*! Tranpose bits in bytes  */
+    kCrcTransposeBitsAndBytes = 2U, /*! Transpose bytes and bits in bytes */
+    kCrcTransposeBytes = 3U,        /*! Transpose bytes */
+} crc_transpose_type_t;
+
+/*!
+* @brief CRC module configuration.
+*
+* This structure holds the configuration for the CRC module.
+*/
+typedef struct _crc_module_config
+{
+    uint32_t polynomial;                 /*!< CRC Polynomial, MSBit first.@n
+                                              Example polynomial: 0x1021 = 1_0000_0010_0001 = x^12+x^5+1 */
+    uint32_t seed;                       /*!< Starting checksum value */
+    crc_transpose_type_t readTranspose;  /*!< Type of transpose when reading CRC result. */
+    crc_transpose_type_t writeTranspose; /*!< Type of transpose when writing CRC input data. */
+    bool complementChecksum;             /*!< True if the result shall be complement of the actual checksum. */
+    crc_bits_t crcBits;                  /*!< Selects 16- or 32- bit CRC protocol. */
+} crc_module_config_t;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+/*!
+ * @brief Returns transpose type for CRC protocol reflect in parameter.
+ *
+ * This functions helps to set writeTranspose member of crc_config_t structure. Reflect in is CRC protocol parameter.
+ *
+ * @param enable True or false for the selected CRC protocol Reflect In (refin) parameter.
+ */
+static inline crc_transpose_type_t crc_GetTransposeTypeFromReflectIn(bool enable)
+{
+    return ((enable) ? kCrcTransposeBitsAndBytes : kCrcTransposeBytes);
+}
+
+/*!
+ * @brief Returns transpose type for CRC protocol reflect out parameter.
+ *
+ * This functions helps to set readTranspose member of crc_config_t structure. Reflect out is CRC protocol parameter.
+ *
+ * @param enable True or false for the selected CRC protocol Reflect Out (refout) parameter.
+ */
+static inline crc_transpose_type_t crc_GetTransposeTypeFromReflectOut(bool enable)
+{
+    return ((enable) ? kCrcTransposeBitsAndBytes : kCrcTransposeNone);
+}
+
+/*!
+ * @brief Starts checksum computation.
+ *
+ * Configures the CRC module for the specified CRC protocol. @n
+ * Starts the checksum computation by writing the seed value
+ *
+ * @param base CRC peripheral address.
+ * @param config Pointer to protocol configuration structure.
+ */
+static void crc_ConfigureAndStart(CRC_Type *base, const crc_module_config_t *config)
+{
+    uint32_t crcControl;
+
+    /* pre-compute value for CRC control registger based on user configuraton without WAS field */
+    crcControl = 0 | CRC_CTRL_TOT(config->writeTranspose) | CRC_CTRL_TOTR(config->readTranspose) |
+                 CRC_CTRL_FXOR(config->complementChecksum) | CRC_CTRL_TCRC(config->crcBits);
+
+    /* make sure the control register is clear - WAS is deasserted, and protocol is set */
+    base->CTRL = crcControl;
+
+    /* write polynomial register */
+    base->GPOLY = config->polynomial;
+
+    /* write pre-computed control register value along with WAS to start checksum computation */
+    base->CTRL = crcControl | CRC_CTRL_WAS(true);
+
+    /* write seed (initial checksum) */
+    base->DATA = config->seed;
+
+    /* deassert WAS by writing pre-computed CRC control register value */
+    base->CTRL = crcControl;
+}
+
+/*!
+ * @brief Starts final checksum computation.
+ *
+ * Configures the CRC module for the specified CRC protocol. @n
+ * Starts final checksum computation by writing the seed value.
+ * @note CRC_Get16bitResult() or CRC_Get32bitResult() return final checksum
+ *       (output reflection and xor functions are applied).
+ *
+ * @param base CRC peripheral address.
+ * @param protocolConfig Pointer to protocol configuration structure.
+ */
+static void crc_SetProtocolConfig(CRC_Type *base, const crc_config_t *protocolConfig)
+{
+    crc_module_config_t moduleConfig;
+    /* convert protocol to CRC peripheral module configuration, prepare for final checksum */
+    moduleConfig.polynomial = protocolConfig->polynomial;
+    moduleConfig.seed = protocolConfig->seed;
+    moduleConfig.readTranspose = crc_GetTransposeTypeFromReflectOut(protocolConfig->reflectOut);
+    moduleConfig.writeTranspose = crc_GetTransposeTypeFromReflectIn(protocolConfig->reflectIn);
+    moduleConfig.complementChecksum = protocolConfig->complementChecksum;
+    moduleConfig.crcBits = protocolConfig->crcBits;
+
+    crc_ConfigureAndStart(base, &moduleConfig);
+}
+
+/*!
+ * @brief Starts intermediate checksum computation.
+ *
+ * Configures the CRC module for the specified CRC protocol. @n
+ * Starts intermediate checksum computation by writing the seed value.
+ * @note CRC_Get16bitResult() or CRC_Get32bitResult() return intermediate checksum (raw data register value).
+ *
+ * @param base CRC peripheral address.
+ * @param protocolConfig Pointer to protocol configuration structure.
+ */
+static void crc_SetRawProtocolConfig(CRC_Type *base, const crc_config_t *protocolConfig)
+{
+    crc_module_config_t moduleConfig;
+    /* convert protocol to CRC peripheral module configuration, prepare for intermediate checksum */
+    moduleConfig.polynomial = protocolConfig->polynomial;
+    moduleConfig.seed = protocolConfig->seed;
+    moduleConfig.readTranspose =
+        kCrcTransposeNone; /* intermediate checksum does no transpose of data register read value */
+    moduleConfig.writeTranspose = crc_GetTransposeTypeFromReflectIn(protocolConfig->reflectIn);
+    moduleConfig.complementChecksum = false; /* intermediate checksum does no xor of data register read value */
+    moduleConfig.crcBits = protocolConfig->crcBits;
+
+    crc_ConfigureAndStart(base, &moduleConfig);
+}
+
+void CRC_Init(CRC_Type *base, const crc_config_t *config)
+{
+    /* ungate clock */
+    CLOCK_EnableClock(kCLOCK_Crc0);
+    /* configure CRC module and write the seed */
+    if (config->crcResult == kCrcFinalChecksum)
+    {
+        crc_SetProtocolConfig(base, config);
+    }
+    else
+    {
+        crc_SetRawProtocolConfig(base, config);
+    }
+}
+
+void CRC_GetDefaultConfig(crc_config_t *config)
+{
+    static const crc_config_t crc16ccit = {
+        CRC_DRIVER_DEFAULT_POLYNOMIAL,          CRC_DRIVER_DEFAULT_SEED,
+        CRC_DRIVER_DEFAULT_REFLECT_IN,          CRC_DRIVER_DEFAULT_REFLECT_OUT,
+        CRC_DRIVER_DEFAULT_COMPLEMENT_CHECKSUM, CRC_DRIVER_DEFAULT_CRC_BITS,
+        CRC_DRIVER_DEFAULT_CRC_RESULT,
+    };
+
+    *config = crc16ccit;
+}
+
+void CRC_WriteData(CRC_Type *base, const uint8_t *data, size_t dataSize)
+{
+    const uint32_t *data32;
+
+    /* 8-bit reads and writes till source address is aligned 4 bytes */
+    while ((dataSize) && ((uint32_t)data & 3U))
+    {
+        base->ACCESS8BIT.DATALL = *data;
+        data++;
+        dataSize--;
+    }
+
+    /* use 32-bit reads and writes as long as possible */
+    data32 = (const uint32_t *)data;
+    while (dataSize >= sizeof(uint32_t))
+    {
+        base->DATA = *data32;
+        data32++;
+        dataSize -= sizeof(uint32_t);
+    }
+
+    data = (const uint8_t *)data32;
+
+    /* 8-bit reads and writes till end of data buffer */
+    while (dataSize)
+    {
+        base->ACCESS8BIT.DATALL = *data;
+        data++;
+        dataSize--;
+    }
+}
+
+uint16_t CRC_Get16bitResult(CRC_Type *base)
+{
+    uint32_t retval;
+    uint32_t totr; /* type of transpose read bitfield */
+
+    retval = base->DATA;
+    totr = (base->CTRL & CRC_CTRL_TOTR_MASK) >> CRC_CTRL_TOTR_SHIFT;
+
+    /* check transpose type to get 16-bit out of 32-bit register */
+    if (totr >= 2U)
+    {
+        /* transpose of bytes for read is set, the result CRC is in CRC_DATA[HU:HL] */
+        retval &= 0xFFFF0000U;
+        retval = retval >> 16U;
+    }
+    else
+    {
+        /* no transpose of bytes for read, the result CRC is in CRC_DATA[LU:LL] */
+        retval &= 0x0000FFFFU;
+    }
+    return (uint16_t)retval;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_crc.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_crc.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_CRC_H_
+#define _FSL_CRC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup crc_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief CRC driver version. Version 2.0.0. */
+#define FSL_CRC_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*! @internal @brief Has data register with name CRC. */
+#if defined(FSL_FEATURE_CRC_HAS_CRC_REG) && FSL_FEATURE_CRC_HAS_CRC_REG
+#define DATA CRC
+#define DATALL CRCLL
+#endif
+
+#ifndef CRC_DRIVER_CUSTOM_DEFAULTS
+/*! @brief Default configuration structure filled by CRC_GetDefaultConfig(). Use CRC16-CCIT-FALSE as defeault. */
+#define CRC_DRIVER_USE_CRC16_CCIT_FALSE_AS_DEFAULT 1
+#endif
+
+/*! @brief CRC bit width */
+typedef enum _crc_bits
+{
+    kCrcBits16 = 0U, /*!< Generate 16-bit CRC code  */
+    kCrcBits32 = 1U  /*!< Generate 32-bit CRC code  */
+} crc_bits_t;
+
+/*! @brief CRC result type */
+typedef enum _crc_result
+{
+    kCrcFinalChecksum = 0U,       /*!< CRC data register read value is the final checksum.
+                                      Reflect out and final xor protocol features are applied. */
+    kCrcIntermediateChecksum = 1U /*!< CRC data register read value is intermediate checksum (raw value).
+                                      Reflect out and final xor protocol feature are not applied.
+                                      Intermediate checksum can be used as a seed for CRC_Init()
+                                      to continue adding data to this checksum. */
+} crc_result_t;
+
+/*!
+* @brief CRC protocol configuration.
+*
+* This structure holds the configuration for the CRC protocol.
+*
+*/
+typedef struct _crc_config
+{
+    uint32_t polynomial;     /*!< CRC Polynomial, MSBit first.
+                                  Example polynomial: 0x1021 = 1_0000_0010_0001 = x^12+x^5+1 */
+    uint32_t seed;           /*!< Starting checksum value */
+    bool reflectIn;          /*!< Reflect bits on input. */
+    bool reflectOut;         /*!< Reflect bits on output. */
+    bool complementChecksum; /*!< True if the result shall be complement of the actual checksum. */
+    crc_bits_t crcBits;      /*!< Selects 16- or 32- bit CRC protocol. */
+    crc_result_t crcResult;  /*!< Selects final or intermediate checksum return from CRC_Get16bitResult() or
+                                CRC_Get32bitResult() */
+} crc_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @brief Enables and configures the CRC peripheral module.
+ *
+ * This functions enables the clock gate in the Kinetis SIM module for the CRC peripheral.
+ * It also configures the CRC module and starts checksum computation by writing the seed.
+ *
+ * @param base CRC peripheral address.
+ * @param config CRC module configuration structure
+ */
+void CRC_Init(CRC_Type *base, const crc_config_t *config);
+
+/*!
+ * @brief Disables the CRC peripheral module.
+ *
+ * This functions disables the clock gate in the Kinetis SIM module for the CRC peripheral.
+ *
+ * @param base CRC peripheral address.
+ */
+static inline void CRC_Deinit(CRC_Type *base)
+{
+    /* gate clock */
+    CLOCK_DisableClock(kCLOCK_Crc0);
+}
+
+/*!
+ * @brief Loads default values to CRC protocol configuration structure.
+ *
+ * Loads default values to CRC protocol configuration structure. The default values are:
+ * @code
+ *   config->polynomial = 0x1021;
+ *   config->seed = 0xFFFF;
+ *   config->reflectIn = false;
+ *   config->reflectOut = false;
+ *   config->complementChecksum = false;
+ *   config->crcBits = kCrcBits16;
+ *   config->crcResult = kCrcFinalChecksum;
+ * @endcode
+ *
+ * @param config CRC protocol configuration structure
+ */
+void CRC_GetDefaultConfig(crc_config_t *config);
+
+/*!
+ * @brief Writes data to the CRC module.
+ *
+ * Writes input data buffer bytes to CRC data register.
+ * The configured type of transpose is applied.
+ *
+ * @param base CRC peripheral address.
+ * @param data Input data stream, MSByte in data[0].
+ * @param dataSize Size in bytes of the input data buffer.
+ */
+void CRC_WriteData(CRC_Type *base, const uint8_t *data, size_t dataSize);
+
+/*!
+ * @brief Reads 32-bit checksum from the CRC module.
+ *
+ * Reads CRC data register (intermediate or final checksum).
+ * The configured type of transpose and complement are applied.
+ *
+ * @param base CRC peripheral address.
+ * @return intermediate or final 32-bit checksum, after configured transpose and complement operations.
+ */
+static inline uint32_t CRC_Get32bitResult(CRC_Type *base)
+{
+    return base->DATA;
+}
+
+/*!
+ * @brief Reads 16-bit checksum from the CRC module.
+ *
+ * Reads CRC data register (intermediate or final checksum).
+ * The configured type of transpose and complement are applied.
+ *
+ * @param base CRC peripheral address.
+ * @return intermediate or final 16-bit checksum, after configured transpose and complement operations.
+ */
+uint16_t CRC_Get16bitResult(CRC_Type *base);
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*!
+ *@}
+ */
+
+#endif /* _FSL_CRC_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dac.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dac.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_dac.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get instance number for DAC module.
+ *
+ * @param base DAC peripheral base address
+ */
+static uint32_t DAC_GetInstance(DAC_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to DAC bases for each instance. */
+static DAC_Type *const s_dacBases[] = DAC_BASE_PTRS;
+/*! @brief Pointers to DAC clocks for each instance. */
+const clock_ip_name_t s_dacClocks[] = DAC_CLOCKS;
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+static uint32_t DAC_GetInstance(DAC_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_DAC_COUNT; instance++)
+    {
+        if (s_dacBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_DAC_COUNT);
+
+    return instance;
+}
+
+void DAC_Init(DAC_Type *base, const dac_config_t *config)
+{
+    assert(NULL != config);
+
+    uint8_t tmp8;
+
+    /* Enable the clock. */
+    CLOCK_EnableClock(s_dacClocks[DAC_GetInstance(base)]);
+
+    /* Configure. */
+    /* DACx_C0. */
+    tmp8 = base->C0 & ~(DAC_C0_DACRFS_MASK | DAC_C0_LPEN_MASK);
+    if (kDAC_ReferenceVoltageSourceVref2 == config->referenceVoltageSource)
+    {
+        tmp8 |= DAC_C0_DACRFS_MASK;
+    }
+    if (config->enableLowPowerMode)
+    {
+        tmp8 |= DAC_C0_LPEN_MASK;
+    }
+    base->C0 = tmp8;
+
+    DAC_Enable(base, true);
+}
+
+void DAC_Deinit(DAC_Type *base)
+{
+    DAC_Enable(base, false);
+
+    /* Disable the clock. */
+    CLOCK_DisableClock(s_dacClocks[DAC_GetInstance(base)]);
+}
+
+void DAC_GetDefaultConfig(dac_config_t *config)
+{
+    assert(NULL != config);
+
+    config->referenceVoltageSource = kDAC_ReferenceVoltageSourceVref2;
+    config->enableLowPowerMode = false;
+}
+
+void DAC_SetBufferConfig(DAC_Type *base, const dac_buffer_config_t *config)
+{
+    assert(NULL != config);
+
+    uint8_t tmp8;
+
+    /* DACx_C0. */
+    tmp8 = base->C0 & ~(DAC_C0_DACTRGSEL_MASK);
+    if (kDAC_BufferTriggerBySoftwareMode == config->triggerMode)
+    {
+        tmp8 |= DAC_C0_DACTRGSEL_MASK;
+    }
+    base->C0 = tmp8;
+
+    /* DACx_C1. */
+    tmp8 = base->C1 &
+           ~(
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION
+               DAC_C1_DACBFWM_MASK |
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION */
+               DAC_C1_DACBFMD_MASK);
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION
+    tmp8 |= DAC_C1_DACBFWM(config->watermark);
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION */
+    tmp8 |= DAC_C1_DACBFMD(config->workMode);
+    base->C1 = tmp8;
+
+    /* DACx_C2. */
+    tmp8 = base->C2 & ~DAC_C2_DACBFUP_MASK;
+    tmp8 |= DAC_C2_DACBFUP(config->upperLimit);
+    base->C2 = tmp8;
+}
+
+void DAC_GetDefaultBufferConfig(dac_buffer_config_t *config)
+{
+    assert(NULL != config);
+
+    config->triggerMode = kDAC_BufferTriggerBySoftwareMode;
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION
+    config->watermark = kDAC_BufferWatermark1Word;
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION */
+    config->workMode = kDAC_BufferWorkAsNormalMode;
+    config->upperLimit = DAC_DATL_COUNT - 1U;
+}
+
+void DAC_SetBufferValue(DAC_Type *base, uint8_t index, uint16_t value)
+{
+    assert(index < DAC_DATL_COUNT);
+
+    base->DAT[index].DATL = (uint8_t)(0xFFU & value);         /* Low 8-bit. */
+    base->DAT[index].DATH = (uint8_t)((0xF00U & value) >> 8); /* High 4-bit. */
+}
+
+void DAC_SetBufferReadPointer(DAC_Type *base, uint8_t index)
+{
+    assert(index < DAC_DATL_COUNT);
+
+    uint8_t tmp8 = base->C2 & ~DAC_C2_DACBFRP_MASK;
+
+    tmp8 |= DAC_C2_DACBFRP(index);
+    base->C2 = tmp8;
+}
+
+void DAC_EnableBufferInterrupts(DAC_Type *base, uint32_t mask)
+{
+    mask &= (
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION
+        DAC_C0_DACBWIEN_MASK |
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION */
+        DAC_C0_DACBTIEN_MASK | DAC_C0_DACBBIEN_MASK);
+    base->C0 |= ((uint8_t)mask); /* Write 1 to enable. */
+}
+
+void DAC_DisableBufferInterrupts(DAC_Type *base, uint32_t mask)
+{
+    mask &= (
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION
+        DAC_C0_DACBWIEN_MASK |
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION */
+        DAC_C0_DACBTIEN_MASK | DAC_C0_DACBBIEN_MASK);
+    base->C0 &= (uint8_t)(~((uint8_t)mask)); /* Write 0 to disable. */
+}
+
+uint32_t DAC_GetBufferStatusFlags(DAC_Type *base)
+{
+    return (uint32_t)(base->SR & (
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION
+                                     DAC_SR_DACBFWMF_MASK |
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION */
+                                     DAC_SR_DACBFRPTF_MASK | DAC_SR_DACBFRPBF_MASK));
+}
+
+void DAC_ClearBufferStatusFlags(DAC_Type *base, uint32_t mask)
+{
+    mask &= (
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION
+        DAC_SR_DACBFWMF_MASK |
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION */
+        DAC_SR_DACBFRPTF_MASK | DAC_SR_DACBFRPBF_MASK);
+    base->SR &= (uint8_t)(~((uint8_t)mask)); /* Write 0 to clear flags. */
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dac.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dac.h
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_DAC_H_
+#define _FSL_DAC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup dac
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief DAC driver version 2.0.0. */
+#define FSL_DAC_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*!
+ * @brief DAC buffer flags.
+ */
+enum _dac_buffer_status_flags
+{
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION
+    kDAC_BufferWatermarkFlag = DAC_SR_DACBFWMF_MASK,                  /*!< DAC Buffer Watermark Flag. */
+#endif                                                                /* FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION */
+    kDAC_BufferReadPointerTopPositionFlag = DAC_SR_DACBFRPTF_MASK,    /*!< DAC Buffer Read Pointer Top Position Flag. */
+    kDAC_BufferReadPointerBottomPositionFlag = DAC_SR_DACBFRPBF_MASK, /*!< DAC Buffer Read Pointer Bottom Position
+                                                                           Flag. */
+};
+
+/*!
+ * @brief DAC buffer interrupts.
+ */
+enum _dac_buffer_interrupt_enable
+{
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION
+    kDAC_BufferWatermarkInterruptEnable = DAC_C0_DACBWIEN_MASK,         /*!< DAC Buffer Watermark Interrupt Enable. */
+#endif                                                                  /* FSL_FEATURE_DAC_HAS_WATERMARK_DETECTION */
+    kDAC_BufferReadPointerTopInterruptEnable = DAC_C0_DACBTIEN_MASK,    /*!< DAC Buffer Read Pointer Top Flag Interrupt
+                                                                             Enable. */
+    kDAC_BufferReadPointerBottomInterruptEnable = DAC_C0_DACBBIEN_MASK, /*!< DAC Buffer Read Pointer Bottom Flag
+                                                                             Interrupt Enable */
+};
+
+/*!
+ * @brief DAC reference voltage source.
+ */
+typedef enum _dac_reference_voltage_source
+{
+    kDAC_ReferenceVoltageSourceVref1 = 0U, /*!< The DAC selects DACREF_1 as the reference voltage. */
+    kDAC_ReferenceVoltageSourceVref2 = 1U, /*!< The DAC selects DACREF_2 as the reference voltage. */
+} dac_reference_voltage_source_t;
+
+/*!
+ * @brief DAC buffer trigger mode.
+ */
+typedef enum _dac_buffer_trigger_mode
+{
+    kDAC_BufferTriggerByHardwareMode = 0U, /*!< The DAC hardware trigger is selected. */
+    kDAC_BufferTriggerBySoftwareMode = 1U, /*!< The DAC software trigger is selected. */
+} dac_buffer_trigger_mode_t;
+
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION
+/*!
+ * @brief DAC buffer watermark.
+ */
+typedef enum _dac_buffer_watermark
+{
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_1_WORD) && FSL_FEATURE_DAC_HAS_WATERMARK_1_WORD
+    kDAC_BufferWatermark1Word = 0U, /*!< 1 word  away from the upper limit. */
+#endif                              /* FSL_FEATURE_DAC_HAS_WATERMARK_1_WORD */
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_2_WORD) && FSL_FEATURE_DAC_HAS_WATERMARK_2_WORD
+    kDAC_BufferWatermark2Word = 1U, /*!< 2 words away from the upper limit. */
+#endif                              /* FSL_FEATURE_DAC_HAS_WATERMARK_2_WORD */
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_3_WORD) && FSL_FEATURE_DAC_HAS_WATERMARK_3_WORD
+    kDAC_BufferWatermark3Word = 2U, /*!< 3 words away from the upper limit. */
+#endif                              /* FSL_FEATURE_DAC_HAS_WATERMARK_3_WORD */
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_4_WORD) && FSL_FEATURE_DAC_HAS_WATERMARK_4_WORD
+    kDAC_BufferWatermark4Word = 3U, /*!< 4 words away from the upper limit. */
+#endif                              /* FSL_FEATURE_DAC_HAS_WATERMARK_4_WORD */
+} dac_buffer_watermark_t;
+#endif /* FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION */
+
+/*!
+ * @brief DAC buffer work mode.
+ */
+typedef enum _dac_buffer_work_mode
+{
+    kDAC_BufferWorkAsNormalMode = 0U, /*!< Normal mode. */
+#if defined(FSL_FEATURE_DAC_HAS_BUFFER_SWING_MODE) && FSL_FEATURE_DAC_HAS_BUFFER_SWING_MODE
+    kDAC_BufferWorkAsSwingMode,       /*!< Swing mode. */
+#endif                                /* FSL_FEATURE_DAC_HAS_BUFFER_SWING_MODE */
+    kDAC_BufferWorkAsOneTimeScanMode, /*!< One-Time Scan mode. */
+#if defined(FSL_FEATURE_DAC_HAS_BUFFER_FIFO_MODE) && FSL_FEATURE_DAC_HAS_BUFFER_FIFO_MODE
+    kDAC_BufferWorkAsFIFOMode, /*!< FIFO mode. */
+#endif                         /* FSL_FEATURE_DAC_HAS_BUFFER_FIFO_MODE */
+} dac_buffer_work_mode_t;
+
+/*!
+ * @brief DAC module configuration.
+ */
+typedef struct _dac_config
+{
+    dac_reference_voltage_source_t referenceVoltageSource; /*!< Select the DAC reference voltage source. */
+    bool enableLowPowerMode;                               /*!< Enable the low power mode. */
+} dac_config_t;
+
+/*!
+ * @brief DAC buffer configuration.
+ */
+typedef struct _dac_buffer_config
+{
+    dac_buffer_trigger_mode_t triggerMode; /*!< Select the buffer's trigger mode. */
+#if defined(FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION) && FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION
+    dac_buffer_watermark_t watermark; /*!< Select the buffer's watermark. */
+#endif                                /* FSL_FEATURE_DAC_HAS_WATERMARK_SELECTION */
+    dac_buffer_work_mode_t workMode;  /*!< Select the buffer's work mode. */
+    uint8_t upperLimit;               /*!< Set the upper limit for buffer index.
+                                           Normally, 0-15 is available for buffer with 16 item. */
+} dac_buffer_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the DAC module.
+ *
+ * This function initializes the DAC module, including:
+ *  - Enabling the clock for DAC module.
+ *  - Configuring the DAC converter with a user configuration.
+ *  - Enabling the DAC module.
+ *
+ * @param base DAC peripheral base address.
+ * @param config Pointer to the configuration structure. See "dac_config_t".
+ */
+void DAC_Init(DAC_Type *base, const dac_config_t *config);
+
+/*!
+ * @brief De-initializes the DAC module.
+ *
+ * This function de-initializes the DAC module, including:
+ *  - Disabling the DAC module.
+ *  - Disabling the clock for the DAC module.
+ *
+ * @param base DAC peripheral base address.
+ */
+void DAC_Deinit(DAC_Type *base);
+
+/*!
+ * @brief Initializes the DAC user configuration structure.
+ *
+ * This function initializes the user configuration structure to a default value. The default values are:
+ * @code
+ *   config->referenceVoltageSource = kDAC_ReferenceVoltageSourceVref2;
+ *   config->enableLowPowerMode = false;
+ * @endcode
+ * @param config Pointer to the configuration structure. See "dac_config_t".
+ */
+void DAC_GetDefaultConfig(dac_config_t *config);
+
+/*!
+ * @brief Enables the DAC module.
+ *
+ * @param base DAC peripheral base address.
+ * @param enable Enables the feature or not.
+ */
+static inline void DAC_Enable(DAC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C0 |= DAC_C0_DACEN_MASK;
+    }
+    else
+    {
+        base->C0 &= ~DAC_C0_DACEN_MASK;
+    }
+}
+
+/* @} */
+
+/*!
+ * @name Buffer
+ * @{
+ */
+
+/*!
+ * @brief Enables the DAC buffer.
+ *
+ * @param base DAC peripheral base address.
+ * @param enable Enables the feature or not.
+ */
+static inline void DAC_EnableBuffer(DAC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C1 |= DAC_C1_DACBFEN_MASK;
+    }
+    else
+    {
+        base->C1 &= ~DAC_C1_DACBFEN_MASK;
+    }
+}
+
+/*!
+ * @brief Configures the CMP buffer.
+ *
+ * @param base   DAC peripheral base address.
+ * @param config Pointer to the configuration structure. See "dac_buffer_config_t".
+ */
+void DAC_SetBufferConfig(DAC_Type *base, const dac_buffer_config_t *config);
+
+/*!
+ * @brief Initializes the DAC buffer configuration structure.
+ *
+ * This function initializes the DAC buffer configuration structure to a default value. The default values are:
+ * @code
+ *   config->triggerMode = kDAC_BufferTriggerBySoftwareMode;
+ *   config->watermark   = kDAC_BufferWatermark1Word;
+ *   config->workMode    = kDAC_BufferWorkAsNormalMode;
+ *   config->upperLimit  = DAC_DATL_COUNT - 1U;
+ * @endcode
+ * @param config Pointer to the configuration structure. See "dac_buffer_config_t".
+ */
+void DAC_GetDefaultBufferConfig(dac_buffer_config_t *config);
+
+/*!
+ * @brief Enables the DMA for DAC buffer.
+ *
+ * @param base DAC peripheral base address.
+ * @param enable Enables the feature or not.
+ */
+static inline void DAC_EnableBufferDMA(DAC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C1 |= DAC_C1_DMAEN_MASK;
+    }
+    else
+    {
+        base->C1 &= ~DAC_C1_DMAEN_MASK;
+    }
+}
+
+/*!
+ * @brief Sets the value for  items in the buffer.
+ *
+ * @param base  DAC peripheral base address.
+ * @param index Setting index for items in the buffer. The available index should not exceed the size of the DAC buffer.
+ * @param value Setting value for items in the buffer. 12-bits are available.
+ */
+void DAC_SetBufferValue(DAC_Type *base, uint8_t index, uint16_t value);
+
+/*!
+ * @brief Triggers the buffer by software and updates the read pointer of the DAC buffer.
+ *
+ * This function triggers the function by software. The read pointer of the DAC buffer is updated with one step
+ * after this function is called. Changing the read pointer depends on the buffer's work mode.
+ *
+ * @param base DAC peripheral base address.
+ */
+static inline void DAC_DoSoftwareTriggerBuffer(DAC_Type *base)
+{
+    base->C0 |= DAC_C0_DACSWTRG_MASK;
+}
+
+/*!
+ * @brief Gets the current read pointer of the DAC buffer.
+ *
+ * This function gets the current read pointer of the DAC buffer.
+ * The current output value depends on the item indexed by the read pointer. It is updated
+ * by software trigger or hardware trigger.
+ *
+ * @param  base DAC peripheral base address.
+ *
+ * @return      Current read pointer of DAC buffer.
+ */
+static inline uint8_t DAC_GetBufferReadPointer(DAC_Type *base)
+{
+    return ((base->C2 & DAC_C2_DACBFRP_MASK) >> DAC_C2_DACBFRP_SHIFT);
+}
+
+/*!
+ * @brief Sets the current read pointer of the DAC buffer.
+ *
+ * This function sets the current read pointer of the DAC buffer.
+ * The current output value depends on the item indexed by the read pointer. It is updated by
+ * software trigger or hardware trigger. After the read pointer changes, the DAC output value also changes.
+ *
+ * @param base  DAC peripheral base address.
+ * @param index Setting index value for the pointer.
+ */
+void DAC_SetBufferReadPointer(DAC_Type *base, uint8_t index);
+
+/*!
+ * @brief Enables interrupts for the DAC buffer.
+ *
+ * @param base DAC peripheral base address.
+ * @param mask Mask value for interrupts. See "_dac_buffer_interrupt_enable".
+ */
+void DAC_EnableBufferInterrupts(DAC_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables interrupts for the DAC buffer.
+ *
+ * @param base DAC peripheral base address.
+ * @param mask Mask value for interrupts. See  "_dac_buffer_interrupt_enable".
+ */
+void DAC_DisableBufferInterrupts(DAC_Type *base, uint32_t mask);
+
+/*!
+ * @brief Gets the flags of events for the DAC buffer.
+ *
+ * @param  base DAC peripheral base address.
+ *
+ * @return      Mask value for the asserted flags. See  "_dac_buffer_status_flags".
+ */
+uint32_t DAC_GetBufferStatusFlags(DAC_Type *base);
+
+/*!
+ * @brief Clears the flags of events for the DAC buffer.
+ *
+ * @param base DAC peripheral base address.
+ * @param mask Mask value for flags. See "_dac_buffer_status_flags_t".
+ */
+void DAC_ClearBufferStatusFlags(DAC_Type *base, uint32_t mask);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+/*!
+ * @}
+ */
+#endif /* _FSL_DAC_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dmamux.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dmamux.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_dmamux.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get instance number for DMAMUX.
+ *
+ * @param base DMAMUX peripheral base address.
+ */
+static uint32_t DMAMUX_GetInstance(DMAMUX_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Array to map DMAMUX instance number to base pointer. */
+static DMAMUX_Type *const s_dmamuxBases[] = DMAMUX_BASE_PTRS;
+
+/*! @brief Array to map DMAMUX instance number to clock name. */
+static const clock_ip_name_t s_dmamuxClockName[] = DMAMUX_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t DMAMUX_GetInstance(DMAMUX_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_DMAMUX_COUNT; instance++)
+    {
+        if (s_dmamuxBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_DMAMUX_COUNT);
+
+    return instance;
+}
+
+void DMAMUX_Init(DMAMUX_Type *base)
+{
+    CLOCK_EnableClock(s_dmamuxClockName[DMAMUX_GetInstance(base)]);
+}
+
+void DMAMUX_Deinit(DMAMUX_Type *base)
+{
+    CLOCK_DisableClock(s_dmamuxClockName[DMAMUX_GetInstance(base)]);
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dmamux.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dmamux.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_DMAMUX_H_
+#define _FSL_DMAMUX_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup dmamux
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief DMAMUX driver version 2.0.0. */
+#define FSL_DMAMUX_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name DMAMUX Initialize and De-initialize
+ * @{
+ */
+
+/*!
+ * @brief Initializes DMAMUX peripheral.
+ *
+ * This function ungate the DMAMUX clock.
+ *
+ * @param base DMAMUX peripheral base address.
+ *
+ */
+void DMAMUX_Init(DMAMUX_Type *base);
+
+/*!
+ * @brief Deinitializes DMAMUX peripheral.
+ *
+ * This function gate the DMAMUX clock.
+ *
+ * @param base DMAMUX peripheral base address.
+ */
+void DMAMUX_Deinit(DMAMUX_Type *base);
+
+/* @} */
+/*!
+ * @name DMAMUX Channel Operation
+ * @{
+ */
+
+/*!
+ * @brief Enable DMAMUX channel.
+ *
+ * This function enable DMAMUX channel to work.
+ *
+ * @param base DMAMUX peripheral base address.
+ * @param channel DMAMUX channel number.
+ */
+static inline void DMAMUX_EnableChannel(DMAMUX_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->CHCFG[channel] |= DMAMUX_CHCFG_ENBL_MASK;
+}
+
+/*!
+ * @brief Disable DMAMUX channel.
+ *
+ * This function disable DMAMUX channel.
+ *
+ * @note User must disable DMAMUX channel before configure it.
+ * @param base DMAMUX peripheral base address.
+ * @param channel DMAMUX channel number.
+ */
+static inline void DMAMUX_DisableChannel(DMAMUX_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->CHCFG[channel] &= ~DMAMUX_CHCFG_ENBL_MASK;
+}
+
+/*!
+ * @brief Configure DMAMUX channel source.
+ *
+ * @param base DMAMUX peripheral base address.
+ * @param channel DMAMUX channel number.
+ * @param source Channel source which is used to trigger DMA transfer.
+ */
+static inline void DMAMUX_SetSource(DMAMUX_Type *base, uint32_t channel, uint8_t source)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->CHCFG[channel] = ((base->CHCFG[channel] & ~DMAMUX_CHCFG_SOURCE_MASK) | DMAMUX_CHCFG_SOURCE(source));
+}
+
+#if defined(FSL_FEATURE_DMAMUX_HAS_TRIG) && FSL_FEATURE_DMAMUX_HAS_TRIG > 0U
+/*!
+ * @brief Enable DMAMUX period trigger.
+ *
+ * This function enable DMAMUX period trigger feature.
+ *
+ * @param base DMAMUX peripheral base address.
+ * @param channel DMAMUX channel number.
+ */
+static inline void DMAMUX_EnablePeriodTrigger(DMAMUX_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->CHCFG[channel] |= DMAMUX_CHCFG_TRIG_MASK;
+}
+
+/*!
+ * @brief Disable DMAMUX period trigger.
+ *
+ * This function disable DMAMUX period trigger.
+ *
+ * @param base DMAMUX peripheral base address.
+ * @param channel DMAMUX channel number.
+ */
+static inline void DMAMUX_DisablePeriodTrigger(DMAMUX_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->CHCFG[channel] &= ~DMAMUX_CHCFG_TRIG_MASK;
+}
+#endif /* FSL_FEATURE_DMAMUX_HAS_TRIG */
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/* @} */
+
+#endif /* _FSL_DMAMUX_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi.c
@@ -1,0 +1,1659 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fsl_dspi.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*! @brief Typedef for master interrupt handler. */
+typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
+
+/*! @brief Typedef for slave interrupt handler. */
+typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
+
+/*!
+ * @brief Configures the DSPI peripheral chip select polarity.
+ *
+ * This function  takes in the desired peripheral chip select (Pcs) and it's corresponding desired polarity and
+ * configures the Pcs signal to operate with the desired characteristic.
+ *
+ * @param base DSPI peripheral address.
+ * @param pcs The particular peripheral chip select (parameter value is of type dspi_which_pcs_t) for which we wish to
+ *            apply the active high or active low characteristic.
+ * @param activeLowOrHigh The setting for either "active high, inactive low (0)"  or "active low, inactive high(1)" of
+ *                        type dspi_pcs_polarity_config_t.
+ */
+static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pcs_polarity_config_t activeLowOrHigh);
+
+/*!
+ * @brief Master fill up the TX FIFO with data.
+ * This is not a public API as it is called from other driver functions.
+ */
+static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle);
+
+/*!
+ * @brief Master finish up a transfer.
+ * It would call back if there is callback function and set the state to idle.
+ * This is not a public API as it is called from other driver functions.
+ */
+static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
+
+/*!
+ * @brief Slave fill up the TX FIFO with data.
+ * This is not a public API as it is called from other driver functions.
+ */
+static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
+
+/*!
+ * @brief Slave finish up a transfer.
+ * It would call back if there is callback function and set the state to idle.
+ * This is not a public API as it is called from other driver functions.
+ */
+static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
+
+/*!
+ * @brief DSPI common interrupt handler.
+ *
+ * @param base DSPI peripheral address.
+ * @param handle pointer to g_dspiHandle which stores the transfer state.
+ */
+static void DSPI_CommonIRQHandler(SPI_Type *base, void *param);
+
+/*!
+ * @brief Master prepare the transfer.
+ * Basically it set up dspi_master_handle .
+ * This is not a public API as it is called from other driver functions. fsl_dspi_edma.c also call this function.
+ */
+static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
+static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
+static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+                                            256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
+
+static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
+static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+                                         512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
+
+/*! @brief Pointers to dspi bases for each instance. */
+static SPI_Type *const s_dspiBases[] = SPI_BASE_PTRS;
+
+/*! @brief Pointers to dspi IRQ number for each instance. */
+static IRQn_Type const s_dspiIRQ[] = SPI_IRQS;
+
+/*! @brief Pointers to dspi clocks for each instance. */
+static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
+
+/*! @brief Pointers to dspi handles for each instance. */
+static void *g_dspiHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+
+/*! @brief Pointer to master IRQ handler for each instance. */
+static dspi_master_isr_t s_dspiMasterIsr;
+
+/*! @brief Pointer to slave IRQ handler for each instance. */
+static dspi_slave_isr_t s_dspiSlaveIsr;
+
+/**********************************************************************************************************************
+* Code
+*********************************************************************************************************************/
+uint32_t DSPI_GetInstance(SPI_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_DSPI_COUNT; instance++)
+    {
+        if (s_dspiBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_DSPI_COUNT);
+
+    return instance;
+}
+
+void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
+{
+    uint32_t temp;
+    /* enable DSPI clock */
+    CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+
+    DSPI_Enable(base, true);
+    DSPI_StopTransfer(base);
+
+    DSPI_SetMasterSlaveMode(base, kDSPI_Master);
+
+    temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
+                          SPI_MCR_DIS_TXF_MASK | SPI_MCR_DIS_RXF_MASK));
+
+    base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
+                SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
+                SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
+                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
+
+    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    {
+        assert(false);
+    }
+
+    temp = base->CTAR[masterConfig->whichCtar] &
+           ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
+
+    base->CTAR[masterConfig->whichCtar] =
+        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+
+    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+
+    DSPI_StartTransfer(base);
+}
+
+void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
+{
+    masterConfig->whichCtar = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate = 500000;
+    masterConfig->ctarConfig.bitsPerFrame = 8;
+    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
+
+    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
+
+    masterConfig->enableContinuousSCK = false;
+    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableModifiedTimingFormat = false;
+    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+}
+
+void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
+{
+    uint32_t temp = 0;
+
+    /* enable DSPI clock */
+    CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+
+    DSPI_Enable(base, true);
+    DSPI_StopTransfer(base);
+
+    DSPI_SetMasterSlaveMode(base, kDSPI_Slave);
+
+    temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
+                          SPI_MCR_DIS_TXF_MASK | SPI_MCR_DIS_RXF_MASK));
+
+    base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
+                SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
+                SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
+                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+
+    DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
+
+    temp = base->CTAR[slaveConfig->whichCtar] &
+           ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
+
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+                                         SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
+                                         SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_StartTransfer(base);
+}
+
+void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
+{
+    slaveConfig->whichCtar = kDSPI_Ctar0;
+    slaveConfig->ctarConfig.bitsPerFrame = 8;
+    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+
+    slaveConfig->enableContinuousSCK = false;
+    slaveConfig->enableRxFifoOverWrite = false;
+    slaveConfig->enableModifiedTimingFormat = false;
+    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+}
+
+void DSPI_Deinit(SPI_Type *base)
+{
+    DSPI_StopTransfer(base);
+    DSPI_Enable(base, false);
+
+    /* disable DSPI clock */
+    CLOCK_DisableClock(s_dspiClock[DSPI_GetInstance(base)]);
+}
+
+static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pcs_polarity_config_t activeLowOrHigh)
+{
+    uint32_t temp;
+
+    temp = base->MCR;
+
+    if (activeLowOrHigh == kDSPI_PcsActiveLow)
+    {
+        temp |= SPI_MCR_PCSIS(pcs);
+    }
+    else
+    {
+        temp &= ~SPI_MCR_PCSIS(pcs);
+    }
+
+    base->MCR = temp;
+}
+
+uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
+                                dspi_ctar_selection_t whichCtar,
+                                uint32_t baudRate_Bps,
+                                uint32_t srcClock_Hz)
+{
+    /* for master mode configuration, if slave mode detected, return 0*/
+    if (!DSPI_IsMaster(base))
+    {
+        return 0;
+    }
+    uint32_t temp;
+    uint32_t prescaler, bestPrescaler;
+    uint32_t scaler, bestScaler;
+    uint32_t dbr, bestDbr;
+    uint32_t realBaudrate, bestBaudrate;
+    uint32_t diff, min_diff;
+    uint32_t baudrate = baudRate_Bps;
+
+    /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
+    min_diff = 0xFFFFFFFFU;
+    bestPrescaler = 0;
+    bestScaler = 0;
+    bestDbr = 1;
+    bestBaudrate = 0; /* required to avoid compilation warning */
+
+    /* In all for loops, if min_diff = 0, the exit for loop*/
+    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    {
+        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        {
+            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            {
+                realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
+
+                /* calculate the baud rate difference based on the conditional statement that states that the calculated
+                * baud rate must not exceed the desired baud rate.
+                */
+                if (baudrate >= realBaudrate)
+                {
+                    diff = baudrate - realBaudrate;
+                    if (min_diff > diff)
+                    {
+                        /* a better match found */
+                        min_diff = diff;
+                        bestPrescaler = prescaler;
+                        bestScaler = scaler;
+                        bestBaudrate = realBaudrate;
+                        bestDbr = dbr;
+                    }
+                }
+            }
+        }
+    }
+
+    /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
+    temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
+
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+                            (bestScaler << SPI_CTAR_BR_SHIFT);
+
+    /* return the actual calculated baud rate */
+    return bestBaudrate;
+}
+
+void DSPI_MasterSetDelayScaler(
+    SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
+{
+    /* these settings are only relevant in master mode */
+    if (DSPI_IsMaster(base))
+    {
+        switch (whichDelay)
+        {
+            case kDSPI_PcsToSck:
+                base->CTAR[whichCtar] = (base->CTAR[whichCtar] & (~SPI_CTAR_PCSSCK_MASK) & (~SPI_CTAR_CSSCK_MASK)) |
+                                        SPI_CTAR_PCSSCK(prescaler) | SPI_CTAR_CSSCK(scaler);
+                break;
+            case kDSPI_LastSckToPcs:
+                base->CTAR[whichCtar] = (base->CTAR[whichCtar] & (~SPI_CTAR_PASC_MASK) & (~SPI_CTAR_ASC_MASK)) |
+                                        SPI_CTAR_PASC(prescaler) | SPI_CTAR_ASC(scaler);
+                break;
+            case kDSPI_BetweenTransfer:
+                base->CTAR[whichCtar] = (base->CTAR[whichCtar] & (~SPI_CTAR_PDT_MASK) & (~SPI_CTAR_DT_MASK)) |
+                                        SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
+                                  dspi_ctar_selection_t whichCtar,
+                                  dspi_delay_type_t whichDelay,
+                                  uint32_t srcClock_Hz,
+                                  uint32_t delayTimeInNanoSec)
+{
+    /* for master mode configuration, if slave mode detected, return 0 */
+    if (!DSPI_IsMaster(base))
+    {
+        return 0;
+    }
+
+    uint32_t prescaler, bestPrescaler;
+    uint32_t scaler, bestScaler;
+    uint32_t realDelay, bestDelay;
+    uint32_t diff, min_diff;
+    uint32_t initialDelayNanoSec;
+
+    /* find combination of prescaler and scaler resulting in the delay closest to the
+    * requested value
+    */
+    min_diff = 0xFFFFFFFFU;
+    /* Initialize prescaler and scaler to their max values to generate the max delay */
+    bestPrescaler = 0x3;
+    bestScaler = 0xF;
+    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+
+    /* First calculate the initial, default delay */
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+
+    /* If the initial, default delay is already greater than the desired delay, then
+    * set the delays to their initial value (0) and return the delay. In other words,
+    * there is no way to decrease the delay value further.
+    */
+    if (initialDelayNanoSec >= delayTimeInNanoSec)
+    {
+        DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
+        return initialDelayNanoSec;
+    }
+
+    /* In all for loops, if min_diff = 0, the exit for loop */
+    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    {
+        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        {
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+
+            /* calculate the delay difference based on the conditional statement
+            * that states that the calculated delay must not be less then the desired delay
+            */
+            if (realDelay >= delayTimeInNanoSec)
+            {
+                diff = realDelay - delayTimeInNanoSec;
+                if (min_diff > diff)
+                {
+                    /* a better match found */
+                    min_diff = diff;
+                    bestPrescaler = prescaler;
+                    bestScaler = scaler;
+                    bestDelay = realDelay;
+                }
+            }
+        }
+    }
+
+    /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
+    DSPI_MasterSetDelayScaler(base, whichCtar, bestPrescaler, bestScaler, whichDelay);
+
+    /* return the actual calculated baud rate */
+    return bestDelay;
+}
+
+void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
+{
+    command->isPcsContinuous = false;
+    command->whichCtar = kDSPI_Ctar0;
+    command->whichPcs = kDSPI_Pcs0;
+    command->isEndOfQueue = false;
+    command->clearTransferCount = false;
+}
+
+void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
+{
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+
+    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    {
+        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    }
+
+    base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
+                  SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
+                  SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
+    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+    /* Wait till TCF sets */
+    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    {
+    }
+}
+
+void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
+{
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+
+    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    {
+        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    }
+
+    base->PUSHR = data;
+
+    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+    /* Wait till TCF sets */
+    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    {
+    }
+}
+
+void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
+{
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+
+    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    {
+        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    }
+
+    base->PUSHR_SLAVE = data;
+
+    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+    /* Wait till TCF sets */
+    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    {
+    }
+}
+
+void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
+{
+    if (mask & SPI_RSER_TFFF_RE_MASK)
+    {
+        base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
+    }
+    if (mask & SPI_RSER_RFDF_RE_MASK)
+    {
+        base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
+    }
+    base->RSER |= mask;
+}
+
+/*Transactional APIs -- Master*/
+
+void DSPI_MasterTransferCreateHandle(SPI_Type *base,
+                                     dspi_master_handle_t *handle,
+                                     dspi_master_transfer_callback_t callback,
+                                     void *userData)
+{
+    assert(handle);
+
+    /* Zero the handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    g_dspiHandle[DSPI_GetInstance(base)] = handle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+}
+
+status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
+{
+    assert(transfer);
+
+    uint16_t wordToSend = 0;
+    uint16_t wordReceived = 0;
+    uint8_t dummyData = DSPI_MASTER_DUMMY_DATA;
+    uint8_t bitsPerFrame;
+
+    uint32_t command;
+    uint32_t lastCommand;
+
+    uint8_t *txData;
+    uint8_t *rxData;
+    uint32_t remainingSendByteCount;
+    uint32_t remainingReceiveByteCount;
+
+    uint32_t fifoSize;
+    dspi_command_data_config_t commandStruct;
+
+    /* If the transfer count is zero, then return immediately.*/
+    if (transfer->dataSize == 0)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    DSPI_StopTransfer(base);
+    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_FlushFifo(base, true, true);
+    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+
+    /*Calculate the command and lastCommand*/
+    commandStruct.whichPcs =
+        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue = false;
+    commandStruct.clearTransferCount = false;
+    commandStruct.whichCtar =
+        (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
+    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+
+    command = DSPI_MasterGetFormattedCommand(&(commandStruct));
+
+    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
+
+    /*Calculate the bitsPerFrame*/
+    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+
+    txData = transfer->txData;
+    rxData = transfer->rxData;
+    remainingSendByteCount = transfer->dataSize;
+    remainingReceiveByteCount = transfer->dataSize;
+
+    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    {
+        fifoSize = 1;
+    }
+    else
+    {
+        fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
+    }
+
+    DSPI_StartTransfer(base);
+
+    if (bitsPerFrame <= 8)
+    {
+        while (remainingSendByteCount > 0)
+        {
+            if (remainingSendByteCount == 1)
+            {
+                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
+                {
+                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    {
+                        if (rxData != NULL)
+                        {
+                            *(rxData) = DSPI_ReadData(base);
+                            rxData++;
+                        }
+                        else
+                        {
+                            DSPI_ReadData(base);
+                        }
+                        remainingReceiveByteCount--;
+
+                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                    }
+                }
+
+                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                {
+                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                }
+
+                if (txData != NULL)
+                {
+                    base->PUSHR = (*txData) | (lastCommand);
+                    txData++;
+                }
+                else
+                {
+                    base->PUSHR = (lastCommand) | (dummyData);
+                }
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                remainingSendByteCount--;
+
+                while (remainingReceiveByteCount > 0)
+                {
+                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    {
+                        if (rxData != NULL)
+                        {
+                            /* Read data from POPR*/
+                            *(rxData) = DSPI_ReadData(base);
+                            rxData++;
+                        }
+                        else
+                        {
+                            DSPI_ReadData(base);
+                        }
+                        remainingReceiveByteCount--;
+
+                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                    }
+                }
+            }
+            else
+            {
+                /*Wait until Tx Fifo is not full*/
+                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                {
+                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                }
+                if (txData != NULL)
+                {
+                    base->PUSHR = command | (uint16_t)(*txData);
+                    txData++;
+                }
+                else
+                {
+                    base->PUSHR = command | dummyData;
+                }
+                remainingSendByteCount--;
+
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                {
+                    if (rxData != NULL)
+                    {
+                        *(rxData) = DSPI_ReadData(base);
+                        rxData++;
+                    }
+                    else
+                    {
+                        DSPI_ReadData(base);
+                    }
+                    remainingReceiveByteCount--;
+
+                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                }
+            }
+        }
+    }
+    else
+    {
+        while (remainingSendByteCount > 0)
+        {
+            if (remainingSendByteCount <= 2)
+            {
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                {
+                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    {
+                        wordReceived = DSPI_ReadData(base);
+
+                        if (rxData != NULL)
+                        {
+                            *rxData = wordReceived;
+                            ++rxData;
+                            *rxData = wordReceived >> 8;
+                            ++rxData;
+                        }
+                        remainingReceiveByteCount -= 2;
+
+                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                    }
+                }
+
+                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                {
+                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                }
+
+                if (txData != NULL)
+                {
+                    wordToSend = *(txData);
+                    ++txData;
+
+                    if (remainingSendByteCount > 1)
+                    {
+                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        ++txData;
+                    }
+                }
+                else
+                {
+                    wordToSend = dummyData;
+                }
+
+                base->PUSHR = lastCommand | wordToSend;
+
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                remainingSendByteCount = 0;
+
+                while (remainingReceiveByteCount > 0)
+                {
+                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    {
+                        wordReceived = DSPI_ReadData(base);
+
+                        if (remainingReceiveByteCount != 1)
+                        {
+                            if (rxData != NULL)
+                            {
+                                *(rxData) = wordReceived;
+                                ++rxData;
+                                *(rxData) = wordReceived >> 8;
+                                ++rxData;
+                            }
+                            remainingReceiveByteCount -= 2;
+                        }
+                        else
+                        {
+                            if (rxData != NULL)
+                            {
+                                *(rxData) = wordReceived;
+                                ++rxData;
+                            }
+                            remainingReceiveByteCount--;
+                        }
+                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                    }
+                }
+            }
+            else
+            {
+                /*Wait until Tx Fifo is not full*/
+                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                {
+                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                }
+
+                if (txData != NULL)
+                {
+                    wordToSend = *(txData);
+                    ++txData;
+                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    ++txData;
+                }
+                else
+                {
+                    wordToSend = dummyData;
+                }
+                base->PUSHR = command | wordToSend;
+                remainingSendByteCount -= 2;
+
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                {
+                    wordReceived = DSPI_ReadData(base);
+
+                    if (rxData != NULL)
+                    {
+                        *rxData = wordReceived;
+                        ++rxData;
+                        *rxData = wordReceived >> 8;
+                        ++rxData;
+                    }
+                    remainingReceiveByteCount -= 2;
+
+                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                }
+            }
+        }
+    }
+
+    return kStatus_Success;
+}
+
+static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
+{
+    dspi_command_data_config_t commandStruct;
+
+    DSPI_StopTransfer(base);
+    DSPI_FlushFifo(base, true, true);
+    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+
+    commandStruct.whichPcs =
+        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue = false;
+    commandStruct.clearTransferCount = false;
+    commandStruct.whichCtar =
+        (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
+    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
+
+    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
+
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+
+    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    {
+        handle->fifoSize = 1;
+    }
+    else
+    {
+        handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
+    }
+    handle->txData = transfer->txData;
+    handle->rxData = transfer->rxData;
+    handle->remainingSendByteCount = transfer->dataSize;
+    handle->remainingReceiveByteCount = transfer->dataSize;
+    handle->totalByteCount = transfer->dataSize;
+}
+
+status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
+{
+    assert(handle && transfer);
+
+    /* If the transfer count is zero, then return immediately.*/
+    if (transfer->dataSize == 0)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Check that we're not busy.*/
+    if (handle->state == kDSPI_Busy)
+    {
+        return kStatus_DSPI_Busy;
+    }
+
+    handle->state = kDSPI_Busy;
+
+    DSPI_MasterTransferPrepare(base, handle, transfer);
+    DSPI_StartTransfer(base);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
+    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+    * The IRQ handler will get the status of RX and TX interrupt flags.
+    */
+    s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
+
+    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    return kStatus_Success;
+}
+
+status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Catch when there is not an active transfer. */
+    if (handle->state != kDSPI_Busy)
+    {
+        *count = 0;
+        return kStatus_NoTransferInProgress;
+    }
+
+    *count = handle->totalByteCount - handle->remainingReceiveByteCount;
+    return kStatus_Success;
+}
+
+static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
+{
+    /* Disable interrupt requests*/
+    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+
+    status_t status = 0;
+    if (handle->state == kDSPI_Error)
+    {
+        status = kStatus_DSPI_Error;
+    }
+    else
+    {
+        status = kStatus_Success;
+    }
+
+    if (handle->callback)
+    {
+        handle->callback(base, handle, status, handle->userData);
+    }
+
+    /* The transfer is complete.*/
+    handle->state = kDSPI_Idle;
+}
+
+static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
+{
+    uint16_t wordToSend = 0;
+    uint8_t dummyData = DSPI_MASTER_DUMMY_DATA;
+
+    /* If bits/frame is greater than one byte */
+    if (handle->bitsPerFrame > 8)
+    {
+        /* Fill the fifo until it is full or until the send word count is 0 or until the difference
+        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+        * The reason for checking the difference is to ensure we only send as much as the
+        * RX FIFO can receive.
+        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+        * send data, hence the difference between the remainingReceiveByteCount and
+        * remainingSendByteCount must be divided by 2 to convert this difference into a
+        * 16-bit (2 byte) value.
+        */
+        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
+               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+        {
+            if (handle->remainingSendByteCount <= 2)
+            {
+                if (handle->txData)
+                {
+                    if (handle->remainingSendByteCount == 1)
+                    {
+                        wordToSend = *(handle->txData);
+                    }
+                    else
+                    {
+                        wordToSend = *(handle->txData);
+                        ++handle->txData; /* increment to next data byte */
+                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    }
+                }
+                else
+                {
+                    wordToSend = dummyData;
+                }
+                handle->remainingSendByteCount = 0;
+                base->PUSHR = handle->lastCommand | wordToSend;
+            }
+            /* For all words except the last word */
+            else
+            {
+                if (handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* increment to next data byte */
+                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    ++handle->txData; /* increment to next data byte */
+                }
+                else
+                {
+                    wordToSend = dummyData;
+                }
+                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                base->PUSHR = handle->command | wordToSend;
+            }
+
+            /* Try to clear the TFFF; if the TX FIFO is full this will clear */
+            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+            /* exit loop if send count is zero, else update local variables for next loop */
+            if (handle->remainingSendByteCount == 0)
+            {
+                break;
+            }
+        } /* End of TX FIFO fill while loop */
+    }
+    /* Optimized for bits/frame less than or equal to one byte. */
+    else
+    {
+        /* Fill the fifo until it is full or until the send word count is 0 or until the difference
+        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+        * The reason for checking the difference is to ensure we only send as much as the
+        * RX FIFO can receive.
+        */
+        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
+               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+        {
+            if (handle->txData)
+            {
+                wordToSend = *(handle->txData);
+                ++handle->txData;
+            }
+            else
+            {
+                wordToSend = dummyData;
+            }
+
+            if (handle->remainingSendByteCount == 1)
+            {
+                base->PUSHR = handle->lastCommand | wordToSend;
+            }
+            else
+            {
+                base->PUSHR = handle->command | wordToSend;
+            }
+
+            /* Try to clear the TFFF; if the TX FIFO is full this will clear */
+            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+            --handle->remainingSendByteCount;
+
+            /* exit loop if send count is zero, else update local variables for next loop */
+            if (handle->remainingSendByteCount == 0)
+            {
+                break;
+            }
+        }
+    }
+}
+
+void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
+{
+    DSPI_StopTransfer(base);
+
+    /* Disable interrupt requests*/
+    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+
+    handle->state = kDSPI_Idle;
+}
+
+void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
+{
+    /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
+    if (handle->remainingReceiveByteCount)
+    {
+        /* Check read buffer.*/
+        uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
+
+        /* If bits/frame is greater than one byte */
+        if (handle->bitsPerFrame > 8)
+        {
+            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            {
+                wordReceived = DSPI_ReadData(base);
+                /* clear the rx fifo drain request, needed for non-DMA applications as this flag
+                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                * either remain clear if no more data is in the fifo, or it will set if there is
+                * more data in the fifo.
+                */
+                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+
+                /* Store read bytes into rx buffer only if a buffer pointer was provided */
+                if (handle->rxData)
+                {
+                    /* For the last word received, if there is an extra byte due to the odd transfer
+                    * byte count, only save the the last byte and discard the upper byte
+                    */
+                    if (handle->remainingReceiveByteCount == 1)
+                    {
+                        *handle->rxData = wordReceived; /* Write first data byte */
+                        --handle->remainingReceiveByteCount;
+                    }
+                    else
+                    {
+                        *handle->rxData = wordReceived;      /* Write first data byte */
+                        ++handle->rxData;                    /* increment to next data byte */
+                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
+                        ++handle->rxData;                    /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2;
+                    }
+                }
+                else
+                {
+                    if (handle->remainingReceiveByteCount == 1)
+                    {
+                        --handle->remainingReceiveByteCount;
+                    }
+                    else
+                    {
+                        handle->remainingReceiveByteCount -= 2;
+                    }
+                }
+                if (handle->remainingReceiveByteCount == 0)
+                {
+                    break;
+                }
+            } /* End of RX FIFO drain while loop */
+        }
+        /* Optimized for bits/frame less than or equal to one byte. */
+        else
+        {
+            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            {
+                wordReceived = DSPI_ReadData(base);
+                /* clear the rx fifo drain request, needed for non-DMA applications as this flag
+                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                * either remain clear if no more data is in the fifo, or it will set if there is
+                * more data in the fifo.
+                */
+                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+
+                /* Store read bytes into rx buffer only if a buffer pointer was provided */
+                if (handle->rxData)
+                {
+                    *handle->rxData = wordReceived;
+                    ++handle->rxData;
+                }
+
+                --handle->remainingReceiveByteCount;
+
+                if (handle->remainingReceiveByteCount == 0)
+                {
+                    break;
+                }
+            } /* End of RX FIFO drain while loop */
+        }
+    }
+
+    /* Check write buffer. We always have to send a word in order to keep the transfer
+    * moving. So if the caller didn't provide a send buffer, we just send a zero.
+    */
+    if (handle->remainingSendByteCount)
+    {
+        DSPI_MasterTransferFillUpTxFifo(base, handle);
+    }
+
+    /* Check if we're done with this transfer.*/
+    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    {
+        /* Complete the transfer and disable the interrupts */
+        DSPI_MasterTransferComplete(base, handle);
+    }
+}
+
+/*Transactional APIs -- Slave*/
+void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
+                                    dspi_slave_handle_t *handle,
+                                    dspi_slave_transfer_callback_t callback,
+                                    void *userData)
+{
+    assert(handle);
+
+    /* Zero the handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    g_dspiHandle[DSPI_GetInstance(base)] = handle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+}
+
+status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
+{
+    assert(handle && transfer);
+
+    /* If receive length is zero */
+    if (transfer->dataSize == 0)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* If both send buffer and receive buffer is null */
+    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Check that we're not busy.*/
+    if (handle->state == kDSPI_Busy)
+    {
+        return kStatus_DSPI_Busy;
+    }
+    handle->state = kDSPI_Busy;
+
+    /* Enable the NVIC for DSPI peripheral. */
+    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+
+    /* Store transfer information */
+    handle->txData = transfer->txData;
+    handle->rxData = transfer->rxData;
+    handle->remainingSendByteCount = transfer->dataSize;
+    handle->remainingReceiveByteCount = transfer->dataSize;
+    handle->totalByteCount = transfer->dataSize;
+
+    handle->errorCount = 0;
+
+    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    handle->bitsPerFrame =
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+
+    DSPI_StopTransfer(base);
+
+    DSPI_FlushFifo(base, true, true);
+    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+
+    DSPI_StartTransfer(base);
+
+    /* Prepare data to transmit */
+    DSPI_SlaveTransferFillUpTxFifo(base, handle);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
+    }
+
+    return kStatus_Success;
+}
+
+status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Catch when there is not an active transfer. */
+    if (handle->state != kDSPI_Busy)
+    {
+        *count = 0;
+        return kStatus_NoTransferInProgress;
+    }
+
+    *count = handle->totalByteCount - handle->remainingReceiveByteCount;
+    return kStatus_Success;
+}
+
+static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
+{
+    uint16_t transmitData = 0;
+    uint8_t dummyPattern = DSPI_SLAVE_DUMMY_DATA;
+
+    /* Service the transmitter, if transmit buffer provided, transmit the data,
+    * else transmit dummy pattern
+    */
+    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+    {
+        /* Transmit data */
+        if (handle->remainingSendByteCount > 0)
+        {
+            /* Have data to transmit, update the transmit data and push to FIFO */
+            if (handle->bitsPerFrame <= 8)
+            {
+                /* bits/frame is 1 byte */
+                if (handle->txData)
+                {
+                    /* Update transmit data and transmit pointer */
+                    transmitData = *handle->txData;
+                    handle->txData++;
+                }
+                else
+                {
+                    transmitData = dummyPattern;
+                }
+
+                /* Decrease remaining dataSize */
+                --handle->remainingSendByteCount;
+            }
+            /* bits/frame is 2 bytes */
+            else
+            {
+                /* With multibytes per frame transmission, the transmit frame contains data from
+                * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                * dummy pattern value.
+                */
+                if (handle->txData)
+                {
+                    /* Update first byte of transmit data and transmit pointer */
+                    transmitData = *handle->txData;
+                    handle->txData++;
+
+                    if (handle->remainingSendByteCount == 1)
+                    {
+                        /* Decrease remaining dataSize */
+                        --handle->remainingSendByteCount;
+                        /* Update second byte of transmit data to second byte of dummy pattern */
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                    }
+                    else
+                    {
+                        /* Update second byte of transmit data and transmit pointer */
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        handle->txData++;
+                        handle->remainingSendByteCount -= 2;
+                    }
+                }
+                else
+                {
+                    if (handle->remainingSendByteCount == 1)
+                    {
+                        --handle->remainingSendByteCount;
+                    }
+                    else
+                    {
+                        handle->remainingSendByteCount -= 2;
+                    }
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                }
+            }
+        }
+        else
+        {
+            break;
+        }
+
+        /* Write the data to the DSPI data register */
+        base->PUSHR_SLAVE = transmitData;
+
+        /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
+        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    }
+}
+
+static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
+{
+    /* Disable interrupt requests */
+    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
+                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    /* The transfer is complete. */
+    handle->txData = NULL;
+    handle->rxData = NULL;
+    handle->remainingReceiveByteCount = 0;
+    handle->remainingSendByteCount = 0;
+
+    status_t status = 0;
+    if (handle->state == kDSPI_Error)
+    {
+        status = kStatus_DSPI_Error;
+    }
+    else
+    {
+        status = kStatus_Success;
+    }
+
+    if (handle->callback)
+    {
+        handle->callback(base, handle, status, handle->userData);
+    }
+
+    handle->state = kDSPI_Idle;
+}
+
+void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
+{
+    DSPI_StopTransfer(base);
+
+    /* Disable interrupt requests */
+    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
+                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    handle->state = kDSPI_Idle;
+    handle->remainingSendByteCount = 0;
+    handle->remainingReceiveByteCount = 0;
+}
+
+void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
+{
+    uint8_t dummyPattern = DSPI_SLAVE_DUMMY_DATA;
+    uint32_t dataReceived;
+    uint32_t dataSend = 0;
+
+    /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
+    * master is the actual number of bytes that the slave transmitted to the master. So we only
+    * monitor the received dataSize to know when the transfer is complete.
+    */
+    if (handle->remainingReceiveByteCount > 0)
+    {
+        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        {
+            /* Have received data in the buffer. */
+            dataReceived = base->POPR;
+            /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
+            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+            * either remain clear if no more data is in the fifo, or it will set if there is
+            * more data in the fifo.
+            */
+            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+
+            /* If bits/frame is one byte */
+            if (handle->bitsPerFrame <= 8)
+            {
+                if (handle->rxData)
+                {
+                    /* Receive buffer is not null, store data into it */
+                    *handle->rxData = dataReceived;
+                    ++handle->rxData;
+                }
+                /* Descrease remaining receive byte count */
+                --handle->remainingReceiveByteCount;
+
+                if (handle->remainingSendByteCount > 0)
+                {
+                    if (handle->txData)
+                    {
+                        dataSend = *handle->txData;
+                        ++handle->txData;
+                    }
+                    else
+                    {
+                        dataSend = dummyPattern;
+                    }
+
+                    --handle->remainingSendByteCount;
+                    /* Write the data to the DSPI data register */
+                    base->PUSHR_SLAVE = dataSend;
+                }
+            }
+            else /* If bits/frame is 2 bytes */
+            {
+                /* With multibytes frame receiving, we only receive till the received dataSize
+                * matches user request. Other bytes will be ignored.
+                */
+                if (handle->rxData)
+                {
+                    /* Receive buffer is not null, store first byte into it */
+                    *handle->rxData = dataReceived;
+                    ++handle->rxData;
+
+                    if (handle->remainingReceiveByteCount == 1)
+                    {
+                        /* Decrease remaining receive byte count */
+                        --handle->remainingReceiveByteCount;
+                    }
+                    else
+                    {
+                        /* Receive buffer is not null, store second byte into it */
+                        *handle->rxData = dataReceived >> 8;
+                        ++handle->rxData;
+                        handle->remainingReceiveByteCount -= 2;
+                    }
+                }
+                /* If no handle->rxData*/
+                else
+                {
+                    if (handle->remainingReceiveByteCount == 1)
+                    {
+                        /* Decrease remaining receive byte count */
+                        --handle->remainingReceiveByteCount;
+                    }
+                    else
+                    {
+                        handle->remainingReceiveByteCount -= 2;
+                    }
+                }
+
+                if (handle->remainingSendByteCount > 0)
+                {
+                    if (handle->txData)
+                    {
+                        dataSend = *handle->txData;
+                        ++handle->txData;
+
+                        if (handle->remainingSendByteCount == 1)
+                        {
+                            --handle->remainingSendByteCount;
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                        }
+                        else
+                        {
+                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            ++handle->txData;
+                            handle->remainingSendByteCount -= 2;
+                        }
+                    }
+                    /* If no handle->txData*/
+                    else
+                    {
+                        if (handle->remainingSendByteCount == 1)
+                        {
+                            --handle->remainingSendByteCount;
+                        }
+                        else
+                        {
+                            handle->remainingSendByteCount -= 2;
+                        }
+                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    }
+                    /* Write the data to the DSPI data register */
+                    base->PUSHR_SLAVE = dataSend;
+                }
+            }
+            /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
+            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+            if (handle->remainingReceiveByteCount == 0)
+            {
+                break;
+            }
+        }
+    }
+    /* Check if remaining receive byte count matches user request */
+    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    {
+        /* Other cases, stop the transfer. */
+        DSPI_SlaveTransferComplete(base, handle);
+        return;
+    }
+
+    /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
+    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    {
+        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
+        /* Change state to error and clear flag */
+        if (handle->txData)
+        {
+            handle->state = kDSPI_Error;
+        }
+        handle->errorCount++;
+    }
+    /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
+    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    {
+        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
+        /* Change state to error and clear flag */
+        if (handle->txData)
+        {
+            handle->state = kDSPI_Error;
+        }
+        handle->errorCount++;
+    }
+}
+
+static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
+{
+    if (DSPI_IsMaster(base))
+    {
+        s_dspiMasterIsr(base, (dspi_master_handle_t *)param);
+    }
+    else
+    {
+        s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
+    }
+}
+
+#if defined(SPI0)
+void SPI0_DriverIRQHandler(void)
+{
+    assert(g_dspiHandle[0]);
+    DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
+}
+#endif
+
+#if defined(SPI1)
+void SPI1_DriverIRQHandler(void)
+{
+    assert(g_dspiHandle[1]);
+    DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
+}
+#endif
+
+#if defined(SPI2)
+void SPI2_DriverIRQHandler(void)
+{
+    assert(g_dspiHandle[2]);
+    DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
+}
+#endif
+
+#if defined(SPI3)
+void SPI3_DriverIRQHandler(void)
+{
+    assert(g_dspiHandle[3]);
+    DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
+}
+#endif
+
+#if defined(SPI4)
+void SPI4_DriverIRQHandler(void)
+{
+    assert(g_dspiHandle[4]);
+    DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
+}
+#endif
+
+#if defined(SPI5)
+void SPI5_DriverIRQHandler(void)
+{
+    assert(g_dspiHandle[5]);
+    DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
+}
+#endif
+
+#if (FSL_FEATURE_SOC_DSPI_COUNT > 6)
+#error "Should write the SPIx_DriverIRQHandler function that instance greater than 5 !"
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi.h
@@ -1,0 +1,1185 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_DSPI_H_
+#define _FSL_DSPI_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup dspi
+ * @{
+ */
+
+/*! @file */
+
+/**********************************************************************************************************************
+ * Definitions
+ *********************************************************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI driver version 2.1.0. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*@}*/
+
+/*! @name Dummy data */
+/*@{*/
+#define DSPI_MASTER_DUMMY_DATA (0x00U) /*!< Master dummy data used for tx if there is not txData. */
+#define DSPI_SLAVE_DUMMY_DATA (0x00U)  /*!< Slave dummy data used for tx if there is not txData. */
+/*@}*/
+
+/*! @brief Status for the DSPI driver.*/
+enum _dspi_status
+{
+    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
+    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out Of range. */
+};
+
+/*! @brief DSPI status flags in SPIx_SR register.*/
+enum _dspi_flags
+{
+    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
+                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All status above.*/
+};
+
+/*! @brief DSPI interrupt source.*/
+enum _dspi_interrupt_enable
+{
+    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    /*!< All above interrupts enable.*/
+};
+
+/*! @brief DSPI DMA source.*/
+enum _dspi_dma_enable
+{
+    kDSPI_TxDmaEnable = (SPI_RSER_TFFF_RE_MASK | SPI_RSER_TFFF_DIRS_MASK), /*!< TFFF flag generates DMA requests.
+                                                                                No Tx interrupt request. */
+    kDSPI_RxDmaEnable = (SPI_RSER_RFDF_RE_MASK | SPI_RSER_RFDF_DIRS_MASK)  /*!< RFDF flag generates DMA requests.
+                                                                                No Rx interrupt request. */
+};
+
+/*! @brief DSPI master or slave mode configuration.*/
+typedef enum _dspi_master_slave_mode
+{
+    kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
+    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+} dspi_master_slave_mode_t;
+
+/*!
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in Modified Transfer Format. This field is valid
+ * only when CPHA bit in CTAR register is 0.
+ */
+typedef enum _dspi_master_sample_point
+{
+    kDSPI_SckToSin0Clock = 0U, /*!< 0 system clocks between SCK edge and SIN sample.*/
+    kDSPI_SckToSin1Clock = 1U, /*!< 1 system clock  between SCK edge and SIN sample.*/
+    kDSPI_SckToSin2Clock = 2U  /*!< 2 system clocks between SCK edge and SIN sample.*/
+} dspi_master_sample_point_t;
+
+/*! @brief DSPI Peripheral Chip Select (Pcs) configuration (which Pcs to configure).*/
+typedef enum _dspi_which_pcs_config
+{
+    kDSPI_Pcs0 = 1U << 0, /*!< Pcs[0] */
+    kDSPI_Pcs1 = 1U << 1, /*!< Pcs[1] */
+    kDSPI_Pcs2 = 1U << 2, /*!< Pcs[2] */
+    kDSPI_Pcs3 = 1U << 3, /*!< Pcs[3] */
+    kDSPI_Pcs4 = 1U << 4, /*!< Pcs[4] */
+    kDSPI_Pcs5 = 1U << 5  /*!< Pcs[5] */
+} dspi_which_pcs_t;
+
+/*! @brief DSPI Peripheral Chip Select (Pcs) Polarity configuration.*/
+typedef enum _dspi_pcs_polarity_config
+{
+    kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
+    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+} dspi_pcs_polarity_config_t;
+
+/*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
+enum _dspi_pcs_polarity
+{
+    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+};
+
+/*! @brief DSPI clock polarity configuration for a given CTAR.*/
+typedef enum _dspi_clock_polarity
+{
+    kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
+    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+} dspi_clock_polarity_t;
+
+/*! @brief DSPI clock phase configuration for a given CTAR.*/
+typedef enum _dspi_clock_phase
+{
+    kDSPI_ClockPhaseFirstEdge = 0U, /*!< CPHA=0. Data is captured on the leading edge of the SCK and changed on the
+                                         following edge.*/
+    kDSPI_ClockPhaseSecondEdge = 1U /*!< CPHA=1. Data is changed on the leading edge of the SCK and captured on the
+                                        following edge.*/
+} dspi_clock_phase_t;
+
+/*! @brief DSPI data shifter direction options for a given CTAR.*/
+typedef enum _dspi_shift_direction
+{
+    kDSPI_MsbFirst = 0U, /*!< Data transfers start with most significant bit.*/
+    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.*/
+} dspi_shift_direction_t;
+
+/*! @brief DSPI delay type selection.*/
+typedef enum _dspi_delay_type
+{
+    kDSPI_PcsToSck = 1U,  /*!< Pcs-to-SCK delay. */
+    kDSPI_LastSckToPcs,   /*!< Last SCK edge to Pcs delay. */
+    kDSPI_BetweenTransfer /*!< Delay between transfers. */
+} dspi_delay_type_t;
+
+/*! @brief DSPI Clock and Transfer Attributes Register (CTAR) selection.*/
+typedef enum _dspi_ctar_selection
+{
+    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode, note that CTAR0 and CTAR0_SLAVE are the
+                         same register address. */
+    kDSPI_Ctar1 = 1U, /*!< CTAR1 selection option for master mode only. */
+    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only , note that some device do not support CTAR2. */
+    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only , note that some device do not support CTAR3. */
+    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only , note that some device do not support CTAR4. */
+    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only , note that some device do not support CTAR5. */
+    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only , note that some device do not support CTAR6. */
+    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only , note that some device do not support CTAR7. */
+} dspi_ctar_selection_t;
+
+#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro , internal used. */
+#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro , internal used. */
+#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro , internal used. */
+#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro , internal used. */
+/*! @brief Can use this enumeration for DSPI master transfer configFlags. */
+enum _dspi_transfer_config_flag_for_master
+{
+    kDSPI_MasterCtar0 = 0U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR0 setting. */
+    kDSPI_MasterCtar1 = 1U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR1 setting. */
+    kDSPI_MasterCtar2 = 2U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR2 setting. */
+    kDSPI_MasterCtar3 = 3U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR3 setting. */
+    kDSPI_MasterCtar4 = 4U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR4 setting. */
+    kDSPI_MasterCtar5 = 5U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR5 setting. */
+    kDSPI_MasterCtar6 = 6U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR6 setting. */
+    kDSPI_MasterCtar7 = 7U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR7 setting. */
+
+    kDSPI_MasterPcs0 = 0U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS0 signal. */
+    kDSPI_MasterPcs1 = 1U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS1 signal. */
+    kDSPI_MasterPcs2 = 2U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS2 signal.*/
+    kDSPI_MasterPcs3 = 3U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS3 signal. */
+    kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
+    kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
+
+    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Is PCS signal continuous. */
+    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Is PCS signal active after last frame transfer.*/
+};
+
+#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro , internal used. */
+#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro , internal used. */
+/*! @brief Can use this enum for DSPI slave transfer configFlags. */
+enum _dspi_transfer_config_flag_for_slave
+{
+    kDSPI_SlaveCtar0 = 0U << DSPI_SLAVE_CTAR_SHIFT, /*!< DSPI slave transfer use CTAR0 setting. */
+                                                    /*!< DSPI slave can only use PCS0. */
+};
+
+/*! @brief DSPI transfer state, which is used for DSPI transactional APIs' state machine. */
+enum _dspi_transfer_state
+{
+    kDSPI_Idle = 0x0U, /*!< Nothing in the transmitter/receiver. */
+    kDSPI_Busy,        /*!< Transfer queue is not finished. */
+    kDSPI_Error        /*!< Transfer error. */
+};
+
+/*! @brief DSPI master command date configuration used for SPIx_PUSHR.*/
+typedef struct _dspi_command_data_config
+{
+    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of chip select between transfers.*/
+    dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
+                                          Register (CTAR) to use for CTAS.*/
+    dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
+    bool isEndOfQueue;               /*!< Signals that the current transfer is the last in the queue.*/
+    bool clearTransferCount;         /*!< Clears SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
+} dspi_command_data_config_t;
+
+/*! @brief DSPI master ctar configuration structure.*/
+typedef struct _dspi_master_ctar_config
+{
+    uint32_t baudRate;                /*!< Baud Rate for DSPI. */
+    uint32_t bitsPerFrame;            /*!< Bits per frame, minimum 4, maximum 16.*/
+    dspi_clock_polarity_t cpol;       /*!< Clock polarity. */
+    dspi_clock_phase_t cpha;          /*!< Clock phase. */
+    dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
+
+    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time with nanosecond , set to 0 sets the minimum
+                                               delay. It sets the boundary value if out of range that can be set.*/
+    uint32_t lastSckToPcsDelayInNanoSec;    /*!< Last SCK to PCS delay time with nanosecond , set to 0 sets the
+                                               minimum delay.It sets the boundary value if out of range that can be
+                                               set.*/
+    uint32_t betweenTransferDelayInNanoSec; /*!< After SCK delay time with nanosecond , set to 0 sets the minimum
+                                             delay.It sets the boundary value if out of range that can be set.*/
+} dspi_master_ctar_config_t;
+
+/*! @brief DSPI master configuration structure.*/
+typedef struct _dspi_master_config
+{
+    dspi_ctar_selection_t whichCtar;      /*!< Desired CTAR to use. */
+    dspi_master_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
+
+    dspi_which_pcs_t whichPcs;                     /*!< Desired Peripheral Chip Select (pcs). */
+    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< Desired PCS active high or low. */
+
+    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable . Note that continuous SCK is only
+                                     supported for CPHA = 1.*/
+    bool enableRxFifoOverWrite; /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
+                                     data is ignored, the data from the transfer that generated the overflow
+                                     is either ignored. ROOE = 1, the incoming data is shifted in to the
+                                     shift to the shift register. */
+
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+                                                 Format. It's valid only when CPHA=0. */
+} dspi_master_config_t;
+
+/*! @brief DSPI slave ctar configuration structure.*/
+typedef struct _dspi_slave_ctar_config
+{
+    uint32_t bitsPerFrame;      /*!< Bits per frame, minimum 4, maximum 16.*/
+    dspi_clock_polarity_t cpol; /*!< Clock polarity. */
+    dspi_clock_phase_t cpha;    /*!< Clock phase. */
+                                /*!< Slave only supports MSB , does not support LSB.*/
+} dspi_slave_ctar_config_t;
+
+/*! @brief DSPI slave configuration structure.*/
+typedef struct _dspi_slave_config
+{
+    dspi_ctar_selection_t whichCtar;     /*!< Desired CTAR to use. */
+    dspi_slave_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
+
+    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that continuous SCK is only
+                                                 supported for CPHA = 1.*/
+    bool enableRxFifoOverWrite;             /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
+                                                 data is ignored, the data from the transfer that generated the overflow
+                                                 is either ignored. ROOE = 1, the incoming data is shifted in to the
+                                                 shift to the shift register. */
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+                                               Format. It's valid only when CPHA=0. */
+} dspi_slave_config_t;
+
+/*!
+* @brief Forward declaration of the _dspi_master_handle typedefs.
+*/
+typedef struct _dspi_master_handle dspi_master_handle_t;
+
+/*!
+* @brief Forward declaration of the _dspi_slave_handle typedefs.
+*/
+typedef struct _dspi_slave_handle dspi_slave_handle_t;
+
+/*!
+ * @brief Completion callback function pointer type.
+ *
+ * @param base DSPI peripheral address.
+ * @param handle Pointer to the handle for the DSPI master.
+ * @param status Success or error code describing whether the transfer completed.
+ * @param userData Arbitrary pointer-dataSized value passed from the application.
+ */
+typedef void (*dspi_master_transfer_callback_t)(SPI_Type *base,
+                                                dspi_master_handle_t *handle,
+                                                status_t status,
+                                                void *userData);
+/*!
+ * @brief Completion callback function pointer type.
+ *
+ * @param base DSPI peripheral address.
+ * @param handle Pointer to the handle for the DSPI slave.
+ * @param status Success or error code describing whether the transfer completed.
+ * @param userData Arbitrary pointer-dataSized value passed from the application.
+ */
+typedef void (*dspi_slave_transfer_callback_t)(SPI_Type *base,
+                                               dspi_slave_handle_t *handle,
+                                               status_t status,
+                                               void *userData);
+
+/*! @brief DSPI master/slave transfer structure.*/
+typedef struct _dspi_transfer
+{
+    uint8_t *txData;          /*!< Send buffer. */
+    uint8_t *rxData;          /*!< Receive buffer. */
+    volatile size_t dataSize; /*!< Transfer bytes. */
+
+    uint32_t
+        configFlags; /*!< Transfer transfer configuration flags , set from _dspi_transfer_config_flag_for_master if the
+                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
+                        is used for slave.*/
+} dspi_transfer_t;
+
+/*! @brief DSPI master transfer handle structure used for transactional API. */
+struct _dspi_master_handle
+{
+    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
+    volatile uint32_t command;     /*!< Desired data command. */
+    volatile uint32_t lastCommand; /*!< Desired last data command. */
+
+    uint8_t fifoSize; /*!< FIFO dataSize. */
+
+    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
+    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+
+    uint8_t *volatile txData;                  /*!< Send buffer. */
+    uint8_t *volatile rxData;                  /*!< Receive buffer. */
+    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+
+    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
+
+    dspi_master_transfer_callback_t callback; /*!< Completion callback. */
+    void *userData;                           /*!< Callback user data. */
+};
+
+/*! @brief DSPI slave transfer handle structure used for transactional API. */
+struct _dspi_slave_handle
+{
+    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
+    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+
+    uint8_t *volatile txData;                  /*!< Send buffer. */
+    uint8_t *volatile rxData;                  /*!< Receive buffer. */
+    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+
+    volatile uint8_t state; /*!< DSPI transfer state.*/
+
+    volatile uint32_t errorCount; /*!< Error count for slave transfer.*/
+
+    dspi_slave_transfer_callback_t callback; /*!< Completion callback. */
+    void *userData;                          /*!< Callback user data. */
+};
+
+/**********************************************************************************************************************
+ * API
+ *********************************************************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /*_cplusplus*/
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. An example use case is as follows:
+ *  @code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param masterConfig Pointer to structure dspi_master_config_t.
+ * @param srcClock_Hz Module source input clock in Hertz
+ */
+void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * User may use the initialized structure unchanged in DSPI_MasterInit() or modify the structure
+ * before calling DSPI_MasterInit().
+ * Example:
+ * @code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * @endcode
+ * @param masterConfig pointer to dspi_master_config_t structure
+ */
+void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
+
+/*!
+ * @brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. An example use case is as follows:
+ *  @code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param slaveConfig Pointer to structure dspi_master_config_t.
+ */
+void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
+
+/*!
+ * @brief Sets the dspi_slave_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * User may use the initialized structure unchanged in DSPI_SlaveInit(), or modify the structure
+ * before calling DSPI_SlaveInit().
+ * Example:
+ * @code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * @endcode
+ * @param slaveConfig pointer to dspi_slave_config_t structure.
+ */
+void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig);
+
+/*!
+ * @brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * @param base DSPI peripheral address.
+ */
+void DSPI_Deinit(SPI_Type *base);
+
+/*!
+ * @brief Enables the DSPI peripheral and sets the MCR MDIS to 0.
+ *
+ * @param base DSPI peripheral address.
+ * @param enable pass true to enable module, false to disable module.
+ */
+static inline void DSPI_Enable(SPI_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->MCR &= ~SPI_MCR_MDIS_MASK;
+    }
+    else
+    {
+        base->MCR |= SPI_MCR_MDIS_MASK;
+    }
+}
+
+/*!
+ *@}
+*/
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Gets the DSPI status flag state.
+ * @param base DSPI peripheral address.
+ * @return The DSPI status(in SR register).
+ */
+static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
+{
+    return (base->SR);
+}
+
+/*!
+ * @brief Clears the DSPI status flag.
+ *
+ * This function  clears the desired status bit by using a write-1-to-clear. The user passes in the base and the
+ * desired status bit to clear.  The list of status bits is defined in the dspi_status_and_interrupt_request_t. The
+ * function uses these bit positions in its algorithm to clear the desired flag state.
+ * Example usage:
+ * @code
+ *  DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag|kDSPI_EndOfQueueFlag);
+ * @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param statusFlags The status flag , used from type dspi_flags.
+ */
+static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
+{
+    base->SR = statusFlags; /*!< The status flags are cleared by writing 1 (w1c).*/
+}
+
+/*!
+ *@}
+*/
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *
+ * @code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ */
+void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables the DSPI interrupts.
+ *
+ * @code
+ *  DSPI_DisableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ */
+static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
+{
+    base->RSER &= ~mask;
+}
+
+/*!
+ *@}
+*/
+
+/*!
+ * @name DMA Control
+ * @{
+ */
+
+/*!
+ * @brief Enables the DSPI DMA request.
+ *
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * @code
+ *  DSPI_EnableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
+ * @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ */
+static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
+{
+    base->RSER |= mask;
+}
+
+/*!
+ * @brief Disables the DSPI DMA request.
+ *
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * @code
+ *  SPI_DisableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
+ * @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ */
+static inline void DSPI_DisableDMA(SPI_Type *base, uint32_t mask)
+{
+    base->RSER &= ~mask;
+}
+
+/*!
+ * @brief Gets the DSPI master PUSHR data register address for the DMA operation.
+ *
+ * This function gets the DSPI master PUSHR data register address because this value is needed for the DMA operation.
+ *
+ * @param base DSPI peripheral address.
+ * @return The DSPI master PUSHR data register address.
+ */
+static inline uint32_t DSPI_MasterGetTxRegisterAddress(SPI_Type *base)
+{
+    return (uint32_t) & (base->PUSHR);
+}
+
+/*!
+ * @brief Gets the DSPI slave PUSHR data register address for the DMA operation.
+ *
+ * This function gets the DSPI slave PUSHR data register address as this value is needed for the DMA operation.
+ *
+ * @param base DSPI peripheral address.
+ * @return The DSPI slave PUSHR data register address.
+ */
+static inline uint32_t DSPI_SlaveGetTxRegisterAddress(SPI_Type *base)
+{
+    return (uint32_t) & (base->PUSHR_SLAVE);
+}
+
+/*!
+ * @brief Gets the DSPI POPR data register address for the DMA operation.
+ *
+ * This function gets the DSPI POPR data register address as this value is needed for the DMA operation.
+ *
+ * @param base DSPI peripheral address.
+ * @return The DSPI POPR data register address.
+ */
+static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
+{
+    return (uint32_t) & (base->POPR);
+}
+
+/*!
+ *@}
+*/
+
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Configures the DSPI for master or slave.
+ *
+ * @param base DSPI peripheral address.
+ * @param mode Mode setting (master or slave) of type dspi_master_slave_mode_t.
+ */
+static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mode_t mode)
+{
+    base->MCR = (base->MCR & (~SPI_MCR_MSTR_MASK)) | SPI_MCR_MSTR(mode);
+}
+
+/*!
+ * @brief Returns whether the DSPI module is in master mode.
+ *
+ * @param base DSPI peripheral address.
+ * @return Returns true if the module is in master mode or false if the module is in slave mode.
+ */
+static inline bool DSPI_IsMaster(SPI_Type *base)
+{
+    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+}
+/*!
+ * @brief Starts the DSPI transfers and clears HALT bit in MCR.
+ *
+ * This function sets the module to begin data transfer in either master or slave mode.
+ *
+ * @param base DSPI peripheral address.
+ */
+static inline void DSPI_StartTransfer(SPI_Type *base)
+{
+    base->MCR &= ~SPI_MCR_HALT_MASK;
+}
+/*!
+ * @brief Stops (halts) DSPI transfers and sets HALT bit in MCR.
+ *
+ * This function stops data transfers in either master or slave mode.
+ *
+ * @param base DSPI peripheral address.
+ */
+static inline void DSPI_StopTransfer(SPI_Type *base)
+{
+    base->MCR |= SPI_MCR_HALT_MASK;
+}
+
+/*!
+ * @brief Enables (or disables) the DSPI FIFOs.
+ *
+ * This function  allows the caller to disable/enable the Tx and Rx FIFOs (independently).
+ * Note that to disable, the caller must pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
+ * the caller must pass in a logic 1 (true).
+ *
+ * @param base DSPI peripheral address.
+ * @param enableTxFifo Disables (false) the TX FIFO, else enables (true) the TX FIFO
+ * @param enableRxFifo Disables (false) the RX FIFO, else enables (true) the RX FIFO
+ */
+static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
+{
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
+                SPI_MCR_DIS_RXF(!enableRxFifo);
+}
+
+/*!
+ * @brief Flushes the DSPI FIFOs.
+ *
+ * @param base DSPI peripheral address.
+ * @param flushTxFifo Flushes (true) the Tx FIFO, else do not flush (false) the Tx FIFO
+ * @param flushRxFifo Flushes (true) the Rx FIFO, else do not flush (false) the Rx FIFO
+ */
+static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
+{
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
+                SPI_MCR_CLR_RXF(flushRxFifo);
+}
+
+/*!
+ * @brief Configures the DSPI peripheral chip select polarity simultaneously.
+ * For example, PCS0 and PCS1 set to active low and other PCS set to active high. Note that the number of
+ * PCSs is specific to the device.
+ * @code
+ *  DSPI_SetAllPcsPolarity(base, kDSPI_Pcs0ActiveLow | kDSPI_Pcs1ActiveLow);
+   @endcode
+ * @param base DSPI peripheral address.
+ * @param mask The PCS polarity mask ,  can use the enum _dspi_pcs_polarity.
+ */
+static inline void DSPI_SetAllPcsPolarity(SPI_Type *base, uint32_t mask)
+{
+    base->MCR = (base->MCR & ~SPI_MCR_PCSIS_MASK) | SPI_MCR_PCSIS(mask);
+}
+
+/*!
+ * @brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * @param base DSPI peripheral address.
+ * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * @param baudRate_Bps The desired baud rate in bits per second
+ * @param srcClock_Hz Module source input clock in Hertz
+ * @return The actual calculated baud rate
+ */
+uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
+                                dspi_ctar_selection_t whichCtar,
+                                uint32_t baudRate_Bps,
+                                uint32_t srcClock_Hz);
+
+/*!
+ * @brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT)and scalar (DT).
+ *
+ * These delay names are available in type dspi_delay_type_t.
+ *
+ * The user passes the delay to configure along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if they have pre-calculated them or if they simply
+ * wish to manually increment either value.
+ *
+ * @param base DSPI peripheral address.
+ * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * @param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * @param scaler The scaler delay value (can be any integer between 0 to 15).
+ * @param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ */
+void DSPI_MasterSetDelayScaler(
+    SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay);
+
+/*!
+ * @brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for:
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT)and scalar (DT).
+ *
+ * These delay names are available in type dspi_delay_type_t.
+ *
+ * The user passes which delay they want to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler and returning the actual calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * @param base DSPI peripheral address.
+ * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * @param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * @param srcClock_Hz Module source input clock in Hertz
+ * @param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * @return The actual calculated delay value.
+ */
+uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
+                                  dspi_ctar_selection_t whichCtar,
+                                  dspi_delay_type_t whichDelay,
+                                  uint32_t srcClock_Hz,
+                                  uint32_t delayTimeInNanoSec);
+
+/*!
+ * @brief Writes data into the data buffer for master mode.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example:
+ * @code
+ *  dspi_command_data_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs0;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteData(base, &commandConfig, dataWord);
+   @endcode
+ *
+ * @param base DSPI peripheral address.
+ * @param command Pointer to command structure.
+ * @param data The data word to be sent.
+ */
+static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
+{
+    base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
+                  SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
+                  SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
+}
+
+/*!
+ * @brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * User may use the initialized structure unchanged in DSPI_MasterWrite_xx() or modify the structure
+ * before calling DSPI_MasterWrite_xx().
+ * Example:
+ * @code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * @endcode
+ * @param command pointer to dspi_command_data_config_t structure.
+ */
+void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
+
+/*!
+ * @brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example:
+ * @code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * @endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * receive data is available when transmit completes.
+ *
+ * @param base DSPI peripheral address.
+ * @param command Pointer to command structure.
+ * @param data The data word to be sent.
+ */
+void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data);
+
+/*!
+ * @brief Returns the DSPI command word formatted to the PUSHR data register bit field.
+ *
+ * This function allows the caller to pass in the data command structure and returns the command word formatted
+ * according to the DSPI PUSHR register bit field placement. The user can then "OR" the returned command word with the
+ * desired data to send and use the function DSPI_HAL_WriteCommandDataMastermode or
+ * DSPI_HAL_WriteCommandDataMastermodeBlocking to write the entire 32-bit command data word to the PUSHR. This helps
+ * improve performance in cases where the command structure is constant. For example, the user calls this function
+ * before starting a transfer to generate the command word. When they are ready to transmit the data, they OR
+ * this formatted command word with the desired data to transmit. This process increases transmit performance when
+ * compared to calling send functions such as DSPI_HAL_WriteDataMastermode which format the command word each time a
+ * data word is to be sent.
+ *
+ * @param command Pointer to command structure.
+ * @return The command word formatted to the PUSHR data register bit field.
+ */
+static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t *command)
+{
+    /* Format the 16-bit command word according to the PUSHR data register bit field*/
+    return (uint32_t)(SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
+                      SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
+                      SPI_PUSHR_CTCNT(command->clearTransferCount));
+}
+
+/*!
+ * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer, master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command info then provide the total 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data such as the optional continuous chip select operation
+* between
+ * transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * @code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_HAL_WriteCommandDataMastermodeBlocking(base, dataWord);
+ * @endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the receive data is available when transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+*   uint32_t data0 = command_to_send | data_need_to_send_0;
+*   uint32_t data1 = command_to_send | data_need_to_send_1;
+*   uint32_t data2 = command_to_send | data_need_to_send_2;
+*
+*   DSPI_MasterWriteCommandDataBlocking(base,data0);
+*   DSPI_MasterWriteCommandDataBlocking(base,data1);
+*   DSPI_MasterWriteCommandDataBlocking(base,data2);
+*
+*  Option 2:
+*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+*
+ * @param base DSPI peripheral address.
+ * @param data The data word (command and data combined) to be sent
+ */
+void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data);
+
+/*!
+ * @brief Writes data into the data buffer in slave mode.
+ *
+ * In slave mode, up to 16-bit words may be written.
+ *
+ * @param base DSPI peripheral address.
+ * @param data The data to send.
+ */
+static inline void DSPI_SlaveWriteData(SPI_Type *base, uint32_t data)
+{
+    base->PUSHR_SLAVE = data;
+}
+
+/*!
+ * @brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * @param base DSPI peripheral address.
+ * @param data The data to send.
+ */
+void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data);
+
+/*!
+ * @brief Reads data from the data buffer.
+ *
+ * @param base DSPI peripheral address.
+ * @return The data from the read data buffer.
+ */
+static inline uint32_t DSPI_ReadData(SPI_Type *base)
+{
+    return (base->POPR);
+}
+
+/*!
+ *@}
+*/
+
+/*!
+ * @name Transactional
+ * @{
+ */
+/*Transactional APIs*/
+
+/*!
+ * @brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle DSPI handle pointer to dspi_master_handle_t.
+ * @param callback dspi callback.
+ * @param userData callback function parameter.
+ */
+void DSPI_MasterTransferCreateHandle(SPI_Type *base,
+                                     dspi_master_handle_t *handle,
+                                     dspi_master_transfer_callback_t callback,
+                                     void *userData);
+
+/*!
+ * @brief DSPI master transfer data using polling.
+ *
+ * This function transfers data with polling. This is a blocking function, which does not return until all transfers
+ * have been
+ * completed.
+ *
+ * @param base DSPI peripheral base address.
+ * @param transfer pointer to dspi_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
+
+/*!
+ * @brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ data
+ * have been transferred, the callback function is called.
+
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param transfer pointer to dspi_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count);
+
+/*!
+ * @brief DSPI master aborts transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ */
+void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
+
+/*!
+ * @brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ */
+void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
+
+/*!
+ * @brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * @param handle DSPI handle pointer to dspi_slave_handle_t.
+ * @param base DSPI peripheral base address.
+ * @param callback DSPI callback.
+ * @param userData callback function parameter.
+ */
+void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
+                                    dspi_slave_handle_t *handle,
+                                    dspi_slave_transfer_callback_t callback,
+                                    void *userData);
+
+/*!
+ * @brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data
+ * have been transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param transfer pointer to dspi_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @return status of status_t.
+ */
+status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count);
+
+/*!
+ * @brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts transfer using an interrupt.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ */
+void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
+
+/*!
+ * @brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ */
+void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
+
+/*!
+ *@}
+*/
+
+#if defined(__cplusplus)
+}
+#endif /*_cplusplus*/
+       /*!
+        *@}
+       */
+
+#endif /*_FSL_DSPI_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi_edma.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi_edma.c
@@ -1,0 +1,1262 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fsl_dspi_edma.h"
+
+/***********************************************************************************************************************
+* Definitons
+***********************************************************************************************************************/
+
+/*!
+* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+*/
+typedef struct _dspi_master_edma_private_handle
+{
+    SPI_Type *base;                    /*!< DSPI peripheral base address. */
+    dspi_master_edma_handle_t *handle; /*!< dspi_master_edma_handle_t handle */
+} dspi_master_edma_private_handle_t;
+
+/*!
+* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+*/
+typedef struct _dspi_slave_edma_private_handle
+{
+    SPI_Type *base;                   /*!< DSPI peripheral base address. */
+    dspi_slave_edma_handle_t *handle; /*!< dspi_master_edma_handle_t handle */
+} dspi_slave_edma_private_handle_t;
+
+/***********************************************************************************************************************
+* Prototypes
+***********************************************************************************************************************/
+/*!
+* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+* This is not a public API as it is called from other driver functions.
+*/
+static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
+                                    void *g_dspiEdmaPrivateHandle,
+                                    bool transferDone,
+                                    uint32_t tcds);
+
+/*!
+* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+* This is not a public API as it is called from other driver functions.
+*/
+static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
+                                   void *g_dspiEdmaPrivateHandle,
+                                   bool transferDone,
+                                   uint32_t tcds);
+/*!
+* @brief Get instance number for DSPI module.
+*
+* This is not a public API and it's extern from fsl_dspi.c.
+*
+* @param base DSPI peripheral base address
+*/
+extern uint32_t DSPI_GetInstance(SPI_Type *base);
+
+/***********************************************************************************************************************
+* Variables
+***********************************************************************************************************************/
+
+/*! @brief Pointers to dspi edma handles for each instance. */
+static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+
+/***********************************************************************************************************************
+* Code
+***********************************************************************************************************************/
+
+void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
+                                         dspi_master_edma_handle_t *handle,
+                                         dspi_master_edma_transfer_callback_t callback,
+                                         void *userData,
+                                         edma_handle_t *edmaRxRegToRxDataHandle,
+                                         edma_handle_t *edmaTxDataToIntermediaryHandle,
+                                         edma_handle_t *edmaIntermediaryToTxRegHandle)
+{
+    assert(handle);
+
+    /* Zero the handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    uint32_t instance = DSPI_GetInstance(base);
+
+    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+
+    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
+    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+}
+
+status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
+{
+    assert(handle && transfer);
+
+    /* If the transfer count is zero, then return immediately.*/
+    if (transfer->dataSize == 0)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* If both send buffer and receive buffer is null */
+    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Check that we're not busy.*/
+    if (handle->state == kDSPI_Busy)
+    {
+        return kStatus_DSPI_Busy;
+    }
+
+    uint32_t instance = DSPI_GetInstance(base);
+    uint16_t wordToSend = 0;
+    uint8_t dummyData = DSPI_MASTER_DUMMY_DATA;
+    uint8_t dataAlreadyFed = 0;
+    uint8_t dataFedMax = 2;
+
+    uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
+    uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
+
+    edma_tcd_t *softwareTCD = (edma_tcd_t *)((uint32_t)(&handle->dspiSoftwareTCD[1]) & (~0x1FU));
+
+    edma_transfer_config_t transferConfigA;
+    edma_transfer_config_t transferConfigB;
+    edma_transfer_config_t transferConfigC;
+
+    handle->txBuffIfNull = ((uint32_t)DSPI_MASTER_DUMMY_DATA << 8) | DSPI_MASTER_DUMMY_DATA;
+
+    handle->state = kDSPI_Busy;
+
+    dspi_command_data_config_t commandStruct;
+    DSPI_StopTransfer(base);
+    DSPI_FlushFifo(base, true, true);
+    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+
+    commandStruct.whichPcs =
+        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue = false;
+    commandStruct.clearTransferCount = false;
+    commandStruct.whichCtar =
+        (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
+    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
+
+    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
+
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+
+    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    {
+        handle->fifoSize = 1;
+    }
+    else
+    {
+        handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
+    }
+    handle->txData = transfer->txData;
+    handle->rxData = transfer->rxData;
+    handle->remainingSendByteCount = transfer->dataSize;
+    handle->remainingReceiveByteCount = transfer->dataSize;
+    handle->totalByteCount = transfer->dataSize;
+
+    /* this limits the amount of data we can transfer due to the linked channel.
+    * The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+    */
+    if (handle->bitsPerFrame > 8)
+    {
+        if (transfer->dataSize > 1022)
+        {
+            return kStatus_DSPI_OutOfRange;
+        }
+    }
+    else
+    {
+        if (transfer->dataSize > 511)
+        {
+            return kStatus_DSPI_OutOfRange;
+        }
+    }
+
+    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
+                     &s_dspiMasterEdmaPrivateHandle[instance]);
+
+    handle->isThereExtraByte = false;
+    if (handle->bitsPerFrame > 8)
+    {
+        if (handle->remainingSendByteCount % 2 == 1)
+        {
+            handle->remainingSendByteCount++;
+            handle->remainingReceiveByteCount--;
+            handle->isThereExtraByte = true;
+        }
+    }
+
+    /*If dspi has separate dma request , prepare the first data in "intermediary" .
+    else (dspi has shared dma request) , send first 2 data if there is fifo or send first 1 data if there is no fifo*/
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
+        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+        */
+
+        /*Prepare the firt data*/
+        if (handle->bitsPerFrame > 8)
+        {
+            /* If it's the last word */
+            if (handle->remainingSendByteCount <= 2)
+            {
+                if (handle->txData)
+                {
+                    if (handle->isThereExtraByte)
+                    {
+                        wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
+                    }
+                    else
+                    {
+                        wordToSend = *(handle->txData);
+                        ++handle->txData; /* increment to next data byte */
+                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    }
+                }
+                else
+                {
+                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                }
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+            }
+            else /* For all words except the last word , frame > 8bits */
+            {
+                if (handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* increment to next data byte */
+                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    ++handle->txData; /* increment to next data byte */
+                }
+                else
+                {
+                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                }
+                handle->command = (handle->command & 0xffff0000U) | wordToSend;
+            }
+        }
+        else /* Optimized for bits/frame less than or equal to one byte. */
+        {
+            if (handle->txData)
+            {
+                wordToSend = *(handle->txData);
+                ++handle->txData; /* increment to next data word*/
+            }
+            else
+            {
+                wordToSend = dummyData;
+            }
+
+            if (handle->remainingSendByteCount == 1)
+            {
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+            }
+            else
+            {
+                handle->command = (handle->command & 0xffff0000U) | wordToSend;
+            }
+        }
+    }
+
+    else /*dspi has shared dma request*/
+
+    {
+        /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
+        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+        */
+
+        /* If bits/frame is greater than one byte */
+        if (handle->bitsPerFrame > 8)
+        {
+            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            {
+                if (handle->remainingSendByteCount <= 2)
+                {
+                    if (handle->txData)
+                    {
+                        if (handle->isThereExtraByte)
+                        {
+                            wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
+                        }
+                        else
+                        {
+                            wordToSend = *(handle->txData);
+                            ++handle->txData;
+                            wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        }
+                    }
+                    else
+                    {
+                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                        ;
+                    }
+                    handle->remainingSendByteCount = 0;
+                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                }
+                /* For all words except the last word */
+                else
+                {
+                    if (handle->txData)
+                    {
+                        wordToSend = *(handle->txData);
+                        ++handle->txData;
+                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        ++handle->txData;
+                    }
+                    else
+                    {
+                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                        ;
+                    }
+                    handle->remainingSendByteCount -= 2;
+                    base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
+                }
+
+                /* Try to clear the TFFF; if the TX FIFO is full this will clear */
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+                dataAlreadyFed += 2;
+
+                /* exit loop if send count is zero, else update local variables for next loop */
+                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                {
+                    break;
+                }
+            } /* End of TX FIFO fill while loop */
+        }
+        else /* Optimized for bits/frame less than or equal to one byte. */
+        {
+            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            {
+                if (handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData;
+                }
+                else
+                {
+                    wordToSend = dummyData;
+                }
+
+                if (handle->remainingSendByteCount == 1)
+                {
+                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                }
+                else
+                {
+                    base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
+                }
+
+                /* Try to clear the TFFF; if the TX FIFO is full this will clear */
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+                --handle->remainingSendByteCount;
+
+                dataAlreadyFed++;
+
+                /* exit loop if send count is zero, else update local variables for next loop */
+                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                {
+                    break;
+                }
+            } /* End of TX FIFO fill while loop */
+        }
+    }
+
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+
+    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcOffset = 0;
+
+    if (handle->rxData)
+    {
+        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destOffset = 1;
+    }
+    else
+    {
+        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destOffset = 0;
+    }
+
+    transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
+
+    if (handle->bitsPerFrame <= 8)
+    {
+        transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
+        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
+    }
+    else
+    {
+        transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
+        transferConfigA.minorLoopBytes = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+    }
+    EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                           &transferConfigA, NULL);
+    EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                 kEDMA_MajorInterruptEnable);
+
+    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
+    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
+    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
+    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
+
+    if (handle->remainingSendByteCount > 0)
+    {
+        if (handle->txData)
+        {
+            transferConfigB.srcAddr = (uint32_t)(handle->txData);
+            transferConfigB.srcOffset = 1;
+        }
+        else
+        {
+            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr = (uint32_t)(&handle->command);
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes = 1;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /*already prepared the first data in "intermediary" , so minus 1 */
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                majorlink , the majorlink would not trigger the channel_C*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
+            }
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes = 2;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /*already prepared the first data in "intermediary" , so minus 1 */
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
+            }
+        }
+
+        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
+    }
+
+    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
+    handle the last data */
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
+    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
+          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
+         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
+    {
+        if (handle->txData)
+        {
+            uint32_t bufferIndex = 0;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                if (handle->bitsPerFrame <= 8)
+                {
+                    bufferIndex = handle->remainingSendByteCount - 1;
+                }
+                else
+                {
+                    bufferIndex = handle->remainingSendByteCount - 2;
+                }
+            }
+            else
+            {
+                bufferIndex = handle->remainingSendByteCount;
+            }
+
+            if (handle->bitsPerFrame <= 8)
+            {
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+            }
+            else
+            {
+                if (handle->isThereExtraByte)
+                {
+                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 2] |
+                                          ((uint32_t)dummyData << 8);
+                }
+                else
+                {
+                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
+                                          ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
+                                          handle->txData[bufferIndex - 2];
+                }
+            }
+        }
+        else
+        {
+            if (handle->bitsPerFrame <= 8)
+            {
+                wordToSend = dummyData;
+            }
+            else
+            {
+                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+            }
+            handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+        }
+    }
+
+    if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
+        ((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+    {
+        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset = 0;
+        transferConfigC.destOffset = 0;
+        transferConfigC.minorLoopBytes = 4;
+        transferConfigC.majorLoopCounts = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+    }
+
+    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
+        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)))
+    {
+        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
+        transferConfigC.destAddr = (uint32_t)txAddr;
+
+        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset = 0;
+        transferConfigC.destOffset = 0;
+        transferConfigC.minorLoopBytes = 4;
+
+        if (handle->bitsPerFrame <= 8)
+        {
+            transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+        }
+        else
+        {
+            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+        }
+
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+        EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel, false);
+    }
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+    }
+
+    /*Start the EDMA channel_A , channel_B , channel_C transfer*/
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_StartTransfer(handle->edmaTxDataToIntermediaryHandle);
+    EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    /*Set channel priority*/
+    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
+    uint8_t t = 0;
+    if (channelPriorityLow > channelPriorityMid)
+    {
+        t = channelPriorityLow;
+        channelPriorityLow = channelPriorityMid;
+        channelPriorityMid = t;
+    }
+
+    if (channelPriorityLow > channelPriorityHigh)
+    {
+        t = channelPriorityLow;
+        channelPriorityLow = channelPriorityHigh;
+        channelPriorityHigh = t;
+    }
+
+    if (channelPriorityMid > channelPriorityHigh)
+    {
+        t = channelPriorityMid;
+        channelPriorityMid = channelPriorityHigh;
+        channelPriorityHigh = t;
+    }
+    edma_channel_Preemption_config_t preemption_config_t;
+    preemption_config_t.enableChannelPreemption = true;
+    preemption_config_t.enablePreemptAbility = true;
+    preemption_config_t.channelPriority = channelPriorityLow;
+
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityMid;
+        EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+    }
+    else
+    {
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityMid;
+        EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+    }
+
+    /*Set the channel link.
+    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
+    For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C -> channel_B . (so need prepare the first data in "intermediary"  before the DMA
+    transfer and then channel_B is used to prepare the next data to "intermediary" ) */
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
+        to prepare the next 32bits data (User_send_buffer to handle->command) */
+        if (handle->remainingSendByteCount > 1)
+        {
+            EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
+                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MinorLink,
+                                handle->edmaTxDataToIntermediaryHandle->channel);
+        }
+
+        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    }
+    else
+    {
+        if (handle->remainingSendByteCount > 0)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
+
+            if (handle->isThereExtraByte)
+            {
+                EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                    kEDMA_MajorLink, handle->edmaTxDataToIntermediaryHandle->channel);
+            }
+
+            EDMA_SetChannelLink(handle->edmaTxDataToIntermediaryHandle->base,
+                                handle->edmaTxDataToIntermediaryHandle->channel, kEDMA_MinorLink,
+                                handle->edmaIntermediaryToTxRegHandle->channel);
+        }
+
+        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+    }
+
+    DSPI_StartTransfer(base);
+
+    return kStatus_Success;
+}
+
+static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
+                                    void *g_dspiEdmaPrivateHandle,
+                                    bool transferDone,
+                                    uint32_t tcds)
+{
+    dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
+
+    dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
+
+    uint32_t dataReceived;
+
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
+    {
+        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
+        {
+        }
+        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
+        if (dspiEdmaPrivateHandle->handle->rxData)
+        {
+            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
+        }
+    }
+
+    if (dspiEdmaPrivateHandle->handle->callback)
+    {
+        dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
+                                                kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
+    }
+
+    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
+}
+
+void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
+{
+    DSPI_StopTransfer(base);
+
+    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
+    EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    handle->state = kDSPI_Idle;
+}
+
+status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Catch when there is not an active transfer. */
+    if (handle->state != kDSPI_Busy)
+    {
+        *count = 0;
+        return kStatus_NoTransferInProgress;
+    }
+
+    size_t bytes;
+
+    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+
+    *count = handle->totalByteCount - bytes;
+
+    return kStatus_Success;
+}
+
+void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
+                                        dspi_slave_edma_handle_t *handle,
+                                        dspi_slave_edma_transfer_callback_t callback,
+                                        void *userData,
+                                        edma_handle_t *edmaRxRegToRxDataHandle,
+                                        edma_handle_t *edmaTxDataToTxRegHandle)
+{
+    assert(handle);
+
+    /* Zero the handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    uint32_t instance = DSPI_GetInstance(base);
+
+    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+
+    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
+}
+
+status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
+{
+    assert(handle && transfer);
+
+    /* If send/receive length is zero */
+    if (transfer->dataSize == 0)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* If both send buffer and receive buffer is null */
+    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Check that we're not busy.*/
+    if (handle->state == kDSPI_Busy)
+    {
+        return kStatus_DSPI_Busy;
+    }
+
+    edma_tcd_t *softwareTCD = (edma_tcd_t *)((uint32_t)(&handle->dspiSoftwareTCD[1]) & (~0x1FU));
+
+    uint32_t instance = DSPI_GetInstance(base);
+    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    handle->bitsPerFrame =
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+
+    /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
+    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+    */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        if (handle->bitsPerFrame > 8)
+        {
+            if (transfer->dataSize > 1022)
+            {
+                return kStatus_DSPI_OutOfRange;
+            }
+        }
+        else
+        {
+            if (transfer->dataSize > 511)
+            {
+                return kStatus_DSPI_OutOfRange;
+            }
+        }
+    }
+
+    if ((handle->bitsPerFrame > 8) && (transfer->dataSize < 2))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
+
+    handle->state = kDSPI_Busy;
+
+    /* Store transfer information */
+    handle->txData = transfer->txData;
+    handle->rxData = transfer->rxData;
+    handle->remainingSendByteCount = transfer->dataSize;
+    handle->remainingReceiveByteCount = transfer->dataSize;
+    handle->totalByteCount = transfer->dataSize;
+    handle->errorCount = 0;
+
+    handle->isThereExtraByte = false;
+    if (handle->bitsPerFrame > 8)
+    {
+        if (handle->remainingSendByteCount % 2 == 1)
+        {
+            handle->remainingSendByteCount++;
+            handle->remainingReceiveByteCount--;
+            handle->isThereExtraByte = true;
+        }
+    }
+
+    uint16_t wordToSend = 0;
+    uint8_t dummyData = DSPI_SLAVE_DUMMY_DATA;
+    uint8_t dataAlreadyFed = 0;
+    uint8_t dataFedMax = 2;
+
+    uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
+    uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
+
+    edma_transfer_config_t transferConfigA;
+    edma_transfer_config_t transferConfigC;
+
+    DSPI_StopTransfer(base);
+
+    DSPI_FlushFifo(base, true, true);
+    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+
+    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    DSPI_StartTransfer(base);
+
+    /*if dspi has separate dma request , need not prepare data first .
+    else (dspi has shared dma request) , send first 2 data into fifo if there is fifo or send first 1 data to
+    slaveGetTxRegister if there is no fifo*/
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
+        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+        */
+        /* If bits/frame is greater than one byte */
+        if (handle->bitsPerFrame > 8)
+        {
+            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            {
+                if (handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* Increment to next data byte */
+                    if ((handle->remainingSendByteCount == 2) && (handle->isThereExtraByte))
+                    {
+                        wordToSend |= (unsigned)(dummyData) << 8U;
+                        ++handle->txData; /* Increment to next data byte */
+                    }
+                    else
+                    {
+                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        ++handle->txData; /* Increment to next data byte */
+                    }
+                }
+                else
+                {
+                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                }
+                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                base->PUSHR_SLAVE = wordToSend;
+
+                /* Try to clear the TFFF; if the TX FIFO is full this will clear */
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+
+                dataAlreadyFed += 2;
+
+                /* Exit loop if send count is zero, else update local variables for next loop */
+                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                {
+                    break;
+                }
+            } /* End of TX FIFO fill while loop */
+        }
+        else /* Optimized for bits/frame less than or equal to one byte. */
+        {
+            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            {
+                if (handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    /* Increment to next data word*/
+                    ++handle->txData;
+                }
+                else
+                {
+                    wordToSend = dummyData;
+                }
+
+                base->PUSHR_SLAVE = wordToSend;
+
+                /* Try to clear the TFFF; if the TX FIFO is full this will clear */
+                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                /* Decrement remainingSendByteCount*/
+                --handle->remainingSendByteCount;
+
+                dataAlreadyFed++;
+
+                /* Exit loop if send count is zero, else update local variables for next loop */
+                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                {
+                    break;
+                }
+            } /* End of TX FIFO fill while loop */
+        }
+    }
+
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    if (handle->remainingReceiveByteCount > 0)
+    {
+        EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+
+        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcOffset = 0;
+
+        if (handle->rxData)
+        {
+            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destOffset = 1;
+        }
+        else
+        {
+            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destOffset = 0;
+        }
+
+        transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8)
+        {
+            transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
+        }
+        else
+        {
+            transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigA.minorLoopBytes = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        }
+        EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                               &transferConfigA, NULL);
+        EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                     kEDMA_MajorInterruptEnable);
+    }
+
+    if (handle->remainingSendByteCount > 0)
+    {
+        /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
+        EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
+
+        /*If there is extra byte , it would use the */
+        if (handle->isThereExtraByte)
+        {
+            if (handle->txData)
+            {
+                handle->txLastData =
+                    handle->txData[handle->remainingSendByteCount - 2] | ((uint32_t)DSPI_SLAVE_DUMMY_DATA << 8);
+            }
+            else
+            {
+                handle->txLastData = DSPI_SLAVE_DUMMY_DATA | ((uint32_t)DSPI_SLAVE_DUMMY_DATA << 8);
+            }
+            transferConfigC.srcAddr = (uint32_t)(&(handle->txLastData));
+            transferConfigC.destAddr = (uint32_t)txAddr;
+            transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
+            transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+            transferConfigC.srcOffset = 0;
+            transferConfigC.destOffset = 0;
+            transferConfigC.minorLoopBytes = 4;
+            transferConfigC.majorLoopCounts = 1;
+
+            EDMA_TcdReset(softwareTCD);
+            EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        }
+
+        /*Set another  transferConfigC*/
+        if ((handle->isThereExtraByte) && (handle->remainingSendByteCount == 2))
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                                   &transferConfigC, NULL);
+        }
+        else
+        {
+            transferConfigC.destAddr = (uint32_t)txAddr;
+            transferConfigC.destOffset = 0;
+
+            if (handle->txData)
+            {
+                transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
+                transferConfigC.srcOffset = 1;
+            }
+            else
+            {
+                transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
+                transferConfigC.srcOffset = 0;
+                if (handle->bitsPerFrame <= 8)
+                {
+                    handle->txBuffIfNull = DSPI_SLAVE_DUMMY_DATA;
+                }
+                else
+                {
+                    handle->txBuffIfNull = (DSPI_SLAVE_DUMMY_DATA << 8) | DSPI_SLAVE_DUMMY_DATA;
+                }
+            }
+
+            transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+            if (handle->bitsPerFrame <= 8)
+            {
+                transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
+                transferConfigC.minorLoopBytes = 1;
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
+            }
+            else
+            {
+                transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
+                transferConfigC.minorLoopBytes = 2;
+                if (handle->isThereExtraByte)
+                {
+                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+                }
+                else
+                {
+                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
+                }
+            }
+
+            if (handle->isThereExtraByte)
+            {
+                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                                       &transferConfigC, softwareTCD);
+                EDMA_EnableAutoStopRequest(handle->edmaTxDataToTxRegHandle->base,
+                                           handle->edmaTxDataToTxRegHandle->channel, false);
+            }
+            else
+            {
+                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                                       &transferConfigC, NULL);
+            }
+
+            EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
+        }
+    }
+
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+
+    /*Set channel priority*/
+    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
+    uint8_t t = 0;
+
+    if (channelPriorityLow > channelPriorityHigh)
+    {
+        t = channelPriorityLow;
+        channelPriorityLow = channelPriorityHigh;
+        channelPriorityHigh = t;
+    }
+
+    edma_channel_Preemption_config_t preemption_config_t;
+    preemption_config_t.enableChannelPreemption = true;
+    preemption_config_t.enablePreemptAbility = true;
+    preemption_config_t.channelPriority = channelPriorityLow;
+
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                                        &preemption_config_t);
+    }
+    else
+    {
+        EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+    }
+
+    /*Set the channel link.
+    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_C.
+    For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        if (handle->remainingSendByteCount > 0)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
+        }
+        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+    }
+    else
+    {
+        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    }
+
+    return kStatus_Success;
+}
+
+static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
+                                   void *g_dspiEdmaPrivateHandle,
+                                   bool transferDone,
+                                   uint32_t tcds)
+{
+    dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
+
+    dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
+
+    uint32_t dataReceived;
+
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
+    {
+        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
+        {
+        }
+        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
+        if (dspiEdmaPrivateHandle->handle->rxData)
+        {
+            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
+        }
+    }
+
+    if (dspiEdmaPrivateHandle->handle->callback)
+    {
+        dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
+                                                kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
+    }
+
+    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
+}
+
+void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
+{
+    DSPI_StopTransfer(base);
+
+    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
+
+    handle->state = kDSPI_Idle;
+}
+
+status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Catch when there is not an active transfer. */
+    if (handle->state != kDSPI_Busy)
+    {
+        *count = 0;
+        return kStatus_NoTransferInProgress;
+    }
+
+    size_t bytes;
+
+    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+
+    *count = handle->totalByteCount - bytes;
+
+    return kStatus_Success;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi_edma.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_dspi_edma.h
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_DSPI_EDMA_H_
+#define _FSL_DSPI_EDMA_H_
+
+#include "fsl_dspi.h"
+#include "fsl_edma.h"
+/*!
+ * @addtogroup dspi_edma_driver
+ * @{
+ */
+
+/*! @file */
+
+/***********************************************************************************************************************
+ * Definitions
+ **********************************************************************************************************************/
+
+/*!
+* @brief Forward declaration of the DSPI eDMA master handle typedefs.
+*/
+typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
+
+/*!
+* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+*/
+typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
+
+/*!
+ * @brief Completion callback function pointer type.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle Pointer to the handle for the DSPI master.
+ * @param status Success or error code describing whether the transfer completed.
+ * @param userData Arbitrary pointer-dataSized value passed from the application.
+ */
+typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
+                                                     dspi_master_edma_handle_t *handle,
+                                                     status_t status,
+                                                     void *userData);
+/*!
+ * @brief Completion callback function pointer type.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle Pointer to the handle for the DSPI slave.
+ * @param status Success or error code describing whether the transfer completed.
+ * @param userData Arbitrary pointer-dataSized value passed from the application.
+ */
+typedef void (*dspi_slave_edma_transfer_callback_t)(SPI_Type *base,
+                                                    dspi_slave_edma_handle_t *handle,
+                                                    status_t status,
+                                                    void *userData);
+
+/*! @brief DSPI master eDMA transfer handle structure used for transactional API. */
+struct _dspi_master_edma_handle
+{
+    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
+    volatile uint32_t command;     /*!< Desired data command. */
+    volatile uint32_t lastCommand; /*!< Desired last data command. */
+
+    uint8_t fifoSize; /*!< FIFO dataSize. */
+
+    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
+    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+
+    uint8_t *volatile txData;                  /*!< Send buffer. */
+    uint8_t *volatile rxData;                  /*!< Receive buffer. */
+    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+
+    uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
+    uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
+
+    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
+
+    dspi_master_edma_transfer_callback_t callback; /*!< Completion callback. */
+    void *userData;                                /*!< Callback user data. */
+
+    edma_handle_t *edmaRxRegToRxDataHandle;        /*!<edma_handle_t handle point used for RxReg to RxData buff*/
+    edma_handle_t *edmaTxDataToIntermediaryHandle; /*!<edma_handle_t handle point used for TxData to Intermediary*/
+    edma_handle_t *edmaIntermediaryToTxRegHandle;  /*!<edma_handle_t handle point used for Intermediary to TxReg*/
+
+    edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
+};
+
+/*! @brief DSPI slave eDMA transfer handle structure used for transactional API.*/
+struct _dspi_slave_edma_handle
+{
+    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
+    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+
+    uint8_t *volatile txData;                  /*!< Send buffer. */
+    uint8_t *volatile rxData;                  /*!< Receive buffer. */
+    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+
+    uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
+    uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
+    uint32_t txLastData;   /*!< Used if there is an extra byte when 16bits per frame for DMA purpose.*/
+
+    volatile uint8_t state; /*!< DSPI transfer state.*/
+
+    uint32_t errorCount; /*!< Error count for slave transfer.*/
+
+    dspi_slave_edma_transfer_callback_t callback; /*!< Completion callback. */
+    void *userData;                               /*!< Callback user data. */
+
+    edma_handle_t *edmaRxRegToRxDataHandle; /*!<edma_handle_t handle point used for RxReg to RxData buff*/
+    edma_handle_t *edmaTxDataToTxRegHandle; /*!<edma_handle_t handle point used for TxData to TxReg*/
+
+    edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
+};
+
+/***********************************************************************************************************************
+ * API
+ **********************************************************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /*_cplusplus*/
+
+/*Transactional APIs*/
+
+/*!
+ * @brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, user need only call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2)For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * @param callback DSPI callback.
+ * @param userData callback function parameter.
+ * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * @param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * @param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
+void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
+                                         dspi_master_edma_handle_t *handle,
+                                         dspi_master_edma_transfer_callback_t callback,
+                                         void *userData,
+                                         edma_handle_t *edmaRxRegToRxDataHandle,
+                                         edma_handle_t *edmaTxDataToIntermediaryHandle,
+                                         edma_handle_t *edmaIntermediaryToTxRegHandle);
+
+/*!
+ * @brief DSPI master transfer data using eDMA.
+ *
+ * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
+ * have been transfer, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer pointer to dspi_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief DSPI master aborts a transfer which using eDMA.
+ *
+ * This function aborts a transfer which using eDMA.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ */
+void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle);
+
+/*!
+ * @brief Gets the master eDMA transfer count.
+ *
+ * This function get the master eDMA transfer count.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * @param callback DSPI callback.
+ * @param userData callback function parameter.
+ * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * @param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
+void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
+                                        dspi_slave_edma_handle_t *handle,
+                                        dspi_slave_edma_transfer_callback_t callback,
+                                        void *userData,
+                                        edma_handle_t *edmaRxRegToRxDataHandle,
+                                        edma_handle_t *edmaTxDataToTxRegHandle);
+
+/*!
+ * @brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
+ * have been transfer, the callback function is called.
+ * Note that slave EDMA transfer cannot support the situation that transfer_size is 1 when the bitsPerFrame is greater
+ * than 8 .
+
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param transfer pointer to dspi_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief DSPI slave aborts a transfer which using eDMA.
+ *
+ * This function aborts a transfer which using eDMA.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
+void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle);
+
+/*!
+ * @brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @return status of status_t.
+ */
+status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count);
+
+#if defined(__cplusplus)
+}
+#endif /*_cplusplus*/
+       /*!
+        *@}
+        */
+
+#endif /*_FSL_DSPI_EDMA_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_edma.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_edma.c
@@ -1,0 +1,1313 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fsl_edma.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+#define EDMA_TRANSFER_ENABLED_MASK 0x80U
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get instance number for EDMA.
+ *
+ * @param base EDMA peripheral base address.
+ */
+static uint32_t EDMA_GetInstance(DMA_Type *base);
+
+/*!
+ * @brief Push content of TCD structure into hardware TCD register.
+ *
+ * @param base EDMA peripheral base address.
+ * @param channel EDMA channel number.
+ * @param tcd Point to TCD structure.
+ */
+static void EDMA_InstallTCD(DMA_Type *base, uint32_t channel, edma_tcd_t *tcd);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Array to map EDMA instance number to base pointer. */
+static DMA_Type *const s_edmaBases[] = DMA_BASE_PTRS;
+
+/*! @brief Array to map EDMA instance number to clock name. */
+static const clock_ip_name_t s_edmaClockName[] = EDMA_CLOCKS;
+
+/*! @brief Array to map EDMA instance number to IRQ number. */
+static const IRQn_Type s_edmaIRQNumber[] = DMA_CHN_IRQS;
+
+/*! @brief Pointers to transfer handle for each EDMA channel. */
+static edma_handle_t *s_EDMAHandle[FSL_FEATURE_EDMA_MODULE_CHANNEL * FSL_FEATURE_SOC_EDMA_COUNT];
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t EDMA_GetInstance(DMA_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_EDMA_COUNT; instance++)
+    {
+        if (s_edmaBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_EDMA_COUNT);
+
+    return instance;
+}
+
+static void EDMA_InstallTCD(DMA_Type *base, uint32_t channel, edma_tcd_t *tcd)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+
+    /* Push tcd into hardware TCD register */
+    base->TCD[channel].SADDR = tcd->SADDR;
+    base->TCD[channel].SOFF = tcd->SOFF;
+    base->TCD[channel].ATTR = tcd->ATTR;
+    base->TCD[channel].NBYTES_MLNO = tcd->NBYTES;
+    base->TCD[channel].SLAST = tcd->SLAST;
+    base->TCD[channel].DADDR = tcd->DADDR;
+    base->TCD[channel].DOFF = tcd->DOFF;
+    base->TCD[channel].CITER_ELINKNO = tcd->CITER;
+    base->TCD[channel].DLAST_SGA = tcd->DLAST_SGA;
+    /* Clear DONE bit first, otherwise ESG cannot be set */
+    base->TCD[channel].CSR = 0;
+    base->TCD[channel].CSR = tcd->CSR;
+    base->TCD[channel].BITER_ELINKNO = tcd->BITER;
+}
+
+void EDMA_Init(DMA_Type *base, const edma_config_t *config)
+{
+    assert(config != NULL);
+
+    uint32_t tmpreg;
+
+    /* Ungate EDMA periphral clock */
+    CLOCK_EnableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+    /* Configure EDMA peripheral according to the configuration structure. */
+    tmpreg = base->CR;
+    tmpreg &= ~(DMA_CR_ERCA_MASK | DMA_CR_HOE_MASK | DMA_CR_CLM_MASK | DMA_CR_EDBG_MASK);
+    tmpreg |= (DMA_CR_ERCA(config->enableRoundRobinArbitration) | DMA_CR_HOE(config->enableHaltOnError) |
+               DMA_CR_CLM(config->enableContinuousLinkMode) | DMA_CR_EDBG(config->enableDebugMode) | DMA_CR_EMLM(true));
+    base->CR = tmpreg;
+}
+
+void EDMA_Deinit(DMA_Type *base)
+{
+    /* Gate EDMA periphral clock */
+    CLOCK_DisableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+}
+
+void EDMA_GetDefaultConfig(edma_config_t *config)
+{
+    assert(config != NULL);
+
+    config->enableRoundRobinArbitration = false;
+    config->enableHaltOnError = true;
+    config->enableContinuousLinkMode = false;
+    config->enableDebugMode = false;
+}
+
+void EDMA_ResetChannel(DMA_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    EDMA_TcdReset((edma_tcd_t *)&base->TCD[channel]);
+}
+
+void EDMA_SetTransferConfig(DMA_Type *base, uint32_t channel, const edma_transfer_config_t *config, edma_tcd_t *nextTcd)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+    assert(config != NULL);
+    assert(((uint32_t)nextTcd & 0x1FU) == 0);
+
+    EDMA_TcdSetTransferConfig((edma_tcd_t *)&base->TCD[channel], config, nextTcd);
+}
+
+void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_minor_offset_config_t *config)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+    assert(config != NULL);
+
+    uint32_t tmpreg;
+
+    tmpreg = base->TCD[channel].NBYTES_MLOFFYES;
+    tmpreg &= ~(DMA_NBYTES_MLOFFYES_SMLOE_MASK | DMA_NBYTES_MLOFFYES_DMLOE_MASK | DMA_NBYTES_MLOFFYES_MLOFF_MASK);
+    tmpreg |=
+        (DMA_NBYTES_MLOFFYES_SMLOE(config->enableSrcMinorOffset) |
+         DMA_NBYTES_MLOFFYES_DMLOE(config->enableDestMinorOffset) | DMA_NBYTES_MLOFFYES_MLOFF(config->minorOffset));
+    base->TCD[channel].NBYTES_MLOFFYES = tmpreg;
+}
+
+void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_type_t type, uint32_t linkedChannel)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+    assert(linkedChannel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    EDMA_TcdSetChannelLink((edma_tcd_t *)&base->TCD[channel], type, linkedChannel);
+}
+
+void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWidth)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    base->TCD[channel].CSR = (base->TCD[channel].CSR & (~DMA_CSR_BWC_MASK)) | DMA_CSR_BWC(bandWidth);
+}
+
+void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, edma_modulo_t destModulo)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    uint32_t tmpreg;
+
+    tmpreg = base->TCD[channel].ATTR & (~(DMA_ATTR_SMOD_MASK | DMA_ATTR_DMOD_MASK));
+    base->TCD[channel].ATTR = tmpreg | DMA_ATTR_DMOD(destModulo) | DMA_ATTR_SMOD(srcModulo);
+}
+
+void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    /* Enable error interrupt */
+    if (mask & kEDMA_ErrorInterruptEnable)
+    {
+        base->EEI |= (0x1U << channel);
+    }
+
+    /* Enable Major interrupt */
+    if (mask & kEDMA_MajorInterruptEnable)
+    {
+        base->TCD[channel].CSR |= DMA_CSR_INTMAJOR_MASK;
+    }
+
+    /* Enable Half major interrupt */
+    if (mask & kEDMA_HalfInterruptEnable)
+    {
+        base->TCD[channel].CSR |= DMA_CSR_INTHALF_MASK;
+    }
+}
+
+void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    /* Disable error interrupt */
+    if (mask & kEDMA_ErrorInterruptEnable)
+    {
+        base->EEI &= ~(0x1U << channel);
+    }
+
+    /* Disable Major interrupt */
+    if (mask & kEDMA_MajorInterruptEnable)
+    {
+        base->TCD[channel].CSR &= ~DMA_CSR_INTMAJOR_MASK;
+    }
+
+    /* Disable Half major interrupt */
+    if (mask & kEDMA_HalfInterruptEnable)
+    {
+        base->TCD[channel].CSR &= ~DMA_CSR_INTHALF_MASK;
+    }
+}
+
+void EDMA_TcdReset(edma_tcd_t *tcd)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+
+    /* Reset channel TCD */
+    tcd->SADDR = 0U;
+    tcd->SOFF = 0U;
+    tcd->ATTR = 0U;
+    tcd->NBYTES = 0U;
+    tcd->SLAST = 0U;
+    tcd->DADDR = 0U;
+    tcd->DOFF = 0U;
+    tcd->CITER = 0U;
+    tcd->DLAST_SGA = 0U;
+    /* Enable auto disable request feature */
+    tcd->CSR = DMA_CSR_DREQ(true);
+    tcd->BITER = 0U;
+}
+
+void EDMA_TcdSetTransferConfig(edma_tcd_t *tcd, const edma_transfer_config_t *config, edma_tcd_t *nextTcd)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+    assert(config != NULL);
+    assert(((uint32_t)nextTcd & 0x1FU) == 0);
+
+    /* source address */
+    tcd->SADDR = config->srcAddr;
+    /* destination address */
+    tcd->DADDR = config->destAddr;
+    /* Source data and destination data transfer size */
+    tcd->ATTR = DMA_ATTR_SSIZE(config->srcTransferSize) | DMA_ATTR_DSIZE(config->destTransferSize);
+    /* Source address signed offset */
+    tcd->SOFF = config->srcOffset;
+    /* Destination address signed offset */
+    tcd->DOFF = config->destOffset;
+    /* Minor byte transfer count */
+    tcd->NBYTES = config->minorLoopBytes;
+    /* Current major iteration count */
+    tcd->CITER = config->majorLoopCounts;
+    /* Starting major iteration count */
+    tcd->BITER = config->majorLoopCounts;
+    /* Enable scatter/gather processing */
+    if (nextTcd != NULL)
+    {
+        tcd->DLAST_SGA = (uint32_t)nextTcd;
+        /*
+            Before call EDMA_TcdSetTransferConfig or EDMA_SetTransferConfig,
+            user must call EDMA_TcdReset or EDMA_ResetChannel which will set
+            DREQ, so must use "|" or "&" rather than "=".
+
+            Clear the DREQ bit because scatter gather has been enabled, so the
+            previous transfer is not the last transfer, and channel request should
+            be enabled at the next transfer(the next TCD).
+        */
+        tcd->CSR = (tcd->CSR | DMA_CSR_ESG_MASK) & ~DMA_CSR_DREQ_MASK;
+    }
+}
+
+void EDMA_TcdSetMinorOffsetConfig(edma_tcd_t *tcd, const edma_minor_offset_config_t *config)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+
+    uint32_t tmpreg;
+
+    tmpreg = tcd->NBYTES &
+             ~(DMA_NBYTES_MLOFFYES_SMLOE_MASK | DMA_NBYTES_MLOFFYES_DMLOE_MASK | DMA_NBYTES_MLOFFYES_MLOFF_MASK);
+    tmpreg |=
+        (DMA_NBYTES_MLOFFYES_SMLOE(config->enableSrcMinorOffset) |
+         DMA_NBYTES_MLOFFYES_DMLOE(config->enableDestMinorOffset) | DMA_NBYTES_MLOFFYES_MLOFF(config->minorOffset));
+    tcd->NBYTES = tmpreg;
+}
+
+void EDMA_TcdSetChannelLink(edma_tcd_t *tcd, edma_channel_link_type_t type, uint32_t linkedChannel)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+    assert(linkedChannel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    if (type == kEDMA_MinorLink) /* Minor link config */
+    {
+        uint32_t tmpreg;
+
+        /* Enable minor link */
+        tcd->CITER |= DMA_CITER_ELINKYES_ELINK_MASK;
+        tcd->BITER |= DMA_BITER_ELINKYES_ELINK_MASK;
+        /* Set likned channel */
+        tmpreg = tcd->CITER & (~DMA_CITER_ELINKYES_LINKCH_MASK);
+        tmpreg |= DMA_CITER_ELINKYES_LINKCH(linkedChannel);
+        tcd->CITER = tmpreg;
+        tmpreg = tcd->BITER & (~DMA_BITER_ELINKYES_LINKCH_MASK);
+        tmpreg |= DMA_BITER_ELINKYES_LINKCH(linkedChannel);
+        tcd->BITER = tmpreg;
+    }
+    else if (type == kEDMA_MajorLink) /* Major link config */
+    {
+        uint32_t tmpreg;
+
+        /* Enable major link */
+        tcd->CSR |= DMA_CSR_MAJORELINK_MASK;
+        /* Set major linked channel */
+        tmpreg = tcd->CSR & (~DMA_CSR_MAJORLINKCH_MASK);
+        tcd->CSR = tmpreg | DMA_CSR_MAJORLINKCH(linkedChannel);
+    }
+    else /* Link none */
+    {
+        tcd->CITER &= ~DMA_CITER_ELINKYES_ELINK_MASK;
+        tcd->BITER &= ~DMA_BITER_ELINKYES_ELINK_MASK;
+        tcd->CSR &= ~DMA_CSR_MAJORELINK_MASK;
+    }
+}
+
+void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t destModulo)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+
+    uint32_t tmpreg;
+
+    tmpreg = tcd->ATTR & (~(DMA_ATTR_SMOD_MASK | DMA_ATTR_DMOD_MASK));
+    tcd->ATTR = tmpreg | DMA_ATTR_DMOD(destModulo) | DMA_ATTR_SMOD(srcModulo);
+}
+
+void EDMA_TcdEnableInterrupts(edma_tcd_t *tcd, uint32_t mask)
+{
+    assert(tcd != NULL);
+
+    /* Enable Major interrupt */
+    if (mask & kEDMA_MajorInterruptEnable)
+    {
+        tcd->CSR |= DMA_CSR_INTMAJOR_MASK;
+    }
+
+    /* Enable Half major interrupt */
+    if (mask & kEDMA_HalfInterruptEnable)
+    {
+        tcd->CSR |= DMA_CSR_INTHALF_MASK;
+    }
+}
+
+void EDMA_TcdDisableInterrupts(edma_tcd_t *tcd, uint32_t mask)
+{
+    assert(tcd != NULL);
+
+    /* Disable Major interrupt */
+    if (mask & kEDMA_MajorInterruptEnable)
+    {
+        tcd->CSR &= ~DMA_CSR_INTMAJOR_MASK;
+    }
+
+    /* Disable Half major interrupt */
+    if (mask & kEDMA_HalfInterruptEnable)
+    {
+        tcd->CSR &= ~DMA_CSR_INTHALF_MASK;
+    }
+}
+
+uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    uint32_t nbytes = 0;
+    uint32_t remainingBytes = 0;
+
+    if (DMA_CSR_DONE_MASK & base->TCD[channel].CSR)
+    {
+        remainingBytes = 0;
+    }
+    else
+    {
+        /* Calculate the nbytes */
+        if (base->TCD[channel].NBYTES_MLOFFYES & (DMA_NBYTES_MLOFFYES_SMLOE_MASK | DMA_NBYTES_MLOFFYES_DMLOE_MASK))
+        {
+            nbytes = (base->TCD[channel].NBYTES_MLOFFYES & DMA_NBYTES_MLOFFYES_NBYTES_MASK) >>
+                     DMA_NBYTES_MLOFFYES_NBYTES_SHIFT;
+        }
+        else
+        {
+            nbytes =
+                (base->TCD[channel].NBYTES_MLOFFNO & DMA_NBYTES_MLOFFNO_NBYTES_MASK) >> DMA_NBYTES_MLOFFNO_NBYTES_SHIFT;
+        }
+        /* Calculate the unfinished bytes */
+        if (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_ELINK_MASK)
+        {
+            remainingBytes = ((base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >>
+                              DMA_CITER_ELINKYES_CITER_SHIFT) *
+                             nbytes;
+        }
+        else
+        {
+            remainingBytes =
+                ((base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT) *
+                nbytes;
+        }
+    }
+
+    return remainingBytes;
+}
+
+uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    uint32_t retval = 0;
+
+    /* Get DONE bit flag */
+    retval |= ((base->TCD[channel].CSR & DMA_CSR_DONE_MASK) >> DMA_CSR_DONE_SHIFT);
+    /* Get ERROR bit flag */
+    retval |= (((base->ERR >> channel) & 0x1U) << 1U);
+    /* Get INT bit flag */
+    retval |= (((base->INT >> channel) & 0x1U) << 2U);
+
+    return retval;
+}
+
+void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mask)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    /* Clear DONE bit flag */
+    if (mask & kEDMA_DoneFlag)
+    {
+        base->CDNE = channel;
+    }
+    /* Clear ERROR bit flag */
+    if (mask & kEDMA_ErrorFlag)
+    {
+        base->CERR = channel;
+    }
+    /* Clear INT bit flag */
+    if (mask & kEDMA_InterruptFlag)
+    {
+        base->CINT = channel;
+    }
+}
+
+void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel)
+{
+    assert(handle != NULL);
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+
+    uint32_t edmaInstance;
+    uint32_t channelIndex;
+    edma_tcd_t *tcdRegs;
+
+    handle->base = base;
+    handle->channel = channel;
+    /* Get the DMA instance number */
+    edmaInstance = EDMA_GetInstance(base);
+    channelIndex = (edmaInstance * FSL_FEATURE_EDMA_MODULE_CHANNEL) + channel;
+    s_EDMAHandle[channelIndex] = handle;
+    /* Enable NVIC interrupt */
+    EnableIRQ(s_edmaIRQNumber[channelIndex]);
+    /*
+       Reset TCD registers to zero. Unlike the EDMA_TcdReset(DREQ will be set),
+       CSR will be 0. Because in order to suit EDMA busy check mechanism in
+       EDMA_SubmitTransfer, CSR must be set 0.
+    */
+    tcdRegs = (edma_tcd_t *)&handle->base->TCD[handle->channel];
+    tcdRegs->SADDR = 0;
+    tcdRegs->SOFF = 0;
+    tcdRegs->ATTR = 0;
+    tcdRegs->NBYTES = 0;
+    tcdRegs->SLAST = 0;
+    tcdRegs->DADDR = 0;
+    tcdRegs->DOFF = 0;
+    tcdRegs->CITER = 0;
+    tcdRegs->DLAST_SGA = 0;
+    tcdRegs->CSR = 0;
+    tcdRegs->BITER = 0;
+}
+
+void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t tcdSize)
+{
+    assert(handle != NULL);
+    assert(((uint32_t)tcdPool & 0x1FU) == 0);
+
+    /* Initialize tcd queue attibute. */
+    handle->header = 0;
+    handle->tail = 0;
+    handle->tcdUsed = 0;
+    handle->tcdSize = tcdSize;
+    handle->flags = 0;
+    handle->tcdPool = tcdPool;
+}
+
+void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userData)
+{
+    assert(handle != NULL);
+
+    handle->callback = callback;
+    handle->userData = userData;
+}
+
+void EDMA_PrepareTransfer(edma_transfer_config_t *config,
+                          void *srcAddr,
+                          uint32_t srcWidth,
+                          void *destAddr,
+                          uint32_t destWidth,
+                          uint32_t bytesEachRequest,
+                          uint32_t transferBytes,
+                          edma_transfer_type_t type)
+{
+    assert(config != NULL);
+    assert(srcAddr != NULL);
+    assert(destAddr != NULL);
+    assert(srcWidth == 1U || srcWidth == 2U || srcWidth == 4U || srcWidth == 16U || srcWidth == 32U);
+    assert(destWidth == 1U || destWidth == 2U || destWidth == 4U || destWidth == 16U || destWidth == 32U);
+    assert(transferBytes % bytesEachRequest == 0);
+
+    config->destAddr = (uint32_t)destAddr;
+    config->srcAddr = (uint32_t)srcAddr;
+    config->minorLoopBytes = bytesEachRequest;
+    config->majorLoopCounts = transferBytes / bytesEachRequest;
+    switch (srcWidth)
+    {
+        case 1U:
+            config->srcTransferSize = kEDMA_TransferSize1Bytes;
+            break;
+        case 2U:
+            config->srcTransferSize = kEDMA_TransferSize2Bytes;
+            break;
+        case 4U:
+            config->srcTransferSize = kEDMA_TransferSize4Bytes;
+            break;
+        case 16U:
+            config->srcTransferSize = kEDMA_TransferSize16Bytes;
+            break;
+        case 32U:
+            config->srcTransferSize = kEDMA_TransferSize32Bytes;
+            break;
+        default:
+            break;
+    }
+    switch (destWidth)
+    {
+        case 1U:
+            config->destTransferSize = kEDMA_TransferSize1Bytes;
+            break;
+        case 2U:
+            config->destTransferSize = kEDMA_TransferSize2Bytes;
+            break;
+        case 4U:
+            config->destTransferSize = kEDMA_TransferSize4Bytes;
+            break;
+        case 16U:
+            config->destTransferSize = kEDMA_TransferSize16Bytes;
+            break;
+        case 32U:
+            config->destTransferSize = kEDMA_TransferSize32Bytes;
+            break;
+        default:
+            break;
+    }
+    switch (type)
+    {
+        case kEDMA_MemoryToMemory:
+            config->destOffset = destWidth;
+            config->srcOffset = srcWidth;
+            break;
+        case kEDMA_MemoryToPeripheral:
+            config->destOffset = 0U;
+            config->srcOffset = srcWidth;
+            break;
+        case kEDMA_PeripheralToMemory:
+            config->destOffset = destWidth;
+            config->srcOffset = 0U;
+            break;
+        default:
+            break;
+    }
+}
+
+status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t *config)
+{
+    assert(handle != NULL);
+    assert(config != NULL);
+
+    edma_tcd_t *tcdRegs = (edma_tcd_t *)&handle->base->TCD[handle->channel];
+
+    if (handle->tcdPool == NULL)
+    {
+        /*
+            Check if EDMA is busy: if the given channel started transfer, CSR will be not zero. Because
+            if it is the last transfer, DREQ will be set. If not, ESG will be set. So in order to suit
+            this check mechanism, EDMA_CreatHandle will clear CSR register.
+        */
+        if ((tcdRegs->CSR != 0) && ((tcdRegs->CSR & DMA_CSR_DONE_MASK) == 0))
+        {
+            return kStatus_EDMA_Busy;
+        }
+        else
+        {
+            EDMA_SetTransferConfig(handle->base, handle->channel, config, NULL);
+            /* Enable auto disable request feature */
+            handle->base->TCD[handle->channel].CSR |= DMA_CSR_DREQ_MASK;
+            /* Enable major interrupt */
+            handle->base->TCD[handle->channel].CSR |= DMA_CSR_INTMAJOR_MASK;
+
+            return kStatus_Success;
+        }
+    }
+    else /* Use the TCD queue. */
+    {
+        uint32_t primask;
+        uint32_t csr;
+        int8_t currentTcd;
+        int8_t previousTcd;
+        int8_t nextTcd;
+
+        /* Check if tcd pool is full. */
+        primask = DisableGlobalIRQ();
+        if (handle->tcdUsed >= handle->tcdSize)
+        {
+            EnableGlobalIRQ(primask);
+
+            return kStatus_EDMA_QueueFull;
+        }
+        currentTcd = handle->tail;
+        handle->tcdUsed++;
+        /* Calculate index of next TCD */
+        nextTcd = currentTcd + 1U;
+        if (nextTcd == handle->tcdSize)
+        {
+            nextTcd = 0U;
+        }
+        /* Advance queue tail index */
+        handle->tail = nextTcd;
+        EnableGlobalIRQ(primask);
+        /* Calculate index of previous TCD */
+        previousTcd = currentTcd ? currentTcd - 1U : handle->tcdSize - 1U;
+        /* Configure current TCD block. */
+        EDMA_TcdReset(&handle->tcdPool[currentTcd]);
+        EDMA_TcdSetTransferConfig(&handle->tcdPool[currentTcd], config, NULL);
+        /* Enable major interrupt */
+        handle->tcdPool[currentTcd].CSR |= DMA_CSR_INTMAJOR_MASK;
+        /* Link current TCD with next TCD for identification of current TCD */
+        handle->tcdPool[currentTcd].DLAST_SGA = (uint32_t)&handle->tcdPool[nextTcd];
+        /* Chain from previous descriptor unless tcd pool size is 1(this descriptor is its own predecessor). */
+        if (currentTcd != previousTcd)
+        {
+            /* Enable scatter/gather feature in the previous TCD block. */
+            csr = (handle->tcdPool[previousTcd].CSR | DMA_CSR_ESG_MASK) & ~DMA_CSR_DREQ_MASK;
+            handle->tcdPool[previousTcd].CSR = csr;
+            /*
+                Check if the TCD blcok in the registers is the previous one (points to current TCD block). It
+                is used to check if the previous TCD linked has been loaded in TCD register. If so, it need to
+                link the TCD register in case link the current TCD with the dead chain when TCD loading occurs
+                before link the previous TCD block.
+            */
+            if (tcdRegs->DLAST_SGA == (uint32_t)&handle->tcdPool[currentTcd])
+            {
+                /* Enable scatter/gather also in the TCD registers. */
+                csr = (tcdRegs->CSR | DMA_CSR_ESG_MASK) & ~DMA_CSR_DREQ_MASK;
+                /* Must write the CSR register one-time, because the transfer maybe finished anytime. */
+                tcdRegs->CSR = csr;
+                /*
+                    It is very important to check the ESG bit!
+                    Because this hardware design: if DONE bit is set, the ESG bit can not be set. So it can
+                    be used to check if the dynamic TCD link operation is successful. If ESG bit is not set
+                    and the DLAST_SGA is not the next TCD address(it means the dynamic TCD link succeed and
+                    the current TCD block has been loaded into TCD registers), it means transfer finished
+                    and TCD link operation fail, so must install TCD content into TCD registers and enable
+                    transfer again. And if ESG is set, it means transfer has notfinished, so TCD dynamic
+                    link succeed.
+                */
+                if (tcdRegs->CSR & DMA_CSR_ESG_MASK)
+                {
+                    return kStatus_Success;
+                }
+                /*
+                    Check whether the current TCD block is already loaded in the TCD registers. It is another
+                    condition when ESG bit is not set: it means the dynamic TCD link succeed and the current
+                    TCD block has been loaded into TCD registers.
+                */
+                if (tcdRegs->DLAST_SGA == (uint32_t)&handle->tcdPool[nextTcd])
+                {
+                    return kStatus_Success;
+                }
+                /*
+                    If go to this, means the previous transfer finished, and the DONE bit is set.
+                    So shall configure TCD registers.
+                */
+            }
+            else if (tcdRegs->DLAST_SGA != 0)
+            {
+                /* The current TCD block has been linked successfully. */
+                return kStatus_Success;
+            }
+            else
+            {
+                /*
+                    DLAST_SGA is 0 and it means the first submit transfer, so shall configure
+                    TCD registers.
+                */
+            }
+        }
+        /* There is no live chain, TCD block need to be installed in TCD registers. */
+        EDMA_InstallTCD(handle->base, handle->channel, &handle->tcdPool[currentTcd]);
+        /* Enable channel request again. */
+        if (handle->flags & EDMA_TRANSFER_ENABLED_MASK)
+        {
+            handle->base->SERQ = DMA_SERQ_SERQ(handle->channel);
+        }
+
+        return kStatus_Success;
+    }
+}
+
+void EDMA_StartTransfer(edma_handle_t *handle)
+{
+    assert(handle != NULL);
+
+    if (handle->tcdPool == NULL)
+    {
+        handle->base->SERQ = DMA_SERQ_SERQ(handle->channel);
+    }
+    else /* Use the TCD queue. */
+    {
+        uint32_t primask;
+        edma_tcd_t *tcdRegs = (edma_tcd_t *)&handle->base->TCD[handle->channel];
+
+        handle->flags |= EDMA_TRANSFER_ENABLED_MASK;
+
+        /* Check if there was at least one descriptor submitted since reset (TCD in registers is valid) */
+        if (tcdRegs->DLAST_SGA != 0U)
+        {
+            primask = DisableGlobalIRQ();
+            /* Check if channel request is actually disable. */
+            if ((handle->base->ERQ & (1U << handle->channel)) == 0U)
+            {
+                /* Check if transfer is paused. */
+                if ((!(tcdRegs->CSR & DMA_CSR_DONE_MASK)) || (tcdRegs->CSR & DMA_CSR_ESG_MASK))
+                {
+                    /*
+                        Re-enable channel request must be as soon as possible, so must put it into
+                        critical section to avoid task switching or interrupt service routine.
+                    */
+                    handle->base->SERQ = DMA_SERQ_SERQ(handle->channel);
+                }
+            }
+            EnableGlobalIRQ(primask);
+        }
+    }
+}
+
+void EDMA_StopTransfer(edma_handle_t *handle)
+{
+    assert(handle != NULL);
+
+    handle->flags &= (~EDMA_TRANSFER_ENABLED_MASK);
+    handle->base->CERQ = DMA_CERQ_CERQ(handle->channel);
+}
+
+void EDMA_AbortTransfer(edma_handle_t *handle)
+{
+    handle->base->CERQ = DMA_CERQ_CERQ(handle->channel);
+    /*
+        Clear CSR to release channel. Because if the given channel started transfer,
+        CSR will be not zero. Because if it is the last transfer, DREQ will be set.
+        If not, ESG will be set.
+    */
+    handle->base->TCD[handle->channel].CSR = 0;
+    /* Cancel all next TCD transfer. */
+    handle->base->TCD[handle->channel].DLAST_SGA = 0;
+}
+
+void EDMA_HandleIRQ(edma_handle_t *handle)
+{
+    assert(handle != NULL);
+
+    /* Clear EDMA interrupt flag */
+    handle->base->CINT = handle->channel;
+    if (handle->tcdPool == NULL)
+    {
+        (handle->callback)(handle, handle->userData, true, 0);
+    }
+    else /* Use the TCD queue. */
+    {
+        uint32_t sga = handle->base->TCD[handle->channel].DLAST_SGA;
+        uint32_t sga_index;
+        int32_t tcds_done;
+        uint8_t new_header;
+        bool transfer_done;
+
+        /* Check if transfer is already finished. */
+        transfer_done = ((handle->base->TCD[handle->channel].CSR & DMA_CSR_DONE_MASK) != 0);
+        /* Get the offset of the current transfer TCD blcoks. */
+        sga -= (uint32_t)handle->tcdPool;
+        /* Get the index of the current transfer TCD blcoks. */
+        sga_index = sga / sizeof(edma_tcd_t);
+        /* Adjust header positions. */
+        if (transfer_done)
+        {
+            /* New header shall point to the next TCD (current one is already finished) */
+            new_header = sga_index;
+        }
+        else
+        {
+            /* New header shall point to this descriptor (not finished yet) */
+            new_header = sga_index ? sga_index - 1U : handle->tcdSize - 1U;
+        }
+        /* Calculate the number of finished TCDs */
+        if (new_header == handle->header)
+        {
+            if (handle->tcdUsed == handle->tcdSize)
+            {
+                tcds_done = handle->tcdUsed;
+            }
+            else
+            {
+                /* Internal error occurs. */
+                tcds_done = 0;
+            }
+        }
+        else
+        {
+            tcds_done = new_header - handle->header;
+            if (tcds_done < 0)
+            {
+                tcds_done += handle->tcdSize;
+            }
+        }
+        /* Advance header to the point beyond the last finished TCD block. */
+        handle->header = new_header;
+        /* Release TCD blocks. */
+        handle->tcdUsed -= tcds_done;
+        /* Invoke callback function. */
+        if (handle->callback)
+        {
+            (handle->callback)(handle, handle->userData, transfer_done, tcds_done);
+        }
+    }
+}
+
+/* 8 channels (Shared): kl28 */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 8U
+
+void DMA0_04_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+}
+
+void DMA0_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+}
+
+void DMA0_26_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+}
+
+void DMA0_37_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+}
+#endif /* 8 channels (Shared) */
+
+/* 32 channels (Shared): k80 */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
+
+void DMA0_DMA16_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 16U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+}
+
+void DMA1_DMA17_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 17U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+}
+
+void DMA2_DMA18_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 18U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+}
+
+void DMA3_DMA19_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 19U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+}
+
+void DMA4_DMA20_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 20U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+}
+
+void DMA5_DMA21_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 21U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+}
+
+void DMA6_DMA22_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 22U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+}
+
+void DMA7_DMA23_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 23U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+}
+
+void DMA8_DMA24_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 24U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+}
+
+void DMA9_DMA25_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 25U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+}
+
+void DMA10_DMA26_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 26U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+}
+
+void DMA11_DMA27_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 27U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+}
+
+void DMA12_DMA28_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 28U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA13_DMA29_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 29U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA14_DMA30_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 30U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA15_DMA31_IRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 31U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif /* 32 channels (Shared) */
+
+/* 4 channels (No Shared): kv10  */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 0
+
+void DMA0_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[0]);
+}
+
+void DMA1_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[1]);
+}
+
+void DMA2_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[2]);
+}
+
+void DMA3_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[3]);
+}
+
+/* 8 channels (No Shared) */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 4U
+
+void DMA4_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[4]);
+}
+
+void DMA5_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[5]);
+}
+
+void DMA6_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[6]);
+}
+
+void DMA7_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[7]);
+}
+#endif /* FSL_FEATURE_EDMA_MODULE_CHANNEL == 8 */
+
+/* 16 channels (No Shared) */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 8U
+
+void DMA8_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[8]);
+}
+
+void DMA9_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[9]);
+}
+
+void DMA10_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[10]);
+}
+
+void DMA11_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[11]);
+}
+
+void DMA12_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[12]);
+}
+
+void DMA13_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[13]);
+}
+
+void DMA14_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[14]);
+}
+
+void DMA15_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[15]);
+}
+#endif /* FSL_FEATURE_EDMA_MODULE_CHANNEL == 16 */
+
+/* 32 channels (No Shared) */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 16U
+
+void DMA16_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[16]);
+}
+
+void DMA17_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[17]);
+}
+
+void DMA18_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[18]);
+}
+
+void DMA19_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[19]);
+}
+
+void DMA20_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[20]);
+}
+
+void DMA21_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[21]);
+}
+
+void DMA22_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[22]);
+}
+
+void DMA23_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[23]);
+}
+
+void DMA24_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[24]);
+}
+
+void DMA25_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[25]);
+}
+
+void DMA26_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[26]);
+}
+
+void DMA27_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[27]);
+}
+
+void DMA28_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[28]);
+}
+
+void DMA29_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[29]);
+}
+
+void DMA30_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[30]);
+}
+
+void DMA31_DriverIRQHandler(void)
+{
+    EDMA_HandleIRQ(s_EDMAHandle[31]);
+}
+#endif /* FSL_FEATURE_EDMA_MODULE_CHANNEL == 32 */
+
+#endif /* 4/8/16/32 channels (No Shared)  */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_edma.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_edma.h
@@ -1,0 +1,879 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _FSL_EDMA_H_
+#define _FSL_EDMA_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup edma_driver
+ * @{
+ */
+
+/*! @file */
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief eDMA driver version */
+#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0. */
+/*@}*/
+
+/*! @brief Compute the offset unit from DCHPRI3 */
+#define DMA_DCHPRI_INDEX(channel) (((channel) & ~0x03U) | (3 - ((channel)&0x03U)))
+
+/*! @brief Get the pointer of DCHPRIn */
+#define DMA_DCHPRIn(base, channel) ((volatile uint8_t *)&(base->DCHPRI3))[DMA_DCHPRI_INDEX(channel)]
+
+/*! @brief eDMA transfer configuration */
+typedef enum _edma_transfer_size
+{
+    kEDMA_TransferSize1Bytes = 0x0U,  /*!< Source/Destination data transfer size is 1 byte every time */
+    kEDMA_TransferSize2Bytes = 0x1U,  /*!< Source/Destination data transfer size is 2 bytes every time */
+    kEDMA_TransferSize4Bytes = 0x2U,  /*!< Source/Destination data transfer size is 4 bytes every time */
+    kEDMA_TransferSize16Bytes = 0x4U, /*!< Source/Destination data transfer size is 16 bytes every time */
+    kEDMA_TransferSize32Bytes = 0x5U, /*!< Source/Destination data transfer size is 32 bytes every time */
+} edma_transfer_size_t;
+
+/*! @brief eDMA modulo configuration */
+typedef enum _edma_modulo
+{
+    kEDMA_ModuloDisable = 0x0U, /*!< Disable modulo */
+    kEDMA_Modulo2bytes,         /*!< Circular buffer size is 2 bytes. */
+    kEDMA_Modulo4bytes,         /*!< Circular buffer size is 4 bytes. */
+    kEDMA_Modulo8bytes,         /*!< Circular buffer size is 8 bytes. */
+    kEDMA_Modulo16bytes,        /*!< Circular buffer size is 16 bytes. */
+    kEDMA_Modulo32bytes,        /*!< Circular buffer size is 32 bytes. */
+    kEDMA_Modulo64bytes,        /*!< Circular buffer size is 64 bytes. */
+    kEDMA_Modulo128bytes,       /*!< Circular buffer size is 128 bytes. */
+    kEDMA_Modulo256bytes,       /*!< Circular buffer size is 256 bytes. */
+    kEDMA_Modulo512bytes,       /*!< Circular buffer size is 512 bytes. */
+    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1K bytes. */
+    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2K bytes. */
+    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4K bytes. */
+    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8K bytes. */
+    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16K bytes. */
+    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32K bytes. */
+    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64K bytes. */
+    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128K bytes. */
+    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256K bytes. */
+    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512K bytes. */
+    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1M bytes. */
+    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2M bytes. */
+    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4M bytes. */
+    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8M bytes. */
+    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16M bytes. */
+    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32M bytes. */
+    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64M bytes. */
+    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128M bytes. */
+    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256M bytes. */
+    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512M bytes. */
+    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1G bytes. */
+    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2G bytes. */
+} edma_modulo_t;
+
+/*! @brief Bandwidth control */
+typedef enum _edma_bandwidth
+{
+    kEDMA_BandwidthStallNone = 0x0U,   /*!< No eDMA engine stalls. */
+    kEDMA_BandwidthStall4Cycle = 0x2U, /*!< eDMA engine stalls for 4 cycles after each read/write. */
+    kEDMA_BandwidthStall8Cycle = 0x3U, /*!< eDMA engine stalls for 8 cycles after each read/write. */
+} edma_bandwidth_t;
+
+/*! @brief Channel link type */
+typedef enum _edma_channel_link_type
+{
+    kEDMA_LinkNone = 0x0U, /*!< No channel link  */
+    kEDMA_MinorLink,       /*!< Channel link after each minor loop */
+    kEDMA_MajorLink,       /*!< Channel link while major loop count exhausted */
+} edma_channel_link_type_t;
+
+/*!@brief eDMA channel status flags. */
+enum _edma_channel_status_flags
+{
+    kEDMA_DoneFlag = 0x1U,      /*!< DONE flag, set while transfer finished, CITER value exhausted*/
+    kEDMA_ErrorFlag = 0x2U,     /*!< eDMA error flag, an error occurred in a transfer */
+    kEDMA_InterruptFlag = 0x4U, /*!< eDMA interrupt flag, set while an interrupt occurred of this channel */
+};
+
+/*! @brief eDMA channel error status flags. */
+enum _edma_error_status_flags
+{
+    kEDMA_DestinationBusErrorFlag = DMA_ES_DBE_MASK,    /*!< Bus error on destination address */
+    kEDMA_SourceBusErrorFlag = DMA_ES_SBE_MASK,         /*!< Bus error on the source address */
+    kEDMA_ScatterGatherErrorFlag = DMA_ES_SGE_MASK,     /*!< Error on the Scatter/Gather address, not 32byte aligned. */
+    kEDMA_NbytesErrorFlag = DMA_ES_NCE_MASK,            /*!< NBYTES/CITER configuration error */
+    kEDMA_DestinationOffsetErrorFlag = DMA_ES_DOE_MASK, /*!< Destination offset not aligned with destination size */
+    kEDMA_DestinationAddressErrorFlag = DMA_ES_DAE_MASK, /*!< Destination address not aligned with destination size */
+    kEDMA_SourceOffsetErrorFlag = DMA_ES_SOE_MASK,       /*!< Source offset not aligned with source size */
+    kEDMA_SourceAddressErrorFlag = DMA_ES_SAE_MASK,      /*!< Source address not aligned with source size*/
+    kEDMA_ErrorChannelFlag = DMA_ES_ERRCHN_MASK,         /*!< Error channel number of the cancelled channel number */
+    kEDMA_ChannelPriorityErrorFlag = DMA_ES_CPE_MASK,    /*!< Channel priority is not unique. */
+    kEDMA_TransferCanceledFlag = DMA_ES_ECX_MASK,        /*!< Transfer cancelled */
+#if defined(FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT) && FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT > 1
+    kEDMA_GroupPriorityErrorFlag = DMA_ES_GPE_MASK, /*!< Group priority is not unique. */
+#endif
+    kEDMA_ValidFlag = DMA_ES_VLD_MASK, /*!< No error occurred, this bit will be 0, otherwise be 1 */
+};
+
+/*! @brief eDMA interrupt source */
+typedef enum _edma_interrupt_enable
+{
+    kEDMA_ErrorInterruptEnable = 0x1U,                  /*!< Enable interrupt while channel error occurs. */
+    kEDMA_MajorInterruptEnable = DMA_CSR_INTMAJOR_MASK, /*!< Enable interrupt while major count exhausted. */
+    kEDMA_HalfInterruptEnable = DMA_CSR_INTHALF_MASK,   /*!< Enable interrupt while major count to half value. */
+} edma_interrupt_enable_t;
+
+/*! @brief eDMA transfer type */
+typedef enum _edma_transfer_type
+{
+    kEDMA_MemoryToMemory = 0x0U, /*!< Transfer from memory to memory */
+    kEDMA_PeripheralToMemory,    /*!< Transfer from peripheral to memory */
+    kEDMA_MemoryToPeripheral,    /*!< Transfer from memory to peripheral */
+} edma_transfer_type_t;
+
+/*! @brief eDMA transfer status */
+enum _edma_transfer_status
+{
+    kStatus_EDMA_QueueFull = MAKE_STATUS(kStatusGroup_EDMA, 0), /*!< TCD queue is full. */
+    kStatus_EDMA_Busy = MAKE_STATUS(kStatusGroup_EDMA, 1),      /*!< Channel is busy and can't handle the
+                                                                     transfer request. */
+};
+
+/*! @brief eDMA global configuration structure.*/
+typedef struct _edma_config
+{
+    bool enableContinuousLinkMode;    /*!< Enable (true) continuous link mode. Upon minor loop completion, the channel
+                                           activates again if that channel has a minor loop channel link enabled and
+                                           the link channel is itself. */
+    bool enableHaltOnError;           /*!< Enable (true) transfer halt on error. Any error causes the HALT bit to set.
+                                           Subsequently, all service requests are ignored until the HALT bit is cleared.*/
+    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method, or fixed priority
+                                           arbitration is used for channel selection */
+    bool enableDebugMode; /*!< Enable(true) eDMA debug mode. When in debug mode, the eDMA stalls the start of
+                               a new channel. Executing channels are allowed to complete. */
+} edma_config_t;
+
+/*!
+ * @brief eDMA transfer configuration
+ *
+ * This structure configures the source/destination transfer attribute.
+ * This figure shows the eDMA's transfer model:
+ *  _________________________________________________
+ *              | Transfer Size |                    |
+ *   Minor Loop |_______________| Major loop Count 1 |
+ *     Bytes    | Transfer Size |                    |
+ *  ____________|_______________|____________________|--> Minor loop complete
+ *               ____________________________________
+ *              |               |                    |
+ *              |_______________| Major Loop Count 2 |
+ *              |               |                    |
+ *              |_______________|____________________|--> Minor loop  Complete
+ *
+ *               ---------------------------------------------------------> Transfer complete
+ */
+typedef struct _edma_transfer_config
+{
+    uint32_t srcAddr;                      /*!< Source data address. */
+    uint32_t destAddr;                     /*!< Destination data address. */
+    edma_transfer_size_t srcTransferSize;  /*!< Source data transfer size. */
+    edma_transfer_size_t destTransferSize; /*!< Destination data transfer size. */
+    int16_t srcOffset;                     /*!< Sign-extended offset applied to the current source address to
+                                                form the next-state value as each source read is completed. */
+    int16_t destOffset;                    /*!< Sign-extended offset applied to the current destination address to
+                                                form the next-state value as each destination write is completed. */
+    uint16_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
+    uint32_t majorLoopCounts;              /*!< Major loop iteration count. */
+} edma_transfer_config_t;
+
+/*! @brief eDMA channel priority configuration */
+typedef struct _edma_channel_Preemption_config
+{
+    bool enableChannelPreemption; /*!< If true: channel can be suspended by other channel with higher priority */
+    bool enablePreemptAbility;    /*!< If true: channel can suspend other channel with low priority */
+    uint8_t channelPriority;      /*!< Channel priority */
+} edma_channel_Preemption_config_t;
+
+/*! @brief eDMA minor offset configuration */
+typedef struct _edma_minor_offset_config
+{
+    bool enableSrcMinorOffset;  /*!< Enable(true) or Disable(false) source minor loop offset. */
+    bool enableDestMinorOffset; /*!< Enable(true) or Disable(false) destination minor loop offset. */
+    uint32_t minorOffset;       /*!< Offset for minor loop mapping. */
+} edma_minor_offset_config_t;
+
+/*!
+ * @brief eDMA TCD.
+ *
+ * This structure is same as TCD register which is described in reference manual,
+ * and is used to configure scatter/gather feature as a next hardware TCD.
+ */
+typedef struct _edma_tcd
+{
+    __IO uint32_t SADDR;     /*!< SADDR register, used to save source address */
+    __IO uint16_t SOFF;      /*!< SOFF register, save offset bytes every transfer */
+    __IO uint16_t ATTR;      /*!< ATTR register, source/destination transfer size and modulo */
+    __IO uint32_t NBYTES;    /*!< Nbytes register, minor loop length in bytes */
+    __IO uint32_t SLAST;     /*!< SLAST register */
+    __IO uint32_t DADDR;     /*!< DADDR register, used for destination address */
+    __IO uint16_t DOFF;      /*!< DOFF register, used for destination offset */
+    __IO uint16_t CITER;     /*!< CITER register, current minor loop numbers, for unfinished minor loop.*/
+    __IO uint32_t DLAST_SGA; /*!< DLASTSGA register, next stcd address used in scatter-gather mode */
+    __IO uint16_t CSR;       /*!< CSR register, for TCD control status */
+    __IO uint16_t BITER;     /*!< BITER register, begin minor loop count. */
+} edma_tcd_t;
+
+/*! @brief Callback for eDMA */
+struct _edma_handle;
+
+/*! @brief Define Callback function for eDMA. */
+typedef void (*edma_callback)(struct _edma_handle *handle, void *userData, bool transferDone, uint32_t tcds);
+
+/*! @brief eDMA transfer handle structure */
+typedef struct _edma_handle
+{
+    edma_callback callback;  /*!< Callback function for major count exhausted. */
+    void *userData;          /*!< Callback function parameter. */
+    DMA_Type *base;          /*!< eDMA peripheral base address. */
+    edma_tcd_t *tcdPool;     /*!< Pointer to memory stored TCDs. */
+    uint8_t channel;         /*!< eDMA channel number. */
+    volatile int8_t header;  /*!< The first TCD index. */
+    volatile int8_t tail;    /*!< The last TCD index. */
+    volatile int8_t tcdUsed; /*!< The number of used TCD slots. */
+    volatile int8_t tcdSize; /*!< The total number of TCD slots in the queue. */
+    uint8_t flags;           /*!< The status of the current channel. */
+} edma_handle_t;
+
+/*******************************************************************************
+ * APIs
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name eDMA initialization and De-initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes eDMA peripheral.
+ *
+ * This function ungates the eDMA clock and configure eDMA peripheral according
+ * to the configuration structure.
+ *
+ * @param base eDMA peripheral base address.
+ * @param config Pointer to configuration structure, see "edma_config_t".
+ * @note This function enable the minor loop map feature.
+ */
+void EDMA_Init(DMA_Type *base, const edma_config_t *config);
+
+/*!
+ * @brief Deinitializes eDMA peripheral.
+ *
+ * This function gates the eDMA clock.
+ *
+ * @param base eDMA peripheral base address.
+ */
+void EDMA_Deinit(DMA_Type *base);
+
+/*!
+ * @brief Gets the eDMA default configuration structure.
+ *
+ * This function sets the configuration structure to a default value.
+ * The default configuration is set to the following value:
+ * @code
+ *   config.enableContinuousLinkMode = false;
+ *   config.enableHaltOnError = true;
+ *   config.enableRoundRobinArbitration = false;
+ *   config.enableDebugMode = false;
+ * @endcode
+ *
+ * @param config Pointer to eDMA configuration structure.
+ */
+void EDMA_GetDefaultConfig(edma_config_t *config);
+
+/* @} */
+/*!
+ * @name eDMA Channel Operation
+ * @{
+ */
+
+/*!
+ * @brief Sets all TCD registers to a default value.
+ *
+ * This function sets TCD registers for this channel to default value.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @note This function must not be called while the channel transfer is on-going,
+ *       or it will case unpredicated results.
+ * @note This function will enable auto stop request feature.
+ */
+void EDMA_ResetChannel(DMA_Type *base, uint32_t channel);
+
+/*!
+ * @brief Configures the eDMA transfer attribute.
+ *
+ * This function configure the transfer attribute, including source address, destination address,
+ * transfer size, address offset, and so on. It also configures the scatter gather feature if the
+ * user supplies the TCD address.
+ * Example:
+ * @code
+ *  edma_transfer_t config;
+ *  edma_tcd_t tcd;
+ *  config.srcAddr = ..;
+ *  config.destAddr = ..;
+ *  ...
+ *  EDMA_SetTransferConfig(DMA0, channel, &config, &stcd);
+ * @endcode
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param config Pointer to eDMA transfer configuration structure.
+ * @param nextTcd Point to TCD structure. It can be NULL if user
+ *                do not want to enable scatter/gather feature.
+ * @note If nextTcd is not NULL, it means scatter gather feature will be enabled.
+ *       And DREQ bit will be cleared in the previous transfer configuration which
+ *       will be set in eDMA_ResetChannel.
+ */
+void EDMA_SetTransferConfig(DMA_Type *base,
+                            uint32_t channel,
+                            const edma_transfer_config_t *config,
+                            edma_tcd_t *nextTcd);
+
+/*!
+ * @brief Configures the eDMA minor offset feature.
+ *
+ * Minor offset means signed-extended value added to source address or destination
+ * address after each minor loop.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param config Pointer to Minor offset configuration structure.
+ */
+void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_minor_offset_config_t *config);
+
+/*!
+ * @brief Configures the eDMA channel preemption feature.
+ *
+ * This function configures the channel preemption attribute and the priority of the channel.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number
+ * @param config Pointer to channel preemption configuration structure.
+ */
+static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
+                                                   uint32_t channel,
+                                                   const edma_channel_Preemption_config_t *config)
+{
+    assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
+    assert(config != NULL);
+
+    DMA_DCHPRIn(base, channel) =
+        (DMA_DCHPRI0_DPA(!config->enablePreemptAbility) | DMA_DCHPRI0_ECP(config->enableChannelPreemption) |
+         DMA_DCHPRI0_CHPRI(config->channelPriority));
+}
+
+/*!
+ * @brief Sets the channel link for the eDMA transfer.
+ *
+ * This function configures  minor link or major link mode. The minor link means that the channel link is
+ * triggered every time CITER decreases by 1. The major link means that the channel link is triggered when the CITER is exhausted.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param type Channel link type, it can be one of:
+ *   @arg kEDMA_LinkNone
+ *   @arg kEDMA_MinorLink
+ *   @arg kEDMA_MajorLink
+ * @param linkedChannel The linked channel number.
+ * @note User should ensure that DONE flag is cleared before call this interface, or the configuration will be invalid.
+ */
+void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_type_t type, uint32_t linkedChannel);
+
+/*!
+ * @brief Sets the bandwidth for the eDMA transfer.
+ *
+ * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
+ * each read/write access to control the bus request bandwidth seen by the crossbar switch.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param bandWidth Bandwidth setting, it can be one of:
+ *     @arg kEDMABandwidthStallNone
+ *     @arg kEDMABandwidthStall4Cycle
+ *     @arg kEDMABandwidthStall8Cycle
+ */
+void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWidth);
+
+/*!
+ * @brief Sets the source modulo and destination modulo for eDMA transfer.
+ *
+ * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
+ * calculation is performed or the original register value. It provides the ability to implement a circular data
+ * queue easily.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param srcModulo Source modulo value.
+ * @param destModulo Destination modulo value.
+ */
+void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, edma_modulo_t destModulo);
+
+#if defined(FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT) && FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT
+/*!
+ * @brief Enables an async request for the eDMA transfer.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param enable The command for enable(ture) or disable(false).
+ */
+static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, bool enable)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->EARS = (base->EARS & (~(1U << channel))) | ((uint32_t)enable << channel);
+}
+#endif /* FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT */
+
+/*!
+ * @brief Enables an auto stop request for the eDMA transfer.
+ *
+ * If enabling the auto stop request, the eDMA hardware automatically disables the hardware channel request.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param enable The command for enable (true) or disable (false).
+ */
+static inline void EDMA_EnableAutoStopRequest(DMA_Type *base, uint32_t channel, bool enable)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->TCD[channel].CSR = (base->TCD[channel].CSR & (~DMA_CSR_DREQ_MASK)) | DMA_CSR_DREQ(enable);
+}
+
+/*!
+ * @brief Enables the interrupt source for the eDMA transfer.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param mask The mask of interrupt source to be set. User need to use
+ *             the defined edma_interrupt_enable_t type.
+ */
+void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
+
+/*!
+ * @brief Disables the interrupt source for the eDMA transfer.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param mask The mask of interrupt source to be set. Use
+ *             the defined edma_interrupt_enable_t type.
+ */
+void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
+
+/* @} */
+/*!
+ * @name eDMA TCD Operation
+ * @{
+ */
+
+/*!
+ * @brief Sets all fields to default values for the TCD structure.
+ *
+ * This function sets all fields for this TCD structure to default value.
+ *
+ * @param tcd Pointer to the TCD structure.
+ * @note This function will enable auto stop request feature.
+ */
+void EDMA_TcdReset(edma_tcd_t *tcd);
+
+/*!
+ * @brief Configures the eDMA TCD transfer attribute.
+ *
+ * TCD is a transfer control descriptor. The content of the TCD is the same as hardware TCD registers.
+ * STCD is used in scatter-gather mode.
+ * This function configures the TCD transfer attribute, including source address, destination address,
+ * transfer size, address offset, and so on. It also configures the scatter gather feature if the
+ * user supplies the next TCD address.
+ * Example:
+ * @code
+ *   edma_transfer_t config = {
+ *   ...
+ *   }
+ *   edma_tcd_t tcd __aligned(32);
+ *   edma_tcd_t nextTcd __aligned(32);
+ *   EDMA_TcdSetTransferConfig(&tcd, &config, &nextTcd);
+ * @endcode
+ *
+ * @param tcd Pointer to the TCD structure.
+ * @param config Pointer to eDMA transfer configuration structure.
+ * @param nextTcd Pointer to the next TCD structure. It can be NULL if user
+ *                do not want to enable scatter/gather feature.
+ * @note TCD address should be 32 bytes aligned, or it will cause eDMA error.
+ * @note If nextTcd is not NULL, it means scatter gather feature will be enabled.
+ *       And DREQ bit will be cleared in the previous transfer configuration which
+ *       will be set in EDMA_TcdReset.
+ */
+void EDMA_TcdSetTransferConfig(edma_tcd_t *tcd, const edma_transfer_config_t *config, edma_tcd_t *nextTcd);
+
+/*!
+ * @brief Configures the eDMA TCD minor offset feature.
+ *
+ * Minor offset is a signed-extended value added to the source address or destination
+ * address after each minor loop.
+ *
+ * @param tcd Point to the TCD structure.
+ * @param config Pointer to Minor offset configuration structure.
+ */
+void EDMA_TcdSetMinorOffsetConfig(edma_tcd_t *tcd, const edma_minor_offset_config_t *config);
+
+/*!
+ * @brief Sets the channel link for eDMA TCD.
+ *
+ * This function configures either a minor link or a major link. The minor link means the channel link is
+ * triggered every time CITER decreases by 1. The major link means that the channel link  is triggered when the CITER is exhausted.
+ *
+ * @note User should ensure that DONE flag is cleared before call this interface, or the configuration will be invalid.
+ * @param tcd Point to the TCD structure.
+ * @param type Channel link type, it can be one of:
+ *   @arg kEDMA_LinkNone
+ *   @arg kEDMA_MinorLink
+ *   @arg kEDMA_MajorLink
+ * @param linkedChannel The linked channel number.
+ */
+void EDMA_TcdSetChannelLink(edma_tcd_t *tcd, edma_channel_link_type_t type, uint32_t linkedChannel);
+
+/*!
+ * @brief Sets the bandwidth for the eDMA TCD.
+ *
+ * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * until the minor count is exhausted. Bandwidth forces the eDMA to stall after the completion of
+ * each read/write access to control the bus request bandwidth seen by the crossbar switch.
+ * @param tcd Point to the TCD structure.
+ * @param bandWidth Bandwidth setting, it can be one of:
+ *     @arg kEDMABandwidthStallNone
+ *     @arg kEDMABandwidthStall4Cycle
+ *     @arg kEDMABandwidthStall8Cycle
+ */
+static inline void EDMA_TcdSetBandWidth(edma_tcd_t *tcd, edma_bandwidth_t bandWidth)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+
+    tcd->CSR = (tcd->CSR & (~DMA_CSR_BWC_MASK)) | DMA_CSR_BWC(bandWidth);
+}
+
+/*!
+ * @brief Sets the source modulo and destination modulo for eDMA TCD.
+ *
+ * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
+ * calculation is performed or the original register value. It provides the ability to implement a circular data
+ * queue easily.
+ *
+ * @param tcd Point to the TCD structure.
+ * @param srcModulo Source modulo value.
+ * @param destModulo Destination modulo value.
+ */
+void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t destModulo);
+
+/*!
+ * @brief Sets the auto stop request for the eDMA TCD.
+ *
+ * If enabling the auto stop request, the eDMA hardware automatically disables the hardware channel request.
+ *
+ * @param tcd Point to the TCD structure.
+ * @param enable The command for enable(ture) or disable(false).
+ */
+static inline void EDMA_TcdEnableAutoStopRequest(edma_tcd_t *tcd, bool enable)
+{
+    assert(tcd != NULL);
+    assert(((uint32_t)tcd & 0x1FU) == 0);
+
+    tcd->CSR = (tcd->CSR & (~DMA_CSR_DREQ_MASK)) | DMA_CSR_DREQ(enable);
+}
+
+/*!
+ * @brief Enables the interrupt source for the eDMA TCD.
+ *
+ * @param tcd Point to the TCD structure.
+ * @param mask The mask of interrupt source to be set. User need to use
+ *             the defined edma_interrupt_enable_t type.
+ */
+void EDMA_TcdEnableInterrupts(edma_tcd_t *tcd, uint32_t mask);
+
+/*!
+ * @brief Disables the interrupt source for the eDMA TCD.
+ *
+ * @param tcd Point to the TCD structure.
+ * @param mask The mask of interrupt source to be set. User need to use
+ *             the defined edma_interrupt_enable_t type.
+ */
+void EDMA_TcdDisableInterrupts(edma_tcd_t *tcd, uint32_t mask);
+
+/*! @} */
+/*!
+ * @name eDMA Channel Transfer Operation
+ * @{
+ */
+
+/*!
+ * @brief Enables the eDMA hardware channel request.
+ *
+ * This function enables the hardware channel request.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ */
+static inline void EDMA_EnableChannelRequest(DMA_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->SERQ = DMA_SERQ_SERQ(channel);
+}
+
+/*!
+ * @brief Disables the eDMA hardware channel request.
+ *
+ * This function disables the hardware channel request.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ */
+static inline void EDMA_DisableChannelRequest(DMA_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->CERQ = DMA_CERQ_CERQ(channel);
+}
+
+/*!
+ * @brief Starts the eDMA transfer by software trigger.
+ *
+ * This function starts a minor loop transfer.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ */
+static inline void EDMA_TriggerChannelStart(DMA_Type *base, uint32_t channel)
+{
+    assert(channel < FSL_FEATURE_DMAMUX_MODULE_CHANNEL);
+
+    base->SSRT = DMA_SSRT_SSRT(channel);
+}
+
+/*! @} */
+/*!
+ * @name eDMA Channel Status Operation
+ * @{
+ */
+
+/*!
+ * @brief Gets the Remaining bytes from the eDMA current channel TCD.
+ *
+ * This function checks the TCD (Task Control Descriptor) status for a specified
+ * eDMA channel and returns the the number of bytes that have not finished.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @return Bytes have not been transferred yet for the current TCD.
+ * @note This function can only be used to get unfinished bytes of transfer without
+ *       the next TCD, or it might be inaccuracy.
+ */
+uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel);
+
+/*!
+ * @brief Gets the eDMA channel error status flags.
+ *
+ * @param base eDMA peripheral base address.
+ * @return The mask of error status flags. User need to use the
+ *         _edma_error_status_flags type to decode the return variables.
+ */
+static inline uint32_t EDMA_GetErrorStatusFlags(DMA_Type *base)
+{
+    return base->ES;
+}
+
+/*!
+ * @brief Gets the eDMA channel status flags.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @return The mask of channel status flags. User need to use the
+ *         _edma_channel_status_flags type to decode the return variables.
+ */
+uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel);
+
+/*!
+ * @brief Clears the eDMA channel status flags.
+ *
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ * @param mask The mask of channel status to be cleared. User need to use
+ *             the defined _edma_channel_status_flags type.
+ */
+void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mask);
+
+/*! @} */
+/*!
+ * @name eDMA Transactional Operation
+ */
+
+/*!
+ * @brief Creates the eDMA handle.
+ *
+ * This function is called if using transaction API for eDMA. This function
+ * initializes the internal state of eDMA handle.
+ *
+ * @param handle eDMA handle pointer. The eDMA handle stores callback function and
+ *               parameters.
+ * @param base eDMA peripheral base address.
+ * @param channel eDMA channel number.
+ */
+void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel);
+
+/*!
+ * @brief Installs the TCDs memory pool into eDMA handle.
+ *
+ * This function is called after the EDMA_CreateHandle to use scatter/gather feature.
+ *
+ * @param handle eDMA handle pointer.
+ * @param tcdPool Memory pool to store TCDs. It must be 32 bytes aligned.
+ * @param tcdSize The number of TCD slots.
+ */
+void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t tcdSize);
+
+/*!
+ * @brief Installs a callback function for the eDMA transfer.
+ *
+ * This callback is called in eDMA IRQ handler. Use the callback to do something after
+ * the current major loop transfer completes.
+ *
+ * @param handle eDMA handle pointer.
+ * @param callback eDMA callback function pointer.
+ * @param userData Parameter for callback function.
+ */
+void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userData);
+
+/*!
+ * @brief Prepares the eDMA transfer structure.
+ *
+ * This function prepares the transfer configuration structure according to the user input.
+ *
+ * @param config The user configuration structure of type edma_transfer_t.
+ * @param srcAddr eDMA transfer source address.
+ * @param srcWidth eDMA transfer source address width(bytes).
+ * @param destAddr eDMA transfer destination address.
+ * @param destWidth eDMA transfer destination address width(bytes).
+ * @param bytesEachRequest eDMA transfer bytes per channel request.
+ * @param transferBytes eDMA transfer bytes to be transferred.
+ * @param type eDMA transfer type.
+ * @note The data address and the data width must be consistent. For example, if the SRC
+ *       is 4 bytes, so the source address must be 4 bytes aligned, or it shall result in
+ *       source address error(SAE).
+ */
+void EDMA_PrepareTransfer(edma_transfer_config_t *config,
+                          void *srcAddr,
+                          uint32_t srcWidth,
+                          void *destAddr,
+                          uint32_t destWidth,
+                          uint32_t bytesEachRequest,
+                          uint32_t transferBytes,
+                          edma_transfer_type_t type);
+
+/*!
+ * @brief Submits the eDMA transfer request.
+ *
+ * This function submits the eDMA transfer request according to the transfer configuration structure.
+ * If the user submits the transfer request repeatedly, this function packs an unprocessed request as
+ * a TCD and enables scatter/gather feature to process it in the next time.
+ *
+ * @param handle eDMA handle pointer.
+ * @param config Pointer to eDMA transfer configuration structure.
+ * @retval kStatus_EDMA_Success It means submit transfer request succeed.
+ * @retval kStatus_EDMA_QueueFull It means TCD queue is full. Submit transfer request is not allowed.
+ * @retval kStatus_EDMA_Busy It means the given channel is busy, need to submit request later.
+ */
+status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t *config);
+
+/*!
+ * @brief eDMA start transfer.
+ *
+ * This function enables the channel request. User can call this function after submitting the transfer request
+ * or before submitting the transfer request.
+ *
+ * @param handle eDMA handle pointer.
+ */
+void EDMA_StartTransfer(edma_handle_t *handle);
+
+/*!
+ * @brief eDMA stop transfer.
+ *
+ * This function disables the channel request to pause the transfer. User can call EDMA_StartTransfer()
+ * again to resume the transfer.
+ *
+ * @param handle eDMA handle pointer.
+ */
+void EDMA_StopTransfer(edma_handle_t *handle);
+
+/*!
+ * @brief eDMA abort transfer.
+ *
+ * This function disables the channel request and clear transfer status bits.
+ * User can submit another transfer after calling this API.
+ *
+ * @param handle DMA handle pointer.
+ */
+void EDMA_AbortTransfer(edma_handle_t *handle);
+
+/*!
+ * @brief eDMA IRQ handler for current major loop transfer complete.
+ *
+ * This function clears the channel major interrupt flag and call
+ * the callback function if it is not NULL.
+ *
+ * @param handle eDMA handle pointer.
+ */
+void EDMA_HandleIRQ(edma_handle_t *handle);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/* @} */
+
+#endif /*_FSL_EDMA_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_enet.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_enet.c
@@ -1,0 +1,1718 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fsl_enet.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief IPv4 PTP message IP version offset. */
+#define ENET_PTP1588_IPVERSION_OFFSET 0x0EU
+/*! @brief IPv4 PTP message UDP protocol offset. */
+#define ENET_PTP1588_IPV4_UDP_PROTOCOL_OFFSET 0x17U
+/*! @brief IPv4 PTP message UDP port offset. */
+#define ENET_PTP1588_IPV4_UDP_PORT_OFFSET 0x24U
+/*! @brief IPv4 PTP message UDP message type offset. */
+#define ENET_PTP1588_IPV4_UDP_MSGTYPE_OFFSET 0x2AU
+/*! @brief IPv4 PTP message UDP version offset. */
+#define ENET_PTP1588_IPV4_UDP_VERSION_OFFSET 0x2BU
+/*! @brief IPv4 PTP message UDP clock id offset. */
+#define ENET_PTP1588_IPV4_UDP_CLKID_OFFSET 0x3EU
+/*! @brief IPv4 PTP message UDP sequence id offset. */
+#define ENET_PTP1588_IPV4_UDP_SEQUENCEID_OFFSET 0x48U
+/*! @brief IPv4 PTP message UDP control offset. */
+#define ENET_PTP1588_IPV4_UDP_CTL_OFFSET 0x4AU
+/*! @brief IPv6 PTP message UDP protocol offset. */
+#define ENET_PTP1588_IPV6_UDP_PROTOCOL_OFFSET 0x14U
+/*! @brief IPv6 PTP message UDP port offset. */
+#define ENET_PTP1588_IPV6_UDP_PORT_OFFSET 0x38U
+/*! @brief IPv6 PTP message UDP message type offset. */
+#define ENET_PTP1588_IPV6_UDP_MSGTYPE_OFFSET 0x3EU
+/*! @brief IPv6 PTP message UDP version offset. */
+#define ENET_PTP1588_IPV6_UDP_VERSION_OFFSET 0x3FU
+/*! @brief IPv6 PTP message UDP clock id offset. */
+#define ENET_PTP1588_IPV6_UDP_CLKID_OFFSET 0x52U
+/*! @brief IPv6 PTP message UDP sequence id offset. */
+#define ENET_PTP1588_IPV6_UDP_SEQUENCEID_OFFSET 0x5CU
+/*! @brief IPv6 PTP message UDP control offset. */
+#define ENET_PTP1588_IPV6_UDP_CTL_OFFSET 0x5EU
+/*! @brief PTPv2 message Ethernet packet type offset. */
+#define ENET_PTP1588_ETHL2_PACKETTYPE_OFFSET 0x0CU
+/*! @brief PTPv2 message Ethernet message type offset. */
+#define ENET_PTP1588_ETHL2_MSGTYPE_OFFSET 0x0EU
+/*! @brief PTPv2 message Ethernet version type offset. */
+#define ENET_PTP1588_ETHL2_VERSION_OFFSET 0X0FU
+/*! @brief PTPv2 message Ethernet clock id offset. */
+#define ENET_PTP1588_ETHL2_CLOCKID_OFFSET 0x22
+/*! @brief PTPv2 message Ethernet sequence id offset. */
+#define ENET_PTP1588_ETHL2_SEQUENCEID_OFFSET 0x2c
+/*! @brief Packet type Ethernet IEEE802.3 for PTPv2. */
+#define ENET_ETHERNETL2 0x88F7U
+/*! @brief Packet type IPv4. */
+#define ENET_IPV4 0x0800U
+/*! @brief Packet type IPv6. */
+#define ENET_IPV6 0x86ddU
+/*! @brief Packet type VLAN. */
+#define ENET_8021QVLAN 0x8100U
+/*! @brief UDP protocol type. */
+#define ENET_UDPVERSION 0x0011U
+/*! @brief Packet IP version IPv4. */
+#define ENET_IPV4VERSION 0x0004U
+/*! @brief Packet IP version IPv6. */
+#define ENET_IPV6VERSION 0x0006U
+/*! @brief Ethernet mac address length. */
+#define ENET_FRAME_MACLEN 6U
+/*! @brief Ethernet Frame header length. */
+#define ENET_FRAME_HEADERLEN 14U
+/*! @brief Ethernet VLAN header length. */
+#define ENET_FRAME_VLAN_HEADERLEN 18U
+/*! @brief MDC frequency. */
+#define ENET_MDC_FREQUENCY 2500000U
+/*! @brief NanoSecond in one second. */
+#define ENET_NANOSECOND_ONE_SECOND 1000000000U
+/*! @brief Define a common clock cycle delays used for time stamp capture. */
+#define ENET_1588TIME_DELAY_COUNT 10U
+/*! @brief Defines the macro for converting constants from host byte order to network byte order. */
+#define ENET_HTONS(n) __REV16(n)
+#define ENET_HTONL(n) __REV(n)
+#define ENET_NTOHS(n) __REV16(n)
+#define ENET_NTOHL(n) __REV(n)
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get the ENET instance from peripheral base address.
+ *
+ * @param base ENET peripheral base address.
+ * @return ENET instance.
+ */
+uint32_t ENET_GetInstance(ENET_Type *base);
+
+/*!
+ * @brief Set ENET MAC controller with the configuration.
+ *
+ * @param base ENET peripheral base address.
+ * @param config ENET Mac configuration.
+ * @param bufferConfig ENET buffer configuration.
+ * @param macAddr ENET six-byte mac address.
+ * @param srcClock_Hz ENET module clock source, normally it's system clock.
+ */
+static void ENET_SetMacController(ENET_Type *base,
+                                  const enet_config_t *config,
+                                  const enet_buffer_config_t *bufferConfig,
+                                  uint8_t *macAddr,
+                                  uint32_t srcClock_Hz);
+
+/*!
+ * @brief Set ENET MAC transmit buffer descriptors.
+ *
+ * @param txBdStartAlign The aligned start address of ENET transmit buffer descriptors.
+ *        is recommended to evenly divisible by 16.
+ * @param txBuffStartAlign The aligned start address of ENET transmit buffers, must be evenly divisible by 16.
+ * @param txBuffSizeAlign The aligned ENET transmit buffer size, must be evenly divisible by 16.
+ * @param txBdNumber The number of ENET transmit buffers.
+ */
+static void ENET_SetTxBufferDescriptors(volatile enet_tx_bd_struct_t *txBdStartAlign,
+                                        uint8_t *txBuffStartAlign,
+                                        uint32_t txBuffSizeAlign,
+                                        uint32_t txBdNumber);
+
+/*!
+ * @brief Set ENET MAC receive buffer descriptors.
+ *
+ * @param rxBdStartAlign The aligned start address of ENET receive buffer descriptors.
+ *        is recommended to evenly divisible by 16.
+ * @param rxBuffStartAlign The aligned start address of ENET receive buffers, must be evenly divisible by 16.
+ * @param rxBuffSizeAlign The aligned ENET receive buffer size, must be evenly divisible by 16.
+ * @param rxBdNumber The number of ENET receive buffers.
+ * @param enableInterrupt Enable/disables to generate the receive byte and frame interrupt.
+ *        It's used for ENET_ENHANCEDBUFFERDESCRIPTOR_MODE enabled case.
+ */
+static void ENET_SetRxBufferDescriptors(volatile enet_rx_bd_struct_t *rxBdStartAlign,
+                                        uint8_t *rxBuffStartAlign,
+                                        uint32_t rxBuffSizeAlign,
+                                        uint32_t rxBdNumber,
+                                        bool enableInterrupt);
+
+/*!
+ * @brief Updates the ENET read buffer descriptors.
+ *
+ * @param base ENET peripheral base address.
+ * @param handle The ENET handle pointer.
+ */
+static void ENET_UpdateReadBuffers(ENET_Type *base, enet_handle_t *handle);
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*!
+ * @brief Parses the ENET frame for time-stamp process of PTP 1588 frame.
+ *
+ * @param data  The ENET read data for frame parse.
+ * @param ptpTsData The ENET PTP message and time-stamp data pointer.
+ * @param isFastEnabled The fast parse flag.
+ *        - true , Fast processing, only check if this is a PTP message.
+ *        - false, Store the PTP message data after check the PTP message.
+ */
+static bool ENET_Ptp1588ParseFrame(uint8_t *data, enet_ptp_time_data_t *ptpTsData, bool isFastEnabled);
+
+/*!
+ * @brief Updates the new PTP 1588 time-stamp to the time-stamp buffer ring.
+ *
+ * @param ptpTsDataRing The PTP message and time-stamp data ring pointer.
+ * @param ptpTimeData   The new PTP 1588 time-stamp data pointer.
+ */
+static status_t ENET_Ptp1588UpdateTimeRing(enet_ptp_time_data_ring_t *ptpTsDataRing, enet_ptp_time_data_t *ptpTimeData);
+
+/*!
+ * @brief Search up the right PTP 1588 time-stamp from the time-stamp buffer ring.
+ *
+ * @param ptpTsDataRing The PTP message and time-stamp data ring pointer.
+ * @param ptpTimeData   The find out right PTP 1588 time-stamp data pointer with the specific PTP message.
+ */
+static status_t ENET_Ptp1588SearchTimeRing(enet_ptp_time_data_ring_t *ptpTsDataRing, enet_ptp_time_data_t *ptpTimedata);
+
+/*!
+ * @brief Store the transmit time-stamp for event PTP frame in the time-stamp buffer ring.
+ *
+ * @param base   ENET peripheral base address.
+ * @param handle The ENET handle pointer.
+ */
+static status_t ENET_StoreTxFrameTime(ENET_Type *base, enet_handle_t *handle);
+
+/*!
+ * @brief Store the receive time-stamp for event PTP frame in the time-stamp buffer ring.
+ *
+ * @param base   ENET peripheral base address.
+ * @param handle The ENET handle pointer.
+ * @param ptpTimeData The PTP 1588 time-stamp data pointer.
+ */
+static status_t ENET_StoreRxFrameTime(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_data_t *ptpTimeData);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to enet handles for each instance. */
+static enet_handle_t *s_ENETHandle[FSL_FEATURE_SOC_ENET_COUNT] = {NULL};
+
+/*! @brief Pointers to enet clocks for each instance. */
+const clock_ip_name_t s_enetClock[FSL_FEATURE_SOC_ENET_COUNT] = ENET_CLOCKS;
+
+/*! @brief Pointers to enet transmit IRQ number for each instance. */
+const IRQn_Type s_enetTxIrqId[] = ENET_Transmit_IRQS;
+/*! @brief Pointers to enet receive IRQ number for each instance. */
+const IRQn_Type s_enetRxIrqId[] = ENET_Receive_IRQS;
+#if defined(ENET_ENHANCEDBUFFERDESCRIPTOR_MODE) && ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*! @brief Pointers to enet timestamp IRQ number for each instance. */
+const IRQn_Type s_enetTsIrqId[] = ENET_1588_Timer_IRQS;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+/*! @brief Pointers to enet error IRQ number for each instance. */
+const IRQn_Type s_enetErrIrqId[] = ENET_Error_IRQS;
+
+/*! @brief Pointers to enet bases for each instance. */
+static ENET_Type *const s_enetBases[] = ENET_BASE_PTRS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+uint32_t ENET_GetInstance(ENET_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_ENET_COUNT; instance++)
+    {
+        if (s_enetBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_ENET_COUNT);
+
+    return instance;
+}
+
+void ENET_GetDefaultConfig(enet_config_t *config)
+{
+    /* Checks input parameter. */
+    assert(config);
+
+    /* Initializes the MAC configure structure to zero. */
+    memset(config, 0, sizeof(enet_config_t));
+
+    /* Sets MII mode, full duplex, 100Mbps for MAC and PHY data interface. */
+    config->miiMode = kENET_RmiiMode;
+    config->miiSpeed = kENET_MiiSpeed100M;
+    config->miiDuplex = kENET_MiiFullDuplex;
+
+    /* Sets the maximum receive frame length. */
+    config->rxMaxFrameLen = ENET_FRAME_MAX_FRAMELEN;
+}
+
+void ENET_Init(ENET_Type *base,
+               enet_handle_t *handle,
+               const enet_config_t *config,
+               const enet_buffer_config_t *bufferConfig,
+               uint8_t *macAddr,
+               uint32_t srcClock_Hz)
+{
+    /* Checks input parameters. */
+    assert(handle);
+    assert(config);
+    assert(bufferConfig);
+    assert(bufferConfig->rxBdStartAddrAlign);
+    assert(bufferConfig->txBdStartAddrAlign);
+    assert(bufferConfig->rxBufferAlign);
+    assert(bufferConfig->txBufferAlign);
+    assert(macAddr);
+    assert(bufferConfig->rxBuffSizeAlign >= ENET_RX_MIN_BUFFERSIZE);
+
+    /* Make sure the buffers should be have the capability of process at least one maximum frame. */
+    if (config->macSpecialConfig & kENET_ControlVLANTagEnable)
+    {
+        assert(bufferConfig->txBuffSizeAlign * bufferConfig->txBdNumber > ENET_FRAME_MAX_VALNFRAMELEN);
+    }
+    else
+    {
+        assert(bufferConfig->txBuffSizeAlign * bufferConfig->txBdNumber > ENET_FRAME_MAX_FRAMELEN);
+        assert(bufferConfig->rxBuffSizeAlign * bufferConfig->rxBdNumber > config->rxMaxFrameLen);
+    }
+
+    uint32_t instance = ENET_GetInstance(base);
+
+    /* Ungate ENET clock. */
+    CLOCK_EnableClock(s_enetClock[instance]);
+
+    /* Reset ENET module. */
+    ENET_Reset(base);
+
+    /* Initializes the ENET transmit buffer descriptors. */
+    ENET_SetTxBufferDescriptors(bufferConfig->txBdStartAddrAlign, bufferConfig->txBufferAlign,
+                                bufferConfig->txBuffSizeAlign, bufferConfig->txBdNumber);
+
+    /* Initializes the ENET receive buffer descriptors. */
+    ENET_SetRxBufferDescriptors(bufferConfig->rxBdStartAddrAlign, bufferConfig->rxBufferAlign,
+                                bufferConfig->rxBuffSizeAlign, bufferConfig->rxBdNumber,
+                                !!(config->interrupt & (kENET_RxFrameInterrupt | kENET_RxByteInterrupt)));
+
+    /* Initializes the ENET MAC controller. */
+    ENET_SetMacController(base, config, bufferConfig, macAddr, srcClock_Hz);
+
+    /* Initialize the handle to zero. */
+    memset(handle, 0, sizeof(enet_handle_t));
+
+    /* Store transfer parameters in handle pointer. */
+    handle->rxBdBase = bufferConfig->rxBdStartAddrAlign;
+    handle->rxBdCurrent = bufferConfig->rxBdStartAddrAlign;
+    handle->rxBdDirty = bufferConfig->rxBdStartAddrAlign;
+    handle->txBdBase = bufferConfig->txBdStartAddrAlign;
+    handle->txBdCurrent = bufferConfig->txBdStartAddrAlign;
+    handle->rxBuffSizeAlign = bufferConfig->rxBuffSizeAlign;
+    handle->txBuffSizeAlign = bufferConfig->txBuffSizeAlign;
+
+    /* Save the handle pointer in the global variables. */
+    s_ENETHandle[instance] = handle;
+}
+
+void ENET_Deinit(ENET_Type *base)
+{
+    /* Disable interrupt. */
+    base->EIMR = 0;
+
+    /* Disable ENET. */
+    base->ECR &= ~ENET_ECR_ETHEREN_MASK;
+
+    /* Disables the clock source. */
+    CLOCK_DisableClock(s_enetClock[ENET_GetInstance(base)]);
+}
+
+void ENET_SetCallback(enet_handle_t *handle, enet_callback_t callback, void *userData)
+{
+    assert(handle);
+
+    /* Set callback and userData. */
+    handle->callback = callback;
+    handle->userData = userData;
+}
+
+static void ENET_SetMacController(ENET_Type *base,
+                                  const enet_config_t *config,
+                                  const enet_buffer_config_t *bufferConfig,
+                                  uint8_t *macAddr,
+                                  uint32_t srcClock_Hz)
+{
+    uint32_t rcr = 0;
+    uint32_t tcr = 0;
+    uint32_t ecr = 0;
+    uint32_t macSpecialConfig = config->macSpecialConfig;
+    uint32_t instance = ENET_GetInstance(base);
+
+    /* Configures MAC receive controller with user configure structure. */
+    rcr = ENET_RCR_NLC(!!(macSpecialConfig & kENET_ControlRxPayloadCheckEnable)) |
+          ENET_RCR_CFEN(!!(macSpecialConfig & kENET_ControlFlowControlEnable)) |
+          ENET_RCR_FCE(!!(macSpecialConfig & kENET_ControlFlowControlEnable)) |
+          ENET_RCR_PADEN(!!(macSpecialConfig & kENET_ControlRxPadRemoveEnable)) |
+          ENET_RCR_BC_REJ(!!(macSpecialConfig & kENET_ControlRxBroadCastRejectEnable)) |
+          ENET_RCR_PROM(!!(macSpecialConfig & kENET_ControlPromiscuousEnable)) | ENET_RCR_MII_MODE(1) |
+          ENET_RCR_RMII_MODE(config->miiMode) | ENET_RCR_RMII_10T(!config->miiSpeed) |
+          ENET_RCR_MAX_FL(config->rxMaxFrameLen) | ENET_RCR_CRCFWD(1);
+    /* Receive setting for half duplex. */
+    if (config->miiDuplex == kENET_MiiHalfDuplex)
+    {
+        rcr |= ENET_RCR_DRT(1);
+    }
+    /* Sets internal loop only for MII mode. */
+    if ((config->macSpecialConfig & kENET_ControlMIILoopEnable) && (config->miiMode == kENET_MiiMode))
+    {
+        rcr |= ENET_RCR_LOOP(1);
+        rcr &= ~ENET_RCR_DRT_MASK;
+    }
+    base->RCR = rcr;
+
+    /* Configures MAC transmit controller: duplex mode, mac address insertion. */
+    tcr = base->TCR & ~(ENET_TCR_FDEN_MASK | ENET_TCR_ADDINS_MASK);
+    tcr |= ENET_TCR_FDEN(config->miiDuplex) | ENET_TCR_ADDINS(!!(macSpecialConfig & kENET_ControlMacAddrInsert));
+    base->TCR = tcr;
+
+    /* Configures receive and transmit accelerator. */
+    base->TACC = config->txAccelerConfig;
+    base->RACC = config->rxAccelerConfig;
+
+    /* Sets the pause duration and FIFO threshold for the flow control enabled case. */
+    if (macSpecialConfig & kENET_ControlFlowControlEnable)
+    {
+        uint32_t reemReg;
+        base->OPD = config->pauseDuration;
+        reemReg = ENET_RSEM_RX_SECTION_EMPTY(config->rxFifoEmptyThreshold);
+#if FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD
+        reemReg |= ENET_RSEM_STAT_SECTION_EMPTY(config->rxFifoStatEmptyThreshold);
+#endif /* FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD */
+        base->RSEM = reemReg;
+    }
+
+    /* FIFO threshold setting for store and forward enable/disable case. */
+    if (macSpecialConfig & kENET_ControlStoreAndFwdDisable)
+    {
+        /* Transmit fifo watermark settings. */
+        base->TFWR = config->txFifoWatermark & ENET_TFWR_TFWR_MASK;
+        /* Receive fifo full threshold settings. */
+        base->RSFL = config->rxFifoFullThreshold & ENET_RSFL_RX_SECTION_FULL_MASK;
+    }
+    else
+    {
+        /* Transmit fifo watermark settings. */
+        base->TFWR = ENET_TFWR_STRFWD_MASK;
+        base->RSFL = 0;
+    }
+
+    /* Enable store and forward when accelerator is enabled */
+    if (config->txAccelerConfig & (kENET_TxAccelIpCheckEnabled | kENET_TxAccelProtoCheckEnabled))
+    {
+        base->TFWR = ENET_TFWR_STRFWD_MASK;
+    }
+    if (config->rxAccelerConfig & (kENET_RxAccelIpCheckEnabled | kENET_RxAccelProtoCheckEnabled))
+    {
+        base->RSFL = 0;
+    }
+
+    /* Initializes transmit buffer descriptor rings start address, two start address should be aligned. */
+    base->TDSR = (uint32_t)bufferConfig->txBdStartAddrAlign;
+    base->RDSR = (uint32_t)bufferConfig->rxBdStartAddrAlign;
+    /* Initializes the maximum buffer size, the buffer size should be aligned. */
+    base->MRBR = bufferConfig->rxBuffSizeAlign;
+
+    /* Configures the Mac address. */
+    ENET_SetMacAddr(base, macAddr);
+
+    /* Initialize the SMI if uninitialized. */
+    if (!ENET_GetSMI(base))
+    {
+        ENET_SetSMI(base, srcClock_Hz, !!(config->macSpecialConfig & kENET_ControlSMIPreambleDisable));
+    }
+
+    /* Enables Ethernet interrupt and NVIC. */
+    ENET_EnableInterrupts(base, config->interrupt);
+    if (config->interrupt & (kENET_RxByteInterrupt | kENET_RxFrameInterrupt))
+    {
+        EnableIRQ(s_enetRxIrqId[instance]);
+    }
+    if (config->interrupt & (kENET_TxByteInterrupt | kENET_TxFrameInterrupt))
+    {
+        EnableIRQ(s_enetTxIrqId[instance]);
+    }
+    if (config->interrupt & (kENET_BabrInterrupt | kENET_BabtInterrupt | kENET_GraceStopInterrupt | kENET_MiiInterrupt |
+                             kENET_EBusERInterrupt | kENET_LateCollisionInterrupt | kENET_RetryLimitInterrupt |
+                             kENET_UnderrunInterrupt | kENET_PayloadRxInterrupt | kENET_WakeupInterrupt))
+    {
+        EnableIRQ(s_enetErrIrqId[instance]);
+    }
+
+    /* ENET control register setting. */
+    ecr = base->ECR;
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    /* Sets the 1588 enhanced feature. */
+    ecr |= ENET_ECR_EN1588_MASK;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+    /* Enables Ethernet module after all configuration except the buffer descriptor active. */
+    ecr |= ENET_ECR_ETHEREN_MASK | ENET_ECR_DBSWP_MASK;
+    base->ECR = ecr;
+}
+
+static void ENET_SetTxBufferDescriptors(volatile enet_tx_bd_struct_t *txBdStartAlign,
+                                        uint8_t *txBuffStartAlign,
+                                        uint32_t txBuffSizeAlign,
+                                        uint32_t txBdNumber)
+{
+    assert(txBdStartAlign);
+    assert(txBuffStartAlign);
+
+    uint32_t count;
+    volatile enet_tx_bd_struct_t *curBuffDescrip = txBdStartAlign;
+
+    for (count = 0; count < txBdNumber; count++)
+    {
+        /* Set data buffer address. */
+        curBuffDescrip->buffer = (uint8_t *)((uint32_t)&txBuffStartAlign[count * txBuffSizeAlign]);
+        /* Initializes data length. */
+        curBuffDescrip->length = 0;
+        /* Sets the crc. */
+        curBuffDescrip->control = ENET_BUFFDESCRIPTOR_TX_TRANMITCRC_MASK;
+        /* Sets the last buffer descriptor with the wrap flag. */
+        if (count == txBdNumber - 1)
+        {
+            curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_TX_WRAP_MASK;
+        }
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+        /* Enable transmit interrupt for store the transmit timestamp. */
+        curBuffDescrip->controlExtend1 |= ENET_BUFFDESCRIPTOR_TX_INTERRUPT_MASK;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+        /* Increase the index. */
+        curBuffDescrip++;
+    }
+}
+
+static void ENET_SetRxBufferDescriptors(volatile enet_rx_bd_struct_t *rxBdStartAlign,
+                                        uint8_t *rxBuffStartAlign,
+                                        uint32_t rxBuffSizeAlign,
+                                        uint32_t rxBdNumber,
+                                        bool enableInterrupt)
+{
+    assert(rxBdStartAlign);
+    assert(rxBuffStartAlign);
+
+    volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdStartAlign;
+    uint32_t count = 0;
+
+    /* Initializes receive buffer descriptors. */
+    for (count = 0; count < rxBdNumber; count++)
+    {
+        /* Set data buffer and the length. */
+        curBuffDescrip->buffer = (uint8_t *)((uint32_t)&rxBuffStartAlign[count * rxBuffSizeAlign]);
+        curBuffDescrip->length = 0;
+
+        /* Initializes the buffer descriptors with empty bit. */
+        curBuffDescrip->control = ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
+        /* Sets the last buffer descriptor with the wrap flag. */
+        if (count == rxBdNumber - 1)
+        {
+            curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
+        }
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+        if (enableInterrupt)
+        {
+            /* Enable receive interrupt. */
+            curBuffDescrip->controlExtend1 |= ENET_BUFFDESCRIPTOR_RX_INTERRUPT_MASK;
+        }
+        else
+        {
+            curBuffDescrip->controlExtend1 = 0;
+        }
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+        /* Increase the index. */
+        curBuffDescrip++;
+    }
+}
+
+void ENET_SetMII(ENET_Type *base, enet_mii_speed_t speed, enet_mii_duplex_t duplex)
+{
+    uint32_t rcr;
+    uint32_t tcr;
+
+    rcr = base->RCR;
+    tcr = base->TCR;
+
+    /* Sets speed mode. */
+    if (kENET_MiiSpeed10M == speed)
+    {
+        rcr |= ENET_RCR_RMII_10T_MASK;
+    }
+    else
+    {
+        rcr &= ~ENET_RCR_RMII_10T_MASK;
+    }
+    /* Set duplex mode. */
+    if (duplex == kENET_MiiHalfDuplex)
+    {
+        rcr |= ENET_RCR_DRT_MASK;
+        tcr &= ~ENET_TCR_FDEN_MASK;
+    }
+    else
+    {
+        rcr &= ~ENET_RCR_DRT_MASK;
+        tcr |= ENET_TCR_FDEN_MASK;
+    }
+
+    base->RCR = rcr;
+    base->TCR = tcr;
+}
+
+void ENET_SetMacAddr(ENET_Type *base, uint8_t *macAddr)
+{
+    uint32_t address;
+
+    /* Set physical address lower register. */
+    address = (uint32_t)(((uint32_t)macAddr[0] << 24U) | ((uint32_t)macAddr[1] << 16U) | ((uint32_t)macAddr[2] << 8U) |
+                         (uint32_t)macAddr[3]);
+    base->PALR = address;
+    /* Set physical address high register. */
+    address = (uint32_t)(((uint32_t)macAddr[4] << 8U) | ((uint32_t)macAddr[5]));
+    base->PAUR = address << ENET_PAUR_PADDR2_SHIFT;
+}
+
+void ENET_GetMacAddr(ENET_Type *base, uint8_t *macAddr)
+{
+    assert(macAddr);
+
+    uint32_t address;
+
+    /* Get from physical address lower register. */
+    address = base->PALR;
+    macAddr[0] = 0xFFU & (address >> 24U);
+    macAddr[1] = 0xFFU & (address >> 16U);
+    macAddr[2] = 0xFFU & (address >> 8U);
+    macAddr[3] = 0xFFU & address;
+
+    /* Get from physical address high register. */
+    address = (base->PAUR & ENET_PAUR_PADDR2_MASK) >> ENET_PAUR_PADDR2_SHIFT;
+    macAddr[4] = 0xFFU & (address >> 8U);
+    macAddr[5] = 0xFFU & address;
+}
+
+void ENET_SetSMI(ENET_Type *base, uint32_t srcClock_Hz, bool isPreambleDisabled)
+{
+    assert(srcClock_Hz);
+
+    uint32_t clkCycle = 0;
+    uint32_t speed = 0;
+    uint32_t mscr = 0;
+
+    /* Calculate the MII speed which controls the frequency of the MDC. */
+    speed = srcClock_Hz / (2 * ENET_MDC_FREQUENCY);
+    /* Calculate the hold time on the MDIO output. */
+    clkCycle = (10 + ENET_NANOSECOND_ONE_SECOND / srcClock_Hz - 1) / (ENET_NANOSECOND_ONE_SECOND / srcClock_Hz) - 1;
+    /* Build the configuration for MDC/MDIO control. */
+    mscr = ENET_MSCR_MII_SPEED(speed) | ENET_MSCR_DIS_PRE(isPreambleDisabled) | ENET_MSCR_HOLDTIME(clkCycle);
+    base->MSCR = mscr;
+}
+
+void ENET_StartSMIWrite(ENET_Type *base, uint32_t phyAddr, uint32_t phyReg, enet_mii_write_t operation, uint32_t data)
+{
+    uint32_t mmfr = 0;
+
+    /* Build MII write command. */
+    mmfr = ENET_MMFR_ST(1) | ENET_MMFR_OP(operation) | ENET_MMFR_PA(phyAddr) | ENET_MMFR_RA(phyReg) | ENET_MMFR_TA(2) |
+           (data & 0xFFFF);
+    base->MMFR = mmfr;
+}
+
+void ENET_StartSMIRead(ENET_Type *base, uint32_t phyAddr, uint32_t phyReg, enet_mii_read_t operation)
+{
+    uint32_t mmfr = 0;
+
+    /* Build MII read command. */
+    mmfr = ENET_MMFR_ST(1) | ENET_MMFR_OP(operation) | ENET_MMFR_PA(phyAddr) | ENET_MMFR_RA(phyReg) | ENET_MMFR_TA(2);
+    base->MMFR = mmfr;
+}
+
+void ENET_GetRxErrBeforeReadFrame(enet_handle_t *handle, enet_data_error_stats_t *eErrorStatic)
+{
+    assert(handle);
+    assert(handle->rxBdCurrent);
+    assert(eErrorStatic);
+
+    uint16_t control = 0;
+    volatile enet_rx_bd_struct_t *curBuffDescrip = handle->rxBdCurrent;
+
+    do
+    {
+        /* The last buffer descriptor of a frame. */
+        if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK)
+        {
+            control = curBuffDescrip->control;
+            if (control & ENET_BUFFDESCRIPTOR_RX_TRUNC_MASK)
+            {
+                /* The receive truncate error. */
+                eErrorStatic->statsRxTruncateErr++;
+            }
+            if (control & ENET_BUFFDESCRIPTOR_RX_OVERRUN_MASK)
+            {
+                /* The receive over run error. */
+                eErrorStatic->statsRxOverRunErr++;
+            }
+            if (control & ENET_BUFFDESCRIPTOR_RX_LENVLIOLATE_MASK)
+            {
+                /* The receive length violation error. */
+                eErrorStatic->statsRxLenGreaterErr++;
+            }
+            if (control & ENET_BUFFDESCRIPTOR_RX_NOOCTET_MASK)
+            {
+                /* The receive alignment error. */
+                eErrorStatic->statsRxAlignErr++;
+            }
+            if (control & ENET_BUFFDESCRIPTOR_RX_CRC_MASK)
+            {
+                /* The receive CRC error. */
+                eErrorStatic->statsRxFcsErr++;
+            }
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+            uint16_t controlExt = curBuffDescrip->controlExtend1;
+            if (controlExt & ENET_BUFFDESCRIPTOR_RX_MACERR_MASK)
+            {
+                /* The MAC error. */
+                eErrorStatic->statsRxMacErr++;
+            }
+            if (controlExt & ENET_BUFFDESCRIPTOR_RX_PHYERR_MASK)
+            {
+                /* The PHY error. */
+                eErrorStatic->statsRxPhyErr++;
+            }
+            if (controlExt & ENET_BUFFDESCRIPTOR_RX_COLLISION_MASK)
+            {
+                /* The receive collision error. */
+                eErrorStatic->statsRxCollisionErr++;
+            }
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+            break;
+        }
+
+        /* Increase the buffer descriptor, if it is the last one, increase to first one of the ring buffer. */
+        if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_WRAP_MASK)
+        {
+            curBuffDescrip = handle->rxBdBase;
+        }
+        else
+        {
+            curBuffDescrip++;
+        }
+
+    } while (curBuffDescrip != handle->rxBdCurrent);
+}
+
+status_t ENET_GetRxFrameSize(enet_handle_t *handle, uint32_t *length)
+{
+    assert(handle);
+    assert(handle->rxBdCurrent);
+    assert(length);
+
+    uint16_t validLastMask = ENET_BUFFDESCRIPTOR_RX_LAST_MASK | ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
+    volatile enet_rx_bd_struct_t *curBuffDescrip = handle->rxBdCurrent;
+
+    /* Check the current buffer descriptor's empty flag.  if empty means there is no frame received. */
+    if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK)
+    {
+        *length = 0;
+        return kStatus_ENET_RxFrameEmpty;
+    }
+
+    do
+    {
+        /* Find the last buffer descriptor. */
+        if ((curBuffDescrip->control & validLastMask) == ENET_BUFFDESCRIPTOR_RX_LAST_MASK)
+        {
+            /* The last buffer descriptor in the frame check the status of the received frame. */
+            if ((curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_ERR_MASK)
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+                || (curBuffDescrip->controlExtend1 & ENET_BUFFDESCRIPTOR_RX_EXT_ERR_MASK)
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+                    )
+            {
+                *length = 0;
+                return kStatus_ENET_RxFrameError;
+            }
+            /* FCS is removed by MAC. */
+            *length = curBuffDescrip->length;
+            return kStatus_Success;
+        }
+        /* Increase the buffer descriptor, if it is the last one, increase to first one of the ring buffer. */
+        if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_WRAP_MASK)
+        {
+            curBuffDescrip = handle->rxBdBase;
+        }
+        else
+        {
+            curBuffDescrip++;
+        }
+
+    } while (curBuffDescrip != handle->rxBdCurrent);
+
+    /* The frame is on processing - set to empty status to make application to receive it next time. */
+    return kStatus_ENET_RxFrameEmpty;
+}
+
+status_t ENET_ReadFrame(ENET_Type *base, enet_handle_t *handle, uint8_t *data, uint32_t length)
+{
+    assert(handle);
+    assert(handle->rxBdCurrent);
+
+    uint32_t len = 0;
+    uint32_t offset = 0;
+    bool isLastBuff = false;
+    volatile enet_rx_bd_struct_t *curBuffDescrip;
+    status_t result = kStatus_Success;
+
+    /* For data-NULL input, only update the buffer descriptor. */
+    if (!data)
+    {
+        do
+        {
+            /* Get the current buffer descriptor. */
+            curBuffDescrip = handle->rxBdCurrent;
+            /* Increase current buffer descriptor to the next one. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_WRAP_MASK)
+            {
+                handle->rxBdCurrent = handle->rxBdBase;
+            }
+            else
+            {
+                handle->rxBdCurrent++;
+            }
+
+            /* The last buffer descriptor of a frame. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK)
+            {
+                /* Find the last buffer descriptor for the frame*/
+                break;
+            }
+        } while (handle->rxBdCurrent != handle->rxBdDirty);
+
+        /* Update all receive buffer descriptors for the whole frame. */
+        ENET_UpdateReadBuffers(base, handle);
+
+        return result;
+    }
+    else
+    {
+        /* Frame read from the MAC to user buffer and update the buffer descriptors.
+        Process the frame, a frame on several receive buffers are considered . */
+        /* Get the current buffer descriptor. */
+        curBuffDescrip = handle->rxBdCurrent;
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+        enet_ptp_time_data_t ptpTimestamp;
+        bool isPtpEventMessage = false;
+
+        /* Parse the PTP message according to the header message. */
+        isPtpEventMessage = ENET_Ptp1588ParseFrame(curBuffDescrip->buffer, &ptpTimestamp, false);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+        while (!isLastBuff)
+        {
+            /* Increase current buffer descriptor to the next one. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_WRAP_MASK)
+            {
+                handle->rxBdCurrent = handle->rxBdBase;
+            }
+            else
+            {
+                handle->rxBdCurrent++;
+            }
+
+            /* The last buffer descriptor of a frame. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK)
+            {
+                /* This is a valid frame. */
+                isLastBuff = true;
+                if (length == curBuffDescrip->length)
+                {
+                    /* Copy the frame to user's buffer without FCS. */
+                    len = curBuffDescrip->length - offset;
+                    memcpy(data + offset, curBuffDescrip->buffer, len);
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+                    /* Store the PTP 1588 timestamp for received PTP event frame. */
+                    if (isPtpEventMessage)
+                    {
+                        /* Set the timestamp to the timestamp ring. */
+                        ptpTimestamp.timeStamp.nanosecond = curBuffDescrip->timestamp;
+                        result = ENET_StoreRxFrameTime(base, handle, &ptpTimestamp);
+                    }
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+                    ENET_UpdateReadBuffers(base, handle);
+                    return result;
+                }
+            }
+            else
+            {
+                /* Store the fragments of a frame on several buffer descriptors. */
+                isLastBuff = false;
+                memcpy(data + offset, curBuffDescrip->buffer, handle->rxBuffSizeAlign);
+                offset += handle->rxBuffSizeAlign;
+                if (offset >= length)
+                {
+                    break;
+                }
+            }
+
+            /* Get the current buffer descriptor. */
+            curBuffDescrip = handle->rxBdCurrent;
+        }
+        /* All error happens will break the while loop and arrive here to update receive buffers. */
+        ENET_UpdateReadBuffers(base, handle);
+    }
+    return kStatus_ENET_RxFrameFail;
+}
+
+static void ENET_UpdateReadBuffers(ENET_Type *base, enet_handle_t *handle)
+{
+    assert(handle);
+
+    do
+    {
+        /* Clears status. */
+        handle->rxBdDirty->control &= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
+        /* Sets the receive buffer descriptor with the empty flag. */
+        handle->rxBdDirty->control |= ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
+        /* Increases the buffer descriptor to the next one. */
+        if (handle->rxBdDirty->control & ENET_BUFFDESCRIPTOR_RX_WRAP_MASK)
+        {
+            handle->rxBdDirty = handle->rxBdBase;
+        }
+        else
+        {
+            handle->rxBdDirty++;
+        }
+
+        /* Actives the receive buffer descriptor. */
+        base->RDAR = ENET_RDAR_RDAR_MASK;
+
+    } while (handle->rxBdDirty != handle->rxBdCurrent);
+}
+
+status_t ENET_SendFrame(ENET_Type *base, enet_handle_t *handle, uint8_t *data, uint32_t length)
+{
+    assert(handle);
+    assert(handle->txBdCurrent);
+    assert(data);
+    assert(length <= (ENET_FRAME_MAX_VALNFRAMELEN - 4));
+
+    volatile enet_tx_bd_struct_t *curBuffDescrip = handle->txBdCurrent;
+    uint32_t len = 0;
+    uint32_t sizeleft = 0;
+
+    /* Check if the transmit buffer is ready. */
+    if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_READY_MASK)
+    {
+        return kStatus_ENET_TxFrameBusy;
+    }
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    bool isPtpEventMessage = false;
+    /* Check PTP message with the PTP header. */
+    isPtpEventMessage = ENET_Ptp1588ParseFrame(data, NULL, true);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+    /* One transmit buffer is enough for one frame. */
+    if (handle->txBuffSizeAlign >= length)
+    {
+        /* Copy data to the buffer for uDMA transfer. */
+        memcpy(curBuffDescrip->buffer, data, length);
+        /* Set data length. */
+        curBuffDescrip->length = length;
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+        /* For enable the timestamp. */
+        if (isPtpEventMessage)
+        {
+            curBuffDescrip->controlExtend1 |= ENET_BUFFDESCRIPTOR_TX_TIMESTAMP_MASK;
+        }
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+        curBuffDescrip->control |= (ENET_BUFFDESCRIPTOR_TX_READY_MASK | ENET_BUFFDESCRIPTOR_TX_LAST_MASK);
+
+        /* Increase the buffer descriptor address. */
+        if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_WRAP_MASK)
+        {
+            handle->txBdCurrent = handle->txBdBase;
+        }
+        else
+        {
+            handle->txBdCurrent++;
+        }
+
+        /* Active the transmit buffer descriptor. */
+        base->TDAR = ENET_TDAR_TDAR_MASK;
+        return kStatus_Success;
+    }
+    else
+    {
+        /* One frame requires more than one transmit buffers. */
+        do
+        {
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+            /* For enable the timestamp. */
+            if (isPtpEventMessage)
+            {
+                curBuffDescrip->controlExtend1 |= ENET_BUFFDESCRIPTOR_TX_TIMESTAMP_MASK;
+            }
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+            /* Increase the buffer descriptor address. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_WRAP_MASK)
+            {
+                handle->txBdCurrent = handle->txBdBase;
+            }
+            else
+            {
+                handle->txBdCurrent++;
+            }
+            /* update the size left to be transmit. */
+            sizeleft = length - len;
+            if (sizeleft > handle->txBuffSizeAlign)
+            {
+                /* Data copy. */
+                memcpy(curBuffDescrip->buffer, data + len, handle->txBuffSizeAlign);
+                /* Data length update. */
+                curBuffDescrip->length = handle->txBuffSizeAlign;
+                len += handle->txBuffSizeAlign;
+                /* Sets the control flag. */
+                curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_TX_READY_MASK;
+                /* Active the transmit buffer descriptor*/
+                base->TDAR = ENET_TDAR_TDAR_MASK;
+            }
+            else
+            {
+                memcpy(curBuffDescrip->buffer, data + len, sizeleft);
+                curBuffDescrip->length = sizeleft;
+                /* Set Last buffer wrap flag. */
+                curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_TX_READY_MASK | ENET_BUFFDESCRIPTOR_TX_LAST_MASK;
+                /* Active the transmit buffer descriptor. */
+                base->TDAR = ENET_TDAR_TDAR_MASK;
+                return kStatus_Success;
+            }
+
+            /* Get the current buffer descriptor address. */
+            curBuffDescrip = handle->txBdCurrent;
+
+        } while (!(curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_READY_MASK));
+
+        return kStatus_ENET_TxFrameFail;
+    }
+}
+
+void ENET_AddMulticastGroup(ENET_Type *base, uint8_t *address)
+{
+    assert(address);
+
+    uint32_t crc = 0xFFFFFFFFU;
+    uint32_t count1 = 0;
+    uint32_t count2 = 0;
+
+    /* Calculates the CRC-32 polynomial on the multicast group address. */
+    for (count1 = 0; count1 < ENET_FRAME_MACLEN; count1++)
+    {
+        uint8_t c = address[count1];
+        for (count2 = 0; count2 < 0x08U; count2++)
+        {
+            if ((c ^ crc) & 1U)
+            {
+                crc >>= 1U;
+                c >>= 1U;
+                crc ^= 0xEDB88320U;
+            }
+            else
+            {
+                crc >>= 1U;
+                c >>= 1U;
+            }
+        }
+    }
+
+    /* Enable a multicast group address. */
+    if (!((crc >> 0x1FU) & 1U))
+    {
+        base->GALR = 1U << ((crc >> 0x1AU) & 0x1FU);
+    }
+    else
+    {
+        base->GAUR = 1U << ((crc >> 0x1AU) & 0x1FU);
+    }
+}
+
+void ENET_LeaveMulticastGroup(ENET_Type *base, uint8_t *address)
+{
+    assert(address);
+
+    uint32_t crc = 0xFFFFFFFFU;
+    uint32_t count1 = 0;
+    uint32_t count2 = 0;
+
+    /* Calculates the CRC-32 polynomial on the multicast group address. */
+    for (count1 = 0; count1 < ENET_FRAME_MACLEN; count1++)
+    {
+        uint8_t c = address[count1];
+        for (count2 = 0; count2 < 0x08U; count2++)
+        {
+            if ((c ^ crc) & 1U)
+            {
+                crc >>= 1U;
+                c >>= 1U;
+                crc ^= 0xEDB88320U;
+            }
+            else
+            {
+                crc >>= 1U;
+                c >>= 1U;
+            }
+        }
+    }
+
+    /* Set the hash table. */
+    if (!((crc >> 0x1FU) & 1U))
+    {
+        base->GALR &= ~(1U << ((crc >> 0x1AU) & 0x1FU));
+    }
+    else
+    {
+        base->GAUR &= ~(1U << ((crc >> 0x1AU) & 0x1FU));
+    }
+}
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+status_t ENET_GetTxErrAfterSendFrame(enet_handle_t *handle, enet_data_error_stats_t *eErrorStatic)
+{
+    assert(handle);
+    assert(eErrorStatic);
+
+    uint16_t control = 0;
+    uint16_t controlExt = 0;
+
+    do
+    {
+        /* Get the current dirty transmit buffer descriptor. */
+        control = handle->txBdDirtyStatic->control;
+        controlExt = handle->txBdDirtyStatic->controlExtend0;
+        /* Get the control status data, If the buffer descriptor has not been processed break out. */
+        if (control & ENET_BUFFDESCRIPTOR_TX_READY_MASK)
+        {
+            return kStatus_ENET_TxFrameBusy;
+        }
+        /* Increase the transmit dirty static pointer. */
+        if (handle->txBdDirtyStatic->control & ENET_BUFFDESCRIPTOR_TX_WRAP_MASK)
+        {
+            handle->txBdDirtyStatic = handle->txBdBase;
+        }
+        else
+        {
+            handle->txBdDirtyStatic++;
+        }
+
+        /* If the transmit buffer descriptor is ready and the last buffer descriptor, store packet statistic. */
+        if (control & ENET_BUFFDESCRIPTOR_TX_LAST_MASK)
+        {
+            if (controlExt & ENET_BUFFDESCRIPTOR_TX_ERR_MASK)
+            {
+                /* Transmit error. */
+                eErrorStatic->statsTxErr++;
+            }
+            if (controlExt & ENET_BUFFDESCRIPTOR_TX_EXCCOLLISIONERR_MASK)
+            {
+                /* Transmit excess collision error. */
+                eErrorStatic->statsTxExcessCollisionErr++;
+            }
+            if (controlExt & ENET_BUFFDESCRIPTOR_TX_LATECOLLISIONERR_MASK)
+            {
+                /* Transmit late collision error. */
+                eErrorStatic->statsTxLateCollisionErr++;
+            }
+            if (controlExt & ENET_BUFFDESCRIPTOR_TX_UNDERFLOWERR_MASK)
+            {
+                /* Transmit under flow error. */
+                eErrorStatic->statsTxUnderFlowErr++;
+            }
+            if (controlExt & ENET_BUFFDESCRIPTOR_TX_OVERFLOWERR_MASK)
+            {
+                /* Transmit over flow error. */
+                eErrorStatic->statsTxOverFlowErr++;
+            }
+            return kStatus_Success;
+        }
+
+    } while (handle->txBdDirtyStatic != handle->txBdCurrent);
+
+    return kStatus_ENET_TxFrameFail;
+}
+
+static bool ENET_Ptp1588ParseFrame(uint8_t *data, enet_ptp_time_data_t *ptpTsData, bool isFastEnabled)
+{
+    assert(data);
+    if (!isFastEnabled)
+    {
+        assert(ptpTsData);
+    }
+
+    bool isPtpMsg = false;
+    uint8_t *buffer = data;
+    uint16_t ptpType;
+
+    /* Check for VLAN frame. */
+    if (*(uint16_t *)(buffer + ENET_PTP1588_ETHL2_PACKETTYPE_OFFSET) == ENET_HTONS(ENET_8021QVLAN))
+    {
+        buffer += (ENET_FRAME_VLAN_HEADERLEN - ENET_FRAME_HEADERLEN);
+    }
+
+    ptpType = *(uint16_t *)(buffer + ENET_PTP1588_ETHL2_PACKETTYPE_OFFSET);
+    switch (ENET_HTONS(ptpType))
+    { /* Ethernet layer 2. */
+        case ENET_ETHERNETL2:
+            if (*(uint8_t *)(buffer + ENET_PTP1588_ETHL2_MSGTYPE_OFFSET) <= kENET_PtpEventMsgType)
+            {
+                isPtpMsg = true;
+                if (!isFastEnabled)
+                {
+                    /* It's a ptpv2 message and store the ptp header information. */
+                    ptpTsData->version = (*(uint8_t *)(buffer + ENET_PTP1588_ETHL2_VERSION_OFFSET)) & 0x0F;
+                    ptpTsData->messageType = (*(uint8_t *)(buffer + ENET_PTP1588_ETHL2_MSGTYPE_OFFSET)) & 0x0F;
+                    ptpTsData->sequenceId = ENET_HTONS(*(uint16_t *)(buffer + ENET_PTP1588_ETHL2_SEQUENCEID_OFFSET));
+                    memcpy((void *)&ptpTsData->sourcePortId[0], (void *)(buffer + ENET_PTP1588_ETHL2_CLOCKID_OFFSET),
+                           kENET_PtpSrcPortIdLen);
+                }
+            }
+            break;
+        /* IPV4. */
+        case ENET_IPV4:
+            if ((*(uint8_t *)(buffer + ENET_PTP1588_IPVERSION_OFFSET) >> 4) == ENET_IPV4VERSION)
+            {
+                if (((*(uint16_t *)(buffer + ENET_PTP1588_IPV4_UDP_PORT_OFFSET)) == ENET_HTONS(kENET_PtpEventPort)) &&
+                    (*(uint8_t *)(buffer + ENET_PTP1588_IPV4_UDP_PROTOCOL_OFFSET) == ENET_UDPVERSION))
+                {
+                    /* Set the PTP message flag. */
+                    isPtpMsg = true;
+                    if (!isFastEnabled)
+                    {
+                        /* It's a IPV4 ptp message and store the ptp header information. */
+                        ptpTsData->version = (*(uint8_t *)(buffer + ENET_PTP1588_IPV4_UDP_VERSION_OFFSET)) & 0x0F;
+                        ptpTsData->messageType = (*(uint8_t *)(buffer + ENET_PTP1588_IPV4_UDP_MSGTYPE_OFFSET)) & 0x0F;
+                        ptpTsData->sequenceId =
+                            ENET_HTONS(*(uint16_t *)(buffer + ENET_PTP1588_IPV4_UDP_SEQUENCEID_OFFSET));
+                        memcpy((void *)&ptpTsData->sourcePortId[0],
+                               (void *)(buffer + ENET_PTP1588_IPV4_UDP_CLKID_OFFSET), kENET_PtpSrcPortIdLen);
+                    }
+                }
+            }
+            break;
+        /* IPV6. */
+        case ENET_IPV6:
+            if ((*(uint8_t *)(buffer + ENET_PTP1588_IPVERSION_OFFSET) >> 4) == ENET_IPV6VERSION)
+            {
+                if (((*(uint16_t *)(buffer + ENET_PTP1588_IPV6_UDP_PORT_OFFSET)) == ENET_HTONS(kENET_PtpEventPort)) &&
+                    (*(uint8_t *)(buffer + ENET_PTP1588_IPV6_UDP_PROTOCOL_OFFSET) == ENET_UDPVERSION))
+                {
+                    /* Set the PTP message flag. */
+                    isPtpMsg = true;
+                    if (!isFastEnabled)
+                    {
+                        /* It's a IPV6 ptp message and store the ptp header information. */
+                        ptpTsData->version = (*(uint8_t *)(buffer + ENET_PTP1588_IPV6_UDP_VERSION_OFFSET)) & 0x0F;
+                        ptpTsData->messageType = (*(uint8_t *)(buffer + ENET_PTP1588_IPV6_UDP_MSGTYPE_OFFSET)) & 0x0F;
+                        ptpTsData->sequenceId =
+                            ENET_HTONS(*(uint16_t *)(buffer + ENET_PTP1588_IPV6_UDP_SEQUENCEID_OFFSET));
+                        memcpy((void *)&ptpTsData->sourcePortId[0],
+                               (void *)(buffer + ENET_PTP1588_IPV6_UDP_CLKID_OFFSET), kENET_PtpSrcPortIdLen);
+                    }
+                }
+            }
+            break;
+        default:
+            break;
+    }
+    return isPtpMsg;
+}
+
+void ENET_Ptp1588Configure(ENET_Type *base, enet_handle_t *handle, enet_ptp_config_t *ptpConfig)
+{
+    assert(handle);
+    assert(ptpConfig);
+
+    uint32_t instance = ENET_GetInstance(base);
+
+    /* Start the 1588 timer. */
+    ENET_Ptp1588StartTimer(base, ptpConfig->ptp1588ClockSrc_Hz);
+
+    /* Enables the time stamp interrupt for the master clock on a device. */
+    ENET_EnableInterrupts(base, kENET_TsTimerInterrupt);
+    EnableIRQ(s_enetTsIrqId[instance]);
+
+    /* Enables the transmit interrupt to store the transmit frame time-stamp. */
+    ENET_EnableInterrupts(base, kENET_TxFrameInterrupt);
+    EnableIRQ(s_enetTxIrqId[instance]);
+
+    /* Setting the receive and transmit state for transaction. */
+    handle->rxPtpTsDataRing.ptpTsData = ptpConfig->rxPtpTsData;
+    handle->rxPtpTsDataRing.size = ptpConfig->ptpTsRxBuffNum;
+    handle->rxPtpTsDataRing.front = 0;
+    handle->rxPtpTsDataRing.end = 0;
+    handle->txPtpTsDataRing.ptpTsData = ptpConfig->txPtpTsData;
+    handle->txPtpTsDataRing.size = ptpConfig->ptpTsTxBuffNum;
+    handle->txPtpTsDataRing.front = 0;
+    handle->txPtpTsDataRing.end = 0;
+    handle->msTimerSecond = 0;
+    handle->txBdDirtyTime = handle->txBdBase;
+    handle->txBdDirtyStatic = handle->txBdBase;
+}
+
+void ENET_Ptp1588StartTimer(ENET_Type *base, uint32_t ptpClkSrc)
+{
+    /* Restart PTP 1588 timer, master clock. */
+    base->ATCR = ENET_ATCR_RESTART_MASK;
+
+    /* Initializes PTP 1588 timer. */
+    base->ATINC = ENET_ATINC_INC(ENET_NANOSECOND_ONE_SECOND / ptpClkSrc);
+    base->ATPER = ENET_NANOSECOND_ONE_SECOND;
+    /* Sets periodical event and the event signal output assertion and Actives PTP 1588 timer.  */
+    base->ATCR = ENET_ATCR_PEREN_MASK | ENET_ATCR_PINPER_MASK | ENET_ATCR_EN_MASK;
+}
+
+void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime)
+{
+    assert(handle);
+    assert(ptpTime);
+    uint16_t count = ENET_1588TIME_DELAY_COUNT;
+    uint32_t primask;
+
+    /* Disables the interrupt. */
+    primask = DisableGlobalIRQ();
+
+    /* Get the current PTP time. */
+    ptpTime->second = handle->msTimerSecond;
+    /* Get the nanosecond from the master timer. */
+    base->ATCR |= ENET_ATCR_CAPTURE_MASK;
+    /* Add at least six clock cycle delay to get accurate time.
+       It's the requirement when the 1588 clock source is slower
+       than the register clock.
+    */
+    while (count--)
+    {
+        __NOP();
+    }
+    /* Get the captured time. */
+    ptpTime->nanosecond = base->ATVR;
+
+    /* Enables the interrupt. */
+    EnableGlobalIRQ(primask);
+}
+
+void ENET_Ptp1588SetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime)
+{
+    assert(handle);
+    assert(ptpTime);
+
+    uint32_t primask;
+
+    /* Disables the interrupt. */
+    primask = DisableGlobalIRQ();
+
+    /* Sets PTP timer. */
+    handle->msTimerSecond = ptpTime->second;
+    base->ATVR = ptpTime->nanosecond;
+
+    /* Enables the interrupt. */
+    EnableGlobalIRQ(primask);
+}
+
+void ENET_Ptp1588AdjustTimer(ENET_Type *base, uint32_t corrIncrease, uint32_t corrPeriod)
+{
+    /* Set correction for PTP timer increment. */
+    base->ATINC = (base->ATINC & ~ENET_ATINC_INC_CORR_MASK) | (corrIncrease << ENET_ATINC_INC_CORR_SHIFT);
+    /* Set correction for PTP timer period. */
+    base->ATCOR = (base->ATCOR & ~ENET_ATCOR_COR_MASK) | (corrPeriod << ENET_ATCOR_COR_SHIFT);
+}
+
+static status_t ENET_Ptp1588UpdateTimeRing(enet_ptp_time_data_ring_t *ptpTsDataRing, enet_ptp_time_data_t *ptpTimeData)
+{
+    assert(ptpTsDataRing);
+    assert(ptpTsDataRing->ptpTsData);
+    assert(ptpTimeData);
+
+    uint16_t usedBuffer = 0;
+
+    /* Check if the buffers ring is full. */
+    if (ptpTsDataRing->end >= ptpTsDataRing->front)
+    {
+        usedBuffer = ptpTsDataRing->end - ptpTsDataRing->front;
+    }
+    else
+    {
+        usedBuffer = ptpTsDataRing->size - (ptpTsDataRing->front - ptpTsDataRing->end);
+    }
+
+    if (usedBuffer == ptpTsDataRing->size)
+    {
+        return kStatus_ENET_PtpTsRingFull;
+    }
+
+    /* Copy the new data into the buffer. */
+    memcpy((ptpTsDataRing->ptpTsData + ptpTsDataRing->end), ptpTimeData, sizeof(enet_ptp_time_data_t));
+
+    /* Increase the buffer pointer to the next empty one. */
+    ptpTsDataRing->end = (ptpTsDataRing->end + 1) % ptpTsDataRing->size;
+
+    return kStatus_Success;
+}
+
+static status_t ENET_Ptp1588SearchTimeRing(enet_ptp_time_data_ring_t *ptpTsDataRing, enet_ptp_time_data_t *ptpTimedata)
+{
+    assert(ptpTsDataRing);
+    assert(ptpTsDataRing->ptpTsData);
+    assert(ptpTimedata);
+
+    uint32_t index;
+    uint32_t size;
+    uint16_t usedBuffer = 0;
+
+    /* Check the PTP 1588 timestamp ring. */
+    if (ptpTsDataRing->front == ptpTsDataRing->end)
+    {
+        return kStatus_ENET_PtpTsRingEmpty;
+    }
+
+    /* Search the element in the ring buffer */
+    index = ptpTsDataRing->front;
+    size = ptpTsDataRing->size;
+    while (index != ptpTsDataRing->end)
+    {
+        if (((ptpTsDataRing->ptpTsData + index)->sequenceId == ptpTimedata->sequenceId) &&
+            (!memcmp(((void *)&(ptpTsDataRing->ptpTsData + index)->sourcePortId[0]),
+                     (void *)&ptpTimedata->sourcePortId[0], kENET_PtpSrcPortIdLen)) &&
+            ((ptpTsDataRing->ptpTsData + index)->version == ptpTimedata->version) &&
+            ((ptpTsDataRing->ptpTsData + index)->messageType == ptpTimedata->messageType))
+        {
+            break;
+        }
+
+        /* Increase the ptp ring index. */
+        index = (index + 1) % size;
+    }
+
+    if (index == ptpTsDataRing->end)
+    {
+        /* Check if buffers is full. */
+        if (ptpTsDataRing->end >= ptpTsDataRing->front)
+        {
+            usedBuffer = ptpTsDataRing->end - ptpTsDataRing->front;
+        }
+        else
+        {
+            usedBuffer = ptpTsDataRing->size - (ptpTsDataRing->front - ptpTsDataRing->end);
+        }
+
+        if (usedBuffer == ptpTsDataRing->size)
+        { /* Drop one in the front. */
+            ptpTsDataRing->front = (ptpTsDataRing->front + 1) % size;
+        }
+        return kStatus_ENET_PtpTsRingFull;
+    }
+
+    /* Get the right timestamp of the required ptp messag. */
+    ptpTimedata->timeStamp.second = (ptpTsDataRing->ptpTsData + index)->timeStamp.second;
+    ptpTimedata->timeStamp.nanosecond = (ptpTsDataRing->ptpTsData + index)->timeStamp.nanosecond;
+
+    /* Increase the index. */
+    ptpTsDataRing->front = (ptpTsDataRing->front + 1) % size;
+
+    return kStatus_Success;
+}
+
+static status_t ENET_StoreRxFrameTime(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_data_t *ptpTimeData)
+{
+    assert(handle);
+    assert(ptpTimeData);
+
+    bool ptpTimerWrap = false;
+    enet_ptp_time_t ptpTimer;
+    uint32_t primask;
+
+    /* Disables the interrupt. */
+    primask = DisableGlobalIRQ();
+
+    /* Get current PTP timer nanosecond value. */
+    ENET_Ptp1588GetTimer(base, handle, &ptpTimer);
+
+    /* Get PTP timer wrap event. */
+    ptpTimerWrap = base->EIR & kENET_TsTimerInterrupt;
+
+    /* Get transmit time stamp second. */
+    if ((ptpTimer.nanosecond > ptpTimeData->timeStamp.nanosecond) ||
+        ((ptpTimer.nanosecond < ptpTimeData->timeStamp.nanosecond) && ptpTimerWrap))
+    {
+        ptpTimeData->timeStamp.second = handle->msTimerSecond;
+    }
+    else
+    {
+        ptpTimeData->timeStamp.second = handle->msTimerSecond - 1;
+    }
+    /* Enable the interrupt. */
+    EnableGlobalIRQ(primask);
+
+    /* Store the timestamp to the receive time stamp ring. */
+    /* Check if the buffers ring is full. */
+    return ENET_Ptp1588UpdateTimeRing(&handle->rxPtpTsDataRing, ptpTimeData);
+}
+
+static status_t ENET_StoreTxFrameTime(ENET_Type *base, enet_handle_t *handle)
+{
+    assert(handle);
+
+    uint32_t primask;
+    bool ptpTimerWrap;
+    bool isPtpEventMessage = false;
+    enet_ptp_time_data_t ptpTimeData;
+    volatile enet_tx_bd_struct_t *curBuffDescrip = handle->txBdDirtyTime;
+
+    /* Get the control status data, If the buffer descriptor has not been processed break out. */
+    if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_READY_MASK)
+    {
+        return kStatus_ENET_TxFrameBusy;
+    }
+
+    /* Parse the PTP message. */
+    isPtpEventMessage = ENET_Ptp1588ParseFrame(curBuffDescrip->buffer, &ptpTimeData, false);
+    if (isPtpEventMessage)
+    {
+        do
+        {
+            /* Increase current buffer descriptor to the next one. */
+            if (handle->txBdDirtyTime->control & ENET_BUFFDESCRIPTOR_TX_WRAP_MASK)
+            {
+                handle->txBdDirtyTime = handle->txBdBase;
+            }
+            else
+            {
+                handle->txBdDirtyTime++;
+            }
+
+            /* Do time stamp check on the last buffer descriptor of the frame. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_LAST_MASK)
+            {
+                /* Disables the interrupt. */
+                primask = DisableGlobalIRQ();
+
+                /* Get current PTP timer nanosecond value. */
+                ENET_Ptp1588GetTimer(base, handle, &ptpTimeData.timeStamp);
+
+                /* Get PTP timer wrap event. */
+                ptpTimerWrap = base->EIR & kENET_TsTimerInterrupt;
+
+                /* Get transmit time stamp second. */
+                if ((ptpTimeData.timeStamp.nanosecond > curBuffDescrip->timestamp) ||
+                    ((ptpTimeData.timeStamp.nanosecond < curBuffDescrip->timestamp) && ptpTimerWrap))
+                {
+                    ptpTimeData.timeStamp.second = handle->msTimerSecond;
+                }
+                else
+                {
+                    ptpTimeData.timeStamp.second = handle->msTimerSecond - 1;
+                }
+
+                /* Enable the interrupt. */
+                EnableGlobalIRQ(primask);
+
+                /* Store the timestamp to the transmit timestamp ring. */
+                return ENET_Ptp1588UpdateTimeRing(&handle->txPtpTsDataRing, &ptpTimeData);
+            }
+
+            /* Get the current transmit buffer descriptor. */
+            curBuffDescrip = handle->txBdDirtyTime;
+
+            /* Get the control status data, If the buffer descriptor has not been processed break out. */
+            if (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_TX_READY_MASK)
+            {
+                return kStatus_ENET_TxFrameBusy;
+            }
+        } while (handle->txBdDirtyTime != handle->txBdCurrent);
+        return kStatus_ENET_TxFrameFail;
+    }
+    return kStatus_Success;
+}
+
+status_t ENET_GetTxFrameTime(enet_handle_t *handle, enet_ptp_time_data_t *ptpTimeData)
+{
+    assert(handle);
+    assert(ptpTimeData);
+
+    return ENET_Ptp1588SearchTimeRing(&handle->txPtpTsDataRing, ptpTimeData);
+}
+
+status_t ENET_GetRxFrameTime(enet_handle_t *handle, enet_ptp_time_data_t *ptpTimeData)
+{
+    assert(handle);
+    assert(ptpTimeData);
+
+    return ENET_Ptp1588SearchTimeRing(&handle->rxPtpTsDataRing, ptpTimeData);
+}
+
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+void ENET_TransmitIRQHandler(ENET_Type *base, enet_handle_t *handle)
+{
+    assert(handle);
+
+    /* Check if the transmit interrupt happen. */
+    if ((kENET_TxByteInterrupt | kENET_TxFrameInterrupt) & base->EIR)
+    {
+        /* Clear the transmit interrupt event. */
+        base->EIR = kENET_TxFrameInterrupt | kENET_TxByteInterrupt;
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+        /* Store the transmit timestamp from the buffer descriptor should be done here. */
+        ENET_StoreTxFrameTime(base, handle);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+        /* Callback function. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kENET_TxEvent, handle->userData);
+        }
+    }
+}
+
+void ENET_ReceiveIRQHandler(ENET_Type *base, enet_handle_t *handle)
+{
+    assert(handle);
+
+    /* Check if the receive interrupt happen. */
+    if ((kENET_RxByteInterrupt | kENET_RxFrameInterrupt) & base->EIR)
+    {
+        /* Clear the transmit interrupt event. */
+        base->EIR = kENET_RxFrameInterrupt | kENET_RxByteInterrupt;
+
+        /* Callback function. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kENET_RxEvent, handle->userData);
+        }
+    }
+}
+
+void ENET_ErrorIRQHandler(ENET_Type *base, enet_handle_t *handle)
+{
+    assert(handle);
+
+    uint32_t errMask = kENET_BabrInterrupt | kENET_BabtInterrupt | kENET_EBusERInterrupt | kENET_PayloadRxInterrupt |
+                       kENET_LateCollisionInterrupt | kENET_RetryLimitInterrupt | kENET_UnderrunInterrupt;
+
+    /* Check if the PTP time stamp interrupt happen. */
+    if (kENET_WakeupInterrupt & base->EIR)
+    {
+        /* Clear the wakeup interrupt. */
+        base->EIR = kENET_WakeupInterrupt;
+        /* wake up and enter the normal mode. */
+        ENET_EnableSleepMode(base, false);
+        /* Callback function. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kENET_WakeUpEvent, handle->userData);
+        }
+    }
+    else
+    {
+        /* Clear the time stamp interrupt. */
+        errMask &= base->EIR;
+        base->EIR = errMask;
+        /* Callback function. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kENET_ErrEvent, handle->userData);
+        }
+    }
+}
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+void ENET_Ptp1588TimerIRQHandler(ENET_Type *base, enet_handle_t *handle)
+{
+    assert(handle);
+
+    /* Check if the PTP time stamp interrupt happen. */
+    if (kENET_TsTimerInterrupt & base->EIR)
+    {
+        /* Clear the time stamp interrupt. */
+        base->EIR = kENET_TsTimerInterrupt;
+
+        /* Increase timer second counter. */
+        handle->msTimerSecond++;
+
+        /* Callback function. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kENET_TimeStampEvent, handle->userData);
+        }
+    }
+    else
+    {
+        /* Clear the time stamp interrupt. */
+        base->EIR = kENET_TsAvailInterrupt;
+        /* Callback function. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kENET_TimeStampAvailEvent, handle->userData);
+        }
+    }
+}
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+void ENET_Transmit_IRQHandler(void)
+{
+    ENET_TransmitIRQHandler(ENET, s_ENETHandle[0]);
+}
+
+void ENET_Receive_IRQHandler(void)
+{
+    ENET_ReceiveIRQHandler(ENET, s_ENETHandle[0]);
+}
+
+void ENET_Error_IRQHandler(void)
+{
+    ENET_ErrorIRQHandler(ENET, s_ENETHandle[0]);
+}
+
+void ENET_1588_Timer_IRQHandler(void)
+{
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    ENET_Ptp1588TimerIRQHandler(ENET, s_ENETHandle[0]);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_enet.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_enet.h
@@ -1,0 +1,1160 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_ENET_H_
+#define _FSL_ENET_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup enet
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief Defines the driver version. */
+#define FSL_ENET_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0. */
+/*@}*/
+
+/*! @name Control and status region bit masks of the receive buffer descriptor. */
+/*@{*/
+#define ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK 0x8000U       /*!< Empty bit mask. */
+#define ENET_BUFFDESCRIPTOR_RX_SOFTOWNER1_MASK 0x4000U  /*!< Software owner one mask. */
+#define ENET_BUFFDESCRIPTOR_RX_WRAP_MASK 0x2000U        /*!< Next buffer descriptor is the start address. */
+#define ENET_BUFFDESCRIPTOR_RX_SOFTOWNER2_Mask 0x1000U  /*!< Software owner two mask. */
+#define ENET_BUFFDESCRIPTOR_RX_LAST_MASK 0x0800U        /*!< Last BD of the frame mask. */
+#define ENET_BUFFDESCRIPTOR_RX_MISS_MASK 0x0100U        /*!< Received because of the promiscuous mode. */
+#define ENET_BUFFDESCRIPTOR_RX_BROADCAST_MASK 0x0080U   /*!< Broadcast packet mask. */
+#define ENET_BUFFDESCRIPTOR_RX_MULTICAST_MASK 0x0040U   /*!< Multicast packet mask. */
+#define ENET_BUFFDESCRIPTOR_RX_LENVLIOLATE_MASK 0x0020U /*!< Length violation mask. */
+#define ENET_BUFFDESCRIPTOR_RX_NOOCTET_MASK 0x0010U     /*!< Non-octet aligned frame mask. */
+#define ENET_BUFFDESCRIPTOR_RX_CRC_MASK 0x0004U         /*!< CRC error mask. */
+#define ENET_BUFFDESCRIPTOR_RX_OVERRUN_MASK 0x0002U     /*!< FIFO overrun mask. */
+#define ENET_BUFFDESCRIPTOR_RX_TRUNC_MASK 0x0001U       /*!< Frame is truncated mask. */
+/*@}*/
+
+/*! @name Control and status bit masks of the transmit buffer descriptor. */
+/*@{*/
+#define ENET_BUFFDESCRIPTOR_TX_READY_MASK 0x8000U       /*!< Ready bit mask. */
+#define ENET_BUFFDESCRIPTOR_TX_SOFTOWENER1_MASK 0x4000U /*!< Software owner one mask. */
+#define ENET_BUFFDESCRIPTOR_TX_WRAP_MASK 0x2000U        /*!< Wrap buffer descriptor mask. */
+#define ENET_BUFFDESCRIPTOR_TX_SOFTOWENER2_MASK 0x1000U /*!< Software owner two mask. */
+#define ENET_BUFFDESCRIPTOR_TX_LAST_MASK 0x0800U        /*!< Last BD of the frame mask. */
+#define ENET_BUFFDESCRIPTOR_TX_TRANMITCRC_MASK 0x0400U  /*!< Transmit CRC mask. */
+/*@}*/
+
+/* Extended control regions for enhanced buffer descriptors. */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*! @name First extended control region bit masks of the receive buffer descriptor. */
+/*@{*/
+#define ENET_BUFFDESCRIPTOR_RX_IPV4_MASK 0x0001U             /*!< Ipv4 frame mask. */
+#define ENET_BUFFDESCRIPTOR_RX_IPV6_MASK 0x0002U             /*!< Ipv6 frame mask. */
+#define ENET_BUFFDESCRIPTOR_RX_VLAN_MASK 0x0004U             /*!< VLAN frame mask. */
+#define ENET_BUFFDESCRIPTOR_RX_PROTOCOLCHECKSUM_MASK 0x0010U /*!< Protocol checksum error mask. */
+#define ENET_BUFFDESCRIPTOR_RX_IPHEADCHECKSUM_MASK 0x0020U   /*!< IP header checksum error mask. */
+/*@}*/
+
+/*! @name Second extended control region bit masks of the receive buffer descriptor. */
+/*@{*/
+#define ENET_BUFFDESCRIPTOR_RX_INTERRUPT_MASK 0x0080U /*!< BD interrupt mask. */
+#define ENET_BUFFDESCRIPTOR_RX_UNICAST_MASK 0x0100U   /*!< Unicast frame mask. */
+#define ENET_BUFFDESCRIPTOR_RX_COLLISION_MASK 0x0200U /*!< BD collision mask. */
+#define ENET_BUFFDESCRIPTOR_RX_PHYERR_MASK 0x0400U    /*!< PHY error mask. */
+#define ENET_BUFFDESCRIPTOR_RX_MACERR_MASK 0x8000U    /*!< Mac error mask. */
+/*@}*/
+
+/*! @name First extended control region bit masks of the transmit buffer descriptor. */
+/*@{*/
+#define ENET_BUFFDESCRIPTOR_TX_ERR_MASK 0x8000U              /*!< Transmit error mask. */
+#define ENET_BUFFDESCRIPTOR_TX_UNDERFLOWERR_MASK 0x2000U     /*!< Underflow error mask. */
+#define ENET_BUFFDESCRIPTOR_TX_EXCCOLLISIONERR_MASK 0x1000U  /*!< Excess collision error mask. */
+#define ENET_BUFFDESCRIPTOR_TX_FRAMEERR_MASK 0x0800U         /*!< Frame error mask. */
+#define ENET_BUFFDESCRIPTOR_TX_LATECOLLISIONERR_MASK 0x0400U /*!< Late collision error mask. */
+#define ENET_BUFFDESCRIPTOR_TX_OVERFLOWERR_MASK 0x0200U      /*!< Overflow error mask. */
+#define ENET_BUFFDESCRIPTOR_TX_TIMESTAMPERR_MASK 0x0100U     /*!< Timestamp error mask. */
+/*@}*/
+
+/*! @name Second extended control region bit masks of the transmit buffer descriptor. */
+/*@{*/
+#define ENET_BUFFDESCRIPTOR_TX_INTERRUPT_MASK 0x4000U /*!< Interrupt mask. */
+#define ENET_BUFFDESCRIPTOR_TX_TIMESTAMP_MASK 0x2000U /*!< Timestamp flag mask. */
+/*@}*/
+#endif                                                /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+/*! @brief Defines the receive error status flag mask. */
+#define ENET_BUFFDESCRIPTOR_RX_ERR_MASK                                        \
+    (ENET_BUFFDESCRIPTOR_RX_TRUNC_MASK | ENET_BUFFDESCRIPTOR_RX_OVERRUN_MASK | \
+     ENET_BUFFDESCRIPTOR_RX_LENVLIOLATE_MASK | ENET_BUFFDESCRIPTOR_RX_NOOCTET_MASK | ENET_BUFFDESCRIPTOR_RX_CRC_MASK)
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+#define ENET_BUFFDESCRIPTOR_RX_EXT_ERR_MASK \
+    (ENET_BUFFDESCRIPTOR_RX_MACERR_MASK | ENET_BUFFDESCRIPTOR_RX_PHYERR_MASK | ENET_BUFFDESCRIPTOR_RX_COLLISION_MASK)
+#endif
+
+/*! @name Defines the maximum Ethernet frame size. */
+/*@{*/
+#define ENET_FRAME_MAX_FRAMELEN 1518U     /*!< Maximum Ethernet frame size. */
+#define ENET_FRAME_MAX_VALNFRAMELEN 1522U /*!< Maximum VLAN frame size. */
+/*@}*/
+
+#define ENET_FIFO_MIN_RX_FULL 5U /*!< ENET minimum receive FIFO full. */
+#define ENET_RX_MIN_BUFFERSIZE 256U /*!< ENET minimum buffer size. */
+#define ENET_BUFF_ALIGNMENT 16U /*!< Ethernet buffer alignment. */
+
+/*! @brief Defines the PHY address scope for the ENET. */
+#define ENET_PHY_MAXADDRESS (ENET_MMFR_PA_MASK >> ENET_MMFR_PA_SHIFT)
+
+/*! @brief Defines the status return codes for transaction. */
+enum _enet_status
+{
+    kStatus_ENET_RxFrameError = MAKE_STATUS(kStatusGroup_ENET, 0U), /*!< A frame received but data error happen. */
+    kStatus_ENET_RxFrameFail = MAKE_STATUS(kStatusGroup_ENET, 1U),  /*!< Failed to receive a frame. */
+    kStatus_ENET_RxFrameEmpty = MAKE_STATUS(kStatusGroup_ENET, 2U), /*!< No frame arrive. */
+    kStatus_ENET_TxFrameBusy =
+        MAKE_STATUS(kStatusGroup_ENET, 3U),                       /*!< Transmit buffer descriptors are under process. */
+    kStatus_ENET_TxFrameFail = MAKE_STATUS(kStatusGroup_ENET, 4U) /*!< Transmit frame fail. */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    ,
+    kStatus_ENET_PtpTsRingFull = MAKE_STATUS(kStatusGroup_ENET, 5U), /*!< Timestamp ring full. */
+    kStatus_ENET_PtpTsRingEmpty = MAKE_STATUS(kStatusGroup_ENET, 6U) /*!< Timestamp ring empty. */
+#endif                                                               /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+};
+
+/*! @brief Defines the RMII or MII mode for data interface between the MAC and the PHY. */
+typedef enum _enet_mii_mode
+{
+    kENET_MiiMode = 0U, /*!< MII mode for data interface. */
+    kENET_RmiiMode      /*!< RMII mode for data interface. */
+} enet_mii_mode_t;
+
+/*! @brief Defines the 10 Mbps or 100 Mbps speed for the  MII data interface. */
+typedef enum _enet_mii_speed
+{
+    kENET_MiiSpeed10M = 0U, /*!< Speed 10 Mbps. */
+    kENET_MiiSpeed100M      /*!< Speed 100 Mbps. */
+} enet_mii_speed_t;
+
+/*! @brief Defines the half or full duplex for the MII data interface. */
+typedef enum _enet_mii_duplex
+{
+    kENET_MiiHalfDuplex = 0U, /*!< Half duplex mode. */
+    kENET_MiiFullDuplex       /*!< Full duplex mode. */
+} enet_mii_duplex_t;
+
+/*! @brief Defines the write operation for the MII management frame. */
+typedef enum _enet_mii_write
+{
+    kENET_MiiWriteNoCompliant = 0U, /*!< Write frame operation, but not MII-compliant. */
+    kENET_MiiWriteValidFrame        /*!< Write frame operation for a valid MII management frame. */
+} enet_mii_write_t;
+
+/*! @brief Defines the read operation for the MII management frame. */
+typedef enum _enet_mii_read
+{
+    kENET_MiiReadValidFrame = 2U, /*!< Read frame operation for a valid MII management frame. */
+    kENET_MiiReadNoCompliant = 3U /*!< Read frame operation, but not MII-compliant. */
+} enet_mii_read_t;
+
+/*! @brief Defines a special configuration for ENET MAC controller.
+ *
+ * These control flags are provided for special user requirements.
+ * Normally, these control flags are unused for ENET initialization.
+ * For special requirements, set the flags to
+ * macSpecialConfig in the enet_config_t.
+ * The kENET_ControlStoreAndFwdDisable is used to disable the FIFO store
+ * and forward. FIFO store and forward means that the FIFO read/send is started
+ * when a complete frame is stored in TX/RX FIFO. If this flag is set,
+ * configure rxFifoFullThreshold and txFifoWatermark
+ * in the enet_config_t.
+ */
+typedef enum _enet_special_control_flag
+{
+    kENET_ControlFlowControlEnable = 0x0001U,       /*!< Enable ENET flow control: pause frame. */
+    kENET_ControlRxPayloadCheckEnable = 0x0002U,    /*!< Enable ENET receive payload length check. */
+    kENET_ControlRxPadRemoveEnable = 0x0004U,       /*!< Padding is removed from received frames. */
+    kENET_ControlRxBroadCastRejectEnable = 0x0008U, /*!< Enable broadcast frame reject. */
+    kENET_ControlMacAddrInsert = 0x0010U,           /*!< Enable MAC address insert. */
+    kENET_ControlStoreAndFwdDisable = 0x0020U,      /*!< Enable FIFO store and forward. */
+    kENET_ControlSMIPreambleDisable = 0x0040U,      /*!< Enable SMI preamble. */
+    kENET_ControlPromiscuousEnable = 0x0080U,       /*!< Enable promiscuous mode. */
+    kENET_ControlMIILoopEnable = 0x0100U,           /*!< Enable ENET MII loop back. */
+    kENET_ControlVLANTagEnable = 0x0200U            /*!< Enable VLAN tag frame. */
+} enet_special_control_flag_t;
+
+/*! @brief List of interrupts supported by the peripheral. This
+ * enumeration uses one-bot encoding to allow a logical OR of multiple
+ * members. Members usually map to interrupt enable bits in one or more
+ * peripheral registers.
+ */
+typedef enum _enet_interrupt_enable
+{
+    kENET_BabrInterrupt = ENET_EIR_BABR_MASK,        /*!< Babbling receive error interrupt source */
+    kENET_BabtInterrupt = ENET_EIR_BABT_MASK,        /*!< Babbling transmit error interrupt source */
+    kENET_GraceStopInterrupt = ENET_EIR_GRA_MASK,    /*!< Graceful stop complete interrupt source */
+    kENET_TxFrameInterrupt = ENET_EIR_TXF_MASK,      /*!< TX FRAME interrupt source */
+    kENET_TxByteInterrupt = ENET_EIR_TXB_MASK,       /*!< TX BYTE interrupt source */
+    kENET_RxFrameInterrupt = ENET_EIR_RXF_MASK,      /*!< RX FRAME interrupt source */
+    kENET_RxByteInterrupt = ENET_EIR_RXB_MASK,       /*!< RX BYTE interrupt source */
+    kENET_MiiInterrupt = ENET_EIR_MII_MASK,          /*!< MII interrupt source */
+    kENET_EBusERInterrupt = ENET_EIR_EBERR_MASK,     /*!< Ethernet bus error interrupt source */
+    kENET_LateCollisionInterrupt = ENET_EIR_LC_MASK, /*!< Late collision interrupt source */
+    kENET_RetryLimitInterrupt = ENET_EIR_RL_MASK,    /*!< Collision Retry Limit interrupt source */
+    kENET_UnderrunInterrupt = ENET_EIR_UN_MASK,      /*!< Transmit FIFO underrun interrupt source */
+    kENET_PayloadRxInterrupt = ENET_EIR_PLR_MASK,    /*!< Payload Receive interrupt source */
+    kENET_WakeupInterrupt = ENET_EIR_WAKEUP_MASK     /*!< WAKEUP interrupt source */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    ,
+    kENET_TsAvailInterrupt = ENET_EIR_TS_AVAIL_MASK, /*!< TS AVAIL interrupt source for PTP */
+    kENET_TsTimerInterrupt = ENET_EIR_TS_TIMER_MASK  /*!< TS WRAP interrupt source for PTP */
+#endif                                               /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+} enet_interrupt_enable_t;
+
+/*! @brief Defines the common interrupt event for callback use. */
+typedef enum _enet_event
+{
+    kENET_RxEvent,     /*!< Receive event. */
+    kENET_TxEvent,     /*!< Transmit event. */
+    kENET_ErrEvent,    /*!< Error event: BABR/BABT/EBERR/LC/RL/UN/PLR . */
+    kENET_WakeUpEvent, /*!< Wake up from sleep mode event. */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    kENET_TimeStampEvent,     /*!< Time stamp event. */
+    kENET_TimeStampAvailEvent /*!< Time stamp available event.*/
+#endif                        /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+} enet_event_t;
+
+/*! @brief Defines the transmit accelerator configuration. */
+typedef enum _enet_tx_accelerator
+{
+    kENET_TxAccelIsShift16Enabled = ENET_TACC_SHIFT16_MASK, /*!< Transmit FIFO shift-16. */
+    kENET_TxAccelIpCheckEnabled = ENET_TACC_IPCHK_MASK,     /*!< Insert IP header checksum. */
+    kENET_TxAccelProtoCheckEnabled = ENET_TACC_PROCHK_MASK  /*!< Insert protocol checksum. */
+} enet_tx_accelerator_t;
+
+/*! @brief Defines the receive accelerator configuration. */
+typedef enum _enet_rx_accelerator
+{
+    kENET_RxAccelPadRemoveEnabled = ENET_RACC_PADREM_MASK,  /*!< Padding removal for short IP frames. */
+    kENET_RxAccelIpCheckEnabled = ENET_RACC_IPDIS_MASK,     /*!< Discard with wrong IP header checksum. */
+    kENET_RxAccelProtoCheckEnabled = ENET_RACC_PRODIS_MASK, /*!< Discard with wrong protocol checksum. */
+    kENET_RxAccelMacCheckEnabled = ENET_RACC_LINEDIS_MASK,  /*!< Discard with Mac layer errors. */
+    kENET_RxAccelisShift16Enabled = ENET_RACC_SHIFT16_MASK  /*!< Receive FIFO shift-16. */
+} enet_rx_accelerator_t;
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*! @brief Defines the ENET PTP message related constant. */
+typedef enum _enet_ptp_event_type
+{
+    kENET_PtpEventMsgType = 3U,  /*!< PTP event message type. */
+    kENET_PtpSrcPortIdLen = 10U, /*!< PTP message sequence id length. */
+    kENET_PtpEventPort = 319U,   /*!< PTP event port number. */
+    kENET_PtpGnrlPort = 320U     /*!< PTP general port number. */
+} enet_ptp_event_type_t;
+
+/*! @brief Defines the IEEE 1588 PTP timer channel numbers. */
+typedef enum _enet_ptp_timer_channel
+{
+    kENET_PtpTimerChannel1 = 0U, /*!< IEEE 1588 PTP timer Channel 1. */
+    kENET_PtpTimerChannel2,      /*!< IEEE 1588 PTP timer Channel 2. */
+    kENET_PtpTimerChannel3,      /*!< IEEE 1588 PTP timer Channel 3. */
+    kENET_PtpTimerChannel4       /*!< IEEE 1588 PTP timer Channel 4. */
+} enet_ptp_timer_channel_t;
+
+/*! @brief Defines the capture or compare mode for IEEE 1588 PTP timer channels. */
+typedef enum _enet_ptp_timer_channel_mode
+{
+    kENET_PtpChannelDisable = 0U,                  /*!< Disable timer channel. */
+    kENET_PtpChannelRisingCapture = 1U,            /*!< Input capture on rising edge. */
+    kENET_PtpChannelFallingCapture = 2U,           /*!< Input capture on falling edge. */
+    kENET_PtpChannelBothCapture = 3U,              /*!< Input capture on both edges. */
+    kENET_PtpChannelSoftCompare = 4U,              /*!< Output compare software only. */
+    kENET_PtpChannelToggleCompare = 5U,            /*!< Toggle output on compare. */
+    kENET_PtpChannelClearCompare = 6U,             /*!< Clear output on compare. */
+    kENET_PtpChannelSetCompare = 7U,               /*!< Set output on compare. */
+    kENET_PtpChannelClearCompareSetOverflow = 10U, /*!< Clear output on compare, set output on overflow. */
+    kENET_PtpChannelSetCompareClearOverflow = 11U, /*!< Set output on compare, clear output on overflow. */
+    kENET_PtpChannelPulseLowonCompare = 14U,       /*!< Pulse output low on compare for one IEEE 1588 clock cycle. */
+    kENET_PtpChannelPulseHighonCompare = 15U       /*!< Pulse output high on compare for one IEEE 1588 clock cycle. */
+} enet_ptp_timer_channel_mode_t;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+/*! @brief Defines the receive buffer descriptor structure for the little endian system.*/
+typedef struct _enet_rx_bd_struct
+{
+    uint16_t length;  /*!< Buffer descriptor data length. */
+    uint16_t control; /*!< Buffer descriptor control and status. */
+    uint8_t *buffer;  /*!< Data buffer pointer. */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    uint16_t controlExtend0;  /*!< Extend buffer descriptor control0. */
+    uint16_t controlExtend1;  /*!< Extend buffer descriptor control1. */
+    uint16_t payloadCheckSum; /*!< Internal payload checksum. */
+    uint8_t headerLength;     /*!< Header length. */
+    uint8_t protocolTyte;     /*!< Protocol type. */
+    uint16_t reserved0;
+    uint16_t controlExtend2; /*!< Extend buffer descriptor control2. */
+    uint32_t timestamp;      /*!< Timestamp. */
+    uint16_t reserved1;
+    uint16_t reserved2;
+    uint16_t reserved3;
+    uint16_t reserved4;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+} enet_rx_bd_struct_t;
+
+/*! @brief Defines the enhanced transmit buffer descriptor structure for the little endian system. */
+typedef struct _enet_tx_bd_struct
+{
+    uint16_t length;  /*!< Buffer descriptor data length. */
+    uint16_t control; /*!< Buffer descriptor control and status. */
+    uint8_t *buffer;  /*!< Data buffer pointer. */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    uint16_t controlExtend0; /*!< Extend buffer descriptor control0. */
+    uint16_t controlExtend1; /*!< Extend buffer descriptor control1. */
+    uint16_t reserved0;
+    uint16_t reserved1;
+    uint16_t reserved2;
+    uint16_t controlExtend2; /*!< Extend buffer descriptor control2. */
+    uint32_t timestamp;      /*!< Timestamp. */
+    uint16_t reserved3;
+    uint16_t reserved4;
+    uint16_t reserved5;
+    uint16_t reserved6;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+} enet_tx_bd_struct_t;
+
+/*! @brief Defines the ENET data error statistic structure. */
+typedef struct _enet_data_error_stats
+{
+    uint32_t statsRxLenGreaterErr; /*!< Receive length greater than RCR[MAX_FL]. */
+    uint32_t statsRxAlignErr;      /*!< Receive non-octet alignment/ */
+    uint32_t statsRxFcsErr;        /*!< Receive CRC error. */
+    uint32_t statsRxOverRunErr;    /*!< Receive over run. */
+    uint32_t statsRxTruncateErr;   /*!< Receive truncate. */
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    uint32_t statsRxProtocolChecksumErr; /*!< Receive protocol checksum error. */
+    uint32_t statsRxIpHeadChecksumErr;   /*!< Receive IP header checksum error. */
+    uint32_t statsRxMacErr;              /*!< Receive Mac error. */
+    uint32_t statsRxPhyErr;              /*!< Receive PHY error. */
+    uint32_t statsRxCollisionErr;        /*!< Receive collision. */
+    uint32_t statsTxErr;                 /*!< The error happen when transmit the frame. */
+    uint32_t statsTxFrameErr;            /*!< The transmit frame is error. */
+    uint32_t statsTxOverFlowErr;         /*!< Transmit overflow. */
+    uint32_t statsTxLateCollisionErr;    /*!< Transmit late collision. */
+    uint32_t statsTxExcessCollisionErr;  /*!< Transmit excess collision.*/
+    uint32_t statsTxUnderFlowErr;        /*!< Transmit under flow error. */
+    uint32_t statsTxTsErr;               /*!< Transmit time stamp error. */
+#endif                                   /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+} enet_data_error_stats_t;
+
+/*! @brief Defines the receive buffer descriptor configure structure.
+ *
+ * Note: For the internal DMA requirements, the buffers have a corresponding alignment requirement:
+ * 1. The aligned receive and transmit buffer size must be evenly divisible by 16.
+ * 2. The aligned transmit and receive buffer descriptor start address must be at
+ *    least 64 bit aligned. However, it's recommended to be evenly divisible by 16.
+ * 3. The aligned transmit and receive buffer start address must be evenly divisible by 16.
+ *    Receive buffers should be continuous with the total size equal to "rxBdNumber * rxBuffSizeAlign".
+ *    Transmit buffers should be continuous with the total size equal to "txBdNumber * txBuffSizeAlign".
+ */
+typedef struct _enet_buffer_config
+{
+    uint16_t rxBdNumber;                              /*!< Receive buffer descriptor number. */
+    uint16_t txBdNumber;                              /*!< Transmit buffer descriptor number. */
+    uint32_t rxBuffSizeAlign;                         /*!< Aligned receive data buffer size. */
+    uint32_t txBuffSizeAlign;                         /*!< Aligned transmit data buffer size. */
+    volatile enet_rx_bd_struct_t *rxBdStartAddrAlign; /*!< Aligned receive buffer descriptor start address. */
+    volatile enet_tx_bd_struct_t *txBdStartAddrAlign; /*!< Aligned transmit buffer descriptor start address. */
+    uint8_t *rxBufferAlign;                           /*!< Receive data buffer start address. */
+    uint8_t *txBufferAlign;                           /*!< Transmit data buffer start address. */
+} enet_buffer_config_t;
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*! @brief Defines the ENET PTP time stamp structure. */
+typedef struct _enet_ptp_time
+{
+    uint64_t second;     /*!< Second. */
+    uint32_t nanosecond; /*!< Nanosecond. */
+} enet_ptp_time_t;
+
+/*! @brief Defines the structure for the ENET PTP message data and timestamp data.*/
+typedef struct _enet_ptp_time_data
+{
+    uint8_t version;                             /*!< PTP version. */
+    uint8_t sourcePortId[kENET_PtpSrcPortIdLen]; /*!< PTP source port ID. */
+    uint16_t sequenceId;                         /*!< PTP sequence ID. */
+    uint8_t messageType;                         /*!< PTP message type. */
+    enet_ptp_time_t timeStamp;                   /*!< PTP timestamp. */
+} enet_ptp_time_data_t;
+
+/*! @brief Defines the ENET PTP ring buffer structure for the PTP message timestamp store.*/
+typedef struct _enet_ptp_time_data_ring
+{
+    uint32_t front;                  /*!< The first index of the ring. */
+    uint32_t end;                    /*!< The end index of the ring. */
+    uint32_t size;                   /*!< The size of the ring. */
+    enet_ptp_time_data_t *ptpTsData; /*!< PTP message data structure. */
+} enet_ptp_time_data_ring_t;
+
+/*! @brief Defines the ENET PTP configure structure. */
+typedef struct _enet_ptp_config
+{
+    uint8_t ptpTsRxBuffNum;            /*!< Receive 1588 timestamp buffer number*/
+    uint8_t ptpTsTxBuffNum;            /*!< Transmit 1588 timestamp buffer number*/
+    enet_ptp_time_data_t *rxPtpTsData; /*!< The start address of 1588 receive timestamp buffers */
+    enet_ptp_time_data_t *txPtpTsData; /*!< The start address of 1588 transmit timestamp buffers */
+    enet_ptp_timer_channel_t channel;  /*!< Used for ERRATA_2579: the PTP 1588 timer channel for time interrupt. */
+    uint32_t ptp1588ClockSrc_Hz;       /*!< The clock source of the PTP 1588 timer. */
+} enet_ptp_config_t;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+
+
+
+/*! @brief Defines the basic configuration structure for the ENET device.
+ *
+ * Note:
+ *  1. macSpecialConfig is used for a special control configuration, A logical OR of
+ *  "enet_special_control_flag_t". For a special configuration for MAC,
+ *  set this parameter to 0.
+ *  2. txWatermark is used for a cut-through operation. It is in steps of 64 bytes:
+ *  0/1  - 64 bytes written to TX FIFO before transmission of a frame begins.
+ *  2    - 128 bytes written to TX FIFO ....
+ *  3    - 192 bytes written to TX FIFO ....
+ *  The maximum of txWatermark is 0x2F   - 4032 bytes written to TX FIFO ....
+ *  txWatermark allows minimizing the transmit latency to set the txWatermark to 0 or 1
+ *  or for larger bus access latency 3 or larger due to contention for the system bus.
+ *  3. rxFifoFullThreshold is similar to the txWatermark for cut-through operation in RX.
+ *  It is in 64-bit words. The minimum is ENET_FIFO_MIN_RX_FULL and the maximum is 0xFF.
+ *  If the end of the frame is stored in FIFO and the frame size if smaller than the
+ *  txWatermark, the frame is still transmitted. The rule  is the
+ *  same for rxFifoFullThreshold in the receive direction.
+ *  4. When "kENET_ControlFlowControlEnable" is set in the macSpecialConfig, ensure
+ *  that the pauseDuration, rxFifoEmptyThreshold, and rxFifoStatEmptyThreshold
+ *  are set for flow control enabled case.
+ *  5. When "kENET_ControlStoreAndFwdDisabled" is set in the macSpecialConfig, ensure
+ *  that the rxFifoFullThreshold and txFifoWatermark are set for store and forward disable.
+ *  6. The rxAccelerConfig and txAccelerConfig default setting with 0 - accelerator
+ *  are disabled. The "enet_tx_accelerator_t" and "enet_rx_accelerator_t" are
+ *  recommended to be used to enable the transmit and receive accelerator.
+ *  After the accelerators are enabled, the store and forward feature should be enabled.
+ *  As a result, kENET_ControlStoreAndFwdDisabled should not be set.
+ */
+typedef struct _enet_config
+{
+    uint32_t macSpecialConfig;    /*!< Mac special configuration. A logical OR of "enet_special_control_flag_t". */
+    uint32_t interrupt;           /*!< Mac interrupt source. A logical OR of "enet_interrupt_enable_t". */
+    uint16_t rxMaxFrameLen;       /*!< Receive maximum frame length. */
+    enet_mii_mode_t miiMode;      /*!< MII mode. */
+    enet_mii_speed_t miiSpeed;    /*!< MII Speed. */
+    enet_mii_duplex_t miiDuplex;  /*!< MII duplex. */
+    uint8_t rxAccelerConfig;      /*!< Receive accelerator, A logical OR of "enet_rx_accelerator_t". */
+    uint8_t txAccelerConfig;      /*!< Transmit accelerator, A logical OR of "enet_rx_accelerator_t". */
+    uint16_t pauseDuration;       /*!< For flow control enabled case: Pause duration. */
+    uint8_t rxFifoEmptyThreshold; /*!< For flow control enabled case:  when RX FIFO level reaches this value,
+                                     it makes MAC generate XOFF pause frame. */
+#if FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD
+    uint8_t rxFifoStatEmptyThreshold; /*!< For flow control enabled case: number of frames in the receive FIFO,
+                                    independent of size, that can be accept. If the limit is reached, reception
+                                    continues and a pause frame is triggered. */
+#endif                                /* FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD */
+    uint8_t rxFifoFullThreshold;      /*!< For store and forward disable case, the data required in RX FIFO to notify
+                                      the MAC receive ready status. */
+    uint8_t txFifoWatermark;          /*!< For store and forward disable case, the data required in TX FIFO
+                                      before a frame transmit start. */
+} enet_config_t;
+
+/* Forward declaration of the handle typedef. */
+typedef struct _enet_handle enet_handle_t;
+
+/*! @brief ENET callback function. */
+typedef void (*enet_callback_t)(ENET_Type *base, enet_handle_t *handle, enet_event_t event, void *userData);
+
+/*! @brief Defines the ENET handler structure. */
+struct _enet_handle
+{
+    volatile enet_rx_bd_struct_t *rxBdBase;    /*!< Receive buffer descriptor base address pointer. */
+    volatile enet_rx_bd_struct_t *rxBdCurrent; /*!< The current available receive buffer descriptor pointer. */
+    volatile enet_rx_bd_struct_t *rxBdDirty;   /*!< The dirty receive buffer descriptor needed to be updated from. */
+    volatile enet_tx_bd_struct_t *txBdBase;    /*!< Transmit buffer descriptor base address pointer. */
+    volatile enet_tx_bd_struct_t *txBdCurrent; /*!< The current available transmit buffer descriptor pointer. */
+    uint32_t rxBuffSizeAlign;                  /*!< Receive buffer size alignment. */
+    uint32_t txBuffSizeAlign;                  /*!< Transmit buffer size alignment. */
+    enet_callback_t callback;                  /*!< Callback function. */
+    void *userData;                            /*!< Callback function parameter.*/
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    volatile enet_tx_bd_struct_t *txBdDirtyStatic; /*!< The dirty transmit buffer descriptor for error static update. */
+    volatile enet_tx_bd_struct_t *txBdDirtyTime;   /*!< The dirty transmit buffer descriptor for time stamp update. */
+    uint64_t msTimerSecond;                        /*!< The second for Master PTP timer .*/
+    enet_ptp_time_data_ring_t rxPtpTsDataRing;     /*!< Receive PTP 1588 time stamp data ring buffer. */
+    enet_ptp_time_data_ring_t txPtpTsDataRing;     /*!< Transmit PTP 1588 time stamp data ring buffer. */
+#endif                                             /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+  * @name Initialization and De-initialization
+  * @{
+  */
+
+/*!
+ * @brief Gets the ENET default configuration structure.
+ *
+ * The purpose of this API is to get the default ENET MAC controller
+ * configure structure for ENET_Init(). User may use the initialized
+ * structure unchanged in ENET_Init(), or modify some fields of the
+ * structure before calling ENET_Init().
+ * Example:
+   @code
+   enet_config_t config;
+   ENET_GetDefaultConfig(&config);
+   @endcode
+ * @param config The ENET mac controller configuration structure pointer.
+ */
+void ENET_GetDefaultConfig(enet_config_t *config);
+
+/*!
+ * @brief Initializes the ENET module.
+ *
+ * This function ungates the module clock and initializes it with the ENET configuration.
+ *
+ * @param base    ENET peripheral base address.
+ * @param handle  ENET handler pointer.
+ * @param config  ENET mac configuration structure pointer.
+ *        The "enet_config_t" type mac configuration return from ENET_GetDefaultConfig
+ *        can be used directly. It is also possible to verify the Mac configuration using other methods.
+ * @param bufferConfig  ENET buffer configuration structure pointer.
+ *        The buffer configuration should be prepared for ENET Initialization.
+ * @param macAddr  ENET mac address of Ethernet device. This MAC address should be
+ *        provided.
+ * @param srcClock_Hz The internal module clock source for MII clock.
+ *
+ * @note ENET has two buffer descriptors: legacy buffer descriptors and
+ * enhanced 1588 buffer descriptors. The legacy descriptor is used by default. To
+ * use 1588 feature, use the enhanced 1588 buffer descriptor
+ * by defining "ENET_ENHANCEDBUFFERDESCRIPTOR_MODE" and calling ENET_Ptp1588Configure()
+ * to configure the 1588 feature and related buffers after calling ENET_Init().
+ */
+void ENET_Init(ENET_Type *base,
+               enet_handle_t *handle,
+               const enet_config_t *config,
+               const enet_buffer_config_t *bufferConfig,
+               uint8_t *macAddr,
+               uint32_t srcClock_Hz);
+/*!
+ * @brief Deinitializes the ENET module.
+
+ * This function gates the module clock, clears ENET interrupts, and disables the ENET module.
+ *
+ * @param base  ENET peripheral base address.
+ */
+void ENET_Deinit(ENET_Type *base);
+
+/*!
+ * @brief Resets the ENET module.
+ *
+ * This function restores the ENET module to reset state.
+ * Note that this function sets all registers to
+ * reset state. As a result, the ENET module can't work after calling this function.
+ *
+ * @param base  ENET peripheral base address.
+ */
+static inline void ENET_Reset(ENET_Type *base)
+{
+    base->ECR |= ENET_ECR_RESET_MASK;
+}
+
+/* @} */
+
+/*!
+ * @name MII interface operation
+ * @{
+ */
+
+/*!
+ * @brief Sets the ENET MII speed and duplex.
+ *
+ * @param base  ENET peripheral base address.
+ * @param speed The speed of the RMII mode.
+ * @param duplex The duplex of the RMII mode.
+ */
+void ENET_SetMII(ENET_Type *base, enet_mii_speed_t speed, enet_mii_duplex_t duplex);
+
+/*!
+ * @brief Sets the ENET SMI(serial management interface)- MII management interface.
+ *
+ * @param base  ENET peripheral base address.
+ * @param srcClock_Hz This is the ENET module clock frequency. Normally it's the system clock. See clock distribution.
+ * @param isPreambleDisabled The preamble disable flag.
+ *        - true   Enables the preamble.
+ *        - false  Disables the preamble.
+ */
+void ENET_SetSMI(ENET_Type *base, uint32_t srcClock_Hz, bool isPreambleDisabled);
+
+/*!
+ * @brief Gets the ENET SMI- MII management interface configuration.
+ *
+ * This API is used to get the SMI configuration to check if the MII management
+ * interface has been set.
+ *
+ * @param base  ENET peripheral base address.
+ * @return The SMI setup status true or false.
+ */
+static inline bool ENET_GetSMI(ENET_Type *base)
+{
+    return (0 != (base->MSCR & 0x7E));
+}
+
+/*!
+ * @brief Reads data from the PHY register through SMI interface.
+ *
+ * @param base  ENET peripheral base address.
+ * @return The data read from PHY
+ */
+static inline uint32_t ENET_ReadSMIData(ENET_Type *base)
+{
+    return (uint32_t)((base->MMFR & ENET_MMFR_DATA_MASK) >> ENET_MMFR_DATA_SHIFT);
+}
+
+/*!
+ * @brief Starts an SMI (Serial Management Interface) read command.
+ *
+ * @param base  ENET peripheral base address.
+ * @param phyAddr The PHY address.
+ * @param phyReg The PHY register.
+ * @param operation The read operation.
+ */
+void ENET_StartSMIRead(ENET_Type *base, uint32_t phyAddr, uint32_t phyReg, enet_mii_read_t operation);
+
+/*!
+ * @brief Starts a SMI write command.
+ *
+ * @param base  ENET peripheral base address.
+ * @param phyAddr The PHY address.
+ * @param phyReg The PHY register.
+ * @param operation The write operation.
+ * @param data The data written to PHY.
+ */
+void ENET_StartSMIWrite(ENET_Type *base, uint32_t phyAddr, uint32_t phyReg, enet_mii_write_t operation, uint32_t data);
+
+/* @} */
+
+/*!
+ * @name MAC Address Filter
+ * @{
+ */
+
+/*!
+ * @brief Sets the ENET module Mac address.
+ *
+ * @param base  ENET peripheral base address.
+ * @param macAddr The six-byte Mac address pointer.
+ *        The pointer is allocated by application and input into the API.
+ */
+void ENET_SetMacAddr(ENET_Type *base, uint8_t *macAddr);
+
+/*!
+ * @brief Gets the ENET module Mac address.
+ *
+ * @param base  ENET peripheral base address.
+ * @param macAddr The six-byte Mac address pointer.
+ *        The pointer is allocated by application and input into the API.
+ */
+void ENET_GetMacAddr(ENET_Type *base, uint8_t *macAddr);
+
+/*!
+ * @brief Adds the ENET device to a multicast group.
+ *
+ * @param base    ENET peripheral base address.
+ * @param address The six-byte multicast group address which is provided by application.
+ */
+void ENET_AddMulticastGroup(ENET_Type *base, uint8_t *address);
+
+/*!
+ * @brief Moves the ENET device from a multicast group.
+ *
+ * @param base  ENET peripheral base address.
+ * @param address The six-byte multicast group address which is provided by application.
+ */
+void ENET_LeaveMulticastGroup(ENET_Type *base, uint8_t *address);
+
+/* @} */
+
+/*!
+ * @name Other basic operation
+ * @{
+ */
+
+/*!
+ * @brief Activates ENET read or receive.
+ *
+ * @param base  ENET peripheral base address.
+ *
+ * @note This must be called after the MAC configuration and
+ * state are ready. It must be called after the ENET_Init() and
+ * ENET_Ptp1588Configure(). This should be called when the ENET receive required.
+ */
+static inline void ENET_ActiveRead(ENET_Type *base)
+{
+    base->RDAR = ENET_RDAR_RDAR_MASK;
+}
+
+/*!
+ * @brief Enables/disables the MAC to enter sleep mode.
+ * This function is used to set the MAC enter sleep mode.
+ * When entering sleep mode, the magic frame wakeup interrupt should be enabled
+ * to wake up MAC from the sleep mode and reset it to normal mode.
+ *
+ * @param base    ENET peripheral base address.
+ * @param enable  True enable sleep mode, false disable sleep mode.
+ */
+static inline void ENET_EnableSleepMode(ENET_Type *base, bool enable)
+{
+    if (enable)
+    {
+        /* When this field is set, MAC enters sleep mode. */
+        base->ECR |= ENET_ECR_SLEEP_MASK | ENET_ECR_MAGICEN_MASK;
+    }
+    else
+    { /* MAC exits sleep mode. */
+        base->ECR &= ~(ENET_ECR_SLEEP_MASK | ENET_ECR_MAGICEN_MASK);
+    }
+}
+
+/*!
+ * @brief Gets ENET transmit and receive accelerator functions from MAC controller.
+ *
+ * @param base  ENET peripheral base address.
+ * @param txAccelOption The transmit accelerator option. The "enet_tx_accelerator_t" is
+ *         recommended to be used to as the mask to get the exact the accelerator option.
+ * @param rxAccelOption The receive accelerator option. The "enet_rx_accelerator_t" is
+ *         recommended to be used to as the mask to get the exact the accelerator option.
+ */
+static inline void ENET_GetAccelFunction(ENET_Type *base, uint32_t *txAccelOption, uint32_t *rxAccelOption)
+{
+    assert(txAccelOption);
+    assert(txAccelOption);
+
+    *txAccelOption = base->TACC;
+    *rxAccelOption = base->RACC;
+}
+
+/* @} */
+
+/*!
+ * @name Interrupts.
+ * @{
+ */
+
+/*!
+ * @brief Enables the ENET interrupt.
+ *
+ * This function enables the ENET interrupt according to the provided mask. The mask
+ * is a logical OR of enumeration members. See @ref enet_interrupt_enable_t.
+ * For example, to enable the TX frame interrupt and RX frame interrupt, do this:
+ * @code
+ *     ENET_EnableInterrupts(ENET, kENET_TxFrameInterrupt | kENET_RxFrameInterrupt);
+ * @endcode
+ *
+ * @param base  ENET peripheral base address.
+ * @param mask  ENET interrupts to enable. This is a logical OR of the
+ *             enumeration :: enet_interrupt_enable_t.
+ */
+static inline void ENET_EnableInterrupts(ENET_Type *base, uint32_t mask)
+{
+    base->EIMR |= mask;
+}
+
+/*!
+ * @brief Disables the ENET interrupt.
+ *
+ * This function disables the ENET interrupts according to the provided mask. The mask
+ * is a logical OR of enumeration members. See @ref enet_interrupt_enable_t.
+ * For example, to disable the TX frame interrupt and RX frame interrupt, do this:
+ * @code
+ *     ENET_DisableInterrupts(ENET, kENET_TxFrameInterrupt | kENET_RxFrameInterrupt);
+ * @endcode
+ *
+ * @param base  ENET peripheral base address.
+ * @param mask  ENET interrupts to disable. This is a logical OR of the
+ *             enumeration :: enet_interrupt_enable_t.
+ */
+static inline void ENET_DisableInterrupts(ENET_Type *base, uint32_t mask)
+{
+    base->EIMR &= ~mask;
+}
+
+/*!
+ * @brief Gets the ENET interrupt status flag.
+ *
+ * @param base  ENET peripheral base address.
+ * @return The event status of the interrupt source. This is the logical OR of members
+ *         of the enumeration :: enet_interrupt_enable_t.
+ */
+static inline uint32_t ENET_GetInterruptStatus(ENET_Type *base)
+{
+    return base->EIR;
+}
+
+/*!
+ * @brief Clears the ENET interrupt events status flag.
+ *
+ * This function clears enabled ENET interrupts according to the provided mask. The mask
+ * is a logical OR of enumeration members. See the @ref enet_interrupt_enable_t.
+ * For example, to clear the TX frame interrupt and RX frame interrupt, do this:
+ * @code
+ *     ENET_ClearInterruptStatus(ENET, kENET_TxFrameInterrupt | kENET_RxFrameInterrupt);
+ * @endcode
+ *
+ * @param base  ENET peripheral base address.
+ * @param mask  ENET interrupt source to be cleared.
+ * This is the logical OR of members of the enumeration :: enet_interrupt_enable_t.
+ */
+static inline void ENET_ClearInterruptStatus(ENET_Type *base, uint32_t mask)
+{
+    base->EIR = mask;
+}
+
+/* @} */
+
+/*!
+ * @name Transactional operation
+ * @{
+ */
+
+/*!
+ * @brief Set the callback function.
+ * This API is provided for application callback required case when ENET
+ * interrupt is enabled. This API should be called after calling ENET_Init.
+ *
+ * @param handle ENET handler pointer. Should be provided by application.
+ * @param callback The ENET callback function.
+ * @param userData The callback function parameter.
+ */
+void ENET_SetCallback(enet_handle_t *handle, enet_callback_t callback, void *userData);
+
+/*!
+ * @brief Gets the ENET the error statistics of a received frame.
+ *
+ * This API must be called after the ENET_GetRxFrameSize and before the ENET_ReadFrame().
+ * If the ENET_GetRxFrameSize returns kStatus_ENET_RxFrameError,
+ * the ENET_GetRxErrBeforeReadFrame can be used to get the exact error statistics.
+ * For example:
+ * @code
+ *       status = ENET_GetRxFrameSize(&g_handle, &length);
+ *       if (status == kStatus_ENET_RxFrameError)
+ *       {
+ *           // Get the error information of the received frame.
+ *           ENET_GetRxErrBeforeReadFrame(&g_handle, &eErrStatic);
+ *           // update the receive buffer.
+ *           ENET_ReadFrame(EXAMPLE_ENET, &g_handle, NULL, 0);
+ *       }
+ * @endcode
+ * @param handle The ENET handler structure pointer. This is the same handler pointer used in the ENET_Init.
+ * @param eErrorStatic The error statistics structure pointer.
+ */
+void ENET_GetRxErrBeforeReadFrame(enet_handle_t *handle, enet_data_error_stats_t *eErrorStatic);
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*!
+ * @brief Gets the ENET transmit frame statistics after the data send.
+ *
+ * This interface gets the error statistics of the transmit frame.
+ * Because the error information is reported by the uDMA after the data delivery, this interface
+ * should be called after the data transmit API. It is recommended to call this function on
+ * transmit interrupt handler. After calling the ENET_SendFrame, the
+ * transmit interrupt notifies the transmit completion.
+ *
+ * @param handle The PTP handler pointer. This is the same handler pointer used in the ENET_Init.
+ * @param eErrorStatic The error statistics structure pointer.
+ * @return The execute status.
+ */
+status_t ENET_GetTxErrAfterSendFrame(enet_handle_t *handle, enet_data_error_stats_t *eErrorStatic);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+       /*!
+       * @brief Gets the size of the read frame.
+       * This function reads a received frame size from the ENET buffer descriptors.
+       * @note The FCS of the frame is removed by MAC controller and the size is the length without the FCS.
+       * After calling ENET_GetRxFrameSize, ENET_ReadFrame() should be called to update the
+       * receive buffers If the result is not "kStatus_ENET_RxFrameEmpty".
+       *
+       * @param handle The ENET handler structure. This is the same handler pointer used in the ENET_Init.
+       * @param length The length of the valid frame received.
+       * @retval kStatus_ENET_RxFrameEmpty No frame received. Should not call ENET_ReadFrame to read frame.
+       * @retval kStatus_ENET_RxFrameError Data error happens. ENET_ReadFrame should be called with NULL data
+       *         and NULL length to update the receive buffers.
+       * @retval kStatus_Success Receive a frame Successfully then the ENET_ReadFrame
+       *         should be called with the right data buffer and the captured data length input.
+       */
+status_t ENET_GetRxFrameSize(enet_handle_t *handle, uint32_t *length);
+
+/*!
+ * @brief Reads a frame from the ENET device.
+ * This function reads a frame (both the data and the length) from the ENET buffer descriptors.
+ * The ENET_GetRxFrameSize should be used to get the size of the prepared data buffer.
+ * @note The FCS of the frame is removed by MAC controller and is not delivered to the application.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET handler structure. This is the same handler pointer used in the ENET_Init.
+ * @param data The data buffer provided by user to store the frame which memory size should be at least "length".
+ * @param length The size of the data buffer which is still the length of the received frame.
+ * @return The execute status, successful or failure.
+ */
+status_t ENET_ReadFrame(ENET_Type *base, enet_handle_t *handle, uint8_t *data, uint32_t length);
+
+/*!
+ * @brief Transmits an ENET frame.
+ * @note The CRC is automatically appended to the data. Input the data
+ * to send without the CRC.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET handler pointer. This is the same handler pointer used in the ENET_Init.
+ * @param data The data buffer provided by user to be send.
+ * @param length The length of the data to be send.
+ * @retval kStatus_Success  Send frame succeed.
+ * @retval kStatus_ENET_TxFrameBusy  Transmit buffer descriptor is busy under transmit.
+ * @retval kStatus_ENET_TxFrameFail  Transmit frame fail.
+ */
+status_t ENET_SendFrame(ENET_Type *base, enet_handle_t *handle, uint8_t *data, uint32_t length);
+
+/*!
+ * @brief The transmit IRQ handler.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET handler pointer.
+ */
+void ENET_TransmitIRQHandler(ENET_Type *base, enet_handle_t *handle);
+
+/*!
+ * @brief The receive IRQ handler.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET handler pointer.
+ */
+void ENET_ReceiveIRQHandler(ENET_Type *base, enet_handle_t *handle);
+
+/*!
+ * @brief The error IRQ handler.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET handler pointer.
+ */
+void ENET_ErrorIRQHandler(ENET_Type *base, enet_handle_t *handle);
+
+/* @} */
+
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+/*!
+ * @name ENET PTP 1588 function operation
+ * @{
+ */
+
+/*!
+ * @brief Configures the ENET PTP 1588 feature with the basic configuration.
+ * The function sets the clock for PTP 1588 timer and enables
+ * time stamp interrupts and transmit interrupts for PTP 1588 features.
+ * This API should be called when the 1588 feature is enabled
+ * or the ENET_ENHANCEDBUFFERDESCRIPTOR_MODE is defined.
+ * ENET_Init should be called before calling this API.
+ *
+ * @note The PTP 1588 time-stamp second increase though time-stamp interrupt handler
+ *  and the transmit time-stamp store is done through transmit interrupt handler.
+ *  As a result, the TS interrupt and TX interrupt are enabled when you call this API.
+ *
+ * @param base    ENET peripheral base address.
+ * @param handle  ENET handler pointer.
+ * @param ptpConfig The ENET PTP1588 configuration.
+ */
+void ENET_Ptp1588Configure(ENET_Type *base, enet_handle_t *handle, enet_ptp_config_t *ptpConfig);
+
+/*!
+ * @brief Starts the ENET PTP 1588 Timer.
+ * This function is used to initialize the PTP timer. After the PTP starts,
+ * the PTP timer starts running.
+ *
+ * @param base  ENET peripheral base address.
+ * @param ptpClkSrc The clock source of the PTP timer.
+ */
+void ENET_Ptp1588StartTimer(ENET_Type *base, uint32_t ptpClkSrc);
+
+/*!
+ * @brief Stops the ENET PTP 1588 Timer.
+ * This function is used to stops the ENET PTP timer.
+ *
+ * @param base  ENET peripheral base address.
+ */
+static inline void ENET_Ptp1588StopTimer(ENET_Type *base)
+{
+    /* Disable PTP timer and reset the timer. */
+    base->ATCR &= ~ENET_ATCR_EN_MASK;
+    base->ATCR |= ENET_ATCR_RESTART_MASK;
+}
+
+/*!
+ * @brief Adjusts the ENET PTP 1588 timer.
+ *
+ * @param base  ENET peripheral base address.
+ * @param corrIncrease The correction increment value. This value is added every time the correction
+ *       timer expires. A value less than the PTP timer frequency(1/ptpClkSrc) slows down the timer,
+ *        a value greater than the 1/ptpClkSrc speeds up the timer.
+ * @param corrPeriod The PTP timer correction counter wrap-around value. This defines after how
+ *       many timer clock the correction counter should be reset and trigger a correction
+ *       increment on the timer. A value of 0 disables the correction counter and no correction occurs.
+ */
+void ENET_Ptp1588AdjustTimer(ENET_Type *base, uint32_t corrIncrease, uint32_t corrPeriod);
+
+/*!
+ * @brief Sets ENET PTP 1588 timer channel mode.
+ *
+ * @param base  ENET peripheral base address.
+ * @param channel The ENET PTP timer channel number.
+ * @param mode The PTP timer channel mode, see "enet_ptp_timer_channel_mode_t".
+ * @param intEnable Enables or disables the interrupt.
+ */
+static inline void ENET_Ptp1588SetChannelMode(ENET_Type *base,
+                                              enet_ptp_timer_channel_t channel,
+                                              enet_ptp_timer_channel_mode_t mode,
+                                              bool intEnable)
+{
+    uint32_t tcrReg = 0;
+
+    tcrReg = ENET_TCSR_TMODE(mode) | ENET_TCSR_TIE(intEnable);
+    /* Disable channel mode first. */
+    base->CHANNEL[channel].TCSR = 0;
+    base->CHANNEL[channel].TCSR = tcrReg;
+}
+
+/*!
+ * @brief Sets ENET PTP 1588 timer channel comparison value.
+ *
+ * @param base  ENET peripheral base address.
+ * @param channel The PTP timer channel, see "enet_ptp_timer_channel_t".
+ * @param cmpValue The compare value for the compare setting.
+ */
+static inline void ENET_Ptp1588SetChannelCmpValue(ENET_Type *base, enet_ptp_timer_channel_t channel, uint32_t cmpValue)
+{
+    base->CHANNEL[channel].TCCR = cmpValue;
+}
+
+/*!
+ * @brief Gets the ENET PTP 1588 timer channel status.
+ *
+ * @param base  ENET peripheral base address.
+ * @param channel The IEEE 1588 timer channel number.
+ * @return True or false, Compare or capture operation status
+ */
+static inline bool ENET_Ptp1588GetChannelStatus(ENET_Type *base, enet_ptp_timer_channel_t channel)
+{
+    return (0 != (base->CHANNEL[channel].TCSR & ENET_TCSR_TF_MASK));
+}
+
+/*!
+ * @brief Clears the ENET PTP 1588 timer channel status.
+ *
+ * @param base  ENET peripheral base address.
+ * @param channel The IEEE 1588 timer channel number.
+ */
+static inline void ENET_Ptp1588ClearChannelStatus(ENET_Type *base, enet_ptp_timer_channel_t channel)
+{
+    base->CHANNEL[channel].TCSR |= ENET_TCSR_TF_MASK;
+    base->TGSR = (1U << channel);
+}
+
+/*!
+ * @brief Gets the current ENET time from the PTP 1588 timer.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET state pointer. This is the same state pointer used in the ENET_Init.
+ * @param ptpTime The PTP timer structure.
+ */
+void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime);
+
+/*!
+ * @brief Sets the ENET PTP 1588 timer to the assigned time.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET state pointer. This is the same state pointer used in the ENET_Init.
+ * @param ptpTime The timer to be set to the PTP timer.
+ */
+void ENET_Ptp1588SetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime);
+
+/*!
+ * @brief The IEEE 1588 PTP time stamp interrupt handler.
+ *
+ * @param base  ENET peripheral base address.
+ * @param handle The ENET state pointer. This is the same state pointer used in the ENET_Init.
+ */
+void ENET_Ptp1588TimerIRQHandler(ENET_Type *base, enet_handle_t *handle);
+
+/*!
+ * @brief Gets the time stamp of the received frame.
+ *
+ * This function is used for PTP stack to get the timestamp captured by the ENET driver.
+ *
+ * @param handle The ENET handler pointer.This is the same state pointer used in
+ *        ENET_Init.
+ * @param ptpTimeData The special PTP timestamp data for search the receive timestamp.
+ * @retval kStatus_Success Get 1588 timestamp success.
+ * @retval kStatus_ENET_PtpTsRingEmpty 1588 timestamp ring empty.
+ * @retval kStatus_ENET_PtpTsRingFull 1588 timestamp ring full.
+ */
+status_t ENET_GetRxFrameTime(enet_handle_t *handle, enet_ptp_time_data_t *ptpTimeData);
+
+/*!
+ * @brief Gets the time stamp of the transmit frame.
+ *
+ * This function is used for PTP stack to get the timestamp captured by the ENET driver.
+ *
+ * @param handle The ENET handler pointer.This is the same state pointer used in
+ *        ENET_Init.
+ * @param ptpTimeData The special PTP timestamp data for search the receive timestamp.
+ * @retval kStatus_Success Get 1588 timestamp success.
+ * @retval kStatus_ENET_PtpTsRingEmpty 1588 timestamp ring empty.
+ * @retval kStatus_ENET_PtpTsRingFull 1588 timestamp ring full.
+ */
+status_t ENET_GetTxFrameTime(enet_handle_t *handle, enet_ptp_time_data_t *ptpTimeData);
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_ENET_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ewm.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ewm.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_ewm.h"
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+void EWM_Init(EWM_Type *base, const ewm_config_t *config)
+{
+    assert(config);
+
+    uint32_t value = 0U;
+
+    CLOCK_EnableClock(kCLOCK_Ewm0);
+    value = EWM_CTRL_EWMEN(config->enableEwm) | EWM_CTRL_ASSIN(config->setInputAssertLogic) |
+            EWM_CTRL_INEN(config->enableEwmInput) | EWM_CTRL_INTEN(config->enableInterrupt);
+#if defined(FSL_FEATURE_EWM_HAS_PRESCALER) && FSL_FEATURE_EWM_HAS_PRESCALER
+    base->CLKPRESCALER = config->prescaler;
+#endif /* FSL_FEATURE_EWM_HAS_PRESCALER */
+
+#if defined(FSL_FEATURE_EWM_HAS_CLOCK_SELECT) && FSL_FEATURE_EWM_HAS_CLOCK_SELECT
+    base->CLKCTRL = config->clockSource;
+#endif /* FSL_FEATURE_EWM_HAS_CLOCK_SELECT*/
+
+    base->CMPL = config->compareLowValue;
+    base->CMPH = config->compareHighValue;
+    base->CTRL = value;
+}
+
+void EWM_Deinit(EWM_Type *base)
+{
+    EWM_DisableInterrupts(base, kEWM_InterruptEnable);
+    CLOCK_DisableClock(kCLOCK_Ewm0);
+}
+
+void EWM_GetDefaultConfig(ewm_config_t *config)
+{
+    assert(config);
+
+    config->enableEwm = true;
+    config->enableEwmInput = false;
+    config->setInputAssertLogic = false;
+    config->enableInterrupt = false;
+#if defined(FSL_FEATURE_EWM_HAS_CLOCK_SELECT) && FSL_FEATURE_EWM_HAS_CLOCK_SELECT
+    config->clockSource = kEWM_LpoClockSource0;
+#endif /* FSL_FEATURE_EWM_HAS_CLOCK_SELECT*/
+#if defined(FSL_FEATURE_EWM_HAS_PRESCALER) && FSL_FEATURE_EWM_HAS_PRESCALER
+    config->prescaler = 0U;
+#endif /* FSL_FEATURE_EWM_HAS_PRESCALER */
+    config->compareLowValue = 0U;
+    config->compareHighValue = 0xFEU;
+}
+
+void EWM_Refresh(EWM_Type *base)
+{
+    uint32_t primaskValue = 0U;
+
+    /* Disable the global interrupt to protect refresh sequence */
+    primaskValue = DisableGlobalIRQ();
+    base->SERV = (uint8_t)0xB4U;
+    base->SERV = (uint8_t)0x2CU;
+    EnableGlobalIRQ(primaskValue);
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ewm.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ewm.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_EWM_H_
+#define _FSL_EWM_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup ewm_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief EWM driver version 2.0.1. */
+#define FSL_EWM_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*! @brief Describes ewm clock source. */
+#if defined(FSL_FEATURE_EWM_HAS_CLOCK_SELECT) && FSL_FEATURE_EWM_HAS_CLOCK_SELECT
+typedef enum _ewm_lpo_clock_source
+{
+    kEWM_LpoClockSource0 = 0U, /*!< ewm clock sourced from lpo_clk[0]*/
+    kEWM_LpoClockSource1 = 1U, /*!< ewm clock sourced from lpo_clk[1]*/
+    kEWM_LpoClockSource2 = 2U, /*!< ewm clock sourced from lpo_clk[2]*/
+    kEWM_LpoClockSource3 = 3U, /*!< ewm clock sourced from lpo_clk[3]*/
+} ewm_lpo_clock_source_t;
+#endif /* FSL_FEATURE_EWM_HAS_CLOCK_SELECT */
+
+/*!
+* @brief Data structure for EWM configuration.
+*
+* This structure is used to configure the EWM.
+*/
+typedef struct _ewm_config
+{
+    bool enableEwm;           /*!< Enable EWM module */
+    bool enableEwmInput;      /*!< Enable EWM_in input */
+    bool setInputAssertLogic; /*!< EWM_in signal assertion state */
+    bool enableInterrupt;     /*!< Enable EWM interrupt */
+#if defined(FSL_FEATURE_EWM_HAS_CLOCK_SELECT) && FSL_FEATURE_EWM_HAS_CLOCK_SELECT
+    ewm_lpo_clock_source_t clockSource; /*!< Clock source select */
+#endif                                  /* FSL_FEATURE_EWM_HAS_CLOCK_SELECT */
+#if defined(FSL_FEATURE_EWM_HAS_PRESCALER) && FSL_FEATURE_EWM_HAS_PRESCALER
+    uint8_t prescaler;        /*!< Clock prescaler value */
+#endif                        /* FSL_FEATURE_EWM_HAS_PRESCALER */
+    uint8_t compareLowValue;  /*!< Compare low register value */
+    uint8_t compareHighValue; /*!< Compare high register value */
+} ewm_config_t;
+
+/*!
+ * @brief EWM interrupt configuration structure, default settings all disabled.
+ *
+ * This structure contains the settings for all of the EWM interrupt configurations.
+ */
+enum _ewm_interrupt_enable_t
+{
+    kEWM_InterruptEnable = EWM_CTRL_INTEN_MASK, /*!< Enable EWM to generate an interrupt*/
+};
+
+/*!
+ * @brief EWM status flags.
+ *
+ * This structure contains the constants for the EWM status flags for use in the EWM functions.
+ */
+enum _ewm_status_flags_t
+{
+    kEWM_RunningFlag = EWM_CTRL_EWMEN_MASK, /*!< Running flag, set when ewm is enabled*/
+};
+
+/*******************************************************************************
+ * API
+ *******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name EWM Initialization and De-initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the EWM peripheral.
+ *
+ * This function is used to initialize the EWM. After calling, the EWM
+ * runs immediately according to the configuration.
+ * Note that except for interrupt enable control bit, other control bits and registers are write once after a
+ * CPU reset. Modifying them more than once generates a bus transfer error.
+ *
+ * Example:
+ * @code
+ *   ewm_config_t config;
+ *   EWM_GetDefaultConfig(&config);
+ *   config.compareHighValue = 0xAAU;
+ *   EWM_Init(ewm_base,&config);
+ * @endcode
+ *
+ * @param base EWM peripheral base address
+ * @param config The configuration of EWM
+*/
+void EWM_Init(EWM_Type *base, const ewm_config_t *config);
+
+/*!
+ * @brief Deinitializes the EWM peripheral.
+ *
+ * This function is used to shut down the EWM.
+ *
+ * @param base EWM peripheral base address
+*/
+void EWM_Deinit(EWM_Type *base);
+
+/*!
+ * @brief Initializes the EWM configuration structure.
+ *
+ * This function initializes the EWM configure structure to default values. The default
+ * values are:
+ * @code
+ *   ewmConfig->enableEwm = true;
+ *   ewmConfig->enableEwmInput = false;
+ *   ewmConfig->setInputAssertLogic = false;
+ *   ewmConfig->enableInterrupt = false;
+ *   ewmConfig->ewm_lpo_clock_source_t = kEWM_LpoClockSource0;
+ *   ewmConfig->prescaler = 0;
+ *   ewmConfig->compareLowValue = 0;
+ *   ewmConfig->compareHighValue = 0xFEU;
+ * @endcode
+ *
+ * @param config Pointer to EWM configuration structure.
+ * @see ewm_config_t
+ */
+void EWM_GetDefaultConfig(ewm_config_t *config);
+
+/* @} */
+
+/*!
+ * @name EWM functional Operation
+ * @{
+ */
+
+/*!
+ * @brief Enables the EWM interrupt.
+ *
+ * This function enables the EWM interrupt.
+ *
+ * @param base EWM peripheral base address
+ * @param mask The interrupts to enable
+ *        The parameter can be combination of the following source if defined:
+ *        @arg kEWM_InterruptEnable
+ */
+static inline void EWM_EnableInterrupts(EWM_Type *base, uint32_t mask)
+{
+    base->CTRL |= mask;
+}
+
+/*!
+ * @brief Disables the EWM interrupt.
+ *
+ * This function enables the EWM interrupt.
+ *
+ * @param base EWM peripheral base address
+ * @param mask The interrupts to disable
+ *        The parameter can be combination of the following source if defined:
+ *        @arg kEWM_InterruptEnable
+ */
+static inline void EWM_DisableInterrupts(EWM_Type *base, uint32_t mask)
+{
+    base->CTRL &= ~mask;
+}
+
+/*!
+ * @brief Gets EWM all status flags.
+ *
+ * This function gets all status flags.
+ *
+ * Example for getting Running Flag:
+ * @code
+ *   uint32_t status;
+ *   status = EWM_GetStatusFlags(ewm_base) & kEWM_RunningFlag;
+ * @endcode
+ * @param base        EWM peripheral base address
+ * @return            State of the status flag: asserted (true) or not-asserted (false).@see _ewm_status_flags_t
+ *                    - true: related status flag has been set.
+ *                    - false: related status flag is not set.
+ */
+static inline uint32_t EWM_GetStatusFlags(EWM_Type *base)
+{
+    return (base->CTRL & EWM_CTRL_EWMEN_MASK);
+}
+
+/*!
+ * @brief Service EWM.
+ *
+ * This function reset EWM counter to zero.
+ *
+ * @param base EWM peripheral base address
+*/
+void EWM_Refresh(EWM_Type *base);
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_EWM_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flash.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flash.c
@@ -1,0 +1,2610 @@
+/*
+ * Copyright (c) 2015-2016, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_flash.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*!
+ * @name Misc utility defines
+ * @{
+ */
+#ifndef ALIGN_DOWN
+#define ALIGN_DOWN(x, a) ((x) & (uint32_t)(-((int32_t)(a))))
+#endif
+#ifndef ALIGN_UP
+#define ALIGN_UP(x, a) (-((int32_t)((uint32_t)(-((int32_t)(x))) & (uint32_t)(-((int32_t)(a))))))
+#endif
+
+#define BYTES_JOIN_TO_WORD_1_3(x, y) ((((uint32_t)(x)&0xFFU) << 24) | ((uint32_t)(y)&0xFFFFFFU))
+#define BYTES_JOIN_TO_WORD_2_2(x, y) ((((uint32_t)(x)&0xFFFFU) << 16) | ((uint32_t)(y)&0xFFFFU))
+#define BYTES_JOIN_TO_WORD_3_1(x, y) ((((uint32_t)(x)&0xFFFFFFU) << 8) | ((uint32_t)(y)&0xFFU))
+#define BYTES_JOIN_TO_WORD_1_1_2(x, y, z) \
+    ((((uint32_t)(x)&0xFFU) << 24) | (((uint32_t)(y)&0xFFU) << 16) | ((uint32_t)(z)&0xFFFFU))
+#define BYTES_JOIN_TO_WORD_1_2_1(x, y, z) \
+    ((((uint32_t)(x)&0xFFU) << 24) | (((uint32_t)(y)&0xFFFFU) << 8) | ((uint32_t)(z)&0xFFU))
+#define BYTES_JOIN_TO_WORD_2_1_1(x, y, z) \
+    ((((uint32_t)(x)&0xFFFFU) << 16) | (((uint32_t)(y)&0xFFU) << 8) | ((uint32_t)(z)&0xFFU))
+#define BYTES_JOIN_TO_WORD_1_1_1_1(x, y, z, w)                                                      \
+    ((((uint32_t)(x)&0xFFU) << 24) | (((uint32_t)(y)&0xFFU) << 16) | (((uint32_t)(z)&0xFFU) << 8) | \
+     ((uint32_t)(w)&0xFFU))
+/*@}*/
+
+/*! @brief Data flash IFR map Field*/
+#if defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
+#define DFLASH_IFR_READRESOURCE_START_ADDRESS 0x8003F8U
+#else /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
+#define DFLASH_IFR_READRESOURCE_START_ADDRESS 0x8000F8U
+#endif
+
+/*!
+ * @name Reserved FlexNVM size (For a variety of purposes) defines
+ * @{
+ */
+#define FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED 0xFFFFFFFFU
+#define FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_RESERVED 0xFFFFU
+/*@}*/
+
+/*!
+ * @name Flash Program Once Field defines
+ * @{
+ */
+#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
+/* FTFA parts(eg. K80, KL80, L5K) support both 4-bytes and 8-bytes unit size */
+#define FLASH_PROGRAM_ONCE_MIN_ID_8BYTES \
+    0x10U /* Minimum Index indcating one of Progam Once Fields which is accessed in 8-byte records */
+#define FLASH_PROGRAM_ONCE_MAX_ID_8BYTES \
+    0x13U /* Maximum Index indcating one of Progam Once Fields which is accessed in 8-byte records */
+#define FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT 1
+#define FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT 1
+#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
+/* FTFE parts(eg. K65, KE18) only support 8-bytes unit size */
+#define FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT 0
+#define FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT 1
+#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
+/* FTFL parts(eg. K20) only support 4-bytes unit size */
+#define FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT 1
+#define FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT 0
+#endif
+/*@}*/
+
+/*!
+ * @name Flash security status defines
+ * @{
+ */
+#define FLASH_SECURITY_STATE_KEYEN 0x80U
+#define FLASH_SECURITY_STATE_UNSECURED 0x02U
+#define FLASH_NOT_SECURE 0x01U
+#define FLASH_SECURE_BACKDOOR_ENABLED 0x02U
+#define FLASH_SECURE_BACKDOOR_DISABLED 0x04U
+/*@}*/
+
+/*!
+ * @name Flash controller command numbers
+ * @{
+ */
+#define FTFx_VERIFY_BLOCK 0x00U                    /*!< RD1BLK*/
+#define FTFx_VERIFY_SECTION 0x01U                  /*!< RD1SEC*/
+#define FTFx_PROGRAM_CHECK 0x02U                   /*!< PGMCHK*/
+#define FTFx_READ_RESOURCE 0x03U                   /*!< RDRSRC*/
+#define FTFx_PROGRAM_LONGWORD 0x06U                /*!< PGM4*/
+#define FTFx_PROGRAM_PHRASE 0x07U                  /*!< PGM8*/
+#define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
+#define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
+#define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
+#define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
+#define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
+#define FTFx_ERASE_ALL_BLOCK 0x44U                 /*!< ERSALL*/
+#define FTFx_SECURITY_BY_PASS 0x45U                /*!< VFYKEY*/
+#define FTFx_SWAP_CONTROL 0x46U                    /*!< SWAP*/
+#define FTFx_ERASE_ALL_BLOCK_UNSECURE 0x49U        /*!< ERSALLU*/
+#define FTFx_VERIFY_ALL_EXECUTE_ONLY_SEGMENT 0x4AU /*!< RD1XA*/
+#define FTFx_ERASE_ALL_EXECUTE_ONLY_SEGMENT 0x4BU  /*!< ERSXA*/
+#define FTFx_PROGRAM_PARTITION 0x80U               /*!< PGMPART)*/
+#define FTFx_SET_FLEXRAM_FUNCTION 0x81U            /*!< SETRAM*/
+                                                   /*@}*/
+
+/*!
+ * @name Common flash register info defines
+ * @{
+ */
+#if defined(FTFA)
+#define FTFx FTFA
+#define FTFx_BASE FTFA_BASE
+#define FTFx_FSTAT_CCIF_MASK FTFA_FSTAT_CCIF_MASK
+#define FTFx_FSTAT_RDCOLERR_MASK FTFA_FSTAT_RDCOLERR_MASK
+#define FTFx_FSTAT_ACCERR_MASK FTFA_FSTAT_ACCERR_MASK
+#define FTFx_FSTAT_FPVIOL_MASK FTFA_FSTAT_FPVIOL_MASK
+#define FTFx_FSTAT_MGSTAT0_MASK FTFA_FSTAT_MGSTAT0_MASK
+#define FTFx_FSEC_SEC_MASK FTFA_FSEC_SEC_MASK
+#define FTFx_FSEC_KEYEN_MASK FTFA_FSEC_KEYEN_MASK
+#if defined(FSL_FEATURE_FLASH_HAS_FLEX_RAM) && FSL_FEATURE_FLASH_HAS_FLEX_RAM
+#define FTFx_FCNFG_RAMRDY_MASK FTFA_FCNFG_RAMRDY_MASK
+#endif /* FSL_FEATURE_FLASH_HAS_FLEX_RAM */
+#if defined(FSL_FEATURE_FLASH_HAS_FLEX_NVM) && FSL_FEATURE_FLASH_HAS_FLEX_NVM
+#define FTFx_FCNFG_EEERDY_MASK FTFA_FCNFG_EEERDY_MASK
+#endif /* FSL_FEATURE_FLASH_HAS_FLEX_NVM */
+#elif defined(FTFE)
+#define FTFx FTFE
+#define FTFx_BASE FTFE_BASE
+#define FTFx_FSTAT_CCIF_MASK FTFE_FSTAT_CCIF_MASK
+#define FTFx_FSTAT_RDCOLERR_MASK FTFE_FSTAT_RDCOLERR_MASK
+#define FTFx_FSTAT_ACCERR_MASK FTFE_FSTAT_ACCERR_MASK
+#define FTFx_FSTAT_FPVIOL_MASK FTFE_FSTAT_FPVIOL_MASK
+#define FTFx_FSTAT_MGSTAT0_MASK FTFE_FSTAT_MGSTAT0_MASK
+#define FTFx_FSEC_SEC_MASK FTFE_FSEC_SEC_MASK
+#define FTFx_FSEC_KEYEN_MASK FTFE_FSEC_KEYEN_MASK
+#if defined(FSL_FEATURE_FLASH_HAS_FLEX_RAM) && FSL_FEATURE_FLASH_HAS_FLEX_RAM
+#define FTFx_FCNFG_RAMRDY_MASK FTFE_FCNFG_RAMRDY_MASK
+#endif /* FSL_FEATURE_FLASH_HAS_FLEX_RAM */
+#if defined(FSL_FEATURE_FLASH_HAS_FLEX_NVM) && FSL_FEATURE_FLASH_HAS_FLEX_NVM
+#define FTFx_FCNFG_EEERDY_MASK FTFE_FCNFG_EEERDY_MASK
+#endif /* FSL_FEATURE_FLASH_HAS_FLEX_NVM */
+#elif defined(FTFL)
+#define FTFx FTFL
+#define FTFx_BASE FTFL_BASE
+#define FTFx_FSTAT_CCIF_MASK FTFL_FSTAT_CCIF_MASK
+#define FTFx_FSTAT_RDCOLERR_MASK FTFL_FSTAT_RDCOLERR_MASK
+#define FTFx_FSTAT_ACCERR_MASK FTFL_FSTAT_ACCERR_MASK
+#define FTFx_FSTAT_FPVIOL_MASK FTFL_FSTAT_FPVIOL_MASK
+#define FTFx_FSTAT_MGSTAT0_MASK FTFL_FSTAT_MGSTAT0_MASK
+#define FTFx_FSEC_SEC_MASK FTFL_FSEC_SEC_MASK
+#define FTFx_FSEC_KEYEN_MASK FTFL_FSEC_KEYEN_MASK
+#if defined(FSL_FEATURE_FLASH_HAS_FLEX_RAM) && FSL_FEATURE_FLASH_HAS_FLEX_RAM
+#define FTFx_FCNFG_RAMRDY_MASK FTFL_FCNFG_RAMRDY_MASK
+#endif /* FSL_FEATURE_FLASH_HAS_FLEX_RAM */
+#if defined(FSL_FEATURE_FLASH_HAS_FLEX_NVM) && FSL_FEATURE_FLASH_HAS_FLEX_NVM
+#define FTFx_FCNFG_EEERDY_MASK FTFL_FCNFG_EEERDY_MASK
+#endif /* FSL_FEATURE_FLASH_HAS_FLEX_NVM */
+#else
+#error "Unknown flash controller"
+#endif
+/*@}*/
+
+/*!
+ * @brief Enumeration for access segment property.
+ */
+enum _flash_access_segment_property
+{
+    kFLASH_accessSegmentBase = 256UL,
+};
+
+/*!
+ * @brief Enumeration for acceleration ram property.
+ */
+enum _flash_acceleration_ram_property
+{
+    kFLASH_accelerationRamSize = 0x400U
+};
+
+/*!
+ * @brief Enumeration for flash config area.
+ */
+enum _flash_config_area_range
+{
+    kFLASH_configAreaStart = 0x400U,
+    kFLASH_configAreaEnd = 0x40FU
+};
+
+/*! @brief program Flash block base address*/
+#define PFLASH_BLOCK_BASE 0x00U
+
+/*! @brief Total flash region count*/
+#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
+
+/*!
+ * @name Flash register access type defines
+ * @{
+ */
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+       /*@}*/
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*! @brief Copy flash_run_command() to RAM*/
+static void copy_flash_run_command(uint8_t *flashRunCommand);
+/*! @brief Copy flash_cache_clear_command() to RAM*/
+static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand);
+/*! @brief Check whether flash execute-in-ram functions are ready*/
+static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+/*! @brief Internal function Flash command sequence. Called by driver APIs only*/
+static status_t flash_command_sequence(flash_config_t *config);
+
+/*! @brief Perform the cache clear to the flash*/
+void flash_cache_clear(flash_config_t *config);
+
+/*! @brief Validates the range and alignment of the given address range.*/
+static status_t flash_check_range(flash_config_t *config,
+                                  uint32_t startAddress,
+                                  uint32_t lengthInBytes,
+                                  uint32_t alignmentBaseline);
+/*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
+static status_t flash_get_matched_operation_info(flash_config_t *config,
+                                                 uint32_t address,
+                                                 flash_operation_config_t *info);
+/*! @brief Validates the given user key for flash erase APIs.*/
+static status_t flash_check_user_key(uint32_t key);
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+/*! @brief Updates FlexNVM memory partition status according to data flash 0 IFR.*/
+static status_t flash_update_flexnvm_memory_partition_status(flash_config_t *config);
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
+/*! @brief Validates the range of the given resource address.*/
+static status_t flash_check_resource_range(uint32_t start,
+                                           uint32_t lengthInBytes,
+                                           uint32_t alignmentBaseline,
+                                           flash_read_resource_option_t option);
+#endif /* FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD */
+
+#if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
+/*! @brief Validates the gived swap control option.*/
+static status_t flash_check_swap_control_option(flash_swap_control_option_t option);
+#endif /* FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD */
+
+#if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
+/*! @brief Validates the gived address to see if it is equal to swap indicator address in pflash swap IFR.*/
+static status_t flash_validate_swap_indicator_address(flash_config_t *config, uint32_t address);
+#endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
+
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+/*! @brief Validates the gived flexram function option.*/
+static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
+#endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Access to FTFx->FCCOB */
+#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
+#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
+#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
+#else
+#error "Unknown flash controller"
+#endif
+
+/*! @brief Access to FTFx->FPROT */
+#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
+volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
+#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
+volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
+#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
+volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
+#else
+#error "Unknown flash controller"
+#endif
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*! @brief A function pointer used to point to relocated flash_run_command() */
+static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
+static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
+/*! @brief A static buffer used to hold flash_run_command() */
+static uint8_t s_flashRunCommand[kFLASH_executeInRamFunctionMaxSize];
+/*! @brief A static buffer used to hold flash_cache_clear_command() */
+static uint8_t s_flashCacheClearCommand[kFLASH_executeInRamFunctionMaxSize];
+/*! @brief Flash execute-in-ram function information */
+static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
+#endif
+
+/*!
+ * @brief Table of pflash sizes.
+ *
+ *  The index into this table is the value of the SIM_FCFG1.PFSIZE bitfield.
+ *
+ *  The values in this table have been right shifted 10 bits so that they will all fit within
+ *  an 16-bit integer. To get the actual flash density, you must left shift the looked up value
+ *  by 10 bits.
+ *
+ *  Elements of this table have a value of 0 in cases where the PFSIZE bitfield value is
+ *  reserved.
+ *
+ *  Code to use the table:
+ *  @code
+ *      uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+ *      flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+ *  @endcode
+ */
+const uint16_t kPFlashDensities[] = {
+    8,    /* 0x0 - 8192, 8KB */
+    16,   /* 0x1 - 16384, 16KB */
+    24,   /* 0x2 - 24576, 24KB */
+    32,   /* 0x3 - 32768, 32KB */
+    48,   /* 0x4 - 49152, 48KB */
+    64,   /* 0x5 - 65536, 64KB */
+    96,   /* 0x6 - 98304, 96KB */
+    128,  /* 0x7 - 131072, 128KB */
+    192,  /* 0x8 - 196608, 192KB */
+    256,  /* 0x9 - 262144, 256KB */
+    384,  /* 0xa - 393216, 384KB */
+    512,  /* 0xb - 524288, 512KB */
+    768,  /* 0xc - 786432, 768KB */
+    1024, /* 0xd - 1048576, 1MB */
+    1536, /* 0xe - 1572864, 1.5MB */
+    /* 2048,  0xf - 2097152, 2MB */
+};
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+status_t FLASH_Init(flash_config_t *config)
+{
+    uint32_t flashDensity;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* calculate the flash density from SIM_FCFG1.PFSIZE */
+    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+     * We just use the pre-defined flash size in feature file here to support pre-production parts */
+    if (pfsize == 0xf)
+    {
+        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+    }
+    else
+    {
+        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+    }
+
+    /* fill out a few of the structure members */
+    config->PFlashBlockBase = PFLASH_BLOCK_BASE;
+    config->PFlashTotalSize = flashDensity;
+    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    config->PFlashAccessSegmentSize = kFLASH_accessSegmentBase << FTFx->FACSS;
+    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#else
+    config->PFlashAccessSegmentSize = 0;
+    config->PFlashAccessSegmentCount = 0;
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
+    config->PFlashCallback = NULL;
+
+/* copy required flash commands to RAM */
+#if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
+    if (kStatus_FLASH_Success != flash_check_execute_in_ram_function_info(config))
+    {
+        s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
+        s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
+        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
+        FLASH_PrepareExecuteInRamFunctions(config);
+    }
+#endif
+
+    config->FlexRAMBlockBase = FSL_FEATURE_FLASH_FLEX_RAM_START_ADDRESS;
+    config->FlexRAMTotalSize = FSL_FEATURE_FLASH_FLEX_RAM_SIZE;
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    {
+        status_t returnCode;
+        config->DFlashBlockBase = FSL_FEATURE_FLASH_FLEX_NVM_START_ADDRESS;
+        returnCode = flash_update_flexnvm_memory_partition_status(config);
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            return returnCode;
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    config->PFlashCallback = callback;
+
+    return kStatus_FLASH_Success;
+}
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
+{
+    flash_execute_in_ram_function_config_t *flashExecuteInRamFunctionInfo;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
+
+    copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
+    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
+    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_executeInRamFunctionTotalNum;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
+{
+    status_t returnCode;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* preparing passing parameter to erase all flash blocks */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_ERASE_ALL_BLOCK, 0xFFFFFFU);
+
+    /* Validate the user key */
+    returnCode = flash_check_user_key(key);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    /* calling flash command sequence function to execute the command */
+    returnCode = flash_command_sequence(config);
+
+    flash_cache_clear(config);
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    /* Data flash IFR will be erased by erase all command, so we need to
+     *  update FlexNVM memory partition status synchronously */
+    if (returnCode == kStatus_FLASH_Success)
+    {
+        returnCode = flash_update_flexnvm_memory_partition_status(config);
+    }
+#endif
+
+    return returnCode;
+}
+
+status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
+{
+    uint32_t sectorSize;
+    flash_operation_config_t flashInfo;
+    uint32_t endAddress;      /* storing end address */
+    uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
+    status_t returnCode;
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+
+    /* Check the supplied address range. */
+    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    start = flashInfo.convertedAddress;
+    sectorSize = flashInfo.activeSectorSize;
+
+    /* calculating Flash end address */
+    endAddress = start + lengthInBytes - 1;
+
+    /* re-calculate the endAddress and align it to the start of the next sector
+     * which will be used in the comparison below */
+    if (endAddress % sectorSize)
+    {
+        numberOfSectors = endAddress / sectorSize + 1;
+        endAddress = numberOfSectors * sectorSize - 1;
+    }
+
+    /* the start address will increment to the next sector address
+     * until it reaches the endAdddress */
+    while (start <= endAddress)
+    {
+        /* preparing passing parameter to erase a flash block */
+        kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_ERASE_SECTOR, start);
+
+        /* Validate the user key */
+        returnCode = flash_check_user_key(key);
+        if (returnCode)
+        {
+            return returnCode;
+        }
+
+        /* calling flash command sequence function to execute the command */
+        returnCode = flash_command_sequence(config);
+
+        /* calling flash callback function if it is available */
+        if (config->PFlashCallback)
+        {
+            config->PFlashCallback();
+        }
+
+        /* checking the success of command execution */
+        if (kStatus_FLASH_Success != returnCode)
+        {
+            break;
+        }
+        else
+        {
+            /* Increment to the next sector */
+            start += sectorSize;
+        }
+    }
+
+    flash_cache_clear(config);
+
+    return (returnCode);
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
+status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key)
+{
+    status_t returnCode;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Prepare passing parameter to erase all flash blocks (unsecure). */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_ERASE_ALL_BLOCK_UNSECURE, 0xFFFFFFU);
+
+    /* Validate the user key */
+    returnCode = flash_check_user_key(key);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    /* calling flash command sequence function to execute the command */
+    returnCode = flash_command_sequence(config);
+
+    flash_cache_clear(config);
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    /* Data flash IFR will be erased by erase all unsecure command, so we need to
+     *  update FlexNVM memory partition status synchronously */
+    if (returnCode == kStatus_FLASH_Success)
+    {
+        returnCode = flash_update_flexnvm_memory_partition_status(config);
+    }
+#endif
+
+    return returnCode;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD */
+
+status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
+{
+    status_t returnCode;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* preparing passing parameter to erase all execute-only segments
+     * 1st element for the FCCOB register */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_ERASE_ALL_EXECUTE_ONLY_SEGMENT, 0xFFFFFFU);
+
+    /* Validate the user key */
+    returnCode = flash_check_user_key(key);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    /* calling flash command sequence function to execute the command */
+    returnCode = flash_command_sequence(config);
+
+    flash_cache_clear(config);
+
+    return returnCode;
+}
+
+status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
+{
+    status_t returnCode;
+    flash_operation_config_t flashInfo;
+
+    if (src == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+
+    /* Check the supplied address range. */
+    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    start = flashInfo.convertedAddress;
+
+    while (lengthInBytes > 0)
+    {
+        /* preparing passing parameter to program the flash block */
+        kFCCOBx[1] = *src++;
+        if (4 == flashInfo.blockWriteUnitSize)
+        {
+            kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
+        }
+        else if (8 == flashInfo.blockWriteUnitSize)
+        {
+            kFCCOBx[2] = *src++;
+            kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
+        }
+        else
+        {
+        }
+
+        /* calling flash command sequence function to execute the command */
+        returnCode = flash_command_sequence(config);
+
+        /* calling flash callback function if it is available */
+        if (config->PFlashCallback)
+        {
+            config->PFlashCallback();
+        }
+
+        /* checking for the success of command execution */
+        if (kStatus_FLASH_Success != returnCode)
+        {
+            break;
+        }
+        else
+        {
+            /* update start address for next iteration */
+            start += flashInfo.blockWriteUnitSize;
+
+            /* update lengthInBytes for next iteration */
+            lengthInBytes -= flashInfo.blockWriteUnitSize;
+        }
+    }
+
+    flash_cache_clear(config);
+
+    return (returnCode);
+}
+
+status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes)
+{
+    status_t returnCode;
+
+    if ((config == NULL) || (src == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* pass paramters to FTFx */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_1_2(FTFx_PROGRAM_ONCE, index, 0xFFFFU);
+
+    kFCCOBx[1] = *src;
+
+/* Note: Have to seperate the first index from the rest if it equals 0
+ * to avoid a pointless comparison of unsigned int to 0 compiler warning */
+#if FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT
+#if FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT
+    if (((index == FLASH_PROGRAM_ONCE_MIN_ID_8BYTES) ||
+         /* Range check */
+         ((index >= FLASH_PROGRAM_ONCE_MIN_ID_8BYTES + 1) && (index <= FLASH_PROGRAM_ONCE_MAX_ID_8BYTES))) &&
+        (lengthInBytes == 8))
+#endif /* FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT */
+    {
+        kFCCOBx[2] = *(src + 1);
+    }
+#endif /* FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT */
+
+    /* calling flash command sequence function to execute the command */
+    returnCode = flash_command_sequence(config);
+
+    flash_cache_clear(config);
+
+    return returnCode;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
+status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
+{
+    status_t returnCode;
+    uint32_t sectorSize;
+    flash_operation_config_t flashInfo;
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+    bool needSwitchFlexRamMode = false;
+#endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+    if (src == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+
+    /* Check the supplied address range. */
+    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    start = flashInfo.convertedAddress;
+    sectorSize = flashInfo.activeSectorSize;
+
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+    /* Switch function of FlexRAM if needed */
+    if (!(FTFx->FCNFG & FTFx_FCNFG_RAMRDY_MASK))
+    {
+        needSwitchFlexRamMode = true;
+
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            return kStatus_FLASH_SetFlexramAsRamError;
+        }
+    }
+#endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+    while (lengthInBytes > 0)
+    {
+        /* Make sure the write operation doesn't span two sectors */
+        uint32_t endAddressOfCurrentSector = ALIGN_UP(start, sectorSize);
+        uint32_t lengthTobeProgrammedOfCurrentSector;
+        uint32_t currentOffset = 0;
+
+        if (endAddressOfCurrentSector == start)
+        {
+            endAddressOfCurrentSector += sectorSize;
+        }
+
+        if (lengthInBytes + start > endAddressOfCurrentSector)
+        {
+            lengthTobeProgrammedOfCurrentSector = endAddressOfCurrentSector - start;
+        }
+        else
+        {
+            lengthTobeProgrammedOfCurrentSector = lengthInBytes;
+        }
+
+        /* Program Current Sector */
+        while (lengthTobeProgrammedOfCurrentSector > 0)
+        {
+            /* Make sure the program size doesn't exceeds Acceleration RAM size */
+            uint32_t programSizeOfCurrentPass;
+            uint32_t numberOfPhases;
+
+            if (lengthTobeProgrammedOfCurrentSector > kFLASH_accelerationRamSize)
+            {
+                programSizeOfCurrentPass = kFLASH_accelerationRamSize;
+            }
+            else
+            {
+                programSizeOfCurrentPass = lengthTobeProgrammedOfCurrentSector;
+            }
+
+            /* Copy data to FlexRAM */
+            memcpy((void *)FSL_FEATURE_FLASH_FLEX_RAM_START_ADDRESS, src + currentOffset / 4, programSizeOfCurrentPass);
+            /* Set start address of the data to be programmed */
+            kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
+            /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
+            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+
+            kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
+
+            /* Peform command sequence */
+            returnCode = flash_command_sequence(config);
+
+            /* calling flash callback function if it is available */
+            if (config->PFlashCallback)
+            {
+                config->PFlashCallback();
+            }
+
+            if (returnCode != kStatus_FLASH_Success)
+            {
+                flash_cache_clear(config);
+                return returnCode;
+            }
+
+            lengthTobeProgrammedOfCurrentSector -= programSizeOfCurrentPass;
+            currentOffset += programSizeOfCurrentPass;
+        }
+
+        src += currentOffset / 4;
+        start += currentOffset;
+        lengthInBytes -= currentOffset;
+    }
+
+    flash_cache_clear(config);
+
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+    /* Restore function of FlexRAM if needed. */
+    if (needSwitchFlexRamMode)
+    {
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            return kStatus_FLASH_RecoverFlexramAsEepromError;
+        }
+    }
+#endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+    return returnCode;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD */
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes)
+{
+    status_t returnCode;
+    bool needSwitchFlexRamMode = false;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Validates the range of the given address */
+    if ((start < config->FlexRAMBlockBase) ||
+        ((start + lengthInBytes) > (config->FlexRAMBlockBase + config->EEpromTotalSize)))
+    {
+        return kStatus_FLASH_AddressError;
+    }
+
+    returnCode = kStatus_FLASH_Success;
+
+    /* Switch function of FlexRAM if needed */
+    if (!(FTFx->FCNFG & FTFx_FCNFG_EEERDY_MASK))
+    {
+        needSwitchFlexRamMode = true;
+
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            return kStatus_FLASH_SetFlexramAsEepromError;
+        }
+    }
+
+    /* Write data to FlexRAM when it is used as EEPROM emulator */
+    while (lengthInBytes > 0)
+    {
+        if ((!(start & 0x3U)) && (lengthInBytes >= 4))
+        {
+            *(uint32_t *)start = *(uint32_t *)src;
+            start += 4;
+            src += 4;
+            lengthInBytes -= 4;
+        }
+        else if ((!(start & 0x1U)) && (lengthInBytes >= 2))
+        {
+            *(uint16_t *)start = *(uint16_t *)src;
+            start += 2;
+            src += 2;
+            lengthInBytes -= 2;
+        }
+        else
+        {
+            *(uint8_t *)start = *src;
+            start += 1;
+            src += 1;
+            lengthInBytes -= 1;
+        }
+        /* Wait till EEERDY bit is set */
+        while (!(FTFx->FCNFG & FTFx_FCNFG_EEERDY_MASK))
+        {
+        }
+
+        /* Check for protection violation error */
+        if (FTFx->FSTAT & FTFx_FSTAT_FPVIOL_MASK)
+        {
+            return kStatus_FLASH_ProtectionViolation;
+        }
+    }
+
+    /* Switch function of FlexRAM if needed */
+    if (needSwitchFlexRamMode)
+    {
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            return kStatus_FLASH_RecoverFlexramAsRamError;
+        }
+    }
+
+    return returnCode;
+}
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
+status_t FLASH_ReadResource(
+    flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
+{
+    status_t returnCode;
+    flash_operation_config_t flashInfo;
+
+    if ((config == NULL) || (dst == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+
+    /* Check the supplied address range. */
+    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    if (returnCode != kStatus_FLASH_Success)
+    {
+        return returnCode;
+    }
+
+    while (lengthInBytes > 0)
+    {
+        /* preparing passing parameter */
+        kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
+        if (flashInfo.resourceCmdAddressAligment == 4)
+        {
+            kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
+        }
+        else if (flashInfo.resourceCmdAddressAligment == 8)
+        {
+            kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
+        }
+        else
+        {
+        }
+
+        /* calling flash command sequence function to execute the command */
+        returnCode = flash_command_sequence(config);
+
+        if (kStatus_FLASH_Success != returnCode)
+        {
+            break;
+        }
+
+        /* fetch data */
+        *dst++ = kFCCOBx[1];
+        if (flashInfo.resourceCmdAddressAligment == 8)
+        {
+            *dst++ = kFCCOBx[2];
+        }
+        /* update start address for next iteration */
+        start += flashInfo.resourceCmdAddressAligment;
+        /* update lengthInBytes for next iteration */
+        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+    }
+
+    return (returnCode);
+}
+#endif /* FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD */
+
+status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes)
+{
+    status_t returnCode;
+
+    if ((config == NULL) || (dst == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* pass paramters to FTFx */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_1_2(FTFx_READ_ONCE, index, 0xFFFFU);
+
+    /* calling flash command sequence function to execute the command */
+    returnCode = flash_command_sequence(config);
+
+    if (kStatus_FLASH_Success == returnCode)
+    {
+        *dst = kFCCOBx[1];
+/* Note: Have to seperate the first index from the rest if it equals 0
+ *       to avoid a pointless comparison of unsigned int to 0 compiler warning */
+#if FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT
+#if FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT
+        if (((index == FLASH_PROGRAM_ONCE_MIN_ID_8BYTES) ||
+             /* Range check */
+             ((index >= FLASH_PROGRAM_ONCE_MIN_ID_8BYTES + 1) && (index <= FLASH_PROGRAM_ONCE_MAX_ID_8BYTES))) &&
+            (lengthInBytes == 8))
+#endif /* FLASH_PROGRAM_ONCE_IS_4BYTES_UNIT_SUPPORT */
+        {
+            *(dst + 1) = kFCCOBx[2];
+        }
+#endif /* FLASH_PROGRAM_ONCE_IS_8BYTES_UNIT_SUPPORT */
+    }
+
+    return returnCode;
+}
+
+status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state)
+{
+    /* store data read from flash register */
+    uint8_t registerValue;
+
+    if ((config == NULL) || (state == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Get flash security register value */
+    registerValue = FTFx->FSEC;
+
+    /* check the status of the flash security bits in the security register */
+    if (FLASH_SECURITY_STATE_UNSECURED == (registerValue & FTFx_FSEC_SEC_MASK))
+    {
+        /* Flash in unsecured state */
+        *state = kFLASH_securityStateNotSecure;
+    }
+    else
+    {
+        /* Flash in secured state
+         * check for backdoor key security enable bit */
+        if (FLASH_SECURITY_STATE_KEYEN == (registerValue & FTFx_FSEC_KEYEN_MASK))
+        {
+            /* Backdoor key security enabled */
+            *state = kFLASH_securityStateBackdoorEnabled;
+        }
+        else
+        {
+            /* Backdoor key security disabled */
+            *state = kFLASH_securityStateBackdoorDisabled;
+        }
+    }
+
+    return (kStatus_FLASH_Success);
+}
+
+status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey)
+{
+    uint8_t registerValue; /* registerValue */
+    status_t returnCode;   /* return code variable */
+
+    if ((config == NULL) || (backdoorKey == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* set the default return code as kStatus_Success */
+    returnCode = kStatus_FLASH_Success;
+
+    /* Get flash security register value */
+    registerValue = FTFx->FSEC;
+
+    /* Check to see if flash is in secure state (any state other than 0x2)
+     * If not, then skip this since flash is not secure */
+    if (0x02 != (registerValue & 0x03))
+    {
+        /* preparing passing parameter to erase a flash block */
+        kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_SECURITY_BY_PASS, 0xFFFFFFU);
+        kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_1_1_1(backdoorKey[0], backdoorKey[1], backdoorKey[2], backdoorKey[3]);
+        kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_1_1_1(backdoorKey[4], backdoorKey[5], backdoorKey[6], backdoorKey[7]);
+
+        /* calling flash command sequence function to execute the command */
+        returnCode = flash_command_sequence(config);
+    }
+
+    return (returnCode);
+}
+
+status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* preparing passing parameter to verify all block command */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_1_2(FTFx_VERIFY_ALL_BLOCK, margin, 0xFFFFU);
+
+    /* calling flash command sequence function to execute the command */
+    return flash_command_sequence(config);
+}
+
+status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin)
+{
+    /* Check arguments. */
+    uint32_t blockSize;
+    flash_operation_config_t flashInfo;
+    uint32_t nextBlockStartAddress;
+    uint32_t remainingBytes;
+    status_t returnCode;
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+
+    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+    start = flashInfo.convertedAddress;
+    blockSize = flashInfo.activeBlockSize;
+
+    nextBlockStartAddress = ALIGN_UP(start, blockSize);
+    if (nextBlockStartAddress == start)
+    {
+        nextBlockStartAddress += blockSize;
+    }
+
+    remainingBytes = lengthInBytes;
+
+    while (remainingBytes)
+    {
+        uint32_t numberOfPhrases;
+        uint32_t verifyLength = nextBlockStartAddress - start;
+        if (verifyLength > remainingBytes)
+        {
+            verifyLength = remainingBytes;
+        }
+
+        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+
+        /* Fill in verify section command parameters. */
+        kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
+        kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_1_1(numberOfPhrases, margin, 0xFFU);
+
+        /* calling flash command sequence function to execute the command */
+        returnCode = flash_command_sequence(config);
+        if (returnCode)
+        {
+            return returnCode;
+        }
+
+        remainingBytes -= verifyLength;
+        start += verifyLength;
+        nextBlockStartAddress += blockSize;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_VerifyProgram(flash_config_t *config,
+                             uint32_t start,
+                             uint32_t lengthInBytes,
+                             const uint32_t *expectedData,
+                             flash_margin_value_t margin,
+                             uint32_t *failedAddress,
+                             uint32_t *failedData)
+{
+    status_t returnCode;
+    flash_operation_config_t flashInfo;
+
+    if (expectedData == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    flash_get_matched_operation_info(config, start, &flashInfo);
+
+    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    start = flashInfo.convertedAddress;
+
+    while (lengthInBytes)
+    {
+        /* preparing passing parameter to program check the flash block */
+        kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_CHECK, start);
+        kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(margin, 0xFFFFFFU);
+        kFCCOBx[2] = *expectedData;
+
+        /* calling flash command sequence function to execute the command */
+        returnCode = flash_command_sequence(config);
+
+        /* checking for the success of command execution */
+        if (kStatus_FLASH_Success != returnCode)
+        {
+            if (failedAddress)
+            {
+                *failedAddress = start;
+            }
+            if (failedData)
+            {
+                *failedData = 0;
+            }
+            break;
+        }
+
+        lengthInBytes -= flashInfo.checkCmdAddressAligment;
+        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashInfo.checkCmdAddressAligment;
+    }
+
+    return (returnCode);
+}
+
+status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* preparing passing parameter to verify erase all execute-only segments command */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_1_2(FTFx_VERIFY_ALL_EXECUTE_ONLY_SEGMENT, margin, 0xFFFFU);
+
+    /* calling flash command sequence function to execute the command */
+    return flash_command_sequence(config);
+}
+
+status_t FLASH_IsProtected(flash_config_t *config,
+                           uint32_t start,
+                           uint32_t lengthInBytes,
+                           flash_protection_state_t *protection_state)
+{
+    uint32_t endAddress;           /* end address for protection check */
+    uint32_t protectionRegionSize; /* size of flash protection region */
+    uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
+                                    * protection status */
+    uint32_t regionCounter;        /* incrementing variable used to increment through the flash
+                                    * protection regions */
+    uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
+
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+                                                                      * protection region */
+    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
+                                                                      * protection region. Note this is REGION_COUNT+1
+                                                                      * due to requiring the next start address after
+                                                                      * the end of flash for loop-check purposes below */
+    status_t returnCode;
+
+    if (protection_state == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Check the supplied address range. */
+    returnCode = flash_check_range(config, start, lengthInBytes, FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    /* calculating Flash end address */
+    endAddress = start + lengthInBytes;
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (config->PFlashTotalSize > 32 * 1024)
+    {
+        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
+    }
+    else
+    {
+        protectionRegionSize = 1024;
+    }
+
+    /* populate the flashRegionAddress array with the start address of each flash region */
+    regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
+
+    /* populate up to 33rd element of array, this is the next address after end of flash array */
+    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    {
+        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        regionCounter++;
+    }
+
+    /* populate flashRegionProtectStatus array with status information
+     * Protection status for each region is stored in the FPROT[3:0] registers
+     * Each bit represents one region of flash
+     * 4 registers * 8-bits-per-register = 32-bits (32-regions)
+     * The convention is:
+     * FPROT3[bit 0] is the first protection region (start of flash memory)
+     * FPROT0[bit 7] is the last protection region (end of flash memory)
+     * regionCounter is used to determine which FPROT[3:0] register to check for protection status
+     * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
+    regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
+    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    {
+        if (regionCounter < 8)
+        {
+            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
+        }
+        else if ((regionCounter >= 8) && (regionCounter < 16))
+        {
+            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
+        }
+        else if ((regionCounter >= 16) && (regionCounter < 24))
+        {
+            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+        }
+        else
+        {
+            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+        }
+        regionCounter++;
+    }
+
+    /* loop through the flash regions and check
+     * desired flash address range for protection status
+     * loop stops when it is detected that start has exceeded the endAddress */
+    regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
+    regionCheckedCounter = 0;
+    protectStatusCounter = 0; /* make sure protectStatusCounter is initialized to 0 first */
+    while (start < endAddress)
+    {
+        /* check to see if the address falls within this protection region
+         * Note that if the entire flash is to be checked, the last protection
+         * region checked would consist of the last protection start address and
+         * the start address following the end of flash */
+        if ((start >= flashRegionAddress[regionCounter]) && (start < flashRegionAddress[regionCounter + 1]))
+        {
+            /* increment regionCheckedCounter to indicate this region was checked */
+            regionCheckedCounter++;
+
+            /* check the protection status of this region
+             * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
+            if (!flashRegionProtectStatus[regionCounter])
+            {
+                /* increment protectStatusCounter to indicate this region is protected */
+                protectStatusCounter++;
+            }
+            start += protectionRegionSize; /* increment to an address within the next region */
+        }
+        regionCounter++; /* increment regionCounter to check for the next flash protection region */
+    }
+
+    /* if protectStatusCounter == 0, then no region of the desired flash region is protected */
+    if (protectStatusCounter == 0)
+    {
+        *protection_state = kFLASH_protectionStateUnprotected;
+    }
+    /* if protectStatusCounter == regionCheckedCounter, then each region checked was protected */
+    else if (protectStatusCounter == regionCheckedCounter)
+    {
+        *protection_state = kFLASH_protectionStateProtected;
+    }
+    /* if protectStatusCounter != regionCheckedCounter, then protection status is mixed
+     * In other words, some regions are protected while others are unprotected */
+    else
+    {
+        *protection_state = kFLASH_protectionStateMixed;
+    }
+
+    return (returnCode);
+}
+
+status_t FLASH_IsExecuteOnly(flash_config_t *config,
+                             uint32_t start,
+                             uint32_t lengthInBytes,
+                             flash_execute_only_access_state_t *access_state)
+{
+    status_t returnCode;
+
+    if (access_state == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Check the supplied address range. */
+    returnCode = flash_check_range(config, start, lengthInBytes, FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    {
+        uint32_t executeOnlySegmentCounter = 0;
+
+        /* calculating end address */
+        uint32_t endAddress = start + lengthInBytes;
+
+        /* Aligning start address and end address */
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+
+        uint32_t segmentIndex = 0;
+        uint32_t maxSupportedExecuteOnlySegmentCount =
+            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+
+        while (start < endAddress)
+        {
+            uint32_t xacc;
+
+            segmentIndex = start / config->PFlashAccessSegmentSize;
+
+            if (segmentIndex < 32)
+            {
+                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
+            }
+            else if (segmentIndex < config->PFlashAccessSegmentCount)
+            {
+                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
+                segmentIndex -= 32;
+            }
+            else
+            {
+                break;
+            }
+
+            /* Determine if this address range is in a execute-only protection flash segment. */
+            if ((~xacc) & (1u << segmentIndex))
+            {
+                executeOnlySegmentCounter++;
+            }
+
+            start += config->PFlashAccessSegmentSize;
+        }
+
+        if (executeOnlySegmentCounter < 1u)
+        {
+            *access_state = kFLASH_accessStateUnLimited;
+        }
+        else if (executeOnlySegmentCounter < maxSupportedExecuteOnlySegmentCount)
+        {
+            *access_state = kFLASH_accessStateMixed;
+        }
+        else
+        {
+            *access_state = kFLASH_accessStateExecuteOnly;
+        }
+    }
+#else
+    *access_state = kFLASH_accessStateUnLimited;
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
+    return (returnCode);
+}
+
+status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value)
+{
+    if ((config == NULL) || (value == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_propertyPflashSectorSize:
+            *value = config->PFlashSectorSize;
+            break;
+
+        case kFLASH_propertyPflashTotalSize:
+            *value = config->PFlashTotalSize;
+            break;
+
+        case kFLASH_propertyPflashBlockSize:
+            *value = config->PFlashTotalSize / FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+            break;
+
+        case kFLASH_propertyPflashBlockCount:
+            *value = config->PFlashBlockCount;
+            break;
+
+        case kFLASH_propertyPflashBlockBaseAddr:
+            *value = config->PFlashBlockBase;
+            break;
+
+        case kFLASH_propertyPflashFacSupport:
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL)
+            *value = FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL;
+#else
+            *value = 0;
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+            break;
+
+        case kFLASH_propertyPflashAccessSegmentSize:
+            *value = config->PFlashAccessSegmentSize;
+            break;
+
+        case kFLASH_propertyPflashAccessSegmentCount:
+            *value = config->PFlashAccessSegmentCount;
+            break;
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_propertyDflashSectorSize:
+            *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
+            break;
+        case kFLASH_propertyDflashTotalSize:
+            *value = config->DFlashTotalSize;
+            break;
+        case kFLASH_propertyDflashBlockSize:
+            *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SIZE;
+            break;
+        case kFLASH_propertyDflashBlockCount:
+            *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
+            break;
+        case kFLASH_propertyDflashBlockBaseAddr:
+            *value = config->DFlashBlockBase;
+            break;
+        case kFLASH_propertyEepromTotalSize:
+            *value = config->EEpromTotalSize;
+            break;
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+        default: /* catch inputs that are not recognized */
+            return kStatus_FLASH_UnknownProperty;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
+{
+    status_t status;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    status = flasn_check_flexram_function_option_range(option);
+    if (status != kStatus_FLASH_Success)
+    {
+        return status;
+    }
+
+    /* preparing passing parameter to verify all block command */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_1_2(FTFx_SET_FLEXRAM_FUNCTION, option, 0xFFFFU);
+
+    /* calling flash command sequence function to execute the command */
+    return flash_command_sequence(config);
+}
+#endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+#if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
+status_t FLASH_SwapControl(flash_config_t *config,
+                           uint32_t address,
+                           flash_swap_control_option_t option,
+                           flash_swap_state_config_t *returnInfo)
+{
+    status_t returnCode;
+
+    if ((config == NULL) || (returnInfo == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    if (address & (FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT - 1))
+    {
+        return kStatus_FLASH_AlignmentError;
+    }
+
+    /* Make sure address provided is in the lower half of Program flash but not in the Flash Configuration Field */
+    if ((address >= (config->PFlashTotalSize / 2)) ||
+        ((address >= kFLASH_configAreaStart) && (address <= kFLASH_configAreaEnd)))
+    {
+        return kStatus_FLASH_SwapIndicatorAddressError;
+    }
+
+    /* Check the option. */
+    returnCode = flash_check_swap_control_option(option);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_SWAP_CONTROL, address);
+    kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
+
+    returnCode = flash_command_sequence(config);
+
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+
+    return returnCode;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD */
+
+#if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
+status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option)
+{
+    flash_swap_state_config_t returnInfo;
+    status_t returnCode;
+
+    memset(&returnInfo, 0xFFU, sizeof(returnInfo));
+
+    do
+    {
+        returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionReportStatus, &returnInfo);
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            return returnCode;
+        }
+
+        if (kFLASH_swapFunctionOptionDisable == option)
+        {
+            if (returnInfo.flashSwapState == kFLASH_swapStateDisabled)
+            {
+                return kStatus_FLASH_Success;
+            }
+            else if (returnInfo.flashSwapState == kFLASH_swapStateUninitialized)
+            {
+                /* The swap system changed to the DISABLED state with Program flash block 0
+                 * located at relative flash address 0x0_0000 */
+                returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionDisableSystem, &returnInfo);
+            }
+            else
+            {
+                /* Swap disable should be requested only when swap system is in the uninitialized state */
+                return kStatus_FLASH_SwapSystemNotInUninitialized;
+            }
+        }
+        else
+        {
+            /* When first swap: the initial swap state is Uninitialized, flash swap inidicator address is unset,
+             *    the swap procedure should be Uninitialized -> Update-Erased -> Complete.
+             * After the first swap has been completed, the flash swap inidicator address cannot be modified
+             *    unless EraseAllBlocks command is issued, the swap procedure is changed to Update -> Update-Erased ->
+             *    Complete. */
+            switch (returnInfo.flashSwapState)
+            {
+                case kFLASH_swapStateUninitialized:
+                    /* If current swap mode is Uninitialized, Initialize Swap to Initialized/READY state. */
+                    returnCode =
+                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionIntializeSystem, &returnInfo);
+                    break;
+                case kFLASH_swapStateReady:
+                    /* Validate whether the address provided to the swap system is matched to
+                     * swap indicator address in the IFR */
+                    returnCode = flash_validate_swap_indicator_address(config, address);
+                    if (returnCode == kStatus_FLASH_Success)
+                    {
+                        /* If current swap mode is Initialized/Ready, Initialize Swap to UPDATE state. */
+                        returnCode =
+                            FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInUpdateState, &returnInfo);
+                    }
+                    break;
+                case kFLASH_swapStateUpdate:
+                    /* If current swap mode is Update, Erase indicator sector in non active block
+                     * to proceed swap system to update-erased state */
+                    returnCode = FLASH_Erase(config, address + (config->PFlashTotalSize >> 1),
+                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_apiEraseKey);
+                    break;
+                case kFLASH_swapStateUpdateErased:
+                    /* If current swap mode is Update or Update-Erased, progress Swap to COMPLETE State */
+                    returnCode =
+                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInCompleteState, &returnInfo);
+                    break;
+                case kFLASH_swapStateComplete:
+                    break;
+                case kFLASH_swapStateDisabled:
+                    /* When swap system is in disabled state, We need to clear swap system back to uninitialized
+                     * by issuing EraseAllBlocks command */
+                    returnCode = kStatus_FLASH_SwapSystemNotInUninitialized;
+                    break;
+                default:
+                    returnCode = kStatus_FLASH_InvalidArgument;
+                    break;
+            }
+        }
+        if (returnCode != kStatus_FLASH_Success)
+        {
+            break;
+        }
+    } while (!((kFLASH_swapStateComplete == returnInfo.flashSwapState) && (kFLASH_swapFunctionOptionEnable == option)));
+
+    return returnCode;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
+
+#if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD
+status_t FLASH_ProgramPartition(flash_config_t *config,
+                                flash_partition_flexram_load_option_t option,
+                                uint32_t eepromDataSizeCode,
+                                uint32_t flexnvmPartitionCode)
+{
+    status_t returnCode;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* eepromDataSizeCode[7:6], flexnvmPartitionCode[7:4] should be all 1'b0
+     *  or it will cause access error. */
+    /* eepromDataSizeCode &= 0x3FU;  */
+    /* flexnvmPartitionCode &= 0x0FU; */
+
+    /* preparing passing parameter to program the flash block */
+    kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_2_1(FTFx_PROGRAM_PARTITION, 0xFFFFU, option);
+    kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_1_2(eepromDataSizeCode, flexnvmPartitionCode, 0xFFFFU);
+
+    /* calling flash command sequence function to execute the command */
+    returnCode = flash_command_sequence(config);
+
+    flash_cache_clear(config);
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    /* Data flash IFR will be updated by program partition command during reset sequence,
+     * so we just set reserved values for partitioned FlexNVM size here */
+    config->EEpromTotalSize = FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_RESERVED;
+    config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif
+
+    return (returnCode);
+}
+#endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
+
+status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    *kFPROT = protectStatus;
+
+    if (protectStatus != *kFPROT)
+    {
+        return kStatus_FLASH_CommandFailure;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+{
+    if ((config == NULL) || (protectStatus == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    *protectStatus = *kFPROT;
+
+    return kStatus_FLASH_Success;
+}
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    if ((config->DFlashTotalSize == 0) || (config->DFlashTotalSize == FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED))
+    {
+        return kStatus_FLASH_CommandNotSupported;
+    }
+
+    FTFx->FDPROT = protectStatus;
+
+    if (FTFx->FDPROT != protectStatus)
+    {
+        return kStatus_FLASH_CommandFailure;
+    }
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus)
+{
+    if ((config == NULL) || (protectStatus == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    if ((config->DFlashTotalSize == 0) || (config->DFlashTotalSize == FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED))
+    {
+        return kStatus_FLASH_CommandNotSupported;
+    }
+
+    *protectStatus = FTFx->FDPROT;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    if ((config->EEpromTotalSize == 0) || (config->EEpromTotalSize == FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_RESERVED))
+    {
+        return kStatus_FLASH_CommandNotSupported;
+    }
+
+    FTFx->FEPROT = protectStatus;
+
+    if (FTFx->FEPROT != protectStatus)
+    {
+        return kStatus_FLASH_CommandFailure;
+    }
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus)
+{
+    if ((config == NULL) || (protectStatus == NULL))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    if ((config->EEpromTotalSize == 0) || (config->EEpromTotalSize == FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_RESERVED))
+    {
+        return kStatus_FLASH_CommandNotSupported;
+    }
+
+    *protectStatus = FTFx->FEPROT;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*!
+ * @brief Run flash command
+ *
+ * This function should be copied to RAM for execution to make sure that code works
+ * properly even flash cache is disabled.
+ * It is for flash-resident bootloader only, not technically required for ROM or
+ *  flashloader (RAM-resident bootloader).
+ */
+void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
+{
+    /* clear CCIF bit */
+    *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+
+    /* Check CCIF bit of the flash status register, wait till it is set.
+     * IP team indicates that this loop will always complete. */
+    while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+    {
+    }
+}
+
+/*!
+ * @brief Be used for determining the size of flash_run_command()
+ *
+ * This function must be defined that lexically follows flash_run_command(),
+ * so we can determine the size of flash_run_command() at runtime and not worry
+ * about toolchain or code generation differences.
+ */
+void flash_run_command_end(void)
+{
+}
+
+/*!
+ * @brief Copy flash_run_command() to RAM
+ *
+ * This function copys the memory between flash_run_command() and flash_run_command_end()
+ * into the buffer which is also means that copying flash_run_command() to RAM.
+ */
+static void copy_flash_run_command(uint8_t *flashRunCommand)
+{
+    /* Calculate the valid length of flash_run_command() memory.
+     * Set max size(64 bytes) as default function size, in case some compiler allocates
+     * flash_run_command_end ahead of flash_run_command. */
+    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
+    uint32_t flash_run_command_start_addr = (uint32_t)flash_run_command & (~1U);
+    uint32_t flash_run_command_end_addr = (uint32_t)flash_run_command_end & (~1U);
+    if (flash_run_command_end_addr > flash_run_command_start_addr)
+    {
+        funcLength = flash_run_command_end_addr - flash_run_command_start_addr;
+
+        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
+
+        /* In case some compiler allocates other function in the middle of flash_run_command
+         * and flash_run_command_end. */
+        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
+        {
+            funcLength = kFLASH_executeInRamFunctionMaxSize;
+        }
+    }
+
+    /* Since the value of ARM function pointer is always odd, but the real start address
+     * of function memory should be even, that's why -1 and +1 operation exist. */
+    memcpy((void *)flashRunCommand, (void *)flash_run_command_start_addr, funcLength);
+    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+}
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+/*!
+ * @brief Flash Command Sequence
+ *
+ * This function is used to perform the command write sequence to the flash.
+ *
+ * @param driver Pointer to storage for the driver runtime state.
+ * @return An error code or kStatus_FLASH_Success
+ */
+static status_t flash_command_sequence(flash_config_t *config)
+{
+    uint8_t registerValue;
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
+    FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
+
+    status_t returnCode = flash_check_execute_in_ram_function_info(config);
+    if (kStatus_FLASH_Success != returnCode)
+    {
+        return returnCode;
+    }
+
+    /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
+     * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
+     * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
+    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+#else
+    /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
+    FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
+
+    /* clear CCIF bit */
+    FTFx->FSTAT = FTFx_FSTAT_CCIF_MASK;
+
+    /* Check CCIF bit of the flash status register, wait till it is set.
+     * IP team indicates that this loop will always complete. */
+    while (!(FTFx->FSTAT & FTFx_FSTAT_CCIF_MASK))
+    {
+    }
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+    /* Check error bits */
+    /* Get flash status register value */
+    registerValue = FTFx->FSTAT;
+
+    /* checking access error */
+    if (registerValue & FTFx_FSTAT_ACCERR_MASK)
+    {
+        return kStatus_FLASH_AccessError;
+    }
+    /* checking protection error */
+    else if (registerValue & FTFx_FSTAT_FPVIOL_MASK)
+    {
+        return kStatus_FLASH_ProtectionViolation;
+    }
+    /* checking MGSTAT0 non-correctable error */
+    else if (registerValue & FTFx_FSTAT_MGSTAT0_MASK)
+    {
+        return kStatus_FLASH_CommandFailure;
+    }
+    else
+    {
+        return kStatus_FLASH_Success;
+    }
+}
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*!
+ * @brief Run flash cache clear command
+ *
+ * This function should be copied to RAM for execution to make sure that code works
+ * properly even flash cache is disabled.
+ * It is for flash-resident bootloader only, not technically required for ROM or
+ * flashloader (RAM-resident bootloader).
+ */
+void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+{
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    *ftfx_reg |= MCM_PLACR_CFCC_MASK;
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+#if defined(FMC_PFB01CR_CINV_WAY_MASK)
+    *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
+#else
+    *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
+#endif
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
+    *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
+#else
+/*    #error "Unknown flash cache controller"  */
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+       /* Memory barriers for good measure.
+        * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
+}
+
+/*!
+ * @brief Be used for determining the size of flash_cache_clear_command()
+ *
+ * This function must be defined that lexically follows flash_cache_clear_command(),
+ * so we can determine the size of flash_cache_clear_command() at runtime and not worry
+ * about toolchain or code generation differences.
+ */
+void flash_cache_clear_command_end(void)
+{
+}
+
+/*!
+ * @brief Copy flash_cache_clear_command() to RAM
+ *
+ * This function copys the memory between flash_cache_clear_command() and flash_cache_clear_command_end()
+ * into the buffer which is also means that copying flash_cache_clear_command() to RAM.
+ */
+static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
+{
+    /* Calculate the valid length of flash_cache_clear_command() memory.
+     * Set max size(64 bytes) as default function size, in case some compiler allocates
+     * flash_cache_clear_command_end ahead of flash_cache_clear_command. */
+    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
+    uint32_t flash_cache_clear_command_start_addr = (uint32_t)flash_cache_clear_command & (~1U);
+    uint32_t flash_cache_clear_command_end_addr = (uint32_t)flash_cache_clear_command_end & (~1U);
+    if (flash_cache_clear_command_end_addr > flash_cache_clear_command_start_addr)
+    {
+        funcLength = flash_cache_clear_command_end_addr - flash_cache_clear_command_start_addr;
+
+        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
+
+        /* In case some compiler allocates other function in the middle of flash_cache_clear_command
+         * and flash_cache_clear_command_end. */
+        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
+        {
+            funcLength = kFLASH_executeInRamFunctionMaxSize;
+        }
+    }
+
+    /* Since the value of ARM function pointer is always odd, but the real start address
+     * of function memory should be even, that's why -1 and +1 operation exist. */
+    memcpy((void *)flashCacheClearCommand, (void *)flash_cache_clear_command_start_addr, funcLength);
+    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+}
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+/*!
+ * @brief Flash Cache Clear
+ *
+ * This function is used to perform the cache clear to the flash.
+ */
+#if (defined(__GNUC__))
+/* #pragma GCC push_options */
+/* #pragma GCC optimize("O0") */
+void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)
+#else
+#if (defined(__ICCARM__))
+#pragma optimize = none
+#endif
+#if (defined(__CC_ARM))
+#pragma push
+#pragma O0
+#endif
+void flash_cache_clear(flash_config_t *config)
+#endif
+{
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    status_t returnCode = flash_check_execute_in_ram_function_info(config);
+    if (kStatus_FLASH_Success != returnCode)
+    {
+        return;
+    }
+
+/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
+ * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
+ * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+#if defined(MCM)
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+#endif
+#if defined(MCM0)
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+#endif
+#if defined(MCM1)
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+#endif
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+#if defined(FMC_PFB01CR_CINV_WAY_MASK)
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+#else
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+#endif
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+#else
+    /* #error "Unknown flash cache controller" */
+    /* meaningless code, just a workaround to solve warning*/
+    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+#else
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+#if defined(MCM)
+    MCM->PLACR |= MCM_PLACR_CFCC_MASK;
+#endif
+#if defined(MCM0)
+    MCM0->PLACR |= MCM_PLACR_CFCC_MASK;
+#endif
+#if defined(MCM1)
+    MCM1->PLACR |= MCM_PLACR_CFCC_MASK;
+#endif
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+#if defined(FMC_PFB01CR_CINV_WAY_MASK)
+    FMC->PFB01CR = (FMC->PFB01CR & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
+#else
+    FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
+#endif
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#else
+/*    #error "Unknown flash cache controller" */
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+}
+#if (defined(__CC_ARM))
+#pragma pop
+#endif
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#endif
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*! @brief Check whether flash execute-in-ram functions are ready  */
+static status_t flash_check_execute_in_ram_function_info(flash_config_t *config)
+{
+    flash_execute_in_ram_function_config_t *flashExecuteInRamFunctionInfo;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
+
+    if ((config->flashExecuteInRamFunctionInfo) &&
+        (kFLASH_executeInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
+    {
+        return kStatus_FLASH_Success;
+    }
+
+    return kStatus_FLASH_ExecuteInRamFunctionNotReady;
+}
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+/*! @brief Validates the range and alignment of the given address range.*/
+static status_t flash_check_range(flash_config_t *config,
+                                  uint32_t startAddress,
+                                  uint32_t lengthInBytes,
+                                  uint32_t alignmentBaseline)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Verify the start and length are alignmentBaseline aligned. */
+    if ((startAddress & (alignmentBaseline - 1)) || (lengthInBytes & (alignmentBaseline - 1)))
+    {
+        return kStatus_FLASH_AlignmentError;
+    }
+
+/* check for valid range of the target addresses */
+#if !FLASH_SSD_IS_FLEXNVM_ENABLED
+    if ((startAddress < config->PFlashBlockBase) ||
+        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
+#else
+    if (!(((startAddress >= config->PFlashBlockBase) &&
+           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
+          ((startAddress >= config->DFlashBlockBase) &&
+           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+#endif
+    {
+        return kStatus_FLASH_AddressError;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+/*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
+static status_t flash_get_matched_operation_info(flash_config_t *config,
+                                                 uint32_t address,
+                                                 flash_operation_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_operation_config_t));
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
+    {
+        info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
+        info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
+        info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
+
+        info->blockWriteUnitSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_WRITE_UNIT_SIZE;
+        info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_FLEX_NVM_SECTOR_CMD_ADDRESS_ALIGMENT;
+        info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_FLEX_NVM_SECTION_CMD_ADDRESS_ALIGMENT;
+        info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_FLEX_NVM_RESOURCE_CMD_ADDRESS_ALIGMENT;
+        info->checkCmdAddressAligment = FSL_FEATURE_FLASH_FLEX_NVM_CHECK_CMD_ADDRESS_ALIGMENT;
+    }
+    else
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+    {
+        info->convertedAddress = address;
+        info->activeSectorSize = config->PFlashSectorSize;
+        info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+
+        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
+        info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
+        info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
+        info->checkCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_CHECK_CMD_ADDRESS_ALIGMENT;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+/*! @brief Validates the given user key for flash erase APIs.*/
+static status_t flash_check_user_key(uint32_t key)
+{
+    /* Validate the user key */
+    if (key != kFLASH_apiEraseKey)
+    {
+        return kStatus_FLASH_EraseKeyError;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+/*! @brief Updates FlexNVM memory partition status according to data flash 0 IFR.*/
+static status_t flash_update_flexnvm_memory_partition_status(flash_config_t *config)
+{
+    struct
+    {
+        uint32_t reserved0;
+        uint8_t FlexNVMPartitionCode;
+        uint8_t EEPROMDataSetSize;
+        uint16_t reserved1;
+    } dataIFRReadOut;
+    status_t returnCode;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Get FlexNVM memory partition info from data flash IFR */
+    returnCode = FLASH_ReadResource(config, DFLASH_IFR_READRESOURCE_START_ADDRESS, (uint32_t *)&dataIFRReadOut,
+                                    sizeof(dataIFRReadOut), kFLASH_resourceOptionFlashIfr);
+    if (returnCode != kStatus_FLASH_Success)
+    {
+        return kStatus_FLASH_PartitionStatusUpdateFailure;
+    }
+
+    /* Fill out partitioned EEPROM size */
+    dataIFRReadOut.EEPROMDataSetSize &= 0x0FU;
+    switch (dataIFRReadOut.EEPROMDataSetSize)
+    {
+        case 0x00U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0000;
+            break;
+        case 0x01U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0001;
+            break;
+        case 0x02U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0010;
+            break;
+        case 0x03U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0011;
+            break;
+        case 0x04U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0100;
+            break;
+        case 0x05U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0101;
+            break;
+        case 0x06U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0110;
+            break;
+        case 0x07U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_0111;
+            break;
+        case 0x08U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1000;
+            break;
+        case 0x09U:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1001;
+            break;
+        case 0x0AU:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1010;
+            break;
+        case 0x0BU:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1011;
+            break;
+        case 0x0CU:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1100;
+            break;
+        case 0x0DU:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1101;
+            break;
+        case 0x0EU:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1110;
+            break;
+        case 0x0FU:
+            config->EEpromTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_1111;
+            break;
+        default:
+            config->EEpromTotalSize = FLEX_NVM_EEPROM_SIZE_FOR_EEESIZE_RESERVED;
+            break;
+    }
+
+    /* Fill out partitioned DFlash size */
+    dataIFRReadOut.FlexNVMPartitionCode &= 0x0FU;
+    switch (dataIFRReadOut.FlexNVMPartitionCode)
+    {
+        case 0x00U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0000 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0000;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0000 */
+            break;
+        case 0x01U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0001 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0001;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0001 */
+            break;
+        case 0x02U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0010 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0010;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0010 */
+            break;
+        case 0x03U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0011 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0011;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0011 */
+            break;
+        case 0x04U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0100 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0100;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0100 */
+            break;
+        case 0x05U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0101 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0101;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0101 */
+            break;
+        case 0x06U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0110 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0110;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0110 */
+            break;
+        case 0x07U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0111 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0111;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_0111 */
+            break;
+        case 0x08U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1000 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1000;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1000 */
+            break;
+        case 0x09U:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1001 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1001;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1001 */
+            break;
+        case 0x0AU:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1010 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1010;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1010 */
+            break;
+        case 0x0BU:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1011 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1011;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1011 */
+            break;
+        case 0x0CU:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1100 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1100;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1100 */
+            break;
+        case 0x0DU:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1101 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1101;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1101 */
+            break;
+        case 0x0EU:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1110 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1110;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1110 */
+            break;
+        case 0x0FU:
+#if (FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1111 != 0xFFFFFFFF)
+            config->DFlashTotalSize = FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1111;
+#else
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+#endif /* FSL_FEATURE_FLASH_FLEX_NVM_DFLASH_SIZE_FOR_DEPART_1111 */
+            break;
+        default:
+            config->DFlashTotalSize = FLEX_NVM_DFLASH_SIZE_FOR_DEPART_RESERVED;
+            break;
+    }
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+
+#if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
+/*! @brief Validates the range of the given resource address.*/
+static status_t flash_check_resource_range(uint32_t start,
+                                           uint32_t lengthInBytes,
+                                           uint32_t alignmentBaseline,
+                                           flash_read_resource_option_t option)
+{
+    status_t status;
+    uint32_t maxReadbleAddress;
+
+    if ((start & (alignmentBaseline - 1)) || (lengthInBytes & (alignmentBaseline - 1)))
+    {
+        return kStatus_FLASH_AlignmentError;
+    }
+
+    status = kStatus_FLASH_Success;
+
+    maxReadbleAddress = start + lengthInBytes - 1;
+    if (option == kFLASH_resourceOptionVersionId)
+    {
+        if ((start != kFLASH_resourceRangeVersionIdStart) ||
+            ((start + lengthInBytes - 1) != kFLASH_resourceRangeVersionIdEnd))
+        {
+            status = kStatus_FLASH_InvalidArgument;
+        }
+    }
+    else if (option == kFLASH_resourceOptionFlashIfr)
+    {
+        if (maxReadbleAddress < kFLASH_resourceRangePflashIfrSizeInBytes)
+        {
+        }
+#if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
+        else if ((start >= kFLASH_resourceRangePflashSwapIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_resourceRangePflashSwapIfrEnd))
+        {
+        }
+#endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
+        else if ((start >= kFLASH_resourceRangeDflashIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_resourceRangeDflashIfrEnd))
+        {
+        }
+        else
+        {
+            status = kStatus_FLASH_InvalidArgument;
+        }
+    }
+    else
+    {
+        status = kStatus_FLASH_InvalidArgument;
+    }
+
+    return status;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD */
+
+#if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
+/*! @brief Validates the gived swap control option.*/
+static status_t flash_check_swap_control_option(flash_swap_control_option_t option)
+{
+    if ((option == kFLASH_swapControlOptionIntializeSystem) || (option == kFLASH_swapControlOptionSetInUpdateState) ||
+        (option == kFLASH_swapControlOptionSetInCompleteState) || (option == kFLASH_swapControlOptionReportStatus) ||
+        (option == kFLASH_swapControlOptionDisableSystem))
+    {
+        return kStatus_FLASH_Success;
+    }
+
+    return kStatus_FLASH_InvalidArgument;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD */
+
+#if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
+/*! @brief Validates the gived address to see if it is equal to swap indicator address in pflash swap IFR.*/
+static status_t flash_validate_swap_indicator_address(flash_config_t *config, uint32_t address)
+{
+    flash_swap_ifr_field_config_t flashSwapIfrField;
+    uint32_t swapIndicatorAddress;
+
+    status_t returnCode;
+    returnCode = FLASH_ReadResource(config, kFLASH_resourceRangePflashSwapIfrStart, (uint32_t *)&flashSwapIfrField,
+                                    sizeof(flash_swap_ifr_field_config_t), kFLASH_resourceOptionFlashIfr);
+    if (returnCode != kStatus_FLASH_Success)
+    {
+        return returnCode;
+    }
+
+    /* The high 2 byte value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
+     * the low 4 bit value of Swap Indicator Address is always 4'b0000 */
+    swapIndicatorAddress =
+        (uint32_t)flashSwapIfrField.swapIndicatorAddress * FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
+    if (address != swapIndicatorAddress)
+    {
+        return kStatus_FLASH_SwapIndicatorAddressError;
+    }
+
+    return returnCode;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
+
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+/*! @brief Validates the gived flexram function option.*/
+static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option)
+{
+    if ((option != kFLASH_flexramFunctionOptionAvailableAsRam) &&
+        (option != kFLASH_flexramFunctionOptionAvailableForEeprom))
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flash.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flash.h
@@ -1,0 +1,1177 @@
+/*
+ * Copyright (c) 2013-2016, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_FLASH_H_
+#define _FSL_FLASH_H_
+
+#if (defined(BL_TARGET_FLASH) || defined(BL_TARGET_ROM) || defined(BL_TARGET_RAM))
+#include <assert.h>
+#include <string.h>
+#include "fsl_device_registers.h"
+#include "bootloader_common.h"
+#else
+#include "fsl_common.h"
+#endif
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*!
+ * @addtogroup flash_driver
+ * @{
+ */
+
+/*!
+ * @name Flash version
+ * @{
+ */
+/*! @brief Construct the version number for drivers. */
+#if !defined(MAKE_VERSION)
+#define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
+#endif
+
+/*! @brief FLASH driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+
+/*! @brief FLASH driver version for ROM*/
+enum _flash_driver_version_constants
+{
+    kFLASH_driverVersionName = 'F', /*!< Flash driver version name.*/
+    kFLASH_driverVersionMajor = 2,  /*!< Major flash driver version.*/
+    kFLASH_driverVersionMinor = 1,  /*!< Minor flash driver version.*/
+    kFLASH_driverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
+};
+/*@}*/
+
+/*!
+ * @name Flash configuration
+ * @{
+ */
+/*! @brief Whether to support FlexNVM in flash driver */
+#if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#endif
+
+/*! @brief Whether the FlexNVM is enabled in flash driver */
+#define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Flash driver location. */
+#if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
+#if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#else
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#endif
+#endif
+
+/*! @brief Flash Driver Export option */
+#if !defined(FLASH_DRIVER_IS_EXPORTED)
+#if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#else
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#endif
+#endif
+/*@}*/
+
+/*!
+ * @name Flash status
+ * @{
+ */
+/*! @brief Flash driver status group. */
+#if defined(kStatusGroup_FlashDriver)
+#define kStatusGroupGeneric kStatusGroup_Generic
+#define kStatusGroupFlashDriver kStatusGroup_FlashDriver
+#elif defined(kStatusGroup_FLASH)
+#define kStatusGroupGeneric kStatusGroup_Generic
+#define kStatusGroupFlashDriver kStatusGroup_FLASH
+#else
+#define kStatusGroupGeneric 0
+#define kStatusGroupFlashDriver 1
+#endif
+
+/*! @brief Construct a status code value from a group and code number. */
+#if !defined(MAKE_STATUS)
+#define MAKE_STATUS(group, code) ((((group)*100) + (code)))
+#endif
+
+/*!
+ * @brief Flash driver status codes.
+ */
+enum _flash_status
+{
+    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< Api is executed successfully*/
+    kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
+    kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
+    kStatus_FLASH_AlignmentError =
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+    kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
+    kStatus_FLASH_AccessError =
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+    kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
+        kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
+    kStatus_FLASH_CommandFailure =
+        MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< Api erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_ExecuteInRamFunctionNotReady =
+        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-ram function is not available.*/
+    kStatus_FLASH_PartitionStatusUpdateFailure =
+        MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
+    kStatus_FLASH_SetFlexramAsEepromError =
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+    kStatus_FLASH_RecoverFlexramAsRamError =
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as ram.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as ram.*/
+    kStatus_FLASH_RecoverFlexramAsEepromError =
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
+    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash api is not supported.*/
+    kStatus_FLASH_SwapSystemNotInUninitialized =
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+    kStatus_FLASH_SwapIndicatorAddressError =
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+};
+/*@}*/
+
+/*!
+ * @name Flash API key
+ * @{
+ */
+/*! @brief Construct the four char code for flash driver API key. */
+#if !defined(FOUR_CHAR_CODE)
+#define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
+#endif
+
+/*!
+ * @brief Enumeration for flash driver API keys.
+ *
+ * @note The resulting value is built with a byte order such that the string
+ * being readable in expected order when viewed in a hex editor, if the value
+ * is treated as a 32-bit little endian value.
+ */
+enum _flash_driver_api_keys
+{
+    kFLASH_apiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
+};
+/*@}*/
+
+/*!
+ * @brief Enumeration for supported flash margin levels.
+ */
+typedef enum _flash_margin_value
+{
+    kFLASH_marginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
+    kFLASH_marginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
+    kFLASH_marginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
+    kFLASH_marginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
+} flash_margin_value_t;
+
+/*!
+ * @brief Enumeration for the three possible flash security states.
+ */
+typedef enum _flash_security_state
+{
+    kFLASH_securityStateNotSecure,       /*!< Flash is not secure.*/
+    kFLASH_securityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
+    kFLASH_securityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
+} flash_security_state_t;
+
+/*!
+ * @brief Enumeration for the three possible flash protection levels.
+ */
+typedef enum _flash_protection_state
+{
+    kFLASH_protectionStateUnprotected, /*!< Flash region is not protected.*/
+    kFLASH_protectionStateProtected,   /*!< Flash region is protected.*/
+    kFLASH_protectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
+} flash_protection_state_t;
+
+/*!
+ * @brief Enumeration for the three possible flash execute access levels.
+ */
+typedef enum _flash_execute_only_access_state
+{
+    kFLASH_accessStateUnLimited,   /*!< Flash region is unLimited.*/
+    kFLASH_accessStateExecuteOnly, /*!< Flash region is execute only.*/
+    kFLASH_accessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+} flash_execute_only_access_state_t;
+
+/*!
+ * @brief Enumeration for various flash properties.
+ */
+typedef enum _flash_property_tag
+{
+    kFLASH_propertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
+    kFLASH_propertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
+    kFLASH_propertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
+    kFLASH_propertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
+    kFLASH_propertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
+    kFLASH_propertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
+    kFLASH_propertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
+    kFLASH_propertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
+    kFLASH_propertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
+    kFLASH_propertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
+    kFLASH_propertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
+    kFLASH_propertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
+    kFLASH_propertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
+    kFLASH_propertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
+    kFLASH_propertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
+    kFLASH_propertyEepromTotalSize = 0x15U
+} flash_property_tag_t;
+
+/*!
+ * @brief Constants for execute-in-ram flash function.
+ */
+enum _flash_execute_in_ram_function_constants
+{
+    kFLASH_executeInRamFunctionMaxSize = 64U, /*!< Max size of execute-in-ram function.*/
+    kFLASH_executeInRamFunctionTotalNum = 2U  /*!< Total number of execute-in-ram functions.*/
+};
+
+/*!
+ * @brief Flash execute-in-ram function information.
+ */
+typedef struct _flash_execute_in_ram_function_config
+{
+    uint32_t activeFunctionCount;    /*!< Number of available execute-in-ram functions.*/
+    uint8_t *flashRunCommand;        /*!< execute-in-ram function: flash_run_command.*/
+    uint8_t *flashCacheClearCommand; /*!< execute-in-ram function: flash_cache_clear_command.*/
+} flash_execute_in_ram_function_config_t;
+
+/*!
+ * @brief Enumeration for the two possible options of flash read resource command.
+ */
+typedef enum _flash_read_resource_option
+{
+    kFLASH_resourceOptionFlashIfr =
+        0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
+    kFLASH_resourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+} flash_read_resource_option_t;
+
+/*!
+ * @brief Enumeration for the range of special-purpose flash resource
+ */
+enum _flash_read_resource_range
+{
+#if (FSL_FEATURE_FLASH_IS_FTFE == 1)
+    kFLASH_resourceRangePflashIfrSizeInBytes = 1024U, /*!< Pflash IFR size in byte.*/
+    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
+    kFLASH_resourceRangeVersionIdStart = 0x08U,       /*!< Version ID IFR start address.*/
+    kFLASH_resourceRangeVersionIdEnd = 0x0FU,         /*!< Version ID IFR end address.*/
+#else                                                 /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
+    kFLASH_resourceRangePflashIfrSizeInBytes = 256U, /*!< Pflash IFR size in byte.*/
+    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,   /*!< Version ID IFR size in byte.*/
+    kFLASH_resourceRangeVersionIdStart = 0x00U,      /*!< Version ID IFR start address.*/
+    kFLASH_resourceRangeVersionIdEnd = 0x07U,        /*!< Version ID IFR end address.*/
+#endif
+    kFLASH_resourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
+    kFLASH_resourceRangePflashSwapIfrEnd = 0x403FFU,   /*!< Pflash swap IFR end address.*/
+    kFLASH_resourceRangeDflashIfrStart = 0x800000U,    /*!< Dflash IFR start address.*/
+    kFLASH_resourceRangeDflashIfrEnd = 0x8003FFU,      /*!< Dflash IFR end address.*/
+};
+
+/*!
+ * @brief Enumeration for the two possilbe options of set flexram function command.
+ */
+typedef enum _flash_flexram_function_option
+{
+    kFLASH_flexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
+    kFLASH_flexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+} flash_flexram_function_option_t;
+
+/*!
+ * @brief Enumeration for the possible options of Swap function
+ */
+typedef enum _flash_swap_function_option
+{
+    kFLASH_swapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
+    kFLASH_swapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+} flash_swap_function_option_t;
+
+/*!
+ * @brief Enumeration for the possible options of Swap Control commands
+ */
+typedef enum _flash_swap_control_option
+{
+    kFLASH_swapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
+    kFLASH_swapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
+    kFLASH_swapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
+    kFLASH_swapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
+    kFLASH_swapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+} flash_swap_control_option_t;
+
+/*!
+ * @brief Enumeration for the possible flash swap status.
+ */
+typedef enum _flash_swap_state
+{
+    kFLASH_swapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
+    kFLASH_swapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
+    kFLASH_swapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
+    kFLASH_swapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
+    kFLASH_swapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
+    kFLASH_swapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+} flash_swap_state_t;
+
+/*!
+ * @breif Enumeration for the possible flash swap block status
+ */
+typedef enum _flash_swap_block_status
+{
+    kFLASH_swapBlockStatusLowerHalfProgramBlocksAtZero =
+        0x00U, /*!< Swap block status is that lower half program block at zero.*/
+    kFLASH_swapBlockStatusUpperHalfProgramBlocksAtZero =
+        0x01U, /*!< Swap block status is that upper half program block at zero.*/
+} flash_swap_block_status_t;
+
+/*!
+ * @brief Flash Swap information.
+ */
+typedef struct _flash_swap_state_config
+{
+    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+} flash_swap_state_config_t;
+
+/*!
+ * @brief Flash Swap IFR fileds.
+ */
+typedef struct _flash_swap_ifr_field_config
+{
+    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
+    uint8_t reserved0[6];          /*!< Reserved field.*/
+    uint16_t swapDisableWord;      /*!< Swap disable word field.*/
+    uint8_t reserved1[4];          /*!< Reserved field.*/
+} flash_swap_ifr_field_config_t;
+
+/*!
+ * @brief Enumeration for FlexRAM load during reset option.
+ */
+typedef enum _flash_partition_flexram_load_option
+{
+    kFLASH_partitionFlexramLoadOptionLoadedWithValidEepromData =
+        0x00U, /*!< FlexRAM is loaded with valid EEPROM data during reset sequence.*/
+    kFLASH_partitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
+} flash_partition_flexram_load_option_t;
+
+/*! @brief callback type used for pflash block*/
+typedef void (*flash_callback_t)(void);
+
+/*!
+ * @brief Active flash information for current operation.
+ */
+typedef struct _flash_operation_config
+{
+    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
+    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
+    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+} flash_operation_config_t;
+
+/*! @brief Flash driver state information.
+ *
+ * An instance of this structure is allocated by the user of the flash driver and
+ * passed into each of the driver APIs.
+ */
+typedef struct _flash_config
+{
+    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-ram function. */
+    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
+                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
+    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
+                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
+    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
+                                   For non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
+                                   For non-FlexNVM device, this field is unused */
+    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
+                                 from FlexRAM;
+                                   For non-FlexNVM device, this field is unused */
+} flash_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes global flash properties structure members
+ *
+ * This function checks and initializes Flash module for the other Flash APIs.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ */
+status_t FLASH_Init(flash_config_t *config);
+
+/*!
+ * @brief Set the desired flash callback function
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param callback callback function to be stored in driver
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ */
+status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
+
+/*!
+ * @brief Prepare flash execute-in-ram functions
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ */
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
+#endif
+
+/*@}*/
+
+/*!
+ * @name Erasing
+ * @{
+ */
+
+/*!
+ * @brief Erases entire flash
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param key value used to validate all flash erase APIs.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ */
+status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
+
+/*!
+ * @brief Erases flash sectors encompassed by parameters passed into function
+ *
+ * This function erases the appropriate number of flash sectors based on the
+ * desired start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be erased.
+ *              The start address does not need to be sector aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *                      to be erased. Must be word aligned.
+ * @param key value used to validate all flash erase APIs.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
+
+/*!
+ * @brief Erases entire flash, including protected sectors.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param key value used to validate all flash erase APIs.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
+status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
+#endif
+
+/*!
+ * @brief Erases all program flash execute-only segments defined by the FXACC registers.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param key value used to validate all flash erase APIs.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
+
+/*@}*/
+
+/*!
+ * @name Programming
+ * @{
+ */
+
+/*!
+ * @brief Programs flash with data at locations passed in through parameters
+ *
+ * This function programs the flash memory with desired data for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be programmed. Must be
+ *              word-aligned.
+ * @param src Pointer to the source buffer of data that is to be programmed
+ *            into the flash.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *                      to be programmed. Must be word-aligned.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
+
+/*!
+ * @brief Programs Program Once Field through parameters
+ *
+ * This function programs the Program Once Field with desired data for a given
+ * flash area as determined by the index and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param index The index indicating which area of Program Once Field to be programmed.
+ * @param src Pointer to the source buffer of data that is to be programmed
+ *            into the Program Once Field.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *                      to be programmed. Must be word-aligned.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
+
+/*!
+ * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ *
+ * This function programs the flash memory with desired data for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be programmed. Must be
+ *              word-aligned.
+ * @param src Pointer to the source buffer of data that is to be programmed
+ *            into the flash.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *                      to be programmed. Must be word-aligned.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as ram
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
+status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
+#endif
+
+/*!
+ * @brief Programs EEPROM with data at locations passed in through parameters
+ *
+ * This function programs the Emulated EEPROM with desired data for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be programmed. Must be
+ *              word-aligned.
+ * @param src Pointer to the source buffer of data that is to be programmed
+ *            into the flash.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *                      to be programmed. Must be word-aligned.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as ram
+ */
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
+#endif
+
+/*@}*/
+
+/*!
+ * @name Reading
+ * @{
+ */
+
+/*!
+ * @brief Read resource with data at locations passed in through parameters
+ *
+ * This function reads the flash memory with desired location for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be programmed. Must be
+ *              word-aligned.
+ * @param dst Pointer to the destination buffer of data that is used to store
+ *        data to be read.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        to be read. Must be word-aligned.
+ * @param option The resource option which indicates which area should be read back.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
+status_t FLASH_ReadResource(
+    flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option);
+#endif
+
+/*!
+ * @brief Read Program Once Field through parameters
+ *
+ * This function reads the read once feild with given index and length
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param index The index indicating the area of program once field to be read.
+ * @param dst Pointer to the destination buffer of data that is used to store
+ *        data to be read.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        to be programmed. Must be word-aligned.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
+
+/*@}*/
+
+/*!
+ * @name Security
+ * @{
+ */
+
+/*!
+ * @brief Returns the security state via the pointer passed into the function
+ *
+ * This function retrieves the current Flash security status, including the
+ * security enabling state and the backdoor key enabling state.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param state Pointer to the value returned for the current security status code:
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ */
+status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
+
+/*!
+ * @brief Allows user to bypass security with a backdoor key
+ *
+ * If the MCU is in secured state, this function will unsecure the MCU by
+ * comparing the provided backdoor key with ones in the Flash Configuration
+ * Field.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
+
+/*@}*/
+
+/*!
+ * @name Verification
+ * @{
+ */
+
+/*!
+ * @brief Verifies erasure of entire flash at specified margin level
+ *
+ * This function will check to see if the flash have been erased to the
+ * specified read margin level.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param margin Read margin choice
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
+
+/*!
+ * @brief Verifies erasure of desired flash area at specified margin level
+ *
+ * This function will check the appropriate number of flash sectors based on
+ * the desired start address and length to see if the flash have been erased
+ * to the specified read margin level.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be verified.
+ *        The start address does not need to be sector aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        to be verified. Must be word-aligned.
+ * @param margin Read margin choice
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
+
+/*!
+ * @brief Verifies programming of desired flash area at specified margin level
+ *
+ * This function verifies the data programed in the flash memory using the
+ * Flash Program Check Command and compares it with expected data for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        to be verified. Must be word-aligned.
+ * @param expectedData Pointer to the expected data that is to be
+ *        verified against.
+ * @param margin Read margin choice
+ * @param failedAddress Pointer to returned failing address.
+ * @param failedData Pointer to returned failing data.  Some derivitives do
+ *        not included failed data as part of the FCCOBx registers.  In this
+ *        case, zeros are returned upon failure.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_VerifyProgram(flash_config_t *config,
+                             uint32_t start,
+                             uint32_t lengthInBytes,
+                             const uint32_t *expectedData,
+                             flash_margin_value_t margin,
+                             uint32_t *failedAddress,
+                             uint32_t *failedData);
+
+/*!
+ * @brief Verifies if the program flash executeonly segments have been erased to
+ *  the specified read margin level
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param margin Read margin choice
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
+
+/*@}*/
+
+/*!
+ * @name Protection
+ * @{
+ */
+
+/*!
+ * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ *
+ * This function retrieves the current Flash protect status for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        to be checked.  Must be word-aligned.
+ * @param protection_state Pointer to the value returned for the current
+ *        protection status code for the desired flash area.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ */
+status_t FLASH_IsProtected(flash_config_t *config,
+                           uint32_t start,
+                           uint32_t lengthInBytes,
+                           flash_protection_state_t *protection_state);
+
+/*!
+ * @brief Returns the access state of desired flash area via the pointer passed into the function
+ *
+ * This function retrieves the current Flash access status for a given
+ * flash area as determined by the start address and length.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        to be checked.  Must be word-aligned.
+ * @param access_state Pointer to the value returned for the current
+ *        access status code for the desired flash area.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_AddressError Address is out of range.
+ */
+status_t FLASH_IsExecuteOnly(flash_config_t *config,
+                             uint32_t start,
+                             uint32_t lengthInBytes,
+                             flash_execute_only_access_state_t *access_state);
+
+/*@}*/
+
+/*!
+ * @name Properties
+ * @{
+ */
+
+/*!
+ * @brief Returns the desired flash property.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value Pointer to the value returned for the desired flash property
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ */
+status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*@}*/
+
+/*!
+ * @name FlexRAM
+ * @{
+ */
+
+/*!
+ * @brief Set FlexRAM Function command
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param option The option used to set work mode of FlexRAM
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
+status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
+#endif
+
+/*@}*/
+
+/*!
+ * @name Swap
+ * @{
+ */
+
+/*!
+ * @brief Configure Swap function or Check the swap state of Flash Module
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param address Address used to configure the flash swap function
+ * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
+status_t FLASH_SwapControl(flash_config_t *config,
+                           uint32_t address,
+                           flash_swap_control_option_t option,
+                           flash_swap_state_config_t *returnInfo);
+#endif
+
+/*!
+ * @brief Swap the lower half flash with the higher half flaock
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param address Address used to configure the flash swap function
+ * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
+status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
+#endif
+
+/*!
+ * @name FlexNVM
+ * @{
+ */
+
+/*!
+ * @brief Prepares the FlexNVM block for use as data flash, EEPROM backup, or a combination of both and initializes the
+ * FlexRAM.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param option The option used to set FlexRAM load behavior during reset.
+ * @param eepromDataSizeCode Determines the amount of FlexRAM used in each of the available EEPROM subsystems.
+ * @param flexnvmPartitionCode Specifies how to split the FlexNVM block between data flash memory and EEPROM backup
+ *        memory supporting EEPROM functions.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
+ * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+#if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD
+status_t FLASH_ProgramPartition(flash_config_t *config,
+                                flash_partition_flexram_load_option_t option,
+                                uint32_t eepromDataSizeCode,
+                                uint32_t flexnvmPartitionCode);
+#endif
+
+/*@}*/
+
+/*!
+* @name Flash Protection Utilities
+* @{
+*/
+
+/*!
+ * @brief Set PFLASH Protection to the intended protection status.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
+ * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * two possible cases as shown below:
+ *       0: this area is protected.
+ *       1: this area is unprotected.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+
+/*!
+ * @brief Get PFLASH Protection Status.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
+ * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
+ * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ *       0: this area is protected.
+ *       1: this area is unprotected.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ */
+status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+
+/*!
+ * @brief Set DFLASH Protection to the intended protection status.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
+ * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
+ * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * two possible cases as shown below:
+ *       0: this area is protected.
+ *       1: this area is unprotected.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus);
+#endif
+
+/*!
+ * @brief Get DFLASH Protection Status.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
+ * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
+ * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * below:
+ *       0: this area is protected.
+ *       1: this area is unprotected.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ */
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
+#endif
+
+/*!
+ * @brief Set EEPROM Protection to the intended protection status.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
+ * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
+ * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * There are two possible cases as shown below:
+ *       0: this area is protected.
+ *       1: this area is unprotected.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ */
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus);
+#endif
+
+/*!
+ * @brief Get DFLASH Protection Status.
+ *
+ * @param config Pointer to storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
+ * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
+ * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ *       0: this area is protected.
+ *       1: this area is unprotected.
+ *
+ * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported.
+ */
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
+#endif
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_FLASH_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexbus.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexbus.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_flexbus.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Gets the instance from the base address
+ *
+ * @param base FLEXBUS peripheral base address
+ *
+ * @return The FLEXBUS instance
+ */
+static uint32_t FLEXBUS_GetInstance(FB_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to FLEXBUS bases for each instance. */
+static FB_Type *const s_flexbusBases[] = FB_BASE_PTRS;
+
+/*! @brief Pointers to FLEXBUS clocks for each instance. */
+static const clock_ip_name_t s_flexbusClocks[] = FLEXBUS_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t FLEXBUS_GetInstance(FB_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_FB_COUNT; instance++)
+    {
+        if (s_flexbusBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_FB_COUNT);
+
+    return instance;
+}
+
+void FLEXBUS_Init(FB_Type *base, const flexbus_config_t *config)
+{
+    assert(config != NULL);
+    assert(config->chip < FB_CSAR_COUNT);
+    assert(config->waitStates <= 0x3FU);
+
+    uint32_t chip = 0;
+    uint32_t reg_value = 0;
+
+    /* Ungate clock for FLEXBUS */
+    CLOCK_EnableClock(s_flexbusClocks[FLEXBUS_GetInstance(base)]);
+
+    /* Reset all the register to default state */
+    for (chip = 0; chip < FB_CSAR_COUNT; chip++)
+    {
+        /* Reset CSMR register, all chips not valid (disabled) */
+        base->CS[chip].CSMR = 0x0000U;
+        /* Set default base address */
+        base->CS[chip].CSAR &= (~FB_CSAR_BA_MASK);
+        /* Reset FB_CSCRx register */
+        base->CS[chip].CSCR = 0x0000U;
+    }
+    /* Set FB_CSPMCR register */
+    /* FlexBus signal group 1 multiplex control */
+    reg_value |= kFLEXBUS_MultiplexGroup1_FB_ALE << FB_CSPMCR_GROUP1_SHIFT;
+    /* FlexBus signal group 2 multiplex control */
+    reg_value |= kFLEXBUS_MultiplexGroup2_FB_CS4 << FB_CSPMCR_GROUP2_SHIFT;
+    /* FlexBus signal group 3 multiplex control */
+    reg_value |= kFLEXBUS_MultiplexGroup3_FB_CS5 << FB_CSPMCR_GROUP3_SHIFT;
+    /* FlexBus signal group 4 multiplex control */
+    reg_value |= kFLEXBUS_MultiplexGroup4_FB_TBST << FB_CSPMCR_GROUP4_SHIFT;
+    /* FlexBus signal group 5 multiplex control */
+    reg_value |= kFLEXBUS_MultiplexGroup5_FB_TA << FB_CSPMCR_GROUP5_SHIFT;
+    /* Write to CSPMCR register */
+    base->CSPMCR = reg_value;
+
+    /* Update chip value */
+    chip = config->chip;
+
+    /* Base address */
+    reg_value = config->chipBaseAddress;
+    /* Write to CSAR register */
+    base->CS[chip].CSAR = reg_value;
+    /* Chip-select validation */
+    reg_value = 0x1U << FB_CSMR_V_SHIFT;
+    /* Write protect */
+    reg_value |= (uint32_t)(config->writeProtect) << FB_CSMR_WP_SHIFT;
+    /* Base address mask */
+    reg_value |= config->chipBaseAddressMask << FB_CSMR_BAM_SHIFT;
+    /* Write to CSMR register */
+    base->CS[chip].CSMR = reg_value;
+    /* Burst write */
+    reg_value = (uint32_t)(config->burstWrite) << FB_CSCR_BSTW_SHIFT;
+    /* Burst read */
+    reg_value |= (uint32_t)(config->burstRead) << FB_CSCR_BSTR_SHIFT;
+    /* Byte-enable mode */
+    reg_value |= (uint32_t)(config->byteEnableMode) << FB_CSCR_BEM_SHIFT;
+    /* Port size */
+    reg_value |= (uint32_t)config->portSize << FB_CSCR_PS_SHIFT;
+    /* The internal transfer acknowledge for accesses */
+    reg_value |= (uint32_t)(config->autoAcknowledge) << FB_CSCR_AA_SHIFT;
+    /* Byte-Lane shift */
+    reg_value |= (uint32_t)config->byteLaneShift << FB_CSCR_BLS_SHIFT;
+    /* The number of wait states */
+    reg_value |= (uint32_t)config->waitStates << FB_CSCR_WS_SHIFT;
+    /* Write address hold or deselect */
+    reg_value |= (uint32_t)config->writeAddressHold << FB_CSCR_WRAH_SHIFT;
+    /* Read address hold or deselect */
+    reg_value |= (uint32_t)config->readAddressHold << FB_CSCR_RDAH_SHIFT;
+    /* Address setup */
+    reg_value |= (uint32_t)config->addressSetup << FB_CSCR_ASET_SHIFT;
+    /* Extended transfer start/extended address latch */
+    reg_value |= (uint32_t)(config->extendTransferAddress) << FB_CSCR_EXTS_SHIFT;
+    /* Secondary wait state */
+    reg_value |= (uint32_t)(config->secondaryWaitStates) << FB_CSCR_SWSEN_SHIFT;
+    /* Write to CSCR register */
+    base->CS[chip].CSCR = reg_value;
+    /* FlexBus signal group 1 multiplex control */
+    reg_value = (uint32_t)config->group1MultiplexControl << FB_CSPMCR_GROUP1_SHIFT;
+    /* FlexBus signal group 2 multiplex control */
+    reg_value |= (uint32_t)config->group2MultiplexControl << FB_CSPMCR_GROUP2_SHIFT;
+    /* FlexBus signal group 3 multiplex control */
+    reg_value |= (uint32_t)config->group3MultiplexControl << FB_CSPMCR_GROUP3_SHIFT;
+    /* FlexBus signal group 4 multiplex control */
+    reg_value |= (uint32_t)config->group4MultiplexControl << FB_CSPMCR_GROUP4_SHIFT;
+    /* FlexBus signal group 5 multiplex control */
+    reg_value |= (uint32_t)config->group5MultiplexControl << FB_CSPMCR_GROUP5_SHIFT;
+    /* Write to CSPMCR register */
+    base->CSPMCR = reg_value;
+}
+
+void FLEXBUS_Deinit(FB_Type *base)
+{
+    /* Gate clock for FLEXBUS */
+    CLOCK_EnableClock(s_flexbusClocks[FLEXBUS_GetInstance(base)]);
+}
+
+void FLEXBUS_GetDefaultConfig(flexbus_config_t *config)
+{
+    config->chip = 0;                                  /* Chip 0 FlexBus for validation */
+    config->writeProtect = 0;                          /* Write accesses are allowed */
+    config->burstWrite = 0;                            /* Burst-Write disable */
+    config->burstRead = 0;                             /* Burst-Read disable */
+    config->byteEnableMode = 0;                        /* Byte-Enable mode is asserted for data write only */
+    config->autoAcknowledge = true;                    /* Auto-Acknowledge enable */
+    config->extendTransferAddress = 0;                 /* Extend transfer start/extend address latch disable */
+    config->secondaryWaitStates = 0;                   /* Secondary wait state disable */
+    config->byteLaneShift = kFLEXBUS_NotShifted;       /* Byte-Lane shift disable */
+    config->writeAddressHold = kFLEXBUS_Hold1Cycle;    /* Write address hold 1 cycles */
+    config->readAddressHold = kFLEXBUS_Hold1Or0Cycles; /* Read address hold 0 cycles */
+    config->addressSetup =
+        kFLEXBUS_FirstRisingEdge;      /* Assert ~FB_CSn on the first rising clock edge after the address is asserted */
+    config->portSize = kFLEXBUS_1Byte; /* 1 byte port size of transfer */
+    config->group1MultiplexControl = kFLEXBUS_MultiplexGroup1_FB_ALE;  /* FB_ALE */
+    config->group2MultiplexControl = kFLEXBUS_MultiplexGroup2_FB_CS4;  /* FB_CS4 */
+    config->group3MultiplexControl = kFLEXBUS_MultiplexGroup3_FB_CS5;  /* FB_CS5 */
+    config->group4MultiplexControl = kFLEXBUS_MultiplexGroup4_FB_TBST; /* FB_TBST */
+    config->group5MultiplexControl = kFLEXBUS_MultiplexGroup5_FB_TA;   /* FB_TA */
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexbus.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexbus.h
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_FLEXBUS_H_
+#define _FSL_FLEXBUS_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup flexbus
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_FLEXBUS_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0. */
+/*@}*/
+
+/*!
+ * @brief Defines port size for FlexBus peripheral.
+ */
+typedef enum _flexbus_port_size
+{
+    kFLEXBUS_4Bytes = 0x00U, /*!< 32-bit port size */
+    kFLEXBUS_1Byte = 0x01U,  /*!< 8-bit port size */
+    kFLEXBUS_2Bytes = 0x02U  /*!< 16-bit port size */
+} flexbus_port_size_t;
+
+/*!
+ * @brief Defines number of cycles to hold address and attributes for FlexBus peripheral.
+ */
+typedef enum _flexbus_write_address_hold
+{
+    kFLEXBUS_Hold1Cycle = 0x00U,  /*!< Hold address and attributes one cycles after FB_CSn negates on writes */
+    kFLEXBUS_Hold2Cycles = 0x01U, /*!< Hold address and attributes two cycles after FB_CSn negates on writes */
+    kFLEXBUS_Hold3Cycles = 0x02U, /*!< Hold address and attributes three cycles after FB_CSn negates on writes */
+    kFLEXBUS_Hold4Cycles = 0x03U  /*!< Hold address and attributes four cycles after FB_CSn negates on writes */
+} flexbus_write_address_hold_t;
+
+/*!
+ * @brief Defines number of cycles to hold address and attributes for FlexBus peripheral.
+ */
+typedef enum _flexbus_read_address_hold
+{
+    kFLEXBUS_Hold1Or0Cycles = 0x00U, /*!< Hold address and attributes 1 or 0 cycles on reads */
+    kFLEXBUS_Hold2Or1Cycles = 0x01U, /*!< Hold address and attributes 2 or 1 cycles on reads */
+    kFLEXBUS_Hold3Or2Cycle = 0x02U,  /*!< Hold address and attributes 3 or 2 cycles on reads */
+    kFLEXBUS_Hold4Or3Cycle = 0x03U   /*!< Hold address and attributes 4 or 3 cycles on reads */
+} flexbus_read_address_hold_t;
+
+/*!
+ * @brief Address setup for FlexBus peripheral.
+ */
+typedef enum _flexbus_address_setup
+{
+    kFLEXBUS_FirstRisingEdge = 0x00U,  /*!< Assert FB_CSn on first rising clock edge after address is asserted */
+    kFLEXBUS_SecondRisingEdge = 0x01U, /*!< Assert FB_CSn on second rising clock edge after address is asserted */
+    kFLEXBUS_ThirdRisingEdge = 0x02U,  /*!< Assert FB_CSn on third rising clock edge after address is asserted */
+    kFLEXBUS_FourthRisingEdge = 0x03U, /*!< Assert FB_CSn on fourth rising clock edge after address is asserted */
+} flexbus_address_setup_t;
+
+/*!
+ * @brief Defines byte-lane shift for FlexBus peripheral.
+ */
+typedef enum _flexbus_bytelane_shift
+{
+    kFLEXBUS_NotShifted = 0x00U, /*!< Not shifted. Data is left-justified on FB_AD */
+    kFLEXBUS_Shifted = 0x01U,    /*!< Shifted. Data is right justified on FB_AD */
+} flexbus_bytelane_shift_t;
+
+/*!
+ * @brief Defines multiplex group1 valid signals.
+ */
+typedef enum _flexbus_multiplex_group1_signal
+{
+    kFLEXBUS_MultiplexGroup1_FB_ALE = 0x00U, /*!< FB_ALE */
+    kFLEXBUS_MultiplexGroup1_FB_CS1 = 0x01U, /*!< FB_CS1 */
+    kFLEXBUS_MultiplexGroup1_FB_TS = 0x02U,  /*!< FB_TS */
+} flexbus_multiplex_group1_t;
+
+/*!
+ * @brief Defines multiplex group2 valid signals.
+ */
+typedef enum _flexbus_multiplex_group2_signal
+{
+    kFLEXBUS_MultiplexGroup2_FB_CS4 = 0x00U,      /*!< FB_CS4 */
+    kFLEXBUS_MultiplexGroup2_FB_TSIZ0 = 0x01U,    /*!< FB_TSIZ0 */
+    kFLEXBUS_MultiplexGroup2_FB_BE_31_24 = 0x02U, /*!< FB_BE_31_24 */
+} flexbus_multiplex_group2_t;
+
+/*!
+ * @brief Defines multiplex group3 valid signals.
+ */
+typedef enum _flexbus_multiplex_group3_signal
+{
+    kFLEXBUS_MultiplexGroup3_FB_CS5 = 0x00U,      /*!< FB_CS5 */
+    kFLEXBUS_MultiplexGroup3_FB_TSIZ1 = 0x01U,    /*!< FB_TSIZ1 */
+    kFLEXBUS_MultiplexGroup3_FB_BE_23_16 = 0x02U, /*!< FB_BE_23_16 */
+} flexbus_multiplex_group3_t;
+
+/*!
+ * @brief Defines multiplex group4 valid signals.
+ */
+typedef enum _flexbus_multiplex_group4_signal
+{
+    kFLEXBUS_MultiplexGroup4_FB_TBST = 0x00U,    /*!< FB_TBST */
+    kFLEXBUS_MultiplexGroup4_FB_CS2 = 0x01U,     /*!< FB_CS2 */
+    kFLEXBUS_MultiplexGroup4_FB_BE_15_8 = 0x02U, /*!< FB_BE_15_8 */
+} flexbus_multiplex_group4_t;
+
+/*!
+ * @brief Defines multiplex group5 valid signals.
+ */
+typedef enum _flexbus_multiplex_group5_signal
+{
+    kFLEXBUS_MultiplexGroup5_FB_TA = 0x00U,     /*!< FB_TA */
+    kFLEXBUS_MultiplexGroup5_FB_CS3 = 0x01U,    /*!< FB_CS3 */
+    kFLEXBUS_MultiplexGroup5_FB_BE_7_0 = 0x02U, /*!< FB_BE_7_0 */
+} flexbus_multiplex_group5_t;
+
+/*!
+ * @brief Configuration structure that the user needs to set.
+ */
+typedef struct _flexbus_config
+{
+    uint8_t chip;                                      /*!< Chip FlexBus for validation */
+    uint8_t waitStates;                                /*!< Value of wait states */
+    uint32_t chipBaseAddress;                          /*!< Chip base address for using FlexBus */
+    uint32_t chipBaseAddressMask;                      /*!< Chip base address mask */
+    bool writeProtect;                                 /*!< Write protected */
+    bool burstWrite;                                   /*!< Burst-Write enable */
+    bool burstRead;                                    /*!< Burst-Read enable */
+    bool byteEnableMode;                               /*!< Byte-enable mode support */
+    bool autoAcknowledge;                              /*!< Auto acknowledge setting */
+    bool extendTransferAddress;                        /*!< Extend transfer start/extend address latch enable */
+    bool secondaryWaitStates;                          /*!< Secondary wait states number */
+    flexbus_port_size_t portSize;                      /*!< Port size of transfer */
+    flexbus_bytelane_shift_t byteLaneShift;            /*!< Byte-lane shift enable */
+    flexbus_write_address_hold_t writeAddressHold;     /*!< Write address hold or deselect option */
+    flexbus_read_address_hold_t readAddressHold;       /*!< Read address hold or deselect option */
+    flexbus_address_setup_t addressSetup;              /*!< Address setup setting */
+    flexbus_multiplex_group1_t group1MultiplexControl; /*!< FlexBus Signal Group 1 Multiplex control */
+    flexbus_multiplex_group2_t group2MultiplexControl; /*!< FlexBus Signal Group 2 Multiplex control */
+    flexbus_multiplex_group3_t group3MultiplexControl; /*!< FlexBus Signal Group 3 Multiplex control */
+    flexbus_multiplex_group4_t group4MultiplexControl; /*!< FlexBus Signal Group 4 Multiplex control */
+    flexbus_multiplex_group5_t group5MultiplexControl; /*!< FlexBus Signal Group 5 Multiplex control */
+} flexbus_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name FlexBus functional operation
+ * @{
+ */
+
+/*!
+ * @brief Initializes and configures the FlexBus module.
+ *
+ * This function enables the clock gate for FlexBus module.
+ * Only chip 0 is validated and set to known values. Other chips are disabled.
+ * NOTE: In this function, certain parameters, depending on external memories,  must
+ * be set before using FLEXBUS_Init() function.
+ * This example shows how to set up the uart_state_t and the
+ * flexbus_config_t parameters and how to call the FLEXBUS_Init function by passing
+ * in these parameters:
+   @code
+    flexbus_config_t flexbusConfig;
+    FLEXBUS_GetDefaultConfig(&flexbusConfig);
+    flexbusConfig.waitStates            = 2U;
+    flexbusConfig.chipBaseAddress       = 0x60000000U;
+    flexbusConfig.chipBaseAddressMask   = 7U;
+    FLEXBUS_Init(FB, &flexbusConfig);
+   @endcode
+ *
+ * @param base FlexBus peripheral address.
+ * @param config Pointer to the configure structure
+*/
+void FLEXBUS_Init(FB_Type *base, const flexbus_config_t *config);
+
+/*!
+ * @brief De-initializes a FlexBus instance.
+ *
+ * This function disables the clock gate of the FlexBus module clock.
+ *
+ * @param base FlexBus peripheral address.
+ */
+void FLEXBUS_Deinit(FB_Type *base);
+
+/*!
+ * @brief Initializes the FlexBus configuration structure.
+ *
+ * This function initializes the FlexBus configuration structure to default value. The default
+ * values are:
+   @code
+   fbConfig->chip                   = 0;
+   fbConfig->writeProtect           = 0;
+   fbConfig->burstWrite             = 0;
+   fbConfig->burstRead              = 0;
+   fbConfig->byteEnableMode         = 0;
+   fbConfig->autoAcknowledge        = true;
+   fbConfig->extendTransferAddress  = 0;
+   fbConfig->secondaryWaitStates    = 0;
+   fbConfig->byteLaneShift          = kFLEXBUS_NotShifted;
+   fbConfig->writeAddressHold       = kFLEXBUS_Hold1Cycle;
+   fbConfig->readAddressHold        = kFLEXBUS_Hold1Or0Cycles;
+   fbConfig->addressSetup           = kFLEXBUS_FirstRisingEdge;
+   fbConfig->portSize               = kFLEXBUS_1Byte;
+   fbConfig->group1MultiplexControl = kFLEXBUS_MultiplexGroup1_FB_ALE;
+   fbConfig->group2MultiplexControl = kFLEXBUS_MultiplexGroup2_FB_CS4 ;
+   fbConfig->group3MultiplexControl = kFLEXBUS_MultiplexGroup3_FB_CS5;
+   fbConfig->group4MultiplexControl = kFLEXBUS_MultiplexGroup4_FB_TBST;
+   fbConfig->group5MultiplexControl = kFLEXBUS_MultiplexGroup5_FB_TA;
+   @endcode
+ * @param config Pointer to the initialization structure.
+ * @see FLEXBUS_Init
+ */
+void FLEXBUS_GetDefaultConfig(flexbus_config_t *config);
+
+/*! @}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_FLEXBUS_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexcan.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexcan.c
@@ -1,0 +1,1314 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_flexcan.h"
+
+/*******************************************************************************
+ * Definitons
+ ******************************************************************************/
+
+#define FLEXCAN_TIME_QUANTA_NUM (10)
+
+/*! @brief FlexCAN Internal State. */
+enum _flexcan_state
+{
+    kFLEXCAN_StateIdle = 0x0,     /*!< MB/RxFIFO idle.*/
+    kFLEXCAN_StateRxData = 0x1,   /*!< MB receiving.*/
+    kFLEXCAN_StateRxRemote = 0x2, /*!< MB receiving remote reply.*/
+    kFLEXCAN_StateTxData = 0x3,   /*!< MB transmitting.*/
+    kFLEXCAN_StateTxRemote = 0x4, /*!< MB transmitting remote request.*/
+    kFLEXCAN_StateRxFifo = 0x5,   /*!< RxFIFO receiving.*/
+};
+
+/*! @brief FlexCAN message buffer CODE for Rx buffers. */
+enum _flexcan_mb_code_rx
+{
+    kFLEXCAN_RxMbInactive = 0x0, /*!< MB is not active.*/
+    kFLEXCAN_RxMbFull = 0x2,     /*!< MB is full.*/
+    kFLEXCAN_RxMbEmpty = 0x4,    /*!< MB is active and empty.*/
+    kFLEXCAN_RxMbOverrun = 0x6,  /*!< MB is overwritten into a full buffer.*/
+    kFLEXCAN_RxMbBusy = 0x8,     /*!< FlexCAN is updating the contents of the MB.*/
+                                 /*!  The CPU must not access the MB.*/
+    kFLEXCAN_RxMbRanswer = 0xA,  /*!< A frame was configured to recognize a Remote Request Frame */
+                                 /*!  and transmit a Response Frame in return.*/
+    kFLEXCAN_RxMbNotUsed = 0xF,  /*!< Not used.*/
+};
+
+/*! @brief FlexCAN message buffer CODE FOR Tx buffers. */
+enum _flexcan_mb_code_tx
+{
+    kFLEXCAN_TxMbInactive = 0x8,     /*!< MB is not active.*/
+    kFLEXCAN_TxMbAbort = 0x9,        /*!< MB is aborted.*/
+    kFLEXCAN_TxMbDataOrRemote = 0xC, /*!< MB is a TX Data Frame(when MB RTR = 0) or */
+                                     /*!< MB is a TX Remote Request Frame (when MB RTR = 1).*/
+    kFLEXCAN_TxMbTanswer = 0xE,      /*!< MB is a TX Response Request Frame from */
+                                     /*!  an incoming Remote Request Frame.*/
+    kFLEXCAN_TxMbNotUsed = 0xF,      /*!< Not used.*/
+};
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get the FlexCAN instance from peripheral base address.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @return FlexCAN instance.
+ */
+uint32_t FLEXCAN_GetInstance(CAN_Type *base);
+
+/*!
+ * @brief Enter FlexCAN Fraze Mode.
+ *
+ * This function makes the FlexCAN work under Fraze Mode.
+ *
+ * @param base FlexCAN peripheral base address.
+ */
+static void FLEXCAN_EnterFrazeMode(CAN_Type *base);
+
+/*!
+ * @brief Exit FlexCAN Fraze Mode.
+ *
+ * This function makes the FlexCAN leave Fraze Mode.
+ *
+ * @param base FlexCAN peripheral base address.
+ */
+static void FLEXCAN_ExitFrazeMode(CAN_Type *base);
+
+/*!
+ * @brief Check if Message Buffer is occupied by Rx FIFO.
+ *
+ * This function check if Message Buffer is occupied by Rx FIFO.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ */
+static bool FLEXCAN_IsMbOccupied(CAN_Type *base, uint8_t mbIdx);
+
+/*!
+ * @brief Check if Message Buffer interrupt is enabled.
+ *
+ * This function check if Message Buffer interrupt is enabled.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ */
+static bool FLEXCAN_IsMbIntEnabled(CAN_Type *base, uint8_t mbIdx);
+
+/*!
+ * @brief Reset the FlexCAN Instance.
+ *
+ * Restores the FlexCAN module to reset state, notice that this function
+ * will set all the registers to reset state so the FlexCAN module can not work
+ * after calling this API.
+ *
+ * @param base FlexCAN peripheral base address.
+*/
+static void FLEXCAN_Reset(CAN_Type *base);
+
+/*!
+ * @brief Set Baud Rate of FlexCAN.
+ *
+ * This function set the baud rate of FlexCAN.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param sourceClock_Hz Source Clock in Hz.
+ * @param baudRate_Bps Baud Rate in Bps.
+ */
+static void FLEXCAN_SetBaudRate(CAN_Type *base, uint32_t sourceClock_Hz, uint32_t baudRate_Bps);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* Array of FlexCAN handle. */
+static flexcan_handle_t *s_flexcanHandle[FSL_FEATURE_SOC_FLEXCAN_COUNT];
+
+/* Array of FlexCAN peripheral base address. */
+static CAN_Type *const s_flexcanBases[] = CAN_BASE_PTRS;
+
+/* Array of FlexCAN IRQ number. */
+static const IRQn_Type s_flexcanRxWarningIRQ[] = CAN_Rx_Warning_IRQS;
+static const IRQn_Type s_flexcanTxWarningIRQ[] = CAN_Tx_Warning_IRQS;
+static const IRQn_Type s_flexcanWakeUpIRQ[] = CAN_Wake_Up_IRQS;
+static const IRQn_Type s_flexcanErrorIRQ[] = CAN_Error_IRQS;
+static const IRQn_Type s_flexcanBusOffIRQ[] = CAN_Bus_Off_IRQS;
+static const IRQn_Type s_flexcanMbIRQ[] = CAN_ORed_Message_buffer_IRQS;
+
+/* Array of FlexCAN clock name. */
+static const clock_ip_name_t s_flexcanClock[] = FLEXCAN_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+uint32_t FLEXCAN_GetInstance(CAN_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_FLEXCAN_COUNT; instance++)
+    {
+        if (s_flexcanBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_FLEXCAN_COUNT);
+
+    return instance;
+}
+
+static void FLEXCAN_EnterFrazeMode(CAN_Type *base)
+{
+    /* Set Freeze, Halt bits. */
+    base->MCR |= CAN_MCR_FRZ_MASK | CAN_MCR_HALT_MASK;
+
+    /* Wait until the FlexCAN Module enter freeze mode. */
+    while (!(base->MCR & CAN_MCR_FRZACK_MASK))
+    {
+    }
+}
+
+static void FLEXCAN_ExitFrazeMode(CAN_Type *base)
+{
+    /* Clear Freeze, Halt bits. */
+    base->MCR &= ~(CAN_MCR_FRZ_MASK | CAN_MCR_HALT_MASK);
+
+    /* Wait until the FlexCAN Module exit freeze mode. */
+    while (base->MCR & CAN_MCR_FRZACK_MASK)
+    {
+    }
+}
+
+static bool FLEXCAN_IsMbOccupied(CAN_Type *base, uint8_t mbIdx)
+{
+    uint8_t lastOccupiedMb;
+
+    /* Is Rx FIFO enabled? */
+    if (base->MCR & CAN_MCR_RFEN_MASK)
+    {
+        /* Get RFFN value. */
+        lastOccupiedMb = ((base->CTRL2 & CAN_CTRL2_RFFN_MASK) >> CAN_CTRL2_RFFN_SHIFT);
+        /* Calculate the number of last Message Buffer occupied by Rx FIFO. */
+        lastOccupiedMb = ((lastOccupiedMb + 1) * 2) + 5;
+
+        if (mbIdx <= lastOccupiedMb)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    else
+    {
+        return false;
+    }
+}
+
+static bool FLEXCAN_IsMbIntEnabled(CAN_Type *base, uint8_t mbIdx)
+{
+    /* Assertion. */
+    assert(mbIdx < FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base));
+
+#if (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    if (mbIdx < 32)
+    {
+#endif
+        if (base->IMASK1 & ((uint32_t)(1 << mbIdx)))
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+#if (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    }
+    else
+    {
+        if (base->IMASK2 & ((uint32_t)(1 << (mbIdx - 32))))
+            return true;
+        else
+            return false;
+    }
+#endif
+}
+
+static void FLEXCAN_Reset(CAN_Type *base)
+{
+    /* The module must should be first exit from low power
+     * mode, and then soft reset can be applied.
+     */
+    assert(!(base->MCR & CAN_MCR_MDIS_MASK));
+
+    uint8_t i;
+
+#if (FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT != 0)
+    /* De-assert DOZE Enable Bit. */
+    base->MCR &= ~CAN_MCR_DOZE_MASK;
+#endif
+
+    /* Wait until FlexCAN exit from any Low Power Mode. */
+    while (base->MCR & CAN_MCR_LPMACK_MASK)
+    {
+    }
+
+    /* Assert Soft Reset Signal. */
+    base->MCR |= CAN_MCR_SOFTRST_MASK;
+    /* Wait until FlexCAN reset completes. */
+    while (base->MCR & CAN_MCR_SOFTRST_MASK)
+    {
+    }
+
+/* Reset MCR rigister. */
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_GLITCH_FILTER) && FSL_FEATURE_FLEXCAN_HAS_GLITCH_FILTER)
+    base->MCR |= CAN_MCR_WRNEN_MASK | CAN_MCR_WAKSRC_MASK |
+                 CAN_MCR_MAXMB(FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base) - 1);
+#else
+        base->MCR |= CAN_MCR_WRNEN_MASK | CAN_MCR_MAXMB(FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base) - 1);
+#endif
+
+    /* Reset CTRL1 and CTRL2 rigister. */
+    base->CTRL1 = CAN_CTRL1_SMP_MASK;
+    base->CTRL2 = CAN_CTRL2_TASD(0x16) | CAN_CTRL2_RRS_MASK | CAN_CTRL2_EACEN_MASK;
+
+    /* Clean all individual Rx Mask of Message Buffers. */
+    for (i = 0; i < FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base); i++)
+    {
+        base->RXIMR[i] = 0x3FFFFFFF;
+    }
+
+    /* Clean Global Mask of Message Buffers. */
+    base->RXMGMASK = 0x3FFFFFFF;
+    /* Clean Global Mask of Message Buffer 14. */
+    base->RX14MASK = 0x3FFFFFFF;
+    /* Clean Global Mask of Message Buffer 15. */
+    base->RX15MASK = 0x3FFFFFFF;
+    /* Clean Global Mask of Rx FIFO. */
+    base->RXFGMASK = 0x3FFFFFFF;
+
+    /* Clean all Message Buffer CS fields. */
+    for (i = 0; i < FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base); i++)
+    {
+        base->MB[i].CS = 0x0;
+    }
+}
+
+static void FLEXCAN_SetBaudRate(CAN_Type *base, uint32_t sourceClock_Hz, uint32_t baudRate_Bps)
+{
+    flexcan_timing_config_t timingConfig;
+    uint32_t priDiv = baudRate_Bps * FLEXCAN_TIME_QUANTA_NUM;
+
+    /* Assertion: Desired baud rate is too high. */
+    assert(baudRate_Bps <= 1000000U);
+    /* Assertion: Source clock should greater than baud rate * FLEXCAN_TIME_QUANTA_NUM. */
+    assert(priDiv <= sourceClock_Hz);
+
+    if (0 == priDiv)
+    {
+        priDiv = 1;
+    }
+
+    priDiv = (sourceClock_Hz / priDiv) - 1;
+
+    /* Desired baud rate is too low. */
+    if (priDiv > 0xFF)
+    {
+        priDiv = 0xFF;
+    }
+
+    /* FlexCAN timing setting formula:
+     * FLEXCAN_TIME_QUANTA_NUM = 1 + (PSEG1 + 1) + (PSEG2 + 1) + (PROPSEG + 1);
+     */
+    timingConfig.preDivider = priDiv;
+    timingConfig.phaseSeg1 = 3;
+    timingConfig.phaseSeg2 = 2;
+    timingConfig.propSeg = 1;
+    timingConfig.rJumpwidth = 1;
+
+    /* Update actual timing characteristic. */
+    FLEXCAN_SetTimingConfig(base, &timingConfig);
+}
+
+void FLEXCAN_Init(CAN_Type *base, const flexcan_config_t *config, uint32_t sourceClock_Hz)
+{
+    uint32_t mcrTemp;
+
+    /* Assertion. */
+    assert(config);
+    assert((config->maxMbNum > 0) && (config->maxMbNum <= FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base)));
+
+    /* Enable FlexCAN clock. */
+    CLOCK_EnableClock(s_flexcanClock[FLEXCAN_GetInstance(base)]);
+
+    /* Disable FlexCAN Module. */
+    FLEXCAN_Enable(base, false);
+
+    /* Protocol-Engine clock source selection, This bit must be set
+     * when FlexCAN Module in Disable Mode.
+     */
+    base->CTRL1 = (kFLEXCAN_ClkSrcOsc == config->clkSrc) ? base->CTRL1 & ~CAN_CTRL1_CLKSRC_MASK :
+                                                           base->CTRL1 | CAN_CTRL1_CLKSRC_MASK;
+
+    /* Enable FlexCAN Module for configuartion. */
+    FLEXCAN_Enable(base, true);
+
+    /* Reset to known status. */
+    FLEXCAN_Reset(base);
+
+    /* Save current MCR value. */
+    mcrTemp = base->MCR;
+
+    /* Set the maximum number of Message Buffers */
+    mcrTemp = (mcrTemp & ~CAN_MCR_MAXMB_MASK) | CAN_MCR_MAXMB(config->maxMbNum - 1);
+
+    /* Enable Loop Back Mode? */
+    base->CTRL1 = (config->enableLoopBack) ? base->CTRL1 | CAN_CTRL1_LPB_MASK : base->CTRL1 & ~CAN_CTRL1_LPB_MASK;
+
+    /* Enable Self Wake Up Mode? */
+    mcrTemp = (config->enableSelfWakeup) ? mcrTemp | CAN_MCR_SLFWAK_MASK : mcrTemp & ~CAN_MCR_SLFWAK_MASK;
+
+    /* Enable Individual Rx Masking? */
+    mcrTemp = (config->enableIndividMask) ? mcrTemp | CAN_MCR_IRMQ_MASK : mcrTemp & ~CAN_MCR_IRMQ_MASK;
+
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT) && FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT)
+    /* Enable Doze Mode? */
+    mcrTemp = (config->enableDoze) ? mcrTemp | CAN_MCR_DOZE_MASK : mcrTemp & ~CAN_MCR_DOZE_MASK;
+#endif
+
+    /* Save MCR Configuation. */
+    base->MCR = mcrTemp;
+
+    /* Baud Rate Configuration.*/
+    FLEXCAN_SetBaudRate(base, sourceClock_Hz, config->baudRate);
+}
+
+void FLEXCAN_Deinit(CAN_Type *base)
+{
+    /* Reset all Register Contents. */
+    FLEXCAN_Reset(base);
+
+    /* Disable FlexCAN module. */
+    FLEXCAN_Enable(base, false);
+
+    /* Disable FlexCAN clock. */
+    CLOCK_DisableClock(s_flexcanClock[FLEXCAN_GetInstance(base)]);
+}
+
+void FLEXCAN_GetDefaultConfig(flexcan_config_t *config)
+{
+    /* Assertion. */
+    assert(config);
+
+    /* Initialize FlexCAN Module config struct with default value. */
+    config->clkSrc = kFLEXCAN_ClkSrcOsc;
+    config->baudRate = 125000U;
+    config->maxMbNum = 16;
+    config->enableLoopBack = false;
+    config->enableSelfWakeup = false;
+    config->enableIndividMask = false;
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT) && FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT)
+    config->enableDoze = false;
+#endif
+}
+
+void FLEXCAN_SetTimingConfig(CAN_Type *base, const flexcan_timing_config_t *config)
+{
+    /* Assertion. */
+    assert(config);
+
+    /* Enter Fraze Mode. */
+    FLEXCAN_EnterFrazeMode(base);
+
+    /* Cleaning previous Timing Setting. */
+    base->CTRL1 &= ~(CAN_CTRL1_PRESDIV_MASK | CAN_CTRL1_RJW_MASK | CAN_CTRL1_PSEG1_MASK | CAN_CTRL1_PSEG2_MASK |
+                     CAN_CTRL1_PROPSEG_MASK);
+
+    /* Updating Timing Setting according to configuration structure. */
+    base->CTRL1 |=
+        (CAN_CTRL1_PRESDIV(config->preDivider) | CAN_CTRL1_RJW(config->rJumpwidth) |
+         CAN_CTRL1_PSEG1(config->phaseSeg1) | CAN_CTRL1_PSEG2(config->phaseSeg2) | CAN_CTRL1_PROPSEG(config->propSeg));
+
+    /* Exit Fraze Mode. */
+    FLEXCAN_ExitFrazeMode(base);
+}
+
+void FlEXCAN_SetRxMbGlobalMask(CAN_Type *base, uint32_t mask)
+{
+    /* Enter Fraze Mode. */
+    FLEXCAN_EnterFrazeMode(base);
+
+    /* Setting Rx Message Buffer Global Mask value. */
+    base->RXMGMASK = mask;
+    base->RX14MASK = mask;
+    base->RX15MASK = mask;
+
+    /* Exit Fraze Mode. */
+    FLEXCAN_ExitFrazeMode(base);
+}
+
+void FlEXCAN_SetRxFifoGlobalMask(CAN_Type *base, uint32_t mask)
+{
+    /* Enter Fraze Mode. */
+    FLEXCAN_EnterFrazeMode(base);
+
+    /* Setting Rx FIFO Global Mask value. */
+    base->RXFGMASK = mask;
+
+    /* Exit Fraze Mode. */
+    FLEXCAN_ExitFrazeMode(base);
+}
+
+void FlEXCAN_SetRxIndividualMask(CAN_Type *base, uint8_t maskIdx, uint32_t mask)
+{
+    assert(maskIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+
+    /* Enter Fraze Mode. */
+    FLEXCAN_EnterFrazeMode(base);
+
+    /* Setting Rx Individual Mask value. */
+    base->RXIMR[maskIdx] = mask;
+
+    /* Exit Fraze Mode. */
+    FLEXCAN_ExitFrazeMode(base);
+}
+
+void FLEXCAN_SetTxMbConfig(CAN_Type *base, uint8_t mbIdx, bool enable)
+{
+    /* Assertion. */
+    assert(mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+
+    if (FLEXCAN_IsMbOccupied(base, mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Inactivate Message Buffer. */
+    if (enable)
+    {
+        base->MB[mbIdx].CS = CAN_CS_CODE(kFLEXCAN_TxMbInactive);
+    }
+    else
+    {
+        base->MB[mbIdx].CS = 0;
+    }
+
+    /* Clean Message Buffer content. */
+    base->MB[mbIdx].ID = 0x0;
+    base->MB[mbIdx].WORD0 = 0x0;
+    base->MB[mbIdx].WORD1 = 0x0;
+}
+
+void FLEXCAN_SetRxMbConfig(CAN_Type *base, uint8_t mbIdx, const flexcan_rx_mb_config_t *config, bool enable)
+{
+    /* Assertion. */
+    assert(mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+    assert(((config) || (false == enable)));
+
+    uint32_t cs_temp = 0;
+
+    if (FLEXCAN_IsMbOccupied(base, mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Inactivate Message Buffer. */
+    base->MB[mbIdx].CS = 0;
+
+    /* Clean Message Buffer content. */
+    base->MB[mbIdx].ID = 0x0;
+    base->MB[mbIdx].WORD0 = 0x0;
+    base->MB[mbIdx].WORD1 = 0x0;
+
+    if (enable)
+    {
+        /* Setup Message Buffer ID. */
+        base->MB[mbIdx].ID = config->id;
+
+        /* Setup Message Buffer format. */
+        if (kFLEXCAN_FrameFormatExtend == config->format)
+        {
+            cs_temp |= CAN_CS_IDE_MASK;
+        }
+
+        /* Setup Message Buffer type. */
+        if (kFLEXCAN_FrameTypeRemote == config->type)
+        {
+            cs_temp |= CAN_CS_RTR_MASK;
+        }
+
+        /* Activate Rx Message Buffer. */
+        cs_temp |= CAN_CS_CODE(kFLEXCAN_RxMbEmpty);
+        base->MB[mbIdx].CS = cs_temp;
+    }
+}
+
+void FlEXCAN_SetRxFifoConfig(CAN_Type *base, const flexcan_rx_fifo_config_t *config, bool enable)
+{
+    /* Assertion. */
+    assert((config) || (false == enable));
+
+    volatile uint32_t *idFilterRegion = (volatile uint32_t *)(&base->MB[6].CS);
+    uint8_t setup_mb, i, rffn = 0;
+
+    /* Enter Fraze Mode. */
+    FLEXCAN_EnterFrazeMode(base);
+
+    if (enable)
+    {
+        assert(config->idFilterNum <= 128);
+
+        /* Get the setup_mb value. */
+        setup_mb = (base->MCR & CAN_MCR_MAXMB_MASK) >> CAN_MCR_MAXMB_SHIFT;
+        setup_mb = (setup_mb < FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base)) ?
+                       setup_mb :
+                       FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base);
+
+        /* Determine RFFN value. */
+        for (i = 0; i <= 0xF; i++)
+        {
+            if ((8 * (i + 1)) >= config->idFilterNum)
+            {
+                rffn = i;
+                assert(((setup_mb - 8) - (2 * rffn)) > 0);
+
+                base->CTRL2 = (base->CTRL2 & ~CAN_CTRL2_RFFN_MASK) | CAN_CTRL2_RFFN(rffn);
+                break;
+            }
+        }
+    }
+    else
+    {
+        rffn = (base->CTRL2 & CAN_CTRL2_RFFN_MASK) >> CAN_CTRL2_RFFN_SHIFT;
+    }
+
+    /* Clean ID filter table occuyied Message Buffer Region. */
+    rffn = (rffn + 1) * 8;
+    for (i = 0; i < rffn; i++)
+    {
+        idFilterRegion[i] = 0x0;
+    }
+
+    if (enable)
+    {
+        /* Disable unused Rx FIFO Filter. */
+        for (i = config->idFilterNum; i < rffn; i++)
+        {
+            idFilterRegion[i] = 0xFFFFFFFFU;
+        }
+
+        /* Copy ID filter table to Message Buffer Region. */
+        for (i = 0; i < config->idFilterNum; i++)
+        {
+            idFilterRegion[i] = config->idFilterTable[i];
+        }
+
+        /* Setup ID Fitlter Type. */
+        switch (config->idFilterType)
+        {
+            case kFLEXCAN_RxFifoFilterTypeA:
+                base->MCR = (base->MCR & ~CAN_MCR_IDAM_MASK) | CAN_MCR_IDAM(0x0);
+                break;
+            case kFLEXCAN_RxFifoFilterTypeB:
+                base->MCR = (base->MCR & ~CAN_MCR_IDAM_MASK) | CAN_MCR_IDAM(0x1);
+                break;
+            case kFLEXCAN_RxFifoFilterTypeC:
+                base->MCR = (base->MCR & ~CAN_MCR_IDAM_MASK) | CAN_MCR_IDAM(0x2);
+                break;
+            case kFLEXCAN_RxFifoFilterTypeD:
+                /* All frames rejected. */
+                base->MCR = (base->MCR & ~CAN_MCR_IDAM_MASK) | CAN_MCR_IDAM(0x3);
+                break;
+            default:
+                break;
+        }
+
+        /* Setting Message Reception Priority. */
+        base->CTRL2 = (config->priority == kFLEXCAN_RxFifoPrioHigh) ? base->CTRL2 & ~CAN_CTRL2_MRP_MASK :
+                                                                      base->CTRL2 | CAN_CTRL2_MRP_MASK;
+
+        /* Enable Rx Message FIFO. */
+        base->MCR |= CAN_MCR_RFEN_MASK;
+    }
+    else
+    {
+        /* Disable Rx Message FIFO. */
+        base->MCR &= ~CAN_MCR_RFEN_MASK;
+
+        /* Clean MB0 ~ MB5. */
+        FLEXCAN_SetRxMbConfig(base, 0, NULL, false);
+        FLEXCAN_SetRxMbConfig(base, 1, NULL, false);
+        FLEXCAN_SetRxMbConfig(base, 2, NULL, false);
+        FLEXCAN_SetRxMbConfig(base, 3, NULL, false);
+        FLEXCAN_SetRxMbConfig(base, 4, NULL, false);
+        FLEXCAN_SetRxMbConfig(base, 5, NULL, false);
+    }
+
+    /* Exit Fraze Mode. */
+    FLEXCAN_ExitFrazeMode(base);
+}
+
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA) && FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA)
+void FLEXCAN_EnableRxFifoDMA(CAN_Type *base, bool enable)
+{
+    if (enable)
+    {
+        /* Enter Fraze Mode. */
+        FLEXCAN_EnterFrazeMode(base);
+
+        /* Enable FlexCAN DMA. */
+        base->MCR |= CAN_MCR_DMA_MASK;
+
+        /* Exit Fraze Mode. */
+        FLEXCAN_ExitFrazeMode(base);
+    }
+    else
+    {
+        /* Enter Fraze Mode. */
+        FLEXCAN_EnterFrazeMode(base);
+
+        /* Disable FlexCAN DMA. */
+        base->MCR &= ~CAN_MCR_DMA_MASK;
+
+        /* Exit Fraze Mode. */
+        FLEXCAN_ExitFrazeMode(base);
+    }
+}
+#endif /* FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA */
+
+status_t FLEXCAN_WriteTxMb(CAN_Type *base, uint8_t mbIdx, const flexcan_frame_t *txFrame)
+{
+    /* Assertion. */
+    assert(mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+    assert(txFrame);
+    assert(txFrame->length <= 8);
+
+    uint32_t cs_temp = 0;
+
+    if (FLEXCAN_IsMbOccupied(base, mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Check if Message Buffer is available. */
+    if (CAN_CS_CODE(kFLEXCAN_TxMbDataOrRemote) != (base->MB[mbIdx].CS & CAN_CS_CODE_MASK))
+    {
+        /* Inactive Tx Message Buffer. */
+        base->MB[mbIdx].CS = (base->MB[mbIdx].CS & ~CAN_CS_CODE_MASK) | CAN_CS_CODE(kFLEXCAN_TxMbInactive);
+
+        /* Fill Message ID field. */
+        base->MB[mbIdx].ID = txFrame->id;
+
+        /* Fill Message Format field. */
+        if (kFLEXCAN_FrameFormatExtend == txFrame->format)
+        {
+            cs_temp |= CAN_CS_SRR_MASK | CAN_CS_IDE_MASK;
+        }
+
+        /* Fill Message Type field. */
+        if (kFLEXCAN_FrameTypeRemote == txFrame->type)
+        {
+            cs_temp |= CAN_CS_RTR_MASK;
+        }
+
+        cs_temp |= CAN_CS_CODE(kFLEXCAN_TxMbDataOrRemote) | CAN_CS_DLC(txFrame->length);
+
+        /* Load Message Payload. */
+        base->MB[mbIdx].WORD0 = txFrame->dataWord0;
+        base->MB[mbIdx].WORD1 = txFrame->dataWord1;
+
+        /* Activate Tx Message Buffer. */
+        base->MB[mbIdx].CS = cs_temp;
+
+        return kStatus_Success;
+    }
+    else
+    {
+        /* Tx Message Buffer is activated, return immediately. */
+        return kStatus_Fail;
+    }
+}
+
+status_t FLEXCAN_ReadRxMb(CAN_Type *base, uint8_t mbIdx, flexcan_frame_t *rxFrame)
+{
+    /* Assertion. */
+    assert(mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+    assert(rxFrame);
+
+    uint32_t cs_temp;
+    uint8_t rx_code;
+
+    if (FLEXCAN_IsMbOccupied(base, mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Read CS field of Rx Message Buffer to lock Message Buffer. */
+    cs_temp = base->MB[mbIdx].CS;
+    /* Get Rx Message Buffer Code field. */
+    rx_code = (cs_temp & CAN_CS_CODE_MASK) >> CAN_CS_CODE_SHIFT;
+
+    /* Check to see if Rx Message Buffer is full. */
+    if ((kFLEXCAN_RxMbFull == rx_code) || (kFLEXCAN_RxMbOverrun == rx_code))
+    {
+        /* Store Message ID. */
+        rxFrame->id = base->MB[mbIdx].ID & (CAN_ID_EXT_MASK | CAN_ID_STD_MASK);
+
+        /* Get the message ID and format. */
+        rxFrame->format = (cs_temp & CAN_CS_IDE_MASK) ? kFLEXCAN_FrameFormatExtend : kFLEXCAN_FrameFormatStandard;
+
+        /* Get the message type. */
+        rxFrame->type = (cs_temp & CAN_CS_RTR_MASK) ? kFLEXCAN_FrameTypeRemote : kFLEXCAN_FrameTypeData;
+
+        /* Get the message length. */
+        rxFrame->length = (cs_temp & CAN_CS_DLC_MASK) >> CAN_CS_DLC_SHIFT;
+
+        /* Store Message Payload. */
+        rxFrame->dataWord0 = base->MB[mbIdx].WORD0;
+        rxFrame->dataWord1 = base->MB[mbIdx].WORD1;
+
+        /* Read free-running timer to unlock Rx Message Buffer. */
+        (void)base->TIMER;
+
+        if (kFLEXCAN_RxMbFull == rx_code)
+        {
+            return kStatus_Success;
+        }
+        else
+        {
+            return kStatus_FLEXCAN_RxOverflow;
+        }
+    }
+    else
+    {
+        /* Read free-running timer to unlock Rx Message Buffer. */
+        (void)base->TIMER;
+
+        return kStatus_Fail;
+    }
+}
+
+status_t FlEXCAN_ReadRxFifo(CAN_Type *base, flexcan_frame_t *rxFrame)
+{
+    /* Assertion. */
+    assert(rxFrame);
+
+    uint32_t cs_temp;
+
+    /* Check if Rx FIFO is Enabled. */
+    if (base->MCR & CAN_MCR_RFEN_MASK)
+    {
+        /* Read CS field of Rx Message Buffer to lock Message Buffer. */
+        cs_temp = base->MB[0].CS;
+
+        /* Read data from Rx FIFO output port. */
+        /* Store Message ID. */
+        rxFrame->id = base->MB[0].ID & (CAN_ID_EXT_MASK | CAN_ID_STD_MASK);
+
+        /* Get the message ID and format. */
+        rxFrame->format = (cs_temp & CAN_CS_IDE_MASK) ? kFLEXCAN_FrameFormatExtend : kFLEXCAN_FrameFormatStandard;
+
+        /* Get the message type. */
+        rxFrame->type = (cs_temp & CAN_CS_RTR_MASK) ? kFLEXCAN_FrameTypeRemote : kFLEXCAN_FrameTypeData;
+
+        /* Get the message length. */
+        rxFrame->length = (cs_temp & CAN_CS_DLC_MASK) >> CAN_CS_DLC_SHIFT;
+
+        /* Store Message Payload. */
+        rxFrame->dataWord0 = base->MB[0].WORD0;
+        rxFrame->dataWord1 = base->MB[0].WORD1;
+
+        /* Store ID Filter Hit Index. */
+        rxFrame->idhit = (uint8_t)(base->RXFIR & CAN_RXFIR_IDHIT_MASK);
+
+        /* Read free-running timer to unlock Rx Message Buffer. */
+        (void)base->TIMER;
+
+        return kStatus_Success;
+    }
+    else
+    {
+        return kStatus_Fail;
+    }
+}
+
+status_t FlEXCAN_TransferSendBlocking(CAN_Type *base, uint8_t mbIdx, flexcan_frame_t *txFrame)
+{
+    /* Write Tx Message Buffer to initiate a data sending. */
+    if (kStatus_Success == FLEXCAN_WriteTxMb(base, mbIdx, txFrame))
+    {
+        /* Wait until CAN Message send out. */
+        while (!FLEXCAN_GetMbStatusFlags(base, 1 << mbIdx))
+        {
+        }
+
+        /* Clean Tx Message Buffer Flag. */
+        FLEXCAN_ClearMbStatusFlags(base, 1 << mbIdx);
+
+        return kStatus_Success;
+    }
+    else
+    {
+        return kStatus_Fail;
+    }
+}
+
+status_t FlEXCAN_TransferReceiveBlocking(CAN_Type *base, uint8_t mbIdx, flexcan_frame_t *rxFrame)
+{
+    /* Wait until Rx Message Buffer non-empty. */
+    while (!FLEXCAN_GetMbStatusFlags(base, 1 << mbIdx))
+    {
+    }
+
+    /* Clean Rx Message Buffer Flag. */
+    FLEXCAN_ClearMbStatusFlags(base, 1 << mbIdx);
+
+    /* Read Received CAN Message. */
+    return FLEXCAN_ReadRxMb(base, mbIdx, rxFrame);
+}
+
+status_t FlEXCAN_TransferReceiveFifoBlocking(CAN_Type *base, flexcan_frame_t *rxFrame)
+{
+    status_t rxFifoStatus;
+
+    /* Wait until Rx FIFO non-empty. */
+    while (!FLEXCAN_GetMbStatusFlags(base, kFLEXCAN_RxFifoFrameAvlFlag))
+    {
+    }
+
+    /*  */
+    rxFifoStatus = FlEXCAN_ReadRxFifo(base, rxFrame);
+
+    /* Clean Rx Fifo available flag. */
+    FLEXCAN_ClearMbStatusFlags(base, kFLEXCAN_RxFifoFrameAvlFlag);
+
+    return rxFifoStatus;
+}
+
+void FLEXCAN_TransferCreateHandle(CAN_Type *base,
+                                  flexcan_handle_t *handle,
+                                  flexcan_transfer_callback_t callback,
+                                  void *userData)
+{
+    assert(handle);
+
+    uint8_t instance;
+
+    /* Clean FlexCAN transfer handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    /* Get instance from peripheral base address. */
+    instance = FLEXCAN_GetInstance(base);
+
+    /* Save the context in global variables to support the double weak mechanism. */
+    s_flexcanHandle[instance] = handle;
+
+    /* Register Callback function. */
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* We Enable Error & Status interrupt here, because this interrupt just
+     * report current status of FlexCAN module through Callback function.
+     * It is insignificance without a available callback function.
+     */
+    if (handle->callback != NULL)
+    {
+        FLEXCAN_EnableInterrupts(base, kFLEXCAN_BusOffInterruptEnable | kFLEXCAN_ErrorInterruptEnable |
+                                           kFLEXCAN_RxWarningInterruptEnable | kFLEXCAN_TxWarningInterruptEnable |
+                                           kFLEXCAN_WakeUpInterruptEnable);
+    }
+    else
+    {
+        FLEXCAN_DisableInterrupts(base, kFLEXCAN_BusOffInterruptEnable | kFLEXCAN_ErrorInterruptEnable |
+                                            kFLEXCAN_RxWarningInterruptEnable | kFLEXCAN_TxWarningInterruptEnable |
+                                            kFLEXCAN_WakeUpInterruptEnable);
+    }
+
+    /* Enable interrupts in NVIC. */
+    EnableIRQ((IRQn_Type)(s_flexcanRxWarningIRQ[instance]));
+    EnableIRQ((IRQn_Type)(s_flexcanTxWarningIRQ[instance]));
+    EnableIRQ((IRQn_Type)(s_flexcanWakeUpIRQ[instance]));
+    EnableIRQ((IRQn_Type)(s_flexcanErrorIRQ[instance]));
+    EnableIRQ((IRQn_Type)(s_flexcanBusOffIRQ[instance]));
+    EnableIRQ((IRQn_Type)(s_flexcanMbIRQ[instance]));
+}
+
+status_t FLEXCAN_TransferSendNonBlocking(CAN_Type *base, flexcan_handle_t *handle, flexcan_mb_transfer_t *xfer)
+{
+    /* Assertion. */
+    assert(handle);
+    assert(xfer);
+    assert(xfer->mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+
+    if (FLEXCAN_IsMbOccupied(base, xfer->mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Check if Message Buffer is idle. */
+    if (kFLEXCAN_StateIdle == handle->mbState[xfer->mbIdx])
+    {
+        /* Distinguish transmit type. */
+        if (kFLEXCAN_FrameTypeRemote == xfer->frame->type)
+        {
+            handle->mbState[xfer->mbIdx] = kFLEXCAN_StateTxRemote;
+
+            /* Register user Frame buffer to receive remote Frame. */
+            handle->mbFrameBuf[xfer->mbIdx] = xfer->frame;
+        }
+        else
+        {
+            handle->mbState[xfer->mbIdx] = kFLEXCAN_StateTxData;
+        }
+
+        if (kStatus_Success == FLEXCAN_WriteTxMb(base, xfer->mbIdx, xfer->frame))
+        {
+            /* Enable Message Buffer Interrupt. */
+            FLEXCAN_EnableMbInterrupts(base, 1 << xfer->mbIdx);
+
+            return kStatus_Success;
+        }
+        else
+        {
+            handle->mbState[xfer->mbIdx] = kFLEXCAN_StateIdle;
+            return kStatus_Fail;
+        }
+    }
+    else
+    {
+        return kStatus_FLEXCAN_TxBusy;
+    }
+}
+
+status_t FLEXCAN_TransferReceiveNonBlocking(CAN_Type *base, flexcan_handle_t *handle, flexcan_mb_transfer_t *xfer)
+{
+    /* Assertion. */
+    assert(handle);
+    assert(xfer);
+    assert(xfer->mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+
+    if (FLEXCAN_IsMbOccupied(base, xfer->mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Check if Message Buffer is idle. */
+    if (kFLEXCAN_StateIdle == handle->mbState[xfer->mbIdx])
+    {
+        handle->mbState[xfer->mbIdx] = kFLEXCAN_StateRxData;
+
+        /* Register Message Buffer. */
+        handle->mbFrameBuf[xfer->mbIdx] = xfer->frame;
+
+        /* Enable Message Buffer Interrupt. */
+        FLEXCAN_EnableMbInterrupts(base, 1 << xfer->mbIdx);
+
+        return kStatus_Success;
+    }
+    else
+    {
+        return kStatus_FLEXCAN_RxBusy;
+    }
+}
+
+status_t FLEXCAN_TransferReceiveFifoNonBlocking(CAN_Type *base, flexcan_handle_t *handle, flexcan_fifo_transfer_t *xfer)
+{
+    /* Assertion. */
+    assert(handle);
+    assert(xfer);
+
+    /* Check if Message Buffer is idle. */
+    if (kFLEXCAN_StateIdle == handle->rxFifoState)
+    {
+        handle->rxFifoState = kFLEXCAN_StateRxFifo;
+
+        /* Register Message Buffer. */
+        handle->rxFifoFrameBuf = xfer->frame;
+
+        /* Enable Message Buffer Interrupt. */
+        FLEXCAN_EnableMbInterrupts(
+            base, kFLEXCAN_RxFifoOverflowFlag | kFLEXCAN_RxFifoWarningFlag | kFLEXCAN_RxFifoFrameAvlFlag);
+
+        return kStatus_Success;
+    }
+    else
+    {
+        return kStatus_FLEXCAN_RxFifoBusy;
+    }
+}
+
+void FLEXCAN_TransferAbortSend(CAN_Type *base, flexcan_handle_t *handle, uint8_t mbIdx)
+{
+    /* Assertion. */
+    assert(handle);
+    assert(mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+
+    if (FLEXCAN_IsMbOccupied(base, mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Disable Message Buffer Interrupt. */
+    FLEXCAN_DisableMbInterrupts(base, 1 << mbIdx);
+
+    /* Un-register handle. */
+    handle->mbFrameBuf[mbIdx] = 0x0;
+
+    /* Clean Message Buffer. */
+    FLEXCAN_SetTxMbConfig(base, mbIdx, true);
+
+    handle->mbState[mbIdx] = kFLEXCAN_StateIdle;
+}
+
+void FLEXCAN_TransferAbortReceive(CAN_Type *base, flexcan_handle_t *handle, uint8_t mbIdx)
+{
+    /* Assertion. */
+    assert(handle);
+    assert(mbIdx <= (base->MCR & CAN_MCR_MAXMB_MASK));
+
+    if (FLEXCAN_IsMbOccupied(base, mbIdx))
+    {
+        assert(false);
+    }
+
+    /* Disable Message Buffer Interrupt. */
+    FLEXCAN_DisableMbInterrupts(base, 1 << mbIdx);
+
+    /* Un-register handle. */
+    handle->mbFrameBuf[mbIdx] = 0x0;
+    handle->mbState[mbIdx] = kFLEXCAN_StateIdle;
+}
+
+void FLEXCAN_TransferAbortReceiveFifo(CAN_Type *base, flexcan_handle_t *handle)
+{
+    /* Assertion. */
+    assert(handle);
+
+    /* Check if Rx FIFO is enabled. */
+    if (base->MCR & CAN_MCR_RFEN_MASK)
+    {
+        /* Disable Rx Message FIFO Interrupts. */
+        FLEXCAN_DisableMbInterrupts(
+            base, kFLEXCAN_RxFifoOverflowFlag | kFLEXCAN_RxFifoWarningFlag | kFLEXCAN_RxFifoFrameAvlFlag);
+
+        /* Un-register handle. */
+        handle->rxFifoFrameBuf = 0x0;
+    }
+
+    handle->rxFifoState = kFLEXCAN_StateIdle;
+}
+
+void FLEXCAN_TransferHandleIRQ(CAN_Type *base, flexcan_handle_t *handle)
+{
+    /* Assertion. */
+    assert(handle);
+
+    status_t status = kStatus_FLEXCAN_UnHandled;
+    uint32_t result;
+
+    /* Store Current FlexCAN Module Error and Status. */
+    result = base->ESR1;
+
+    do
+    {
+        /* Solve FlexCAN Error and Status Interrupt. */
+        if (result & (kFLEXCAN_TxWarningIntFlag | kFLEXCAN_RxWarningIntFlag | kFLEXCAN_BusOffIntFlag |
+                      kFLEXCAN_ErrorIntFlag | kFLEXCAN_WakeUpIntFlag))
+        {
+            status = kStatus_FLEXCAN_ErrorStatus;
+
+            /* Clear FlexCAN Error and Status Interrupt. */
+            FLEXCAN_ClearStatusFlags(base, kFLEXCAN_TxWarningIntFlag | kFLEXCAN_RxWarningIntFlag |
+                                               kFLEXCAN_BusOffIntFlag | kFLEXCAN_ErrorIntFlag | kFLEXCAN_WakeUpIntFlag);
+        }
+        /* Solve FlexCAN Rx FIFO & Message Buffer Interrupt. */
+        else
+        {
+            /* For this implementation, we solve the Message with lowest MB index first. */
+            for (result = 0; result < FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base); result++)
+            {
+                /* Get the lowest unhandled Message Buffer */
+                if ((FLEXCAN_GetMbStatusFlags(base, 1 << result)) && (FLEXCAN_IsMbIntEnabled(base, result)))
+                {
+                    break;
+                }
+            }
+
+            /* Does not find Message to deal with. */
+            if (result == FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(base))
+            {
+                break;
+            }
+
+            /* Solve Rx FIFO interrupt. */
+            if ((kFLEXCAN_StateIdle != handle->rxFifoState) && ((1 << result) <= kFLEXCAN_RxFifoOverflowFlag))
+            {
+                switch (1 << result)
+                {
+                    case kFLEXCAN_RxFifoOverflowFlag:
+                        status = kStatus_FLEXCAN_RxFifoOverflow;
+                        break;
+
+                    case kFLEXCAN_RxFifoWarningFlag:
+                        status = kStatus_FLEXCAN_RxFifoWarning;
+                        break;
+
+                    case kFLEXCAN_RxFifoFrameAvlFlag:
+                        status = FlEXCAN_ReadRxFifo(base, handle->rxFifoFrameBuf);
+                        if (kStatus_Success == status)
+                        {
+                            status = kStatus_FLEXCAN_RxFifoIdle;
+                        }
+                        FLEXCAN_TransferAbortReceiveFifo(base, handle);
+                        break;
+
+                    default:
+                        status = kStatus_FLEXCAN_UnHandled;
+                        break;
+                }
+            }
+            else
+            {
+                /* Get current State of Message Buffer. */
+                switch (handle->mbState[result])
+                {
+                    /* Solve Rx Data Frame. */
+                    case kFLEXCAN_StateRxData:
+                        status = FLEXCAN_ReadRxMb(base, result, handle->mbFrameBuf[result]);
+                        if (kStatus_Success == status)
+                        {
+                            status = kStatus_FLEXCAN_RxIdle;
+                        }
+                        FLEXCAN_TransferAbortReceive(base, handle, result);
+                        break;
+
+                    /* Solve Rx Remote Frame. */
+                    case kFLEXCAN_StateRxRemote:
+                        status = FLEXCAN_ReadRxMb(base, result, handle->mbFrameBuf[result]);
+                        if (kStatus_Success == status)
+                        {
+                            status = kStatus_FLEXCAN_RxIdle;
+                        }
+                        FLEXCAN_TransferAbortReceive(base, handle, result);
+                        break;
+
+                    /* Solve Tx Data Frame. */
+                    case kFLEXCAN_StateTxData:
+                        status = kStatus_FLEXCAN_TxIdle;
+                        FLEXCAN_TransferAbortSend(base, handle, result);
+                        break;
+
+                    /* Solve Tx Remote Frame. */
+                    case kFLEXCAN_StateTxRemote:
+                        handle->mbState[result] = kFLEXCAN_StateRxRemote;
+                        status = kStatus_FLEXCAN_TxSwitchToRx;
+                        break;
+
+                    default:
+                        status = kStatus_FLEXCAN_UnHandled;
+                        break;
+                }
+            }
+
+            /* Clear resolved Message Buffer IRQ. */
+            FLEXCAN_ClearMbStatusFlags(base, 1 << result);
+        }
+
+        /* Calling Callback Function if has one. */
+        if (handle->callback != NULL)
+        {
+            handle->callback(base, handle, status, result, handle->userData);
+        }
+
+        /* Reset return status */
+        status = kStatus_FLEXCAN_UnHandled;
+
+        /* Store Current FlexCAN Module Error and Status. */
+        result = base->ESR1;
+    }
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    while ((0 != FLEXCAN_GetMbStatusFlags(base, 0xFFFFFFFFFFFFFFFFU)) ||
+           (0 != (result & (kFLEXCAN_TxWarningIntFlag | kFLEXCAN_RxWarningIntFlag | kFLEXCAN_BusOffIntFlag |
+                            kFLEXCAN_ErrorIntFlag | kFLEXCAN_WakeUpIntFlag))));
+#else
+        while ((0 != FLEXCAN_GetMbStatusFlags(base, 0xFFFFFFFFU)) ||
+               (0 != (result & (kFLEXCAN_TxWarningIntFlag | kFLEXCAN_RxWarningIntFlag | kFLEXCAN_BusOffIntFlag |
+                                kFLEXCAN_ErrorIntFlag | kFLEXCAN_WakeUpIntFlag))));
+#endif
+}
+
+#if (FSL_FEATURE_SOC_FLEXCAN_COUNT > 0)
+void CAN0_DriverIRQHandler(void)
+{
+    assert(s_flexcanHandle[0]);
+
+    FLEXCAN_TransferHandleIRQ(CAN0, s_flexcanHandle[0]);
+}
+#endif
+
+#if (FSL_FEATURE_SOC_FLEXCAN_COUNT > 1)
+void CAN1_DriverIRQHandler(void)
+{
+    assert(s_flexcanHandle[1]);
+
+    FLEXCAN_TransferHandleIRQ(CAN1, s_flexcanHandle[1]);
+}
+#endif
+
+#if (FSL_FEATURE_SOC_FLEXCAN_COUNT > 2)
+void CAN2_DriverIRQHandler(void)
+{
+    assert(s_flexcanHandle[2]);
+
+    FLEXCAN_TransferHandleIRQ(CAN2, s_flexcanHandle[2]);
+}
+#endif
+
+#if (FSL_FEATURE_SOC_FLEXCAN_COUNT > 3)
+void CAN3_DriverIRQHandler(void)
+{
+    assert(s_flexcanHandle[3]);
+
+    FLEXCAN_TransferHandleIRQ(CAN3, s_flexcanHandle[3]);
+}
+#endif
+
+#if (FSL_FEATURE_SOC_FLEXCAN_COUNT > 4)
+void CAN4_DriverIRQHandler(void)
+{
+    assert(s_flexcanHandle[4]);
+
+    FLEXCAN_TransferHandleIRQ(CAN4, s_flexcanHandle[4]);
+}
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexcan.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_flexcan.h
@@ -1,0 +1,1053 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_FLEXCAN_H_
+#define _FSL_FLEXCAN_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup flexcan_driver
+ * @{
+ */
+
+/*! @file*/
+
+/******************************************************************************
+ * Definitions
+ *****************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief FlexCAN driver version 2.1.0. */
+#define FLEXCAN_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*@}*/
+
+/*! @brief FlexCAN Frame ID helper macro. */
+#define FLEXCAN_ID_STD(id) \
+    (((uint32_t)(((uint32_t)(id)) << CAN_ID_STD_SHIFT)) & CAN_ID_STD_MASK) /*!< Standard Frame ID helper macro. */
+#define FLEXCAN_ID_EXT(id)                                \
+    (((uint32_t)(((uint32_t)(id)) << CAN_ID_EXT_SHIFT)) & \
+     (CAN_ID_EXT_MASK | CAN_ID_STD_MASK)) /*!< Extend Frame ID helper macro. */
+
+/*! @brief FlexCAN Rx Message Buffer Mask helper macro. */
+#define FLEXCAN_RX_MB_STD_MASK(id, rtr, ide)                                   \
+    (((uint32_t)((uint32_t)(rtr) << 31) | (uint32_t)((uint32_t)(ide) << 30)) | \
+     FLEXCAN_ID_STD(id)) /*!< Standard Rx Message Buffer Mask helper macro. */
+#define FLEXCAN_RX_MB_EXT_MASK(id, rtr, ide)                                   \
+    (((uint32_t)((uint32_t)(rtr) << 31) | (uint32_t)((uint32_t)(ide) << 30)) | \
+     FLEXCAN_ID_EXT(id)) /*!< Extend Rx Message Buffer Mask helper macro. */
+
+/*! @brief FlexCAN Rx FIFO Mask helper macro. */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_A(id, rtr, ide)                          \
+    (((uint32_t)((uint32_t)(rtr) << 31) | (uint32_t)((uint32_t)(ide) << 30)) | \
+     (FLEXCAN_ID_STD(id) << 1)) /*!< Standard Rx FIFO Mask helper macro Type A helper macro. */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_B_HIGH(id, rtr, ide)                     \
+    (((uint32_t)((uint32_t)(rtr) << 31) | (uint32_t)((uint32_t)(ide) << 30)) | \
+     (FLEXCAN_ID_STD(id) << 16)) /*!< Standard Rx FIFO Mask helper macro Type B upper part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_B_LOW(id, rtr, ide)                      \
+    (((uint32_t)((uint32_t)(rtr) << 15) | (uint32_t)((uint32_t)(ide) << 14)) | \
+     FLEXCAN_ID_STD(id)) /*!< Standard Rx FIFO Mask helper macro Type B lower part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_HIGH(id) \
+    ((FLEXCAN_ID_STD(id) & 0x7F8) << 21) /*!< Standard Rx FIFO Mask helper macro Type C upper part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_MID_HIGH(id)                                                                 \
+    ((FLEXCAN_ID_STD(id) & 0x7F8) << 13) /*!< Standard Rx FIFO Mask helper macro Type C mid-upper part helper macro. \
+                                                */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_MID_LOW(id) \
+    ((FLEXCAN_ID_STD(id) & 0x7F8) << 5) /*!< Standard Rx FIFO Mask helper macro Type C mid-lower part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_LOW(id) \
+    ((FLEXCAN_ID_STD(id) & 0x7F8) >> 3) /*!< Standard Rx FIFO Mask helper macro Type C lower part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_A(id, rtr, ide)                          \
+    (((uint32_t)((uint32_t)(rtr) << 31) | (uint32_t)((uint32_t)(ide) << 30)) | \
+     (FLEXCAN_ID_EXT(id) << 1)) /*!< Extend Rx FIFO Mask helper macro Type A helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_B_HIGH(id, rtr, ide)                        \
+    (                                                                             \
+        ((uint32_t)((uint32_t)(rtr) << 31) | (uint32_t)((uint32_t)(ide) << 30)) | \
+        ((FLEXCAN_ID_EXT(id) & 0x1FFF8000)                                        \
+         << 1)) /*!< Extend Rx FIFO Mask helper macro Type B upper part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_B_LOW(id, rtr, ide)                      \
+    (((uint32_t)((uint32_t)(rtr) << 15) | (uint32_t)((uint32_t)(ide) << 14)) | \
+     ((FLEXCAN_ID_EXT(id) & 0x1FFF8000) >>                                     \
+      15)) /*!< Extend Rx FIFO Mask helper macro Type B lower part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_HIGH(id) \
+    ((FLEXCAN_ID_EXT(id) & 0x1FE00000) << 3) /*!< Extend Rx FIFO Mask helper macro Type C upper part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_MID_HIGH(id) \
+    ((FLEXCAN_ID_EXT(id) & 0x1FE00000) >>            \
+     5) /*!< Extend Rx FIFO Mask helper macro Type C mid-upper part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_MID_LOW(id) \
+    ((FLEXCAN_ID_EXT(id) & 0x1FE00000) >>           \
+     13) /*!< Extend Rx FIFO Mask helper macro Type C mid-lower part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_LOW(id) \
+    ((FLEXCAN_ID_EXT(id) & 0x1FE00000) >> 21) /*!< Extend Rx FIFO Mask helper macro Type C lower part helper macro. */
+
+/*! @brief FlexCAN Rx FIFO Filter helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_A(id, rtr, ide) \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_A(id, rtr, ide) /*!< Standard Rx FIFO Filter helper macro Type A helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_B_HIGH(id, rtr, ide) \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_B_HIGH(                    \
+        id, rtr, ide) /*!< Standard Rx FIFO Filter helper macro Type B upper part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_B_LOW(id, rtr, ide) \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_B_LOW(                    \
+        id, rtr, ide) /*!< Standard Rx FIFO Filter helper macro Type B lower part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_C_HIGH(id) \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_HIGH(          \
+        id) /*!< Standard Rx FIFO Filter helper macro Type C upper part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_C_MID_HIGH(id) \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_MID_HIGH(          \
+        id) /*!< Standard Rx FIFO Filter helper macro Type C mid-upper part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_C_MID_LOW(id) \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_MID_LOW(          \
+        id) /*!< Standard Rx FIFO Filter helper macro Type C mid-lower part helper macro. */
+#define FLEXCAN_RX_FIFO_STD_FILTER_TYPE_C_LOW(id)                                                                     \
+    FLEXCAN_RX_FIFO_STD_MASK_TYPE_C_LOW(id) /*!< Standard Rx FIFO Filter helper macro Type C lower part helper macro. \
+                                               */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_A(id, rtr, ide) \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_A(id, rtr, ide) /*!< Extend Rx FIFO Filter helper macro Type A helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_B_HIGH(id, rtr, ide) \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_B_HIGH(                    \
+        id, rtr, ide) /*!< Extend Rx FIFO Filter helper macro Type B upper part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_B_LOW(id, rtr, ide) \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_B_LOW(                    \
+        id, rtr, ide) /*!< Extend Rx FIFO Filter helper macro Type B lower part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_C_HIGH(id)                                                                   \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_HIGH(id) /*!< Extend Rx FIFO Filter helper macro Type C upper part helper macro. \
+                                                */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_C_MID_HIGH(id) \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_MID_HIGH(          \
+        id) /*!< Extend Rx FIFO Filter helper macro Type C mid-upper part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_C_MID_LOW(id) \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_MID_LOW(          \
+        id) /*!< Extend Rx FIFO Filter helper macro Type C mid-lower part helper macro. */
+#define FLEXCAN_RX_FIFO_EXT_FILTER_TYPE_C_LOW(id) \
+    FLEXCAN_RX_FIFO_EXT_MASK_TYPE_C_LOW(id) /*!< Extend Rx FIFO Filter helper macro Type C lower part helper macro. */
+
+/*! @brief FlexCAN transfer status. */
+enum _flexcan_status
+{
+    kStatus_FLEXCAN_TxBusy = MAKE_STATUS(kStatusGroup_FLEXCAN, 0), /*!< Tx Message Buffer is Busy. */
+    kStatus_FLEXCAN_TxIdle = MAKE_STATUS(kStatusGroup_FLEXCAN, 1), /*!< Tx Message Buffer is Idle. */
+    kStatus_FLEXCAN_TxSwitchToRx = MAKE_STATUS(
+        kStatusGroup_FLEXCAN, 2), /*!< Remote Message is send out and Message buffer changed to Receive one. */
+    kStatus_FLEXCAN_RxBusy = MAKE_STATUS(kStatusGroup_FLEXCAN, 3),         /*!< Rx Message Buffer is Busy. */
+    kStatus_FLEXCAN_RxIdle = MAKE_STATUS(kStatusGroup_FLEXCAN, 4),         /*!< Rx Message Buffer is Idle. */
+    kStatus_FLEXCAN_RxOverflow = MAKE_STATUS(kStatusGroup_FLEXCAN, 5),     /*!< Rx Message Buffer is Overflowed. */
+    kStatus_FLEXCAN_RxFifoBusy = MAKE_STATUS(kStatusGroup_FLEXCAN, 6),     /*!< Rx Message FIFO is Busy. */
+    kStatus_FLEXCAN_RxFifoIdle = MAKE_STATUS(kStatusGroup_FLEXCAN, 7),     /*!< Rx Message FIFO is Idle. */
+    kStatus_FLEXCAN_RxFifoOverflow = MAKE_STATUS(kStatusGroup_FLEXCAN, 8), /*!< Rx Message FIFO is overflowed. */
+    kStatus_FLEXCAN_RxFifoWarning = MAKE_STATUS(kStatusGroup_FLEXCAN, 0),  /*!< Rx Message FIFO is almost overflowed. */
+    kStatus_FLEXCAN_ErrorStatus = MAKE_STATUS(kStatusGroup_FLEXCAN, 10),   /*!< FlexCAN Module Error and Status. */
+    kStatus_FLEXCAN_UnHandled = MAKE_STATUS(kStatusGroup_FLEXCAN, 11),     /*!< UnHadled Interrupt asserted. */
+};
+
+/*! @brief FlexCAN frame format. */
+typedef enum _flexcan_frame_format
+{
+    kFLEXCAN_FrameFormatStandard = 0x0U, /*!< Standard frame format attribute. */
+    kFLEXCAN_FrameFormatExtend = 0x1U,   /*!< Extend frame format attribute. */
+} flexcan_frame_format_t;
+
+/*! @brief FlexCAN frame type. */
+typedef enum _flexcan_frame_type
+{
+    kFLEXCAN_FrameTypeData = 0x0U,   /*!< Data frame type attribute. */
+    kFLEXCAN_FrameTypeRemote = 0x1U, /*!< Remote frame type attribute. */
+} flexcan_frame_type_t;
+
+/*! @brief FlexCAN clock source. */
+typedef enum _flexcan_clock_source
+{
+    kFLEXCAN_ClkSrcOsc = 0x0U,  /*!< FlexCAN Protocol Engine clock from Oscillator. */
+    kFLEXCAN_ClkSrcPeri = 0x1U, /*!< FlexCAN Protocol Engine clock from Peripheral Clock. */
+} flexcan_clock_source_t;
+
+/*! @brief FlexCAN Rx Fifo Filter type. */
+typedef enum _flexcan_rx_fifo_filter_type
+{
+    kFLEXCAN_RxFifoFilterTypeA = 0x0U, /*!< One full ID (standard and extended) per ID Filter element. */
+    kFLEXCAN_RxFifoFilterTypeB =
+        0x1U, /*!< Two full standard IDs or two partial 14-bit ID slices per ID Filter Table element. */
+    kFLEXCAN_RxFifoFilterTypeC =
+        0x2U, /*!< Four partial 8-bit Standard or extended ID slices per ID Filter Table element. */
+    kFLEXCAN_RxFifoFilterTypeD = 0x3U, /*!< All frames rejected. */
+} flexcan_rx_fifo_filter_type_t;
+
+/*!
+ * @brief FlexCAN Rx FIFO priority
+ *
+ * The matching process starts from the Rx MB(or Rx FIFO) with higher priority.
+ * If no MB(or Rx FIFO filter) is satisfied, the matching process goes on with
+ * the Rx FIFO(or Rx MB) with lower priority.
+ */
+typedef enum _flexcan_rx_fifo_priority
+{
+    kFLEXCAN_RxFifoPrioLow = 0x0U,  /*!< Matching process start from Rx Message Buffer first*/
+    kFLEXCAN_RxFifoPrioHigh = 0x1U, /*!< Matching process start from Rx FIFO first*/
+} flexcan_rx_fifo_priority_t;
+
+/*!
+ * @brief FlexCAN interrupt configuration structure, default settings all disabled.
+ *
+ * This structure contains the settings for all of the FlexCAN Module interrupt configurations.
+ * Note: FlexCAN Message Buffers and Rx FIFO have their own interrupts.
+ */
+enum _flexcan_interrupt_enable
+{
+    kFLEXCAN_BusOffInterruptEnable = CAN_CTRL1_BOFFMSK_MASK,    /*!< Bus Off interrupt. */
+    kFLEXCAN_ErrorInterruptEnable = CAN_CTRL1_ERRMSK_MASK,      /*!< Error interrupt. */
+    kFLEXCAN_RxWarningInterruptEnable = CAN_CTRL1_RWRNMSK_MASK, /*!< Rx Warning interrupt. */
+    kFLEXCAN_TxWarningInterruptEnable = CAN_CTRL1_TWRNMSK_MASK, /*!< Tx Warning interrupt. */
+    kFLEXCAN_WakeUpInterruptEnable = CAN_MCR_WAKMSK_MASK,       /*!< Wake Up interrupt. */
+};
+
+/*!
+ * @brief FlexCAN status flags.
+ *
+ * This provides constants for the FlexCAN status flags for use in the FlexCAN functions.
+ * Note: The CPU read action clears FlEXCAN_ErrorFlag, therefore user need to
+ * read FlEXCAN_ErrorFlag and distinguish which error is occur using
+ * @ref _flexcan_error_flags enumerations.
+ */
+enum _flexcan_flags
+{
+    kFLEXCAN_SynchFlag = CAN_ESR1_SYNCH_MASK,              /*!< CAN Synchronization Status. */
+    kFLEXCAN_TxWarningIntFlag = CAN_ESR1_TWRNINT_MASK,     /*!< Tx Warning Interrupt Flag. */
+    kFLEXCAN_RxWarningIntFlag = CAN_ESR1_RWRNINT_MASK,     /*!< Rx Warning Interrupt Flag. */
+    kFLEXCAN_TxErrorWarningFlag = CAN_ESR1_TXWRN_MASK,     /*!< Tx Error Warning Status. */
+    kFLEXCAN_RxErrorWarningFlag = CAN_ESR1_RXWRN_MASK,     /*!< Rx Error Warning Status. */
+    kFLEXCAN_IdleFlag = CAN_ESR1_IDLE_MASK,                /*!< CAN IDLE Status Flag. */
+    kFLEXCAN_FaultConfinementFlag = CAN_ESR1_FLTCONF_MASK, /*!< Fault Confinement State Flag. */
+    kFLEXCAN_TransmittingFlag = CAN_ESR1_TX_MASK,          /*!< FlexCAN In Transmission Status. */
+    kFLEXCAN_ReceivingFlag = CAN_ESR1_RX_MASK,             /*!< FlexCAN In Reception Status. */
+    kFLEXCAN_BusOffIntFlag = CAN_ESR1_BOFFINT_MASK,        /*!< Bus Off Interrupt Flag. */
+    kFLEXCAN_ErrorIntFlag = CAN_ESR1_ERRINT_MASK,          /*!< Error Interrupt Flag. */
+    kFLEXCAN_WakeUpIntFlag = CAN_ESR1_WAKINT_MASK,         /*!< Wake-Up Interrupt Flag. */
+    kFLEXCAN_ErrorFlag = CAN_ESR1_BIT1ERR_MASK |           /*!< All FlexCAN Error Status. */
+                         CAN_ESR1_BIT0ERR_MASK |
+                         CAN_ESR1_ACKERR_MASK | CAN_ESR1_CRCERR_MASK | CAN_ESR1_FRMERR_MASK | CAN_ESR1_STFERR_MASK,
+};
+
+/*!
+ * @brief FlexCAN error status flags.
+ *
+ * The FlexCAN Error Status enumerations is used to report current error of the FlexCAN bus.
+ * This enumerations should be used with KFLEXCAN_ErrorFlag in @ref _flexcan_flags enumerations
+ * to ditermine which error is generated.
+ */
+enum _flexcan_error_flags
+{
+    kFLEXCAN_StuffingError = CAN_ESR1_STFERR_MASK, /*!< Stuffing Error. */
+    kFLEXCAN_FormError = CAN_ESR1_FRMERR_MASK,     /*!< Form Error. */
+    kFLEXCAN_CrcError = CAN_ESR1_CRCERR_MASK,      /*!< Cyclic Redundancy Check Error. */
+    kFLEXCAN_AckError = CAN_ESR1_ACKERR_MASK,      /*!< Received no ACK on transmission. */
+    kFLEXCAN_Bit0Error = CAN_ESR1_BIT0ERR_MASK,    /*!< Unable to send dominant bit. */
+    kFLEXCAN_Bit1Error = CAN_ESR1_BIT1ERR_MASK,    /*!< Unable to send recessive bit. */
+};
+
+/*!
+ * @brief FlexCAN Rx FIFO status flags.
+ *
+ * The FlexCAN Rx FIFO Status enumerations are used to determine the status of the
+ * Rx FIFO. Because Rx FIFO occupy the MB0 ~ MB7 (Rx Fifo filter also occupies
+ * more Message Buffer space), Rx FIFO status flags are mapped to the corresponding
+ * Message Buffer status flags.
+ */
+enum _flexcan_rx_fifo_flags
+{
+    kFLEXCAN_RxFifoOverflowFlag = CAN_IFLAG1_BUF7I_MASK, /*!< Rx FIFO overflow flag. */
+    kFLEXCAN_RxFifoWarningFlag = CAN_IFLAG1_BUF6I_MASK,  /*!< Rx FIFO almost full flag. */
+    kFLEXCAN_RxFifoFrameAvlFlag = CAN_IFLAG1_BUF5I_MASK, /*!< Frames available in Rx FIFO flag. */
+};
+
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+/*! @brief FlexCAN message frame structure. */
+typedef struct _flexcan_frame
+{
+    struct
+    {
+        uint32_t timestamp : 16; /*!< FlexCAN internal Free-Running Counter Time Stamp. */
+        uint32_t length : 4;     /*!< CAN frame payload length in bytes(Range: 0~8). */
+        uint32_t type : 1;       /*!< CAN Frame Type(DATA or REMOTE). */
+        uint32_t format : 1;     /*!< CAN Frame Identifier(STD or EXT format). */
+        uint32_t reserve1 : 1;   /*!< Reserved for placeholder. */
+        uint32_t idhit : 9;      /*!< CAN Rx FIFO filter hit id(This value is only used in Rx FIFO receive mode). */
+    };
+    struct
+    {
+        uint32_t id : 29; /*!< CAN Frame Identifier, should be set using FLEXCAN_ID_EXT() or FLEXCAN_ID_STD() macro. */
+        uint32_t reserve2 : 3; /*!< Reserved for place holder. */
+    };
+    union
+    {
+        struct
+        {
+            uint32_t dataWord0; /*!< CAN Frame payload word0. */
+            uint32_t dataWord1; /*!< CAN Frame payload word1. */
+        };
+        struct
+        {
+            uint8_t dataByte3; /*!< CAN Frame payload byte3. */
+            uint8_t dataByte2; /*!< CAN Frame payload byte2. */
+            uint8_t dataByte1; /*!< CAN Frame payload byte1. */
+            uint8_t dataByte0; /*!< CAN Frame payload byte0. */
+            uint8_t dataByte7; /*!< CAN Frame payload byte7. */
+            uint8_t dataByte6; /*!< CAN Frame payload byte6. */
+            uint8_t dataByte5; /*!< CAN Frame payload byte5. */
+            uint8_t dataByte4; /*!< CAN Frame payload byte4. */
+        };
+    };
+} flexcan_frame_t;
+
+/*! @brief FlexCAN module configuration structure. */
+typedef struct _flexcan_config
+{
+    uint32_t baudRate;             /*!< FlexCAN baud rate in bps. */
+    flexcan_clock_source_t clkSrc; /*!< Clock source for FlexCAN Protocol Engine. */
+    uint8_t maxMbNum;              /*!< The maximum number of Message Buffers used by user. */
+    bool enableLoopBack;           /*!< Enable or Disable Loop Back Self Test Mode. */
+    bool enableSelfWakeup;         /*!< Enable or Disable Self Wakeup Mode. */
+    bool enableIndividMask;        /*!< Enable or Disable Rx Individual Mask. */
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT) && FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT)
+    bool enableDoze; /*!< Enable or Disable Doze Mode. */
+#endif
+} flexcan_config_t;
+
+/*! @brief FlexCAN protocol timing characteristic configuration structure. */
+typedef struct _flexcan_timing_config
+{
+    uint8_t preDivider; /*!< Clock Pre-scaler Division Factor. */
+    uint8_t rJumpwidth; /*!< Re-sync Jump Width. */
+    uint8_t phaseSeg1;  /*!< Phase Segment 1. */
+    uint8_t phaseSeg2;  /*!< Phase Segment 2. */
+    uint8_t propSeg;    /*!< Propagation Segment. */
+} flexcan_timing_config_t;
+
+/*!
+ * @brief FlexCAN Receive Message Buffer configuration structure
+ *
+ * This structure is used as the parameter of FLEXCAN_SetRxMbConfig() function.
+ * The FLEXCAN_SetRxMbConfig() function is used to configure FlexCAN Receive
+ * Message Buffer. The function abort previous receiving process, clean the
+ * Message Buffer and activate the Rx Message Buffer using given Message Buffer
+ * setting.
+ */
+typedef struct _flexcan_rx_mb_config
+{
+    uint32_t id;                   /*!< CAN Message Buffer Frame Identifier, should be set using
+                                        FLEXCAN_ID_EXT() or FLEXCAN_ID_STD() macro. */
+    flexcan_frame_format_t format; /*!< CAN Frame Identifier format(Standard of Extend). */
+    flexcan_frame_type_t type;     /*!< CAN Frame Type(Data or Remote). */
+} flexcan_rx_mb_config_t;
+
+/*! @brief FlexCAN Rx FIFO configure structure. */
+typedef struct _flexcan_rx_fifo_config
+{
+    uint32_t *idFilterTable;                    /*!< Pointer to FlexCAN Rx FIFO identifier filter table. */
+    uint8_t idFilterNum;                        /*!< The quantity of filter elements. */
+    flexcan_rx_fifo_filter_type_t idFilterType; /*!< The FlexCAN Rx FIFO Filter type. */
+    flexcan_rx_fifo_priority_t priority;        /*!< The FlexCAN Rx FIFO receive priority. */
+} flexcan_rx_fifo_config_t;
+
+/*! @brief FlexCAN Message Buffer transfer. */
+typedef struct _flexcan_mb_transfer
+{
+    flexcan_frame_t *frame; /*!< The buffer of CAN Message to be transfer. */
+    uint8_t mbIdx;          /*!< The index of Message buffer used to transfer Message. */
+} flexcan_mb_transfer_t;
+
+/*! @brief FlexCAN Rx FIFO transfer. */
+typedef struct _flexcan_fifo_transfer
+{
+    flexcan_frame_t *frame; /*!< The buffer of CAN Message to be received from Rx FIFO. */
+} flexcan_fifo_transfer_t;
+
+/*! @brief FlexCAN handle structure definition. */
+typedef struct _flexcan_handle flexcan_handle_t;
+
+/*! @brief FlexCAN transfer callback function.
+ *
+ *  The FlexCAN transfer callback returns a value from the underlying layer.
+ *  If the status equals to kStatus_FLEXCAN_ErrorStatus, the result parameter is the Content of
+ *  FlexCAN status register which can be used to get the working status(or error status) of FlexCAN module.
+ *  If the status equals to other FlexCAN Message Buffer transfer status, the result is the index of
+ *  Message Buffer that generate transfer event.
+ *  If the status equals to other FlexCAN Message Buffer transfer status, the result is meaningless and should be
+ *  Ignored.
+ */
+typedef void (*flexcan_transfer_callback_t)(
+    CAN_Type *base, flexcan_handle_t *handle, status_t status, uint32_t result, void *userData);
+
+/*! @brief FlexCAN handle structure. */
+struct _flexcan_handle
+{
+    flexcan_transfer_callback_t callback; /*!< Callback function. */
+    void *userData;                       /*!< FlexCAN callback function parameter.*/
+    flexcan_frame_t *volatile mbFrameBuf[CAN_WORD1_COUNT];
+    /*!< The buffer for received data from Message Buffers. */
+    flexcan_frame_t *volatile rxFifoFrameBuf;  /*!< The buffer for received data from Rx FIFO. */
+    volatile uint8_t mbState[CAN_WORD1_COUNT]; /*!< Message Buffer transfer state. */
+    volatile uint8_t rxFifoState;              /*!< Rx FIFO transfer state. */
+};
+
+/******************************************************************************
+ * API
+ *****************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes a FlexCAN instance.
+ *
+ * This function initializes the FlexCAN module with user-defined settings.
+ * This example shows how to set up the flexcan_config_t parameters and how
+ * to call the FLEXCAN_Init function by passing in these parameters:
+ *  @code
+ *   flexcan_config_t flexcanConfig;
+ *   flexcanConfig.clkSrc            = KFLEXCAN_ClkSrcOsc;
+ *   flexcanConfig.baudRate          = 125000U;
+ *   flexcanConfig.maxMbNum          = 16;
+ *   flexcanConfig.enableLoopBack    = false;
+ *   flexcanConfig.enableSelfWakeup  = false;
+ *   flexcanConfig.enableIndividMask = false;
+ *   flexcanConfig.enableDoze        = false;
+ *   FLEXCAN_Init(CAN0, &flexcanConfig, 8000000UL);
+ *   @endcode
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param config Pointer to user-defined configuration structure.
+ * @param sourceClock_Hz FlexCAN Protocol Engine clock source frequency in Hz.
+ */
+void FLEXCAN_Init(CAN_Type *base, const flexcan_config_t *config, uint32_t sourceClock_Hz);
+
+/*!
+ * @brief De-initializes a FlexCAN instance.
+ *
+ * This function disable the FlexCAN module clock and set all register value
+ * to reset value.
+ *
+ * @param base FlexCAN peripheral base address.
+ */
+void FLEXCAN_Deinit(CAN_Type *base);
+
+/*!
+ * @brief Get the default configuration structure.
+ *
+ * This function initializes the FlexCAN configure structure to default value. The default
+ * value are:
+ *   flexcanConfig->clkSrc            = KFLEXCAN_ClkSrcOsc;
+ *   flexcanConfig->baudRate          = 125000U;
+ *   flexcanConfig->maxMbNum          = 16;
+ *   flexcanConfig->enableLoopBack    = false;
+ *   flexcanConfig->enableSelfWakeup  = false;
+ *   flexcanConfig->enableIndividMask = false;
+ *   flexcanConfig->enableDoze        = false;
+ *
+ * @param config Pointer to FlexCAN configuration structure.
+ */
+void FLEXCAN_GetDefaultConfig(flexcan_config_t *config);
+
+/* @} */
+
+/*!
+ * @name Configuration.
+ * @{
+ */
+
+/*!
+ * @brief Sets the FlexCAN protocol timing characteristic.
+ *
+ * This function gives user settings to CAN bus timing characteristic.
+ * The function is for an experienced user. For less experienced users, call
+ * the FLEXCAN_Init() and fill the baud rate field with a desired value.
+ * This provides the default timing characteristics to the module.
+ *
+ * Note that calling FLEXCAN_SetTimingConfig() overrides the baud rate set
+ * in FLEXCAN_Init().
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param config Pointer to the timing configuration structure.
+ */
+void FLEXCAN_SetTimingConfig(CAN_Type *base, const flexcan_timing_config_t *config);
+
+/*!
+ * @brief Sets the FlexCAN receive message buffer global mask.
+ *
+ * This function sets the global mask for FlexCAN message buffer in a matching process.
+ * The configuration is only effective when the Rx individual mask is disabled in the FLEXCAN_Init().
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask Rx Message Buffer Global Mask value.
+ */
+void FlEXCAN_SetRxMbGlobalMask(CAN_Type *base, uint32_t mask);
+
+/*!
+ * @brief Sets the FlexCAN receive FIFO global mask.
+ *
+ * This function sets the global mask for FlexCAN FIFO in a matching process.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask Rx Fifo Global Mask value.
+ */
+void FlEXCAN_SetRxFifoGlobalMask(CAN_Type *base, uint32_t mask);
+
+/*!
+ * @brief Sets the FlexCAN receive individual mask.
+ *
+ * This function sets the individual mask for FlexCAN matching process.
+ * The configuration is only effective when the Rx individual mask is enabled in FLEXCAN_Init().
+ * If Rx FIFO is disabled, the individual mask is applied to the corresponding Message Buffer.
+ * If Rx FIFO is enabled, the individual mask for Rx FIFO occupied Message Buffer is applied to
+ * the Rx Filter with same index. What calls for special attention is that only the first 32
+ * individual masks can be used as Rx FIFO filter mask.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param maskIdx The Index of individual Mask.
+ * @param mask Rx Individual Mask value.
+ */
+void FlEXCAN_SetRxIndividualMask(CAN_Type *base, uint8_t maskIdx, uint32_t mask);
+
+/*!
+ * @brief Configures a FlexCAN transmit message buffer.
+ *
+ * This function aborts the previous transmission, cleans the Message Buffer, and
+ * configures it as a Transmit Message Buffer.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mbIdx The Message Buffer index.
+ * @param enable Enable/Disable Tx Message Buffer.
+ *               - true: Enable Tx Message Buffer.
+ *               - false: Disable Tx Message Buffer.
+ */
+void FLEXCAN_SetTxMbConfig(CAN_Type *base, uint8_t mbIdx, bool enable);
+
+/*!
+ * @brief Configures a FlexCAN Receive Message Buffer.
+ *
+ * This function cleans a FlexCAN build-in Message Buffer and configures it
+ * as a Receive Message Buffer.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mbIdx The Message Buffer index.
+ * @param config Pointer to FlexCAN Message Buffer configuration structure.
+ * @param enable Enable/Disable Rx Message Buffer.
+ *               - true: Enable Rx Message Buffer.
+ *               - false: Disable Rx Message Buffer.
+ */
+void FLEXCAN_SetRxMbConfig(CAN_Type *base, uint8_t mbIdx, const flexcan_rx_mb_config_t *config, bool enable);
+
+/*!
+ * @brief Configures the FlexCAN Rx FIFO.
+ *
+ * This function configures the Rx FIFO with given Rx FIFO configuration.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param config Pointer to FlexCAN Rx FIFO configuration structure.
+ * @param enable Enable/Disable Rx FIFO.
+ *               - true: Enable Rx FIFO.
+ *               - false: Disable Rx FIFO.
+ */
+void FlEXCAN_SetRxFifoConfig(CAN_Type *base, const flexcan_rx_fifo_config_t *config, bool enable);
+
+/* @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Gets the FlexCAN module interrupt flags.
+ *
+ * This function gets all FlexCAN status flags. The flags are returned as the logical
+ * OR value of the enumerators @ref _flexcan_flags. To check the specific status,
+ * compare the return value with enumerators in @ref _flexcan_flags.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @return FlexCAN status flags which are ORed by the enumerators in the _flexcan_flags.
+ */
+static inline uint32_t FLEXCAN_GetStatusFlags(CAN_Type *base)
+{
+    return base->ESR1;
+}
+
+/*!
+ * @brief Clears status flags with the provided mask.
+ *
+ * This function clears the FlexCAN status flags with a provided mask. An automatically cleared flag
+ * can't be cleared by this function.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The status flags to be cleared, it is logical OR value of @ref _flexcan_flags.
+ */
+static inline void FLEXCAN_ClearStatusFlags(CAN_Type *base, uint32_t mask)
+{
+    /* Write 1 to clear status flag. */
+    base->ESR1 = mask;
+}
+
+/*!
+ * @brief Gets the FlexCAN Bus Error Counter value.
+ *
+ * This function gets the FlexCAN Bus Error Counter value for both Tx and
+ * Rx direction. These values may be needed in the upper layer error handling.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param txErrBuf Buffer to store Tx Error Counter value.
+ * @param rxErrBuf Buffer to store Rx Error Counter value.
+ */
+static inline void FlEXCAN_GetBusErrCount(CAN_Type *base, uint8_t *txErrBuf, uint8_t *rxErrBuf)
+{
+    if (txErrBuf)
+    {
+        *txErrBuf = (uint8_t)((base->ECR & CAN_ECR_TXERRCNT_MASK) >> CAN_ECR_TXERRCNT_SHIFT);
+    }
+
+    if (rxErrBuf)
+    {
+        *rxErrBuf = (uint8_t)((base->ECR & CAN_ECR_RXERRCNT_MASK) >> CAN_ECR_RXERRCNT_SHIFT);
+    }
+}
+
+/*!
+ * @brief Gets the FlexCAN Message Buffer interrupt flags.
+ *
+ * This function gets the interrupt flags of a given Message Buffers.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The ORed FlexCAN Message Buffer mask.
+ * @return The status of given Message Buffers.
+ */
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+static inline uint64_t FLEXCAN_GetMbStatusFlags(CAN_Type *base, uint64_t mask)
+#else
+static inline uint32_t FLEXCAN_GetMbStatusFlags(CAN_Type *base, uint32_t mask)
+#endif
+{
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    return ((((uint64_t)base->IFLAG1) & mask) | ((((uint64_t)base->IFLAG2) << 32) & mask));
+#else
+    return (base->IFLAG1 & mask);
+#endif
+}
+
+/*!
+ * @brief Clears the FlexCAN Message Buffer interrupt flags.
+ *
+ * This function clears the interrupt flags of a given Message Buffers.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The ORed FlexCAN Message Buffer mask.
+ */
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+static inline void FLEXCAN_ClearMbStatusFlags(CAN_Type *base, uint64_t mask)
+#else
+static inline void FLEXCAN_ClearMbStatusFlags(CAN_Type *base, uint32_t mask)
+#endif
+{
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    base->IFLAG1 = (uint32_t)(mask & 0xFFFFFFFF);
+    base->IFLAG2 = (uint32_t)(mask >> 32);
+#else
+    base->IFLAG1 = mask;
+#endif
+}
+
+/* @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enables FlexCAN interrupts according to provided mask.
+ *
+ * This function enables the FlexCAN interrupts according to provided mask. The mask
+ * is a logical OR of enumeration members, see @ref _flexcan_interrupt_enable.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The interrupts to enable. Logical OR of @ref _flexcan_interrupt_enable.
+ */
+static inline void FLEXCAN_EnableInterrupts(CAN_Type *base, uint32_t mask)
+{
+    /* Solve Wake Up Interrupt. */
+    if (mask & kFLEXCAN_WakeUpInterruptEnable)
+    {
+        base->MCR |= CAN_MCR_WAKMSK_MASK;
+    }
+
+    /* Solve others. */
+    base->CTRL1 |= (mask & (~((uint32_t)kFLEXCAN_WakeUpInterruptEnable)));
+}
+
+/*!
+ * @brief Disables FlexCAN interrupts according to provided mask.
+ *
+ * This function disables the FlexCAN interrupts according to provided mask. The mask
+ * is a logical OR of enumeration members, see @ref _flexcan_interrupt_enable.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The interrupts to disable. Logical OR of @ref _flexcan_interrupt_enable.
+ */
+static inline void FLEXCAN_DisableInterrupts(CAN_Type *base, uint32_t mask)
+{
+    /* Solve Wake Up Interrupt. */
+    if (mask & kFLEXCAN_WakeUpInterruptEnable)
+    {
+        base->MCR &= ~CAN_MCR_WAKMSK_MASK;
+    }
+
+    /* Solve others. */
+    base->CTRL1 &= ~(mask & (~((uint32_t)kFLEXCAN_WakeUpInterruptEnable)));
+}
+
+/*!
+ * @brief Enables FlexCAN Message Buffer interrupts.
+ *
+ * This function enables the interrupts of given Message Buffers
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The ORed FlexCAN Message Buffer mask.
+ */
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+static inline void FLEXCAN_EnableMbInterrupts(CAN_Type *base, uint64_t mask)
+#else
+static inline void FLEXCAN_EnableMbInterrupts(CAN_Type *base, uint32_t mask)
+#endif
+{
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    base->IMASK1 |= (uint32_t)(mask & 0xFFFFFFFF);
+    base->IMASK2 |= (uint32_t)(mask >> 32);
+#else
+    base->IMASK1 |= mask;
+#endif
+}
+
+/*!
+ * @brief Disables FlexCAN Message Buffer interrupts.
+ *
+ * This function disables the interrupts of given Message Buffers
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mask The ORed FlexCAN Message Buffer mask.
+ */
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+static inline void FLEXCAN_DisableMbInterrupts(CAN_Type *base, uint64_t mask)
+#else
+static inline void FLEXCAN_DisableMbInterrupts(CAN_Type *base, uint32_t mask)
+#endif
+{
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER)) && (FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER > 0)
+    base->IMASK1 &= ~((uint32_t)(mask & 0xFFFFFFFF));
+    base->IMASK2 &= ~((uint32_t)(mask >> 32));
+#else
+    base->IMASK1 &= ~mask;
+#endif
+}
+
+/* @} */
+
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA) && FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA)
+/*!
+ * @name DMA Control
+ * @{
+ */
+
+/*!
+ * @brief Enables or disables the FlexCAN Rx FIFO DMA request.
+ *
+ * This function enables or disables the DMA feature of FlexCAN build-in Rx FIFO.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param enable true to enable, false to disable.
+ */
+void FLEXCAN_EnableRxFifoDMA(CAN_Type *base, bool enable);
+
+/*!
+ * @brief Gets the Rx FIFO Head address.
+ *
+ * This function returns the FlexCAN Rx FIFO Head address, which is mainly used for the DMA/eDMA use case.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @return FlexCAN Rx FIFO Head address.
+ */
+static inline uint32_t FLEXCAN_GetRxFifoHeadAddr(CAN_Type *base)
+{
+    return (uint32_t) & (base->MB[0].CS);
+}
+
+/* @} */
+#endif /* FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA */
+
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Enables or disables the FlexCAN module operation.
+ *
+ * This function enables or disables the FlexCAN module.
+ *
+ * @param base FlexCAN base pointer.
+ * @param enable true to enable, false to disable.
+ */
+static inline void FLEXCAN_Enable(CAN_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->MCR &= ~CAN_MCR_MDIS_MASK;
+
+        /* Wait FlexCAN exit from low-power mode. */
+        while (base->MCR & CAN_MCR_LPMACK_MASK)
+        {
+        }
+    }
+    else
+    {
+        base->MCR |= CAN_MCR_MDIS_MASK;
+
+        /* Wait FlexCAN enter low-power mode. */
+        while (!(base->MCR & CAN_MCR_LPMACK_MASK))
+        {
+        }
+    }
+}
+
+/*!
+ * @brief Writes a FlexCAN Message to Transmit Message Buffer.
+ *
+ * This function writes a CAN Message to the specified Transmit Message Buffer
+ * and changes the Message Buffer state to start CAN Message transmit. After
+ * that the function returns immediately.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ * @param txFrame Pointer to CAN message frame to be sent.
+ * @retval kStatus_Success - Write Tx Message Buffer Successfully.
+ * @retval kStatus_Fail    - Tx Message Buffer is currently in use.
+ */
+status_t FLEXCAN_WriteTxMb(CAN_Type *base, uint8_t mbIdx, const flexcan_frame_t *txFrame);
+
+/*!
+ * @brief Reads a FlexCAN Message from Receive Message Buffer.
+ *
+ * This function reads a CAN message from a specified Receive Message Buffer.
+ * The function fills a receive CAN message frame structure with
+ * just received data and activates the Message Buffer again.
+ * The function returns immediately.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ * @param rxFrame Pointer to CAN message frame structure for reception.
+ * @retval kStatus_Success            - Rx Message Buffer is full and has been read successfully.
+ * @retval kStatus_FLEXCAN_RxOverflow - Rx Message Buffer is already overflowed and has been read successfully.
+ * @retval kStatus_Fail               - Rx Message Buffer is empty.
+ */
+status_t FLEXCAN_ReadRxMb(CAN_Type *base, uint8_t mbIdx, flexcan_frame_t *rxFrame);
+
+/*!
+ * @brief Reads a FlexCAN Message from Rx FIFO.
+ *
+ * This function reads a CAN message from the FlexCAN build-in Rx FIFO.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param rxFrame Pointer to CAN message frame structure for reception.
+ * @retval kStatus_Success - Read Message from Rx FIFO successfully.
+ * @retval kStatus_Fail    - Rx FIFO is not enabled.
+ */
+status_t FlEXCAN_ReadRxFifo(CAN_Type *base, flexcan_frame_t *rxFrame);
+
+/* @} */
+
+/*!
+ * @name Transactional
+ * @{
+ */
+
+/*!
+ * @brief Performs a polling send transaction on the CAN bus.
+ *
+ * Note that a transfer handle does not need to be created  before calling this API.
+ *
+ * @param base FlexCAN peripheral base pointer.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ * @param txFrame Pointer to CAN message frame to be sent.
+ * @retval kStatus_Success - Write Tx Message Buffer Successfully.
+ * @retval kStatus_Fail    - Tx Message Buffer is currently in use.
+ */
+status_t FlEXCAN_TransferSendBlocking(CAN_Type *base, uint8_t mbIdx, flexcan_frame_t *txFrame);
+
+/*!
+ * @brief Performs a polling receive transaction on the CAN bus.
+ *
+ * Note that a transfer handle does not need to be created  before calling this API.
+ *
+ * @param base FlexCAN peripheral base pointer.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ * @param rxFrame Pointer to CAN message frame structure for reception.
+ * @retval kStatus_Success            - Rx Message Buffer is full and has been read successfully.
+ * @retval kStatus_FLEXCAN_RxOverflow - Rx Message Buffer is already overflowed and has been read successfully.
+ * @retval kStatus_Fail               - Rx Message Buffer is empty.
+ */
+status_t FlEXCAN_TransferReceiveBlocking(CAN_Type *base, uint8_t mbIdx, flexcan_frame_t *rxFrame);
+
+/*!
+ * @brief Performs a polling receive transaction from Rx FIFO on the CAN bus.
+ *
+ * Note that a transfer handle does not need to be created  before calling this API.
+ *
+ * @param base FlexCAN peripheral base pointer.
+ * @param rxFrame Pointer to CAN message frame structure for reception.
+ * @retval kStatus_Success - Read Message from Rx FIFO successfully.
+ * @retval kStatus_Fail    - Rx FIFO is not enabled.
+ */
+status_t FlEXCAN_TransferReceiveFifoBlocking(CAN_Type *base, flexcan_frame_t *rxFrame);
+
+/*!
+ * @brief Initializes the FlexCAN handle.
+ *
+ * This function initializes the FlexCAN handle which can be used for other FlexCAN
+ * transactional APIs. Usually, for a specified FlexCAN instance,
+ * call this API once to get the initialized handle.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ * @param callback The callback function.
+ * @param userData The parameter of the callback function.
+ */
+void FLEXCAN_TransferCreateHandle(CAN_Type *base,
+                                  flexcan_handle_t *handle,
+                                  flexcan_transfer_callback_t callback,
+                                  void *userData);
+
+/*!
+ * @brief Sends a message using IRQ.
+ *
+ * This function sends a message using IRQ. This is a non-blocking function, which returns
+ * right away. When messages have been sent out, the send callback function is called.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ * @param xfer FlexCAN Message Buffer transfer structure. See the #flexcan_mb_transfer_t.
+ * @retval kStatus_Success        Start Tx Message Buffer sending process successfully.
+ * @retval kStatus_Fail           Write Tx Message Buffer failed.
+ * @retval kStatus_FLEXCAN_TxBusy Tx Message Buffer is in use.
+ */
+status_t FLEXCAN_TransferSendNonBlocking(CAN_Type *base, flexcan_handle_t *handle, flexcan_mb_transfer_t *xfer);
+
+/*!
+ * @brief Receives a message using IRQ.
+ *
+ * This function receives a message using IRQ. This is non-blocking function, which returns
+ * right away. When the message has been received, the receive callback function is called.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ * @param xfer FlexCAN Message Buffer transfer structure. See the #flexcan_mb_transfer_t.
+ * @retval kStatus_Success        - Start Rx Message Buffer receiving process successfully.
+ * @retval kStatus_FLEXCAN_RxBusy - Rx Message Buffer is in use.
+ */
+status_t FLEXCAN_TransferReceiveNonBlocking(CAN_Type *base, flexcan_handle_t *handle, flexcan_mb_transfer_t *xfer);
+
+/*!
+ * @brief Receives a message from Rx FIFO using IRQ.
+ *
+ * This function receives a message using IRQ. This is a non-blocking function, which returns
+ * right away. When all messages have been received, the receive callback function is called.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ * @param xfer FlexCAN Rx FIFO transfer structure. See the @ref flexcan_fifo_transfer_t.
+ * @retval kStatus_Success            - Start Rx FIFO receiving process successfully.
+ * @retval kStatus_FLEXCAN_RxFifoBusy - Rx FIFO is currently in use.
+ */
+status_t FLEXCAN_TransferReceiveFifoNonBlocking(CAN_Type *base,
+                                                flexcan_handle_t *handle,
+                                                flexcan_fifo_transfer_t *xfer);
+
+/*!
+ * @brief Aborts the interrupt driven message send process.
+ *
+ * This function aborts the interrupt driven message send process.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ */
+void FLEXCAN_TransferAbortSend(CAN_Type *base, flexcan_handle_t *handle, uint8_t mbIdx);
+
+/*!
+ * @brief Aborts the interrupt driven message receive process.
+ *
+ * This function aborts the interrupt driven message receive process.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ * @param mbIdx The FlexCAN Message Buffer index.
+ */
+void FLEXCAN_TransferAbortReceive(CAN_Type *base, flexcan_handle_t *handle, uint8_t mbIdx);
+
+/*!
+ * @brief Aborts the interrupt driven message receive from Rx FIFO process.
+ *
+ * This function aborts the interrupt driven message receive from Rx FIFO process.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ */
+void FLEXCAN_TransferAbortReceiveFifo(CAN_Type *base, flexcan_handle_t *handle);
+
+/*!
+ * @brief FlexCAN IRQ handle function.
+ *
+ * This function handles the FlexCAN Error, the Message Buffer, and the Rx FIFO IRQ request.
+ *
+ * @param base FlexCAN peripheral base address.
+ * @param handle FlexCAN handle pointer.
+ */
+void FLEXCAN_TransferHandleIRQ(CAN_Type *base, flexcan_handle_t *handle);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_FLEXCAN_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ftm.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ftm.c
@@ -1,0 +1,876 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_ftm.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Gets the instance from the base address
+ *
+ * @param base FTM peripheral base address
+ *
+ * @return The FTM instance
+ */
+static uint32_t FTM_GetInstance(FTM_Type *base);
+
+/*!
+ * @brief Sets the FTM register PWM synchronization method
+ *
+ * This function will set the necessary bits for the PWM synchronization mode that
+ * user wishes to use.
+ *
+ * @param base       FTM peripheral base address
+ * @param syncMethod Syncronization methods to use to update buffered registers. This is a logical
+ *                   OR of members of the enumeration ::ftm_pwm_sync_method_t
+ */
+static void FTM_SetPwmSync(FTM_Type *base, uint32_t syncMethod);
+
+/*!
+ * @brief Sets the reload points used as loading points for register update
+ *
+ * This function will set the necessary bits based on what the user wishes to use as loading
+ * points for FTM register update. When using this it is not required to use PWM synchnronization.
+ *
+ * @param base         FTM peripheral base address
+ * @param reloadPoints FTM reload points. This is a logical OR of members of the
+ *                     enumeration ::ftm_reload_point_t
+ */
+static void FTM_SetReloadPoints(FTM_Type *base, uint32_t reloadPoints);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to FTM bases for each instance. */
+static FTM_Type *const s_ftmBases[] = FTM_BASE_PTRS;
+
+/*! @brief Pointers to FTM clocks for each instance. */
+static const clock_ip_name_t s_ftmClocks[] = FTM_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t FTM_GetInstance(FTM_Type *base)
+{
+    uint32_t instance;
+    uint32_t ftmArrayCount = (sizeof(s_ftmBases) / sizeof(s_ftmBases[0]));
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ftmArrayCount; instance++)
+    {
+        if (s_ftmBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ftmArrayCount);
+
+    return instance;
+}
+
+static void FTM_SetPwmSync(FTM_Type *base, uint32_t syncMethod)
+{
+    uint8_t chnlNumber = 0;
+    uint32_t reg = 0, syncReg = 0;
+
+    syncReg = base->SYNC;
+    /* Enable PWM synchronization of output mask register */
+    syncReg |= FTM_SYNC_SYNCHOM_MASK;
+
+    reg = base->COMBINE;
+    for (chnlNumber = 0; chnlNumber < (FSL_FEATURE_FTM_CHANNEL_COUNTn(base) / 2); chnlNumber++)
+    {
+        /* Enable PWM synchronization of registers C(n)V and C(n+1)V */
+        reg |= (1U << (FTM_COMBINE_SYNCEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlNumber)));
+    }
+    base->COMBINE = reg;
+
+    reg = base->SYNCONF;
+
+    /* Use enhanced PWM synchronization method. Use PWM sync to update register values */
+    reg |= (FTM_SYNCONF_SYNCMODE_MASK | FTM_SYNCONF_CNTINC_MASK | FTM_SYNCONF_INVC_MASK | FTM_SYNCONF_SWOC_MASK);
+
+    if (syncMethod & FTM_SYNC_SWSYNC_MASK)
+    {
+        /* Enable needed bits for software trigger to update registers with its buffer value */
+        reg |= (FTM_SYNCONF_SWRSTCNT_MASK | FTM_SYNCONF_SWWRBUF_MASK | FTM_SYNCONF_SWINVC_MASK |
+                FTM_SYNCONF_SWSOC_MASK | FTM_SYNCONF_SWOM_MASK);
+    }
+
+    if (syncMethod & (FTM_SYNC_TRIG0_MASK | FTM_SYNC_TRIG1_MASK | FTM_SYNC_TRIG2_MASK))
+    {
+        /* Enable needed bits for hardware trigger to update registers with its buffer value */
+        reg |= (FTM_SYNCONF_HWRSTCNT_MASK | FTM_SYNCONF_HWWRBUF_MASK | FTM_SYNCONF_HWINVC_MASK |
+                FTM_SYNCONF_HWSOC_MASK | FTM_SYNCONF_HWOM_MASK);
+
+        /* Enable the appropriate hardware trigger that is used for PWM sync */
+        if (syncMethod & FTM_SYNC_TRIG0_MASK)
+        {
+            syncReg |= FTM_SYNC_TRIG0_MASK;
+        }
+        if (syncMethod & FTM_SYNC_TRIG1_MASK)
+        {
+            syncReg |= FTM_SYNC_TRIG1_MASK;
+        }
+        if (syncMethod & FTM_SYNC_TRIG2_MASK)
+        {
+            syncReg |= FTM_SYNC_TRIG2_MASK;
+        }
+    }
+
+    /* Write back values to the SYNC register */
+    base->SYNC = syncReg;
+
+    /* Write the PWM synch values to the SYNCONF register */
+    base->SYNCONF = reg;
+}
+
+static void FTM_SetReloadPoints(FTM_Type *base, uint32_t reloadPoints)
+{
+    uint32_t chnlNumber = 0;
+    uint32_t reg = 0;
+
+    /* Need CNTINC bit to be 1 for CNTIN register to update with its buffer value on reload  */
+    base->SYNCONF |= FTM_SYNCONF_CNTINC_MASK;
+
+    reg = base->COMBINE;
+    for (chnlNumber = 0; chnlNumber < (FSL_FEATURE_FTM_CHANNEL_COUNTn(base) / 2); chnlNumber++)
+    {
+        /* Need SYNCEN bit to be 1 for CnV reg to update with its buffer value on reload  */
+        reg |= (1U << (FTM_COMBINE_SYNCEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlNumber)));
+    }
+    base->COMBINE = reg;
+
+    /* Set the reload points */
+    reg = base->PWMLOAD;
+
+    /* Enable the selected channel match reload points */
+    reg &= ~((1U << FSL_FEATURE_FTM_CHANNEL_COUNTn(base)) - 1);
+    reg |= (reloadPoints & ((1U << FSL_FEATURE_FTM_CHANNEL_COUNTn(base)) - 1));
+
+#if defined(FSL_FEATURE_FTM_HAS_HALFCYCLE_RELOAD) && (FSL_FEATURE_FTM_HAS_HALFCYCLE_RELOAD)
+    /* Enable half cycle match as a reload point */
+    if (reloadPoints & kFTM_HalfCycMatch)
+    {
+        reg |= FTM_PWMLOAD_HCSEL_MASK;
+    }
+    else
+    {
+        reg &= ~FTM_PWMLOAD_HCSEL_MASK;
+    }
+#endif /* FSL_FEATURE_FTM_HAS_HALFCYCLE_RELOAD */
+
+    base->PWMLOAD = reg;
+
+    /* These reload points are used when counter is in up-down counting mode */
+    reg = base->SYNC;
+    if (reloadPoints & kFTM_CntMax)
+    {
+        /* Reload when counter turns from up to down */
+        reg |= FTM_SYNC_CNTMAX_MASK;
+    }
+    else
+    {
+        reg &= ~FTM_SYNC_CNTMAX_MASK;
+    }
+
+    if (reloadPoints & kFTM_CntMin)
+    {
+        /* Reload when counter turns from down to up */
+        reg |= FTM_SYNC_CNTMIN_MASK;
+    }
+    else
+    {
+        reg &= ~FTM_SYNC_CNTMIN_MASK;
+    }
+    base->SYNC = reg;
+}
+
+status_t FTM_Init(FTM_Type *base, const ftm_config_t *config)
+{
+    assert(config);
+
+    uint32_t reg;
+
+    if (!(config->pwmSyncMode &
+          (FTM_SYNC_TRIG0_MASK | FTM_SYNC_TRIG1_MASK | FTM_SYNC_TRIG2_MASK | FTM_SYNC_SWSYNC_MASK)))
+    {
+        /* Invalid PWM sync mode */
+        return kStatus_Fail;
+    }
+
+    /* Ungate the FTM clock*/
+    CLOCK_EnableClock(s_ftmClocks[FTM_GetInstance(base)]);
+
+    /* Configure the fault mode, enable FTM mode and disable write protection */
+    base->MODE = FTM_MODE_FAULTM(config->faultMode) | FTM_MODE_FTMEN_MASK | FTM_MODE_WPDIS_MASK;
+
+    /* Configure the update mechanism for buffered registers */
+    FTM_SetPwmSync(base, config->pwmSyncMode);
+
+    if (config->reloadPoints)
+    {
+        /* Setup intermediate register reload points */
+        FTM_SetReloadPoints(base, config->reloadPoints);
+    }
+
+    /* Set the clock prescale factor */
+    base->SC = FTM_SC_PS(config->prescale);
+
+    /* Setup the counter operation */
+    base->CONF = (FTM_CONF_BDMMODE(config->bdmMode) | FTM_CONF_GTBEEN(config->useGlobalTimeBase));
+
+    /* Initial state of channel output */
+    base->OUTINIT = config->chnlInitState;
+
+    /* Channel polarity */
+    base->POL = config->chnlPolarity;
+
+    /* Set the external trigger sources */
+    base->EXTTRIG = config->extTriggers;
+#if defined(FSL_FEATURE_FTM_HAS_RELOAD_INITIALIZATION_TRIGGER) && (FSL_FEATURE_FTM_HAS_RELOAD_INITIALIZATION_TRIGGER)
+    if (config->extTriggers & kFTM_ReloadInitTrigger)
+    {
+        base->CONF |= FTM_CONF_ITRIGR_MASK;
+    }
+    else
+    {
+        base->CONF &= ~FTM_CONF_ITRIGR_MASK;
+    }
+#endif /* FSL_FEATURE_FTM_HAS_RELOAD_INITIALIZATION_TRIGGER */
+
+    /* FTM deadtime insertion control */
+    base->DEADTIME = (FTM_DEADTIME_DTPS(config->deadTimePrescale) | FTM_DEADTIME_DTVAL(config->deadTimeValue));
+
+    /* FTM fault filter value */
+    reg = base->FLTCTRL;
+    reg &= ~FTM_FLTCTRL_FFVAL_MASK;
+    reg |= FTM_FLTCTRL_FFVAL(config->faultFilterValue);
+    base->FLTCTRL = reg;
+
+    return kStatus_Success;
+}
+
+void FTM_Deinit(FTM_Type *base)
+{
+    /* Set clock source to none to disable counter */
+    base->SC &= ~(FTM_SC_CLKS_MASK);
+
+    /* Gate the FTM clock */
+    CLOCK_DisableClock(s_ftmClocks[FTM_GetInstance(base)]);
+}
+
+void FTM_GetDefaultConfig(ftm_config_t *config)
+{
+    assert(config);
+
+    /* Divide FTM clock by 1 */
+    config->prescale = kFTM_Prescale_Divide_1;
+    /* FTM behavior in BDM mode */
+    config->bdmMode = kFTM_BdmMode_0;
+    /* Software trigger will be used to update registers */
+    config->pwmSyncMode = kFTM_SoftwareTrigger;
+    /* No intermediate register load */
+    config->reloadPoints = 0;
+    /* Fault control disabled for all channels */
+    config->faultMode = kFTM_Fault_Disable;
+    /* Disable the fault filter */
+    config->faultFilterValue = 0;
+    /* Divide the system clock by 1 */
+    config->deadTimePrescale = kFTM_Deadtime_Prescale_1;
+    /* No counts are inserted */
+    config->deadTimeValue = 0;
+    /* No external trigger */
+    config->extTriggers = 0;
+    /* Initialization value is 0 for all channels */
+    config->chnlInitState = 0;
+    /* Active high polarity for all channels */
+    config->chnlPolarity = 0;
+    /* Use internal FTM counter as timebase */
+    config->useGlobalTimeBase = false;
+}
+
+status_t FTM_SetupPwm(FTM_Type *base,
+                      const ftm_chnl_pwm_signal_param_t *chnlParams,
+                      uint8_t numOfChnls,
+                      ftm_pwm_mode_t mode,
+                      uint32_t pwmFreq_Hz,
+                      uint32_t srcClock_Hz)
+{
+    assert(chnlParams);
+
+    uint32_t mod, reg;
+    uint32_t ftmClock = (srcClock_Hz / (1U << (base->SC & FTM_SC_PS_MASK)));
+    uint16_t cnv, cnvFirstEdge;
+    uint8_t i;
+
+    switch (mode)
+    {
+        case kFTM_EdgeAlignedPwm:
+        case kFTM_CombinedPwm:
+            base->SC &= ~FTM_SC_CPWMS_MASK;
+            mod = (ftmClock / pwmFreq_Hz) - 1;
+            break;
+        case kFTM_CenterAlignedPwm:
+            base->SC |= FTM_SC_CPWMS_MASK;
+            mod = ftmClock / (pwmFreq_Hz * 2);
+            break;
+        default:
+            return kStatus_Fail;
+    }
+
+    /* Return an error in case we overflow the registers, probably would require changing
+     * clock source to get the desired frequency */
+    if (mod > 65535U)
+    {
+        return kStatus_Fail;
+    }
+    /* Set the PWM period */
+    base->MOD = mod;
+
+    /* Setup each FTM channel */
+    for (i = 0; i < numOfChnls; i++)
+    {
+        /* Return error if requested dutycycle is greater than the max allowed */
+        if (chnlParams->dutyCyclePercent > 100)
+        {
+            return kStatus_Fail;
+        }
+
+        if ((mode == kFTM_EdgeAlignedPwm) || (mode == kFTM_CenterAlignedPwm))
+        {
+            /* Clear the current mode and edge level bits */
+            reg = base->CONTROLS[chnlParams->chnlNumber].CnSC;
+            reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+
+            /* Setup the active level */
+            reg |= (FTM_CnSC_ELSA(chnlParams->level) | FTM_CnSC_ELSB(chnlParams->level));
+
+            /* Edge-aligned mode needs MSB to be 1, don't care for Center-aligned mode */
+            reg |= FTM_CnSC_MSB(1U);
+
+            /* Update the mode and edge level */
+            base->CONTROLS[chnlParams->chnlNumber].CnSC = reg;
+
+            if (chnlParams->dutyCyclePercent == 0)
+            {
+                /* Signal stays low */
+                cnv = 0;
+            }
+            else
+            {
+                cnv = (mod * chnlParams->dutyCyclePercent) / 100;
+                /* For 100% duty cycle */
+                if (cnv >= mod)
+                {
+                    cnv = mod + 1;
+                }
+            }
+
+            base->CONTROLS[chnlParams->chnlNumber].CnV = cnv;
+        }
+        else
+        {
+            /* This check is added for combined mode as the channel number should be the pair number */
+            if (chnlParams->chnlNumber >= (FSL_FEATURE_FTM_CHANNEL_COUNTn(base) / 2))
+            {
+                return kStatus_Fail;
+            }
+
+            /* Return error if requested value is greater than the max allowed */
+            if (chnlParams->firstEdgeDelayPercent > 100)
+            {
+                return kStatus_Fail;
+            }
+
+            /* Configure delay of the first edge */
+            if (chnlParams->firstEdgeDelayPercent == 0)
+            {
+                /* No delay for the first edge */
+                cnvFirstEdge = 0;
+            }
+            else
+            {
+                cnvFirstEdge = (mod * chnlParams->firstEdgeDelayPercent) / 100;
+            }
+
+            /* Configure dutycycle */
+            if (chnlParams->dutyCyclePercent == 0)
+            {
+                /* Signal stays low */
+                cnv = 0;
+                cnvFirstEdge = 0;
+            }
+            else
+            {
+                cnv = (mod * chnlParams->dutyCyclePercent) / 100;
+                /* For 100% duty cycle */
+                if (cnv >= mod)
+                {
+                    cnv = mod + 1;
+                }
+            }
+
+            /* Clear the current mode and edge level bits for channel n */
+            reg = base->CONTROLS[chnlParams->chnlNumber * 2].CnSC;
+            reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+
+            /* Setup the active level for channel n */
+            reg |= (FTM_CnSC_ELSA(chnlParams->level) | FTM_CnSC_ELSB(chnlParams->level));
+
+            /* Update the mode and edge level for channel n */
+            base->CONTROLS[chnlParams->chnlNumber * 2].CnSC = reg;
+
+            /* Clear the current mode and edge level bits for channel n + 1 */
+            reg = base->CONTROLS[(chnlParams->chnlNumber * 2) + 1].CnSC;
+            reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+
+            /* Setup the active level for channel n + 1 */
+            reg |= (FTM_CnSC_ELSA(chnlParams->level) | FTM_CnSC_ELSB(chnlParams->level));
+
+            /* Update the mode and edge level for channel n + 1*/
+            base->CONTROLS[(chnlParams->chnlNumber * 2) + 1].CnSC = reg;
+
+            /* Set the channel pair values */
+            base->CONTROLS[chnlParams->chnlNumber * 2].CnV = cnvFirstEdge;
+            base->CONTROLS[(chnlParams->chnlNumber * 2) + 1].CnV = cnvFirstEdge + cnv;
+
+            /* Set the combine bit for the channel pair */
+            base->COMBINE |=
+                (1U << (FTM_COMBINE_COMBINE0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlParams->chnlNumber)));
+        }
+
+#if defined(FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT) && (FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT)
+        /* Set to output mode */
+        FTM_SetPwmOutputEnable(base, chnlParams->chnlNumber, true);
+#endif
+
+        chnlParams++;
+    }
+
+    return kStatus_Success;
+}
+
+void FTM_UpdatePwmDutycycle(FTM_Type *base,
+                            ftm_chnl_t chnlNumber,
+                            ftm_pwm_mode_t currentPwmMode,
+                            uint8_t dutyCyclePercent)
+{
+    uint16_t cnv, cnvFirstEdge = 0, mod;
+
+    mod = base->MOD;
+    if ((currentPwmMode == kFTM_EdgeAlignedPwm) || (currentPwmMode == kFTM_CenterAlignedPwm))
+    {
+        cnv = (mod * dutyCyclePercent) / 100;
+        /* For 100% duty cycle */
+        if (cnv >= mod)
+        {
+            cnv = mod + 1;
+        }
+        base->CONTROLS[chnlNumber].CnV = cnv;
+    }
+    else
+    {
+        /* This check is added for combined mode as the channel number should be the pair number */
+        if (chnlNumber >= (FSL_FEATURE_FTM_CHANNEL_COUNTn(base) / 2))
+        {
+            return;
+        }
+
+        cnv = (mod * dutyCyclePercent) / 100;
+        cnvFirstEdge = base->CONTROLS[chnlNumber * 2].CnV;
+        /* For 100% duty cycle */
+        if (cnv >= mod)
+        {
+            cnv = mod + 1;
+        }
+        base->CONTROLS[(chnlNumber * 2) + 1].CnV = cnvFirstEdge + cnv;
+    }
+}
+
+void FTM_UpdateChnlEdgeLevelSelect(FTM_Type *base, ftm_chnl_t chnlNumber, uint8_t level)
+{
+    uint32_t reg = base->CONTROLS[chnlNumber].CnSC;
+
+    /* Clear the field and write the new level value */
+    reg &= ~(FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+    reg |= ((uint32_t)level << FTM_CnSC_ELSA_SHIFT) & (FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+
+    base->CONTROLS[chnlNumber].CnSC = reg;
+}
+
+void FTM_SetupInputCapture(FTM_Type *base,
+                           ftm_chnl_t chnlNumber,
+                           ftm_input_capture_edge_t captureMode,
+                           uint32_t filterValue)
+{
+    uint32_t reg;
+
+    reg = base->CONTROLS[chnlNumber].CnSC;
+    reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+    reg |= captureMode;
+
+    /* Set the requested input capture mode */
+    base->CONTROLS[chnlNumber].CnSC = reg;
+    /* Input filter available only for channels 0, 1, 2, 3 */
+    if (chnlNumber < kFTM_Chnl_4)
+    {
+        reg = base->FILTER;
+        reg &= ~(FTM_FILTER_CH0FVAL_MASK << (FTM_FILTER_CH1FVAL_SHIFT * chnlNumber));
+        reg |= (filterValue << (FTM_FILTER_CH1FVAL_SHIFT * chnlNumber));
+        base->FILTER = reg;
+    }
+#if defined(FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT) && (FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT)
+    /* Set to input mode */
+    FTM_SetPwmOutputEnable(base, chnlNumber, false);
+#endif
+}
+
+void FTM_SetupOutputCompare(FTM_Type *base,
+                            ftm_chnl_t chnlNumber,
+                            ftm_output_compare_mode_t compareMode,
+                            uint32_t compareValue)
+{
+    uint32_t reg;
+
+    /* Set output on match to the requested level */
+    base->CONTROLS[chnlNumber].CnV = compareValue;
+
+    reg = base->CONTROLS[chnlNumber].CnSC;
+    reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+    reg |= compareMode;
+    /* Setup the channel output behaviour when a match occurs with the compare value */
+    base->CONTROLS[chnlNumber].CnSC = reg;
+
+#if defined(FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT) && (FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT)
+    /* Set to output mode */
+    FTM_SetPwmOutputEnable(base, chnlNumber, true);
+#endif
+}
+
+void FTM_SetupDualEdgeCapture(FTM_Type *base,
+                              ftm_chnl_t chnlPairNumber,
+                              const ftm_dual_edge_capture_param_t *edgeParam,
+                              uint32_t filterValue)
+{
+    assert(edgeParam);
+
+    uint32_t reg;
+
+    reg = base->COMBINE;
+    /* Clear the combine bit for the channel pair */
+    reg &= ~(1U << (FTM_COMBINE_COMBINE0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    /* Enable the DECAPEN bit */
+    reg |= (1U << (FTM_COMBINE_DECAPEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    reg |= (1U << (FTM_COMBINE_DECAP0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    base->COMBINE = reg;
+
+    /* Setup the edge detection from channel n and n + 1 */
+    reg = base->CONTROLS[chnlPairNumber * 2].CnSC;
+    reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+    reg |= ((uint32_t)edgeParam->mode | (uint32_t)edgeParam->currChanEdgeMode);
+    base->CONTROLS[chnlPairNumber * 2].CnSC = reg;
+
+    reg = base->CONTROLS[(chnlPairNumber * 2) + 1].CnSC;
+    reg &= ~(FTM_CnSC_MSA_MASK | FTM_CnSC_MSB_MASK | FTM_CnSC_ELSA_MASK | FTM_CnSC_ELSB_MASK);
+    reg |= ((uint32_t)edgeParam->mode | (uint32_t)edgeParam->nextChanEdgeMode);
+    base->CONTROLS[(chnlPairNumber * 2) + 1].CnSC = reg;
+
+    /* Input filter available only for channels 0, 1, 2, 3 */
+    if (chnlPairNumber < kFTM_Chnl_4)
+    {
+        reg = base->FILTER;
+        reg &= ~(FTM_FILTER_CH0FVAL_MASK << (FTM_FILTER_CH1FVAL_SHIFT * chnlPairNumber));
+        reg |= (filterValue << (FTM_FILTER_CH1FVAL_SHIFT * chnlPairNumber));
+        base->FILTER = reg;
+    }
+
+#if defined(FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT) && (FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT)
+    /* Set to input mode */
+    FTM_SetPwmOutputEnable(base, chnlPairNumber, false);
+#endif
+}
+
+void FTM_SetupQuadDecode(FTM_Type *base,
+                         const ftm_phase_params_t *phaseAParams,
+                         const ftm_phase_params_t *phaseBParams,
+                         ftm_quad_decode_mode_t quadMode)
+{
+    assert(phaseAParams);
+    assert(phaseBParams);
+
+    uint32_t reg;
+
+    /* Set Phase A filter value if phase filter is enabled */
+    if (phaseAParams->enablePhaseFilter)
+    {
+        reg = base->FILTER;
+        reg &= ~(FTM_FILTER_CH0FVAL_MASK);
+        reg |= FTM_FILTER_CH0FVAL(phaseAParams->phaseFilterVal);
+        base->FILTER = reg;
+    }
+
+    /* Set Phase B filter value if phase filter is enabled */
+    if (phaseBParams->enablePhaseFilter)
+    {
+        reg = base->FILTER;
+        reg &= ~(FTM_FILTER_CH1FVAL_MASK);
+        reg |= FTM_FILTER_CH1FVAL(phaseBParams->phaseFilterVal);
+        base->FILTER = reg;
+    }
+
+    /* Set Quadrature decode properties */
+    reg = base->QDCTRL;
+    reg &= ~(FTM_QDCTRL_QUADMODE_MASK | FTM_QDCTRL_PHAFLTREN_MASK | FTM_QDCTRL_PHBFLTREN_MASK | FTM_QDCTRL_PHAPOL_MASK |
+             FTM_QDCTRL_PHBPOL_MASK);
+    reg |= (FTM_QDCTRL_QUADMODE(quadMode) | FTM_QDCTRL_PHAFLTREN(phaseAParams->enablePhaseFilter) |
+            FTM_QDCTRL_PHBFLTREN(phaseBParams->enablePhaseFilter) | FTM_QDCTRL_PHAPOL(phaseAParams->phasePolarity) |
+            FTM_QDCTRL_PHBPOL(phaseBParams->phasePolarity));
+    base->QDCTRL = reg;
+    /* Enable Quad decode */
+    base->QDCTRL |= FTM_QDCTRL_QUADEN_MASK;
+}
+
+void FTM_SetupFault(FTM_Type *base, ftm_fault_input_t faultNumber, const ftm_fault_param_t *faultParams)
+{
+    uint32_t reg;
+
+    reg = base->FLTCTRL;
+    if (faultParams->enableFaultInput)
+    {
+        /* Enable the fault input */
+        reg |= (FTM_FLTCTRL_FAULT0EN_MASK << faultNumber);
+    }
+    else
+    {
+        /* Disable the fault input */
+        reg &= ~(FTM_FLTCTRL_FAULT0EN_MASK << faultNumber);
+    }
+
+    if (faultParams->useFaultFilter)
+    {
+        /* Enable the fault filter */
+        reg |= (FTM_FLTCTRL_FFLTR0EN_MASK << (FTM_FLTCTRL_FFLTR0EN_SHIFT + faultNumber));
+    }
+    else
+    {
+        /* Disable the fault filter */
+        reg &= ~(FTM_FLTCTRL_FFLTR0EN_MASK << (FTM_FLTCTRL_FFLTR0EN_SHIFT + faultNumber));
+    }
+    base->FLTCTRL = reg;
+
+    if (faultParams->faultLevel)
+    {
+        /* Active low polarity for the fault input pin */
+        base->FLTPOL |= (1U << faultNumber);
+    }
+    else
+    {
+        /* Active high polarity for the fault input pin */
+        base->FLTPOL &= ~(1U << faultNumber);
+    }
+}
+
+void FTM_EnableInterrupts(FTM_Type *base, uint32_t mask)
+{
+    uint32_t chnlInts = (mask & 0xFFU);
+    uint8_t chnlNumber = 0;
+
+    /* Enable the timer overflow interrupt */
+    if (mask & kFTM_TimeOverflowInterruptEnable)
+    {
+        base->SC |= FTM_SC_TOIE_MASK;
+    }
+
+    /* Enable the fault interrupt */
+    if (mask & kFTM_FaultInterruptEnable)
+    {
+        base->MODE |= FTM_MODE_FAULTIE_MASK;
+    }
+
+#if defined(FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT) && (FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT)
+    /* Enable the reload interrupt available only on certain SoC's */
+    if (mask & kFTM_ReloadInterruptEnable)
+    {
+        base->SC |= FTM_SC_RIE_MASK;
+    }
+#endif
+
+    /* Enable the channel interrupts */
+    while (chnlInts)
+    {
+        if (chnlInts & 0x1)
+        {
+            base->CONTROLS[chnlNumber].CnSC |= FTM_CnSC_CHIE_MASK;
+        }
+        chnlNumber++;
+        chnlInts = chnlInts >> 1U;
+    }
+}
+
+void FTM_DisableInterrupts(FTM_Type *base, uint32_t mask)
+{
+    uint32_t chnlInts = (mask & 0xFF);
+    uint8_t chnlNumber = 0;
+
+    /* Disable the timer overflow interrupt */
+    if (mask & kFTM_TimeOverflowInterruptEnable)
+    {
+        base->SC &= ~FTM_SC_TOIE_MASK;
+    }
+    /* Disable the fault interrupt */
+    if (mask & kFTM_FaultInterruptEnable)
+    {
+        base->MODE &= ~FTM_MODE_FAULTIE_MASK;
+    }
+
+#if defined(FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT) && (FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT)
+    /* Disable the reload interrupt available only on certain SoC's */
+    if (mask & kFTM_ReloadInterruptEnable)
+    {
+        base->SC &= ~FTM_SC_RIE_MASK;
+    }
+#endif
+
+    /* Disable the channel interrupts */
+    while (chnlInts)
+    {
+        if (chnlInts & 0x1)
+        {
+            base->CONTROLS[chnlNumber].CnSC &= ~FTM_CnSC_CHIE_MASK;
+        }
+        chnlNumber++;
+        chnlInts = chnlInts >> 1U;
+    }
+}
+
+uint32_t FTM_GetEnabledInterrupts(FTM_Type *base)
+{
+    uint32_t enabledInterrupts = 0;
+    int8_t chnlCount = FSL_FEATURE_FTM_CHANNEL_COUNTn(base);
+
+    /* The CHANNEL_COUNT macro returns -1 if it cannot match the FTM instance */
+    assert(chnlCount != -1);
+
+    /* Check if timer overflow interrupt is enabled */
+    if (base->SC & FTM_SC_TOIE_MASK)
+    {
+        enabledInterrupts |= kFTM_TimeOverflowInterruptEnable;
+    }
+    /* Check if fault interrupt is enabled */
+    if (base->MODE & FTM_MODE_FAULTIE_MASK)
+    {
+        enabledInterrupts |= kFTM_FaultInterruptEnable;
+    }
+
+#if defined(FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT) && (FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT)
+    /* Check if the reload interrupt is enabled */
+    if (base->SC & FTM_SC_RIE_MASK)
+    {
+        enabledInterrupts |= kFTM_ReloadInterruptEnable;
+    }
+#endif
+
+    /* Check if the channel interrupts are enabled */
+    while (chnlCount > 0)
+    {
+        chnlCount--;
+        if (base->CONTROLS[chnlCount].CnSC & FTM_CnSC_CHIE_MASK)
+        {
+            enabledInterrupts |= (1U << chnlCount);
+        }
+    }
+
+    return enabledInterrupts;
+}
+
+uint32_t FTM_GetStatusFlags(FTM_Type *base)
+{
+    uint32_t statusFlags = 0;
+
+    /* Check the timer flag */
+    if (base->SC & FTM_SC_TOF_MASK)
+    {
+        statusFlags |= kFTM_TimeOverflowFlag;
+    }
+    /* Check fault flag */
+    if (base->FMS & FTM_FMS_FAULTF_MASK)
+    {
+        statusFlags |= kFTM_FaultFlag;
+    }
+    /* Check channel trigger flag */
+    if (base->EXTTRIG & FTM_EXTTRIG_TRIGF_MASK)
+    {
+        statusFlags |= kFTM_ChnlTriggerFlag;
+    }
+#if defined(FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT) && (FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT)
+    /* Check reload flag */
+    if (base->SC & FTM_SC_RF_MASK)
+    {
+        statusFlags |= kFTM_ReloadFlag;
+    }
+#endif
+
+    /* Lower 8 bits contain the channel status flags */
+    statusFlags |= (base->STATUS & 0xFFU);
+
+    return statusFlags;
+}
+
+void FTM_ClearStatusFlags(FTM_Type *base, uint32_t mask)
+{
+    /* Clear the timer overflow flag by writing a 0 to the bit while it is set */
+    if (mask & kFTM_TimeOverflowFlag)
+    {
+        base->SC &= ~FTM_SC_TOF_MASK;
+    }
+    /* Clear fault flag by writing a 0 to the bit while it is set */
+    if (mask & kFTM_FaultFlag)
+    {
+        base->FMS &= ~FTM_FMS_FAULTF_MASK;
+    }
+    /* Clear channel trigger flag */
+    if (mask & kFTM_ChnlTriggerFlag)
+    {
+        base->EXTTRIG &= ~FTM_EXTTRIG_TRIGF_MASK;
+    }
+
+#if defined(FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT) && (FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT)
+    /* Check reload flag by writing a 0 to the bit while it is set */
+    if (mask & kFTM_ReloadFlag)
+    {
+        base->SC &= ~FTM_SC_RF_MASK;
+    }
+#endif
+    /* Clear the channel status flags by writing a 0 to the bit */
+    base->STATUS &= ~(mask & 0xFFU);
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ftm.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_ftm.h
@@ -1,0 +1,862 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_FTM_H_
+#define _FSL_FTM_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup ftm_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_FTM_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0 */
+/*@}*/
+
+/*!
+ * @brief List of FTM channels
+ * @note Actual number of available channels is SoC dependent
+ */
+typedef enum _ftm_chnl
+{
+    kFTM_Chnl_0 = 0U, /*!< FTM channel number 0*/
+    kFTM_Chnl_1,      /*!< FTM channel number 1 */
+    kFTM_Chnl_2,      /*!< FTM channel number 2 */
+    kFTM_Chnl_3,      /*!< FTM channel number 3 */
+    kFTM_Chnl_4,      /*!< FTM channel number 4 */
+    kFTM_Chnl_5,      /*!< FTM channel number 5 */
+    kFTM_Chnl_6,      /*!< FTM channel number 6 */
+    kFTM_Chnl_7       /*!< FTM channel number 7 */
+} ftm_chnl_t;
+
+/*! @brief List of FTM faults */
+typedef enum _ftm_fault_input
+{
+    kFTM_Fault_0 = 0U, /*!< FTM fault 0 input pin */
+    kFTM_Fault_1,      /*!< FTM fault 1 input pin */
+    kFTM_Fault_2,      /*!< FTM fault 2 input pin */
+    kFTM_Fault_3       /*!< FTM fault 3 input pin */
+} ftm_fault_input_t;
+
+/*! @brief FTM PWM operation modes */
+typedef enum _ftm_pwm_mode
+{
+    kFTM_EdgeAlignedPwm = 0U, /*!< Edge-aligned PWM */
+    kFTM_CenterAlignedPwm,    /*!< Center-aligned PWM */
+    kFTM_CombinedPwm          /*!< Combined PWM */
+} ftm_pwm_mode_t;
+
+/*! @brief FTM PWM output pulse mode: high-true, low-true or no output */
+typedef enum _ftm_pwm_level_select
+{
+    kFTM_NoPwmSignal = 0U, /*!< No PWM output on pin */
+    kFTM_LowTrue,          /*!< Low true pulses */
+    kFTM_HighTrue          /*!< High true pulses */
+} ftm_pwm_level_select_t;
+
+/*! @brief Options to configure a FTM channel's PWM signal */
+typedef struct _ftm_chnl_pwm_signal_param
+{
+    ftm_chnl_t chnlNumber;         /*!< The channel/channel pair number.
+                                        In combined mode, this represents the channel pair number. */
+    ftm_pwm_level_select_t level;  /*!< PWM output active level select. */
+    uint8_t dutyCyclePercent;      /*!< PWM pulse width, value should be between 0 to 100
+                                        0 = inactive signal(0% duty cycle)...
+                                        100 = always active signal (100% duty cycle).*/
+    uint8_t firstEdgeDelayPercent; /*!< Used only in combined PWM mode to generate an asymmetrical PWM.
+                                        Specifies the delay to the first edge in a PWM period.
+                                        If unsure leave as 0; Should be specified as a
+                                        percentage of the PWM period */
+} ftm_chnl_pwm_signal_param_t;
+
+/*! @brief FlexTimer output compare mode */
+typedef enum _ftm_output_compare_mode
+{
+    kFTM_NoOutputSignal = (1U << FTM_CnSC_MSA_SHIFT), /*!< No channel output when counter reaches CnV  */
+    kFTM_ToggleOnMatch = ((1U << FTM_CnSC_MSA_SHIFT) | (1U << FTM_CnSC_ELSA_SHIFT)), /*!< Toggle output */
+    kFTM_ClearOnMatch = ((1U << FTM_CnSC_MSA_SHIFT) | (2U << FTM_CnSC_ELSA_SHIFT)),  /*!< Clear output */
+    kFTM_SetOnMatch = ((1U << FTM_CnSC_MSA_SHIFT) | (3U << FTM_CnSC_ELSA_SHIFT))     /*!< Set output */
+} ftm_output_compare_mode_t;
+
+/*! @brief FlexTimer input capture edge */
+typedef enum _ftm_input_capture_edge
+{
+    kFTM_RisingEdge = (1U << FTM_CnSC_ELSA_SHIFT),     /*!< Capture on rising edge only*/
+    kFTM_FallingEdge = (2U << FTM_CnSC_ELSA_SHIFT),    /*!< Capture on falling edge only*/
+    kFTM_RiseAndFallEdge = (3U << FTM_CnSC_ELSA_SHIFT) /*!< Capture on rising or falling edge */
+} ftm_input_capture_edge_t;
+
+/*! @brief FlexTimer dual edge capture modes */
+typedef enum _ftm_dual_edge_capture_mode
+{
+    kFTM_OneShot = 0U,                           /*!< One-shot capture mode */
+    kFTM_Continuous = (1U << FTM_CnSC_MSA_SHIFT) /*!< Continuous capture mode */
+} ftm_dual_edge_capture_mode_t;
+
+/*! @brief FlexTimer dual edge capture parameters */
+typedef struct _ftm_dual_edge_capture_param
+{
+    ftm_dual_edge_capture_mode_t mode;         /*!< Dual Edge Capture mode */
+    ftm_input_capture_edge_t currChanEdgeMode; /*!< Input capture edge select for channel n */
+    ftm_input_capture_edge_t nextChanEdgeMode; /*!< Input capture edge select for channel n+1 */
+} ftm_dual_edge_capture_param_t;
+
+/*! @brief FlexTimer quadrature decode modes */
+typedef enum _ftm_quad_decode_mode
+{
+    kFTM_QuadPhaseEncode = 0U, /*!< Phase A and Phase B encoding mode */
+    kFTM_QuadCountAndDir       /*!< Count and direction encoding mode */
+} ftm_quad_decode_mode_t;
+
+/*! @brief FlexTimer quadrature phase polarities */
+typedef enum _ftm_phase_polarity
+{
+    kFTM_QuadPhaseNormal = 0U, /*!< Phase input signal is not inverted */
+    kFTM_QuadPhaseInvert       /*!< Phase input signal is inverted */
+} ftm_phase_polarity_t;
+
+/*! @brief FlexTimer quadrature decode phase parameters */
+typedef struct _ftm_phase_param
+{
+    bool enablePhaseFilter;             /*!< True: enable phase filter; false: disable filter */
+    uint32_t phaseFilterVal;            /*!< Filter value, used only if phase filter is enabled */
+    ftm_phase_polarity_t phasePolarity; /*!< Phase polarity */
+} ftm_phase_params_t;
+
+/*! @brief Structure is used to hold the parameters to configure a FTM fault */
+typedef struct _ftm_fault_param
+{
+    bool enableFaultInput; /*!< True: Fault input is enabled; false: Fault input is disabled */
+    bool faultLevel;       /*!< True: Fault polarity is active low i.e '0' indicates a fault;
+                                False: Fault polarity is active high */
+    bool useFaultFilter;   /*!< True: Use the filtered fault signal;
+                                False: Use the direct path from fault input */
+} ftm_fault_param_t;
+
+/*! @brief FlexTimer pre-scaler factor for the dead time insertion*/
+typedef enum _ftm_deadtime_prescale
+{
+    kFTM_Deadtime_Prescale_1 = 1U, /*!< Divide by 1 */
+    kFTM_Deadtime_Prescale_4,      /*!< Divide by 4 */
+    kFTM_Deadtime_Prescale_16      /*!< Divide by 16 */
+} ftm_deadtime_prescale_t;
+
+/*! @brief FlexTimer clock source selection*/
+typedef enum _ftm_clock_source
+{
+    kFTM_SystemClock = 1U, /*!< System clock selected */
+    kFTM_FixedClock,       /*!< Fixed frequency clock */
+    kFTM_ExternalClock     /*!< External clock */
+} ftm_clock_source_t;
+
+/*! @brief FlexTimer pre-scaler factor selection for the clock source*/
+typedef enum _ftm_clock_prescale
+{
+    kFTM_Prescale_Divide_1 = 0U, /*!< Divide by 1 */
+    kFTM_Prescale_Divide_2,      /*!< Divide by 2 */
+    kFTM_Prescale_Divide_4,      /*!< Divide by 4 */
+    kFTM_Prescale_Divide_8,      /*!< Divide by 8 */
+    kFTM_Prescale_Divide_16,     /*!< Divide by 16 */
+    kFTM_Prescale_Divide_32,     /*!< Divide by 32 */
+    kFTM_Prescale_Divide_64,     /*!< Divide by 64 */
+    kFTM_Prescale_Divide_128     /*!< Divide by 128 */
+} ftm_clock_prescale_t;
+
+/*! @brief Options for the FlexTimer behaviour in BDM Mode */
+typedef enum _ftm_bdm_mode
+{
+    kFTM_BdmMode_0 = 0U,
+    /*!< FTM counter stopped, CH(n)F bit can be set, FTM channels in functional mode, writes to MOD,CNTIN and C(n)V
+       registers bypass the register buffers */
+    kFTM_BdmMode_1,
+    /*!< FTM counter stopped, CH(n)F bit is not set, FTM channels outputs are forced to their safe value , writes to
+       MOD,CNTIN and C(n)V registers bypass the register buffers */
+    kFTM_BdmMode_2,
+    /*!< FTM counter stopped, CH(n)F bit is not set, FTM channels outputs are frozen when chip enters in BDM mode,
+       writes to MOD,CNTIN and C(n)V registers bypass the register buffers */
+    kFTM_BdmMode_3
+    /*!< FTM counter in functional mode, CH(n)F bit can be set, FTM channels in functional mode, writes to MOD,CNTIN and
+       C(n)V registers is in fully functional mode */
+} ftm_bdm_mode_t;
+
+/*! @brief Options for the FTM fault control mode */
+typedef enum _ftm_fault_mode
+{
+    kFTM_Fault_Disable = 0U, /*!< Fault control is disabled for all channels */
+    kFTM_Fault_EvenChnls,    /*!< Enabled for even channels only(0,2,4,6) with manual fault clearing */
+    kFTM_Fault_AllChnlsMan,  /*!< Enabled for all channels with manual fault clearing */
+    kFTM_Fault_AllChnlsAuto  /*!< Enabled for all channels with automatic fault clearing */
+} ftm_fault_mode_t;
+
+/*!
+ * @brief FTM external trigger options
+ * @note Actual available external trigger sources are SoC-specific
+ */
+typedef enum _ftm_external_trigger
+{
+    kFTM_Chnl0Trigger = (1U << 4), /*!< Generate trigger when counter equals chnl 0 CnV reg */
+    kFTM_Chnl1Trigger = (1U << 5), /*!< Generate trigger when counter equals chnl 1 CnV reg */
+    kFTM_Chnl2Trigger = (1U << 0), /*!< Generate trigger when counter equals chnl 2 CnV reg */
+    kFTM_Chnl3Trigger = (1U << 1), /*!< Generate trigger when counter equals chnl 3 CnV reg */
+    kFTM_Chnl4Trigger = (1U << 2), /*!< Generate trigger when counter equals chnl 4 CnV reg */
+    kFTM_Chnl5Trigger = (1U << 3), /*!< Generate trigger when counter equals chnl 5 CnV reg */
+    kFTM_Chnl6Trigger =
+        (1U << 8), /*!< Available on certain SoC's, generate trigger when counter equals chnl 6 CnV reg */
+    kFTM_Chnl7Trigger =
+        (1U << 9), /*!< Available on certain SoC's, generate trigger when counter equals chnl 7 CnV reg */
+    kFTM_InitTrigger = (1U << 6),      /*!< Generate Trigger when counter is updated with CNTIN */
+    kFTM_ReloadInitTrigger = (1U << 7) /*!< Available on certain SoC's, trigger on reload point */
+} ftm_external_trigger_t;
+
+/*! @brief FlexTimer PWM sync options to update registers with buffer */
+typedef enum _ftm_pwm_sync_method
+{
+    kFTM_SoftwareTrigger = FTM_SYNC_SWSYNC_MASK,  /*!< Software triggers PWM sync */
+    kFTM_HardwareTrigger_0 = FTM_SYNC_TRIG0_MASK, /*!< Hardware trigger 0 causes PWM sync */
+    kFTM_HardwareTrigger_1 = FTM_SYNC_TRIG1_MASK, /*!< Hardware trigger 1 causes PWM sync */
+    kFTM_HardwareTrigger_2 = FTM_SYNC_TRIG2_MASK  /*!< Hardware trigger 2 causes PWM sync */
+} ftm_pwm_sync_method_t;
+
+/*!
+ * @brief FTM options available as loading point for register reload
+ * @note Actual available reload points are SoC-specific
+ */
+typedef enum _ftm_reload_point
+{
+    kFTM_Chnl0Match = (1U << 0),   /*!< Channel 0 match included as a reload point */
+    kFTM_Chnl1Match = (1U << 1),   /*!< Channel 1 match included as a reload point */
+    kFTM_Chnl2Match = (1U << 2),   /*!< Channel 2 match included as a reload point */
+    kFTM_Chnl3Match = (1U << 3),   /*!< Channel 3 match included as a reload point */
+    kFTM_Chnl4Match = (1U << 4),   /*!< Channel 4 match included as a reload point */
+    kFTM_Chnl5Match = (1U << 5),   /*!< Channel 5 match included as a reload point */
+    kFTM_Chnl6Match = (1U << 6),   /*!< Channel 6 match included as a reload point */
+    kFTM_Chnl7Match = (1U << 7),   /*!< Channel 7 match included as a reload point */
+    kFTM_CntMax = (1U << 8),       /*!< Use in up-down count mode only, reload when counter reaches the maximum value */
+    kFTM_CntMin = (1U << 9),       /*!< Use in up-down count mode only, reload when counter reaches the minimum value */
+    kFTM_HalfCycMatch = (1U << 10) /*!< Available on certain SoC's, half cycle match reload point */
+} ftm_reload_point_t;
+
+/*!
+ * @brief List of FTM interrupts
+ * @note Actual available interrupts are SoC-specific
+ */
+typedef enum _ftm_interrupt_enable
+{
+    kFTM_Chnl0InterruptEnable = (1U << 0),        /*!< Channel 0 interrupt */
+    kFTM_Chnl1InterruptEnable = (1U << 1),        /*!< Channel 1 interrupt */
+    kFTM_Chnl2InterruptEnable = (1U << 2),        /*!< Channel 2 interrupt */
+    kFTM_Chnl3InterruptEnable = (1U << 3),        /*!< Channel 3 interrupt */
+    kFTM_Chnl4InterruptEnable = (1U << 4),        /*!< Channel 4 interrupt */
+    kFTM_Chnl5InterruptEnable = (1U << 5),        /*!< Channel 5 interrupt */
+    kFTM_Chnl6InterruptEnable = (1U << 6),        /*!< Channel 6 interrupt */
+    kFTM_Chnl7InterruptEnable = (1U << 7),        /*!< Channel 7 interrupt */
+    kFTM_FaultInterruptEnable = (1U << 8),        /*!< Fault interrupt */
+    kFTM_TimeOverflowInterruptEnable = (1U << 9), /*!< Time overflow interrupt */
+    kFTM_ReloadInterruptEnable = (1U << 10)       /*!< Reload interrupt; Available only on certain SoC's */
+} ftm_interrupt_enable_t;
+
+/*!
+ * @brief List of FTM flags
+ * @note Actual available flags are SoC-specific
+ */
+typedef enum _ftm_status_flags
+{
+    kFTM_Chnl0Flag = (1U << 0),        /*!< Channel 0 Flag */
+    kFTM_Chnl1Flag = (1U << 1),        /*!< Channel 1 Flag */
+    kFTM_Chnl2Flag = (1U << 2),        /*!< Channel 2 Flag */
+    kFTM_Chnl3Flag = (1U << 3),        /*!< Channel 3 Flag */
+    kFTM_Chnl4Flag = (1U << 4),        /*!< Channel 4 Flag */
+    kFTM_Chnl5Flag = (1U << 5),        /*!< Channel 5 Flag */
+    kFTM_Chnl6Flag = (1U << 6),        /*!< Channel 6 Flag */
+    kFTM_Chnl7Flag = (1U << 7),        /*!< Channel 7 Flag */
+    kFTM_FaultFlag = (1U << 8),        /*!< Fault Flag */
+    kFTM_TimeOverflowFlag = (1U << 9), /*!< Time overflow Flag */
+    kFTM_ChnlTriggerFlag = (1U << 10), /*!< Channel trigger Flag */
+    kFTM_ReloadFlag = (1U << 11)       /*!< Reload Flag; Available only on certain SoC's */
+} ftm_status_flags_t;
+
+/*!
+ * @brief FTM configuration structure
+ *
+ * This structure holds the configuration settings for the FTM peripheral. To initialize this
+ * structure to reasonable defaults, call the FTM_GetDefaultConfig() function and pass a
+ * pointer to the configuration structure instance.
+ *
+ * The configuration structure can be made constant so as to reside in flash.
+ */
+typedef struct _ftm_config
+{
+    ftm_clock_prescale_t prescale;            /*!< FTM clock prescale value */
+    ftm_bdm_mode_t bdmMode;                   /*!< FTM behavior in BDM mode */
+    uint32_t pwmSyncMode;                     /*!< Synchronization methods to use to update buffered registers; Multiple
+                                                   update modes can be used by providing an OR'ed list of options
+                                                   available in enumeration ::ftm_pwm_sync_method_t. */
+    uint32_t reloadPoints;                    /*!< FTM reload points; When using this, the PWM
+                                                   synchronization is not required. Multiple reload points can be used by providing
+                                                   an OR'ed list of options available in
+                                                   enumeration ::ftm_reload_point_t. */
+    ftm_fault_mode_t faultMode;               /*!< FTM fault control mode */
+    uint8_t faultFilterValue;                 /*!< Fault input filter value */
+    ftm_deadtime_prescale_t deadTimePrescale; /*!< The dead time prescalar value */
+    uint8_t deadTimeValue;                    /*!< The dead time value */
+    uint32_t extTriggers;                     /*!< External triggers to enable. Multiple trigger sources can be
+                                                   enabled by providing an OR'ed list of options available in
+                                                   enumeration ::ftm_external_trigger_t. */
+    uint8_t chnlInitState;  /*!< Defines the initialization value of the channels in OUTINT register */
+    uint8_t chnlPolarity;   /*!< Defines the output polarity of the channels in POL register */
+    bool useGlobalTimeBase; /*!< True: Use of an external global time base is enabled;
+                                 False: disabled */
+} ftm_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Ungates the FTM clock and configures the peripheral for basic operation.
+ *
+ * @note This API should be called at the beginning of the application using the FTM driver.
+ *
+ * @param base   FTM peripheral base address
+ * @param config Pointer to the user configuration structure.
+ *
+ * @return kStatus_Success indicates success; Else indicates failure.
+ */
+status_t FTM_Init(FTM_Type *base, const ftm_config_t *config);
+
+/*!
+ * @brief Gates the FTM clock.
+ *
+ * @param base FTM peripheral base address
+ */
+void FTM_Deinit(FTM_Type *base);
+
+/*!
+ * @brief  Fills in the FTM configuration structure with the default settings.
+ *
+ * The default values are:
+ * @code
+ *   config->prescale = kFTM_Prescale_Divide_1;
+ *   config->bdmMode = kFTM_BdmMode_0;
+ *   config->pwmSyncMode = kFTM_SoftwareTrigger;
+ *   config->reloadPoints = 0;
+ *   config->faultMode = kFTM_Fault_Disable;
+ *   config->faultFilterValue = 0;
+ *   config->deadTimePrescale = kFTM_Deadtime_Prescale_1;
+ *   config->deadTimeValue =  0;
+ *   config->extTriggers = 0;
+ *   config->chnlInitState = 0;
+ *   config->chnlPolarity = 0;
+ *   config->useGlobalTimeBase = false;
+ * @endcode
+ * @param config Pointer to the user configuration structure.
+ */
+void FTM_GetDefaultConfig(ftm_config_t *config);
+
+/*! @}*/
+
+/*!
+ * @name Channel mode operations
+ * @{
+ */
+
+/*!
+ * @brief Configures the PWM signal parameters.
+ *
+ * Call this function to configure the PWM signal period, mode, duty cycle, and edge. Use this
+ * function to configure all FTM channels that are used to output a PWM signal.
+ *
+ * @param base        FTM peripheral base address
+ * @param chnlParams  Array of PWM channel parameters to configure the channel(s)
+ * @param numOfChnls  Number of channels to configure; This should be the size of the array passed in
+ * @param mode        PWM operation mode, options available in enumeration ::ftm_pwm_mode_t
+ * @param pwmFreq_Hz  PWM signal frequency in Hz
+ * @param srcClock_Hz FTM counter clock in Hz
+ *
+ * @return kStatus_Success if the PWM setup was successful
+ *         kStatus_Error on failure
+ */
+status_t FTM_SetupPwm(FTM_Type *base,
+                      const ftm_chnl_pwm_signal_param_t *chnlParams,
+                      uint8_t numOfChnls,
+                      ftm_pwm_mode_t mode,
+                      uint32_t pwmFreq_Hz,
+                      uint32_t srcClock_Hz);
+
+/*!
+ * @brief Updates the duty cycle of an active PWM signal.
+ *
+ * @param base              FTM peripheral base address
+ * @param chnlNumber        The channel/channel pair number. In combined mode, this represents
+ *                          the channel pair number
+ * @param currentPwmMode    The current PWM mode set during PWM setup
+ * @param dutyCyclePercent  New PWM pulse width; The value should be between 0 to 100
+ *                          0=inactive signal(0% duty cycle)...
+ *                          100=active signal (100% duty cycle)
+ */
+void FTM_UpdatePwmDutycycle(FTM_Type *base,
+                            ftm_chnl_t chnlNumber,
+                            ftm_pwm_mode_t currentPwmMode,
+                            uint8_t dutyCyclePercent);
+
+/*!
+ * @brief Updates the edge level selection for a channel.
+ *
+ * @param base       FTM peripheral base address
+ * @param chnlNumber The channel number
+ * @param level      The level to be set to the ELSnB:ELSnA field; Valid values are 00, 01, 10, 11.
+ *                   See the Kinetis SoC reference manual for details about this field.
+ */
+void FTM_UpdateChnlEdgeLevelSelect(FTM_Type *base, ftm_chnl_t chnlNumber, uint8_t level);
+
+/*!
+ * @brief Enables capturing an input signal on the channel using the function parameters.
+ *
+ * When the edge specified in the captureMode argument occurs on the channel, the FTM counter is
+ * captured into the CnV register. The user has to read the CnV register separately to get this
+ * value. The filter function is disabled if the filterVal argument passed in is 0. The filter
+ * function is available only for channels 0, 1, 2, 3.
+ *
+ * @param base        FTM peripheral base address
+ * @param chnlNumber  The channel number
+ * @param captureMode Specifies which edge to capture
+ * @param filterValue Filter value, specify 0 to disable filter. Available only for channels 0-3.
+ */
+void FTM_SetupInputCapture(FTM_Type *base,
+                           ftm_chnl_t chnlNumber,
+                           ftm_input_capture_edge_t captureMode,
+                           uint32_t filterValue);
+
+/*!
+ * @brief Configures the FTM to generate timed pulses.
+ *
+ * When the FTM counter matches the value of compareVal argument (this is written into CnV reg),
+ * the channel output is changed based on what is specified in the compareMode argument.
+ *
+ * @param base         FTM peripheral base address
+ * @param chnlNumber   The channel number
+ * @param compareMode  Action to take on the channel output when the compare condition is met
+ * @param compareValue Value to be programmed in the CnV register.
+ */
+void FTM_SetupOutputCompare(FTM_Type *base,
+                            ftm_chnl_t chnlNumber,
+                            ftm_output_compare_mode_t compareMode,
+                            uint32_t compareValue);
+
+/*!
+ * @brief Configures the dual edge capture mode of the FTM.
+ *
+ * This function sets up the dual edge capture mode on a channel pair. The capture edge for the
+ * channel pair and the capture mode (one-shot or continuous) is specified in the parameter
+ * argument. The filter function is disabled if the filterVal argument passed is zero. The filter
+ * function is available only on channels 0 and 2. The user has to read the channel CnV registers
+ * separately to get the capture values.
+ *
+ * @param base           FTM peripheral base address
+ * @param chnlPairNumber The FTM channel pair number; options are 0, 1, 2, 3
+ * @param edgeParam      Sets up the dual edge capture function
+ * @param filterValue    Filter value, specify 0 to disable filter. Available only for channel pair 0 and 1.
+ */
+void FTM_SetupDualEdgeCapture(FTM_Type *base,
+                              ftm_chnl_t chnlPairNumber,
+                              const ftm_dual_edge_capture_param_t *edgeParam,
+                              uint32_t filterValue);
+
+/*! @}*/
+
+/*!
+ * @brief Configures the parameters and activates the quadrature decoder mode.
+ *
+ * @param base         FTM peripheral base address
+ * @param phaseAParams Phase A configuration parameters
+ * @param phaseBParams Phase B configuration parameters
+ * @param quadMode     Selects encoding mode used in quadrature decoder mode
+ */
+void FTM_SetupQuadDecode(FTM_Type *base,
+                         const ftm_phase_params_t *phaseAParams,
+                         const ftm_phase_params_t *phaseBParams,
+                         ftm_quad_decode_mode_t quadMode);
+
+/*!
+ * @brief Sets up the working of the FTM fault protection.
+ *
+ * FTM can have up to 4 fault inputs. This function sets up fault parameters, fault level, and a filter.
+ *
+ * @param base        FTM peripheral base address
+ * @param faultNumber FTM fault to configure.
+ * @param faultParams Parameters passed in to set up the fault
+ */
+void FTM_SetupFault(FTM_Type *base, ftm_fault_input_t faultNumber, const ftm_fault_param_t *faultParams);
+
+/*!
+ * @name Interrupt Interface
+ * @{
+ */
+
+/*!
+ * @brief Enables the selected FTM interrupts.
+ *
+ * @param base FTM peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::ftm_interrupt_enable_t
+ */
+void FTM_EnableInterrupts(FTM_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables the selected FTM interrupts.
+ *
+ * @param base FTM peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::ftm_interrupt_enable_t
+ */
+void FTM_DisableInterrupts(FTM_Type *base, uint32_t mask);
+
+/*!
+ * @brief Gets the enabled FTM interrupts.
+ *
+ * @param base FTM peripheral base address
+ *
+ * @return The enabled interrupts. This is the logical OR of members of the
+ *         enumeration ::ftm_interrupt_enable_t
+ */
+uint32_t FTM_GetEnabledInterrupts(FTM_Type *base);
+
+/*! @}*/
+
+/*!
+ * @name Status Interface
+ * @{
+ */
+
+/*!
+ * @brief Gets the FTM status flags.
+ *
+ * @param base FTM peripheral base address
+ *
+ * @return The status flags. This is the logical OR of members of the
+ *         enumeration ::ftm_status_flags_t
+ */
+uint32_t FTM_GetStatusFlags(FTM_Type *base);
+
+/*!
+ * @brief Clears the FTM status flags.
+ *
+ * @param base FTM peripheral base address
+ * @param mask The status flags to clear. This is a logical OR of members of the
+ *             enumeration ::ftm_status_flags_t
+ */
+void FTM_ClearStatusFlags(FTM_Type *base, uint32_t mask);
+
+/*! @}*/
+
+/*!
+ * @name Timer Start and Stop
+ * @{
+ */
+
+/*!
+ * @brief Starts the FTM counter.
+ *
+ * @param base        FTM peripheral base address
+ * @param clockSource FTM clock source; After the clock source is set, the counter starts running.
+ */
+static inline void FTM_StartTimer(FTM_Type *base, ftm_clock_source_t clockSource)
+{
+    uint32_t reg = base->SC;
+
+    reg &= ~(FTM_SC_CLKS_MASK);
+    reg |= FTM_SC_CLKS(clockSource);
+    base->SC = reg;
+}
+
+/*!
+ * @brief Stops the FTM counter.
+ *
+ * @param base FTM peripheral base address
+ */
+static inline void FTM_StopTimer(FTM_Type *base)
+{
+    /* Set clock source to none to disable counter */
+    base->SC &= ~(FTM_SC_CLKS_MASK);
+}
+
+/*! @}*/
+
+/*!
+ * @name Software output control
+ * @{
+ */
+
+/*!
+ * @brief Enables or disables the channel software output control.
+ *
+ * @param base       FTM peripheral base address
+ * @param chnlNumber Channel to be enabled or disabled
+ * @param value      true: channel output is affected by software output control
+                     false: channel output is unaffected by software output control
+ */
+static inline void FTM_SetSoftwareCtrlEnable(FTM_Type *base, ftm_chnl_t chnlNumber, bool value)
+{
+    if (value)
+    {
+        base->SWOCTRL |= (1U << chnlNumber);
+    }
+    else
+    {
+        base->SWOCTRL &= ~(1U << chnlNumber);
+    }
+}
+
+/*!
+ * @brief Sets the channel software output control value.
+ *
+ * @param base       FTM peripheral base address.
+ * @param chnlNumber Channel to be configured
+ * @param value      true to set 1, false to set 0
+ */
+static inline void FTM_SetSoftwareCtrlVal(FTM_Type *base, ftm_chnl_t chnlNumber, bool value)
+{
+    if (value)
+    {
+        base->SWOCTRL |= (1U << (chnlNumber + FTM_SWOCTRL_CH0OCV_SHIFT));
+    }
+    else
+    {
+        base->SWOCTRL &= ~(1U << (chnlNumber + FTM_SWOCTRL_CH0OCV_SHIFT));
+    }
+}
+
+/*! @}*/
+
+/*!
+ * @brief Enables or disables the FTM global time base signal generation to other FTMs.
+ *
+ * @param base   FTM peripheral base address
+ * @param enable true to enable, false to disable
+ */
+static inline void FTM_SetGlobalTimeBaseOutputEnable(FTM_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->CONF |= FTM_CONF_GTBEOUT_MASK;
+    }
+    else
+    {
+        base->CONF &= ~FTM_CONF_GTBEOUT_MASK;
+    }
+}
+
+/*!
+ * @brief Sets the FTM peripheral timer channel output mask.
+ *
+ * @param base       FTM peripheral base address
+ * @param chnlNumber Channel to be configured
+ * @param mask       true: masked, channel is forced to its inactive state; false: unmasked
+ */
+static inline void FTM_SetOutputMask(FTM_Type *base, ftm_chnl_t chnlNumber, bool mask)
+{
+    if (mask)
+    {
+        base->OUTMASK |= (1U << chnlNumber);
+    }
+    else
+    {
+        base->OUTMASK &= ~(1U << chnlNumber);
+    }
+}
+
+#if defined(FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT) && (FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT)
+/*!
+ * @brief Allows user to enable an output on an FTM channel.
+ *
+ * To enable the PWM channel output call this function with val=true. For input mode,
+ * call this function with val=false.
+ *
+ * @param base       FTM peripheral base address
+ * @param chnlNumber Channel to be configured
+ * @param value      true: enable output; false: output is disabled, used in input mode
+ */
+static inline void FTM_SetPwmOutputEnable(FTM_Type *base, ftm_chnl_t chnlNumber, bool value)
+{
+    if (value)
+    {
+        base->SC |= (1U << (chnlNumber + FTM_SC_PWMEN0_SHIFT));
+    }
+    else
+    {
+        base->SC &= ~(1U << (chnlNumber + FTM_SC_PWMEN0_SHIFT));
+    }
+}
+#endif
+
+/*!
+ * @name Channel pair operations
+ * @{
+ */
+
+/*!
+ * @brief This function enables/disables the fault control in a channel pair.
+ *
+ * @param base           FTM peripheral base address
+ * @param chnlPairNumber The FTM channel pair number; options are 0, 1, 2, 3
+ * @param value          true: Enable fault control for this channel pair; false: No fault control
+ */
+static inline void FTM_SetFaultControlEnable(FTM_Type *base, ftm_chnl_t chnlPairNumber, bool value)
+{
+    if (value)
+    {
+        base->COMBINE |= (1U << (FTM_COMBINE_FAULTEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    }
+    else
+    {
+        base->COMBINE &= ~(1U << (FTM_COMBINE_FAULTEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    }
+}
+
+/*!
+ * @brief This function enables/disables the dead time insertion in a channel pair.
+ *
+ * @param base           FTM peripheral base address
+ * @param chnlPairNumber The FTM channel pair number; options are 0, 1, 2, 3
+ * @param value          true: Insert dead time in this channel pair; false: No dead time inserted
+ */
+static inline void FTM_SetDeadTimeEnable(FTM_Type *base, ftm_chnl_t chnlPairNumber, bool value)
+{
+    if (value)
+    {
+        base->COMBINE |= (1U << (FTM_COMBINE_DTEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    }
+    else
+    {
+        base->COMBINE &= ~(1U << (FTM_COMBINE_DTEN0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    }
+}
+
+/*!
+ * @brief This function enables/disables complementary mode in a channel pair.
+ *
+ * @param base           FTM peripheral base address
+ * @param chnlPairNumber The FTM channel pair number; options are 0, 1, 2, 3
+ * @param value          true: enable complementary mode; false: disable complementary mode
+ */
+static inline void FTM_SetComplementaryEnable(FTM_Type *base, ftm_chnl_t chnlPairNumber, bool value)
+{
+    if (value)
+    {
+        base->COMBINE |= (1U << (FTM_COMBINE_COMP0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    }
+    else
+    {
+        base->COMBINE &= ~(1U << (FTM_COMBINE_COMP0_SHIFT + (FTM_COMBINE_COMBINE1_SHIFT * chnlPairNumber)));
+    }
+}
+
+/*!
+ * @brief This function enables/disables inverting control in a channel pair.
+ *
+ * @param base            FTM peripheral base address
+ * @param chnlPairNumber  The FTM channel pair number; options are 0, 1, 2, 3
+ * @param value           true: enable inverting; false: disable inverting
+ */
+static inline void FTM_SetInvertEnable(FTM_Type *base, ftm_chnl_t chnlPairNumber, bool value)
+{
+    if (value)
+    {
+        base->INVCTRL |= (1U << chnlPairNumber);
+    }
+    else
+    {
+        base->INVCTRL &= ~(1U << chnlPairNumber);
+    }
+}
+
+/*! @}*/
+
+/*!
+ * @brief Enables or disables the FTM software trigger for PWM synchronization.
+ *
+ * @param base   FTM peripheral base address
+ * @param enable true: software trigger is selected, false: software trigger is not selected
+ */
+static inline void FTM_SetSoftwareTrigger(FTM_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->SYNC |= FTM_SYNC_SWSYNC_MASK;
+    }
+    else
+    {
+        base->SYNC &= ~FTM_SYNC_SWSYNC_MASK;
+    }
+}
+
+/*!
+ * @brief Enables or disables the FTM write protection.
+ *
+ * @param base   FTM peripheral base address
+ * @param enable true: Write-protection is enabled, false: Write-protection is disabled
+ */
+static inline void FTM_SetWriteProtection(FTM_Type *base, bool enable)
+{
+    /* Configure write protection */
+    if (enable)
+    {
+        base->FMS |= FTM_FMS_WPEN_MASK;
+    }
+    else
+    {
+        base->MODE |= FTM_MODE_WPDIS_MASK;
+    }
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_FTM_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_gpio.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_gpio.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_gpio.h"
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+static PORT_Type *const s_portBases[] = PORT_BASE_PTRS;
+static GPIO_Type *const s_gpioBases[] = GPIO_BASE_PTRS;
+
+/*******************************************************************************
+* Prototypes
+******************************************************************************/
+
+/*!
+* @brief Gets the GPIO instance according to the GPIO base
+*
+* @param base    GPIO peripheral base pointer(PTA, PTB, PTC, etc.)
+* @retval GPIO instance
+*/
+static uint32_t GPIO_GetInstance(GPIO_Type *base);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t GPIO_GetInstance(GPIO_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_GPIO_COUNT; instance++)
+    {
+        if (s_gpioBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_GPIO_COUNT);
+
+    return instance;
+}
+
+void GPIO_PinInit(GPIO_Type *base, uint32_t pin, const gpio_pin_config_t *config)
+{
+    assert(config);
+
+    if (config->pinDirection == kGPIO_DigitalInput)
+    {
+        base->PDDR &= ~(1U << pin);
+    }
+    else
+    {
+        GPIO_WritePinOutput(base, pin, config->outputLogic);
+        base->PDDR |= (1U << pin);
+    }
+}
+
+uint32_t GPIO_GetPinsInterruptFlags(GPIO_Type *base)
+{
+    uint8_t instance;
+    PORT_Type *portBase;
+    instance = GPIO_GetInstance(base);
+    portBase = s_portBases[instance];
+    return portBase->ISFR;
+}
+
+void GPIO_ClearPinsInterruptFlags(GPIO_Type *base, uint32_t mask)
+{
+    uint8_t instance;
+    PORT_Type *portBase;
+    instance = GPIO_GetInstance(base);
+    portBase = s_portBases[instance];
+    portBase->ISFR = mask;
+}
+
+#if defined(FSL_FEATURE_SOC_FGPIO_COUNT) && FSL_FEATURE_SOC_FGPIO_COUNT
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+static FGPIO_Type *const s_fgpioBases[] = FGPIO_BASE_PTRS;
+
+/*******************************************************************************
+* Prototypes
+******************************************************************************/
+/*!
+* @brief Gets the FGPIO instance according to the GPIO base
+*
+* @param base    FGPIO peripheral base pointer(PTA, PTB, PTC, etc.)
+* @retval FGPIO instance
+*/
+static uint32_t FGPIO_GetInstance(FGPIO_Type *base);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t FGPIO_GetInstance(FGPIO_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_FGPIO_COUNT; instance++)
+    {
+        if (s_fgpioBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_FGPIO_COUNT);
+
+    return instance;
+}
+
+void FGPIO_PinInit(FGPIO_Type *base, uint32_t pin, const gpio_pin_config_t *config)
+{
+    assert(config);
+
+    if (config->pinDirection == kGPIO_DigitalInput)
+    {
+        base->PDDR &= ~(1U << pin);
+    }
+    else
+    {
+        FGPIO_WritePinOutput(base, pin, config->outputLogic);
+        base->PDDR |= (1U << pin);
+    }
+}
+
+uint32_t FGPIO_GetPinsInterruptFlags(FGPIO_Type *base)
+{
+    uint8_t instance;
+    instance = FGPIO_GetInstance(base);
+    PORT_Type *portBase;
+    portBase = s_portBases[instance];
+    return portBase->ISFR;
+}
+
+void FGPIO_ClearPinsInterruptFlags(FGPIO_Type *base, uint32_t mask)
+{
+    uint8_t instance;
+    instance = FGPIO_GetInstance(base);
+    PORT_Type *portBase;
+    portBase = s_portBases[instance];
+    portBase->ISFR = mask;
+}
+
+#endif /* FSL_FEATURE_SOC_FGPIO_COUNT */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_gpio.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_gpio.h
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SDRVL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_GPIO_H_
+#define _FSL_GPIO_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup gpio
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief GPIO driver version 2.1.0. */
+#define FSL_GPIO_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*@}*/
+
+/*! @brief GPIO direction definition*/
+typedef enum _gpio_pin_direction
+{
+    kGPIO_DigitalInput = 0U,  /*!< Set current pin as digital input*/
+    kGPIO_DigitalOutput = 1U, /*!< Set current pin as digital output*/
+} gpio_pin_direction_t;
+
+/*!
+ * @brief The GPIO pin configuration structure.
+ *
+ * Every pin can only be configured as either output pin or input pin at a time.
+ * If configured as a input pin, then leave the outputConfig unused
+ * Note : In some cases, the corresponding port property should be configured in advance
+ *        with the PORT_SetPinConfig()
+ */
+typedef struct _gpio_pin_config
+{
+    gpio_pin_direction_t pinDirection; /*!< gpio direction, input or output */
+    /* Output configurations, please ignore if configured as a input one */
+    uint8_t outputLogic; /*!< Set default output logic, no use in input */
+} gpio_pin_config_t;
+
+/*! @} */
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @addtogroup gpio_driver
+ * @{
+ */
+
+/*! @name GPIO Configuration */
+/*@{*/
+
+/*!
+ * @brief Initializes a GPIO pin used by the board.
+ *
+ * To initialize the GPIO, define a pin configuration, either input or output, in the user file.
+ * Then, call the GPIO_PinInit() function.
+ *
+ * This is an example to define an input pin or output pin configuration:
+ * @code
+ * // Define a digital input pin configuration,
+ * gpio_pin_config_t config =
+ * {
+ *   kGPIO_DigitalInput,
+ *   0,
+ * }
+ * //Define a digital output pin configuration,
+ * gpio_pin_config_t config =
+ * {
+ *   kGPIO_DigitalOutput,
+ *   0,
+ * }
+ * @endcode
+ *
+ * @param base   GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param pin    GPIO port pin number
+ * @param config GPIO pin configuration pointer
+ */
+void GPIO_PinInit(GPIO_Type *base, uint32_t pin, const gpio_pin_config_t *config);
+
+/*@}*/
+
+/*! @name GPIO Output Operations */
+/*@{*/
+
+/*!
+ * @brief Sets the output level of the multiple GPIO pins to the logic 1 or 0.
+ *
+ * @param base    GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param pin     GPIO pin's number
+ * @param output  GPIO pin output logic level.
+ *        - 0: corresponding pin output low logic level.
+ *        - 1: corresponding pin output high logic level.
+ */
+static inline void GPIO_WritePinOutput(GPIO_Type *base, uint32_t pin, uint8_t output)
+{
+    if (output == 0U)
+    {
+        base->PCOR = 1 << pin;
+    }
+    else
+    {
+        base->PSOR = 1 << pin;
+    }
+}
+
+/*!
+ * @brief Sets the output level of the multiple GPIO pins to the logic 1.
+ *
+ * @param base GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask GPIO pins' numbers macro
+ */
+static inline void GPIO_SetPinsOutput(GPIO_Type *base, uint32_t mask)
+{
+    base->PSOR = mask;
+}
+
+/*!
+ * @brief Sets the output level of the multiple GPIO pins to the logic 0.
+ *
+ * @param base GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask GPIO pins' numbers macro
+ */
+static inline void GPIO_ClearPinsOutput(GPIO_Type *base, uint32_t mask)
+{
+    base->PCOR = mask;
+}
+
+/*!
+ * @brief Reverses current output logic of the multiple GPIO pins.
+ *
+ * @param base GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask GPIO pins' numbers macro
+ */
+static inline void GPIO_TogglePinsOutput(GPIO_Type *base, uint32_t mask)
+{
+    base->PTOR = mask;
+}
+/*@}*/
+
+/*! @name GPIO Input Operations */
+/*@{*/
+
+/*!
+ * @brief Reads the current input value of the whole GPIO port.
+ *
+ * @param base GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param pin     GPIO pin's number
+ * @retval GPIO port input value
+ *        - 0: corresponding pin input low logic level.
+ *        - 1: corresponding pin input high logic level.
+ */
+static inline uint32_t GPIO_ReadPinInput(GPIO_Type *base, uint32_t pin)
+{
+    return (((base->PDIR) >> pin) & 0x01U);
+}
+/*@}*/
+
+/*! @name GPIO Interrupt */
+/*@{*/
+
+/*!
+ * @brief Reads whole GPIO port interrupt status flag.
+ *
+ * If a pin is configured to generate the DMA request, the corresponding flag
+ * is cleared automatically at the completion of the requested DMA transfer.
+ * Otherwise, the flag remains set until a logic one is written to that flag.
+ * If configured for a level sensitive interrupt that remains asserted, the flag
+ * is set again immediately.
+ *
+ * @param base GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @retval Current GPIO port interrupt status flag, for example, 0x00010001 means the
+ *         pin 0 and 17 have the interrupt.
+ */
+uint32_t GPIO_GetPinsInterruptFlags(GPIO_Type *base);
+
+/*!
+ * @brief Clears multiple GPIO pins' interrupt status flag.
+ *
+ * @param base GPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask GPIO pins' numbers macro
+ */
+void GPIO_ClearPinsInterruptFlags(GPIO_Type *base, uint32_t mask);
+
+/*@}*/
+/*! @} */
+
+/*!
+ * @addtogroup fgpio_driver
+ * @{
+ */
+
+/*
+ * Introduce the FGPIO feature.
+ *
+ * The FGPIO features are only support on some of Kinetis chips. The FGPIO registers are aliased to the IOPORT
+ * interface. Accesses via the IOPORT interface occur in parallel with any instruction fetches and will therefore
+ * complete in a single cycle. This aliased Fast GPIO memory map is called FGPIO.
+ */
+
+#if defined(FSL_FEATURE_SOC_FGPIO_COUNT) && FSL_FEATURE_SOC_FGPIO_COUNT
+
+/*! @name FGPIO Configuration */
+/*@{*/
+
+/*!
+ * @brief Initializes a FGPIO pin used by the board.
+ *
+ * To initialize the FGPIO driver, define a pin configuration, either input or output, in the user file.
+ * Then, call the FGPIO_PinInit() function.
+ *
+ * This is an example to define an input pin or output pin configuration:
+ * @code
+ * // Define a digital input pin configuration,
+ * gpio_pin_config_t config =
+ * {
+ *   kGPIO_DigitalInput,
+ *   0,
+ * }
+ * //Define a digital output pin configuration,
+ * gpio_pin_config_t config =
+ * {
+ *   kGPIO_DigitalOutput,
+ *   0,
+ * }
+ * @endcode
+ *
+ * @param base   FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param pin    FGPIO port pin number
+ * @param config FGPIO pin configuration pointer
+ */
+void FGPIO_PinInit(FGPIO_Type *base, uint32_t pin, const gpio_pin_config_t *config);
+
+/*@}*/
+
+/*! @name FGPIO Output Operations */
+/*@{*/
+
+/*!
+ * @brief Sets the output level of the multiple FGPIO pins to the logic 1 or 0.
+ *
+ * @param base    FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param pin     FGPIO pin's number
+ * @param output  FGPIOpin output logic level.
+ *        - 0: corresponding pin output low logic level.
+ *        - 1: corresponding pin output high logic level.
+ */
+static inline void FGPIO_WritePinOutput(FGPIO_Type *base, uint32_t pin, uint8_t output)
+{
+    if (output == 0U)
+    {
+        base->PCOR = 1 << pin;
+    }
+    else
+    {
+        base->PSOR = 1 << pin;
+    }
+}
+
+/*!
+ * @brief Sets the output level of the multiple FGPIO pins to the logic 1.
+ *
+ * @param base FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask FGPIO pins' numbers macro
+ */
+static inline void FGPIO_SetPinsOutput(FGPIO_Type *base, uint32_t mask)
+{
+    base->PSOR = mask;
+}
+
+/*!
+ * @brief Sets the output level of the multiple FGPIO pins to the logic 0.
+ *
+ * @param base FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask FGPIO pins' numbers macro
+ */
+static inline void FGPIO_ClearPinsOutput(FGPIO_Type *base, uint32_t mask)
+{
+    base->PCOR = mask;
+}
+
+/*!
+ * @brief Reverses current output logic of the multiple FGPIO pins.
+ *
+ * @param base FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask FGPIO pins' numbers macro
+ */
+static inline void FGPIO_TogglePinsOutput(FGPIO_Type *base, uint32_t mask)
+{
+    base->PTOR = mask;
+}
+/*@}*/
+
+/*! @name FGPIO Input Operations */
+/*@{*/
+
+/*!
+ * @brief Reads the current input value of the whole FGPIO port.
+ *
+ * @param base FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param pin  FGPIO pin's number
+ * @retval FGPIO port input value
+ *        - 0: corresponding pin input low logic level.
+ *        - 1: corresponding pin input high logic level.
+ */
+static inline uint32_t FGPIO_ReadPinInput(FGPIO_Type *base, uint32_t pin)
+{
+    return (((base->PDIR) >> pin) & 0x01U);
+}
+/*@}*/
+
+/*! @name FGPIO Interrupt */
+/*@{*/
+
+/*!
+ * @brief Reads the whole FGPIO port interrupt status flag.
+ *
+ * If a pin is configured to generate the DMA request,  the corresponding flag
+ * is cleared automatically at the completion of the requested DMA transfer.
+ * Otherwise, the flag remains set until a logic one is written to that flag.
+ * If configured for a level sensitive interrupt that remains asserted, the flag
+ * is set again immediately.
+ *
+ * @param base FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @retval Current FGPIO port interrupt status flags, for example, 0x00010001 means the
+ *         pin 0 and 17 have the interrupt.
+ */
+uint32_t FGPIO_GetPinsInterruptFlags(FGPIO_Type *base);
+
+/*!
+ * @brief Clears the multiple FGPIO pins' interrupt status flag.
+ *
+ * @param base FGPIO peripheral base pointer(GPIOA, GPIOB, GPIOC, and so on.)
+ * @param mask FGPIO pins' numbers macro
+ */
+void FGPIO_ClearPinsInterruptFlags(FGPIO_Type *base, uint32_t mask);
+
+/*@}*/
+
+#endif /* FSL_FEATURE_SOC_FGPIO_COUNT */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*!
+ * @}
+ */
+
+#endif /* _FSL_GPIO_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c.c
@@ -1,0 +1,1536 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "fsl_i2c.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief i2c transfer state. */
+enum _i2c_transfer_states
+{
+    kIdleState = 0x0U,             /*!< I2C bus idle. */
+    kCheckAddressState = 0x1U,     /*!< 7-bit address check state. */
+    kSendCommandState = 0x2U,      /*!< Send command byte phase. */
+    kSendDataState = 0x3U,         /*!< Send data transfer phase. */
+    kReceiveDataBeginState = 0x4U, /*!< Receive data transfer phase begin. */
+    kReceiveDataState = 0x5U,      /*!< Receive data transfer phase. */
+};
+
+/*! @brief Common sets of flags used by the driver. */
+enum _i2c_flag_constants
+{
+/*! All flags which are cleared by the driver upon starting a transfer. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag | kI2C_StartDetectFlag | kI2C_StopDetectFlag,
+    kIrqFlags = kI2C_GlobalInterruptEnable | kI2C_StartStopDetectInterruptEnable,
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag | kI2C_StopDetectFlag,
+    kIrqFlags = kI2C_GlobalInterruptEnable | kI2C_StopDetectInterruptEnable,
+#else
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag,
+    kIrqFlags = kI2C_GlobalInterruptEnable,
+#endif
+
+};
+
+/*! @brief Typedef for interrupt handler. */
+typedef void (*i2c_isr_t)(I2C_Type *base, void *i2cHandle);
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get instance number for I2C module.
+ *
+ * @param base I2C peripheral base address.
+ */
+uint32_t I2C_GetInstance(I2C_Type *base);
+
+/*!
+ * @brief Set up master transfer, send slave address and decide the initial
+ * transfer state.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * @param xfer pointer to i2c_master_transfer_t structure.
+ */
+static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer);
+
+/*!
+ * @brief Check and clear status operation.
+ *
+ * @param base I2C peripheral base address.
+ * @param status current i2c hardware status.
+ * @retval kStatus_Success No error found.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStatus_I2C_Nak Received Nak error.
+ */
+static status_t I2C_CheckAndClearError(I2C_Type *base, uint32_t status);
+
+/*!
+ * @brief Master run transfer state machine to perform a byte of transfer.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ * @param isDone input param to get whether the thing is done, true is done
+ * @retval kStatus_Success No error found.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStatus_I2C_Nak Received Nak error.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ */
+static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_handle_t *handle, bool *isDone);
+
+/*!
+ * @brief I2C common interrupt handler.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ */
+static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to i2c handles for each instance. */
+static void *s_i2cHandle[FSL_FEATURE_SOC_I2C_COUNT] = {NULL};
+
+/*! @brief SCL clock divider used to calculate baudrate. */
+const uint16_t s_i2cDividerTable[] = {20,   22,   24,   26,   28,   30,   34,   40,   28,   32,   36,   40,  44,
+                                      48,   56,   68,   48,   56,   64,   72,   80,   88,   104,  128,  80,  96,
+                                      112,  128,  144,  160,  192,  240,  160,  192,  224,  256,  288,  320, 384,
+                                      480,  320,  384,  448,  512,  576,  640,  768,  960,  640,  768,  896, 1024,
+                                      1152, 1280, 1536, 1920, 1280, 1536, 1792, 2048, 2304, 2560, 3072, 3840};
+
+/*! @brief Pointers to i2c bases for each instance. */
+static I2C_Type *const s_i2cBases[] = I2C_BASE_PTRS;
+
+/*! @brief Pointers to i2c IRQ number for each instance. */
+const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
+
+/*! @brief Pointers to i2c clocks for each instance. */
+const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+
+/*! @brief Pointer to master IRQ handler for each instance. */
+static i2c_isr_t s_i2cMasterIsr;
+
+/*! @brief Pointer to slave IRQ handler for each instance. */
+static i2c_isr_t s_i2cSlaveIsr;
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+
+uint32_t I2C_GetInstance(I2C_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_I2C_COUNT; instance++)
+    {
+        if (s_i2cBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_I2C_COUNT);
+
+    return instance;
+}
+
+static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
+{
+    status_t result = kStatus_Success;
+    i2c_direction_t direction = xfer->direction;
+    uint16_t timeout = UINT16_MAX;
+
+    /* Initialize the handle transfer information. */
+    handle->transfer = *xfer;
+
+    /* Save total transfer size. */
+    handle->transferSize = xfer->dataSize;
+
+    /* Initial transfer state. */
+    if (handle->transfer.subaddressSize > 0)
+    {
+        handle->state = kSendCommandState;
+        if (xfer->direction == kI2C_Read)
+        {
+            direction = kI2C_Write;
+        }
+    }
+    else
+    {
+        handle->state = kCheckAddressState;
+    }
+
+    /* Wait until the data register is ready for transmit. */
+    while ((!(base->S & kI2C_TransferCompleteFlag)) && (--timeout))
+    {
+    }
+
+    /* Failed to start the transfer. */
+    if (timeout == 0)
+    {
+        return kStatus_I2C_Timeout;
+    }
+
+    /* Clear all status before transfer. */
+    I2C_MasterClearStatusFlags(base, kClearFlags);
+
+    /* If repeated start is requested, send repeated start. */
+    if (handle->transfer.flags & kI2C_TransferRepeatedStartFlag)
+    {
+        result = I2C_MasterRepeatedStart(base, handle->transfer.slaveAddress, direction);
+    }
+    else /* For normal transfer, send start. */
+    {
+        result = I2C_MasterStart(base, handle->transfer.slaveAddress, direction);
+    }
+
+    return result;
+}
+
+static status_t I2C_CheckAndClearError(I2C_Type *base, uint32_t status)
+{
+    status_t result = kStatus_Success;
+
+    /* Check arbitration lost. */
+    if (status & kI2C_ArbitrationLostFlag)
+    {
+        /* Clear arbitration lost flag. */
+        base->S = kI2C_ArbitrationLostFlag;
+        result = kStatus_I2C_ArbitrationLost;
+    }
+    /* Check NAK */
+    else if (status & kI2C_ReceiveNakFlag)
+    {
+        result = kStatus_I2C_Nak;
+    }
+    else
+    {
+    }
+
+    return result;
+}
+
+static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_handle_t *handle, bool *isDone)
+{
+    status_t result = kStatus_Success;
+    uint32_t statusFlags = base->S;
+    *isDone = false;
+    volatile uint8_t dummy = 0;
+    bool ignoreNak = ((handle->state == kSendDataState) && (handle->transfer.dataSize == 0U)) ||
+                     ((handle->state == kReceiveDataState) && (handle->transfer.dataSize == 1U));
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    /* Check & clear error flags. */
+    result = I2C_CheckAndClearError(base, statusFlags);
+
+    /* Ignore Nak when it's appeared for last byte. */
+    if ((result == kStatus_I2C_Nak) && ignoreNak)
+    {
+        result = kStatus_Success;
+    }
+
+    if (result)
+    {
+        return result;
+    }
+
+    /* Handle Check address state to check the slave address is Acked in slave
+       probe application. */
+    if (handle->state == kCheckAddressState)
+    {
+        if (statusFlags & kI2C_ReceiveNakFlag)
+        {
+            return kStatus_I2C_Nak;
+        }
+        else
+        {
+            if (handle->transfer.direction == kI2C_Write)
+            {
+                /* Next state, send data. */
+                handle->state = kSendDataState;
+            }
+            else
+            {
+                /* Next state, receive data begin. */
+                handle->state = kReceiveDataBeginState;
+            }
+        }
+    }
+
+    /* Run state machine. */
+    switch (handle->state)
+    {
+        /* Send I2C command. */
+        case kSendCommandState:
+            if (handle->transfer.subaddressSize)
+            {
+                handle->transfer.subaddressSize--;
+                base->D = ((handle->transfer.subaddress) >> (8 * handle->transfer.subaddressSize));
+            }
+            else
+            {
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Next state, send data. */
+                    handle->state = kSendDataState;
+
+                    /* Send first byte of data. */
+                    if (handle->transfer.dataSize > 0)
+                    {
+                        base->D = *handle->transfer.data;
+                        handle->transfer.data++;
+                        handle->transfer.dataSize--;
+                    }
+                }
+                else
+                {
+                    /* Send repeated start and slave address. */
+                    result = I2C_MasterRepeatedStart(base, handle->transfer.slaveAddress, kI2C_Read);
+
+                    /* Next state, receive data begin. */
+                    handle->state = kReceiveDataBeginState;
+                }
+            }
+            break;
+
+        /* Send I2C data. */
+        case kSendDataState:
+            /* Send one byte of data. */
+            if (handle->transfer.dataSize > 0)
+            {
+                base->D = *handle->transfer.data;
+                handle->transfer.data++;
+                handle->transfer.dataSize--;
+            }
+            else
+            {
+                *isDone = true;
+            }
+            break;
+
+        /* Start I2C data receive. */
+        case kReceiveDataBeginState:
+            base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+            /* Send nak at the last receive byte. */
+            if (handle->transfer.dataSize == 1)
+            {
+                base->C1 |= I2C_C1_TXAK_MASK;
+            }
+
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+
+            /* Next state, receive data. */
+            handle->state = kReceiveDataState;
+            break;
+
+        /* Receive I2C data. */
+        case kReceiveDataState:
+            /* Receive one byte of data. */
+            if (handle->transfer.dataSize--)
+            {
+                if (handle->transfer.dataSize == 0)
+                {
+                    *isDone = true;
+
+                    /* Send stop if kI2C_TransferNoStop is not asserted. */
+                    if (!(handle->transfer.flags & kI2C_TransferNoStopFlag))
+                    {
+                        result = I2C_MasterStop(base);
+                    }
+                }
+
+                /* Send NAK at the last receive byte. */
+                if (handle->transfer.dataSize == 1)
+                {
+                    base->C1 |= I2C_C1_TXAK_MASK;
+                }
+
+                /* Read the data byte into the transfer buffer. */
+                *handle->transfer.data = base->D;
+                handle->transfer.data++;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    return result;
+}
+
+static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle)
+{
+    /* Check if master interrupt. */
+    if ((base->S & kI2C_ArbitrationLostFlag) || (base->C1 & I2C_C1_MST_MASK))
+    {
+        s_i2cMasterIsr(base, handle);
+    }
+    else
+    {
+        s_i2cSlaveIsr(base, handle);
+    }
+}
+
+void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz)
+{
+    assert(masterConfig && srcClock_Hz);
+
+    /* Temporary register for filter read. */
+    uint8_t fltReg;
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    uint8_t c2Reg;
+#endif
+
+    /* Enable I2C clock. */
+    CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+
+    /* Disable I2C prior to configuring it. */
+    base->C1 &= ~(I2C_C1_IICEN_MASK);
+
+    /* Clear all flags. */
+    I2C_MasterClearStatusFlags(base, kClearFlags);
+
+    /* Configure baud rate. */
+    I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
+
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    /* Configure high drive feature. */
+    c2Reg = base->C2;
+    c2Reg &= ~(I2C_C2_HDRS_MASK);
+    c2Reg |= I2C_C2_HDRS(masterConfig->enableHighDrive);
+    base->C2 = c2Reg;
+#endif
+
+    /* Read out the FLT register. */
+    fltReg = base->FLT;
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
+    /* Configure the stop / hold enable. */
+    fltReg &= ~(I2C_FLT_SHEN_MASK);
+    fltReg |= I2C_FLT_SHEN(masterConfig->enableStopHold);
+#endif
+
+    /* Configure the glitch filter value. */
+    fltReg &= ~(I2C_FLT_FLT_MASK);
+    fltReg |= I2C_FLT_FLT(masterConfig->glitchFilterWidth);
+
+    /* Write the register value back to the filter register. */
+    base->FLT = fltReg;
+
+    /* Enable the I2C peripheral based on the configuration. */
+    base->C1 = I2C_C1_IICEN(masterConfig->enableMaster);
+}
+
+void I2C_MasterDeinit(I2C_Type *base)
+{
+    /* Disable I2C module. */
+    I2C_Enable(base, false);
+
+    /* Disable I2C clock. */
+    CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+}
+
+void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
+{
+    assert(masterConfig);
+
+    /* Default baud rate at 100kbps. */
+    masterConfig->baudRate_Bps = 100000U;
+
+/* Default pin high drive is disabled. */
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    masterConfig->enableHighDrive = false;
+#endif
+
+/* Default stop hold enable is disabled. */
+#if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
+    masterConfig->enableStopHold = false;
+#endif
+
+    /* Default glitch filter value is no filter. */
+    masterConfig->glitchFilterWidth = 0U;
+
+    /* Enable the I2C peripheral. */
+    masterConfig->enableMaster = true;
+}
+
+void I2C_EnableInterrupts(I2C_Type *base, uint32_t mask)
+{
+    if (mask & kI2C_GlobalInterruptEnable)
+    {
+        base->C1 |= I2C_C1_IICIE_MASK;
+    }
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    if (mask & kI2C_StopDetectInterruptEnable)
+    {
+        base->FLT |= I2C_FLT_STOPIE_MASK;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    if (mask & kI2C_StartStopDetectInterruptEnable)
+    {
+        base->FLT |= I2C_FLT_SSIE_MASK;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+}
+
+void I2C_DisableInterrupts(I2C_Type *base, uint32_t mask)
+{
+    if (mask & kI2C_GlobalInterruptEnable)
+    {
+        base->C1 &= ~I2C_C1_IICIE_MASK;
+    }
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    if (mask & kI2C_StopDetectInterruptEnable)
+    {
+        base->FLT &= ~I2C_FLT_STOPIE_MASK;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    if (mask & kI2C_StartStopDetectInterruptEnable)
+    {
+        base->FLT &= ~I2C_FLT_SSIE_MASK;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+}
+
+void I2C_MasterSetBaudRate(I2C_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedRate;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult = 0u;
+    uint32_t bestIcr = 0u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    for (mult = 0u; (mult <= 2u) && (bestError != 0); ++mult)
+    {
+        multiplier = 1u << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(uint16_t); ++i)
+        {
+            computedRate = srcClock_Hz / (multiplier * s_i2cDividerTable[i]);
+            absError = baudRate_Bps > computedRate ? (baudRate_Bps - computedRate) : (computedRate - baudRate_Bps);
+
+            if (absError < bestError)
+            {
+                bestMult = mult;
+                bestIcr = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
+}
+
+status_t I2C_MasterStart(I2C_Type *base, uint8_t address, i2c_direction_t direction)
+{
+    status_t result = kStatus_Success;
+    uint32_t statusFlags = I2C_MasterGetStatusFlags(base);
+
+    /* Return an error if the bus is already in use. */
+    if (statusFlags & kI2C_BusBusyFlag)
+    {
+        result = kStatus_I2C_Busy;
+    }
+    else
+    {
+        /* Send the START signal. */
+        base->C1 |= I2C_C1_MST_MASK | I2C_C1_TX_MASK;
+
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING
+        while (!(base->S2 & I2C_S2_EMPTY_MASK))
+        {
+        }
+#endif /* FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING */
+
+        base->D = (((uint32_t)address) << 1U | ((direction == kI2C_Read) ? 1U : 0U));
+    }
+
+    return result;
+}
+
+status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction)
+{
+    status_t result = kStatus_Success;
+    uint8_t savedMult;
+    uint32_t statusFlags = I2C_MasterGetStatusFlags(base);
+    uint8_t timeDelay = 6;
+
+    /* Return an error if the bus is already in use, but not by us. */
+    if ((statusFlags & kI2C_BusBusyFlag) && ((base->C1 & I2C_C1_MST_MASK) == 0))
+    {
+        result = kStatus_I2C_Busy;
+    }
+    else
+    {
+        savedMult = base->F;
+        base->F = savedMult & (~I2C_F_MULT_MASK);
+
+        /* We are already in a transfer, so send a repeated start. */
+        base->C1 |= I2C_C1_RSTA_MASK;
+
+        /* Restore the multiplier factor. */
+        base->F = savedMult;
+
+        /* Add some delay to wait the Re-Start signal. */
+        while (timeDelay--)
+        {
+            __NOP();
+        }
+
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING
+        while (!(base->S2 & I2C_S2_EMPTY_MASK))
+        {
+        }
+#endif /* FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING */
+
+        base->D = (((uint32_t)address) << 1U | ((direction == kI2C_Read) ? 1U : 0U));
+    }
+
+    return result;
+}
+
+status_t I2C_MasterStop(I2C_Type *base)
+{
+    status_t result = kStatus_Success;
+    uint16_t timeout = UINT16_MAX;
+
+    /* Issue the STOP command on the bus. */
+    base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+    /* Wait until data transfer complete. */
+    while ((base->S & kI2C_BusBusyFlag) && (--timeout))
+    {
+    }
+
+    if (timeout == 0)
+    {
+        result = kStatus_I2C_Timeout;
+    }
+
+    return result;
+}
+
+uint32_t I2C_MasterGetStatusFlags(I2C_Type *base)
+{
+    uint32_t statusFlags = base->S;
+
+#ifdef I2C_HAS_STOP_DETECT
+    /* Look up the STOPF bit from the filter register. */
+    if (base->FLT & I2C_FLT_STOPF_MASK)
+    {
+        statusFlags |= kI2C_StopDetectFlag;
+    }
+#endif
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Look up the STARTF bit from the filter register. */
+    if (base->FLT & I2C_FLT_STARTF_MASK)
+    {
+        statusFlags |= kI2C_StartDetectFlag;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+    return statusFlags;
+}
+
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+{
+    status_t result = kStatus_Success;
+    uint8_t statusFlags = 0;
+
+    /* Wait until the data register is ready for transmit. */
+    while (!(base->S & kI2C_TransferCompleteFlag))
+    {
+    }
+
+    /* Clear the IICIF flag. */
+    base->S = kI2C_IntPendingFlag;
+
+    /* Setup the I2C peripheral to transmit data. */
+    base->C1 |= I2C_C1_TX_MASK;
+
+    while (txSize--)
+    {
+        /* Send a byte of data. */
+        base->D = *txBuff++;
+
+        /* Wait until data transfer complete. */
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+
+        statusFlags = base->S;
+
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Check if arbitration lost or no acknowledgement (NAK), return failure status. */
+        if (statusFlags & kI2C_ArbitrationLostFlag)
+        {
+            base->S = kI2C_ArbitrationLostFlag;
+            result = kStatus_I2C_ArbitrationLost;
+        }
+
+        if (statusFlags & kI2C_ReceiveNakFlag)
+        {
+            base->S = kI2C_ReceiveNakFlag;
+            result = kStatus_I2C_Nak;
+        }
+
+        if (result != kStatus_Success)
+        {
+            /* Breaking out of the send loop. */
+            break;
+        }
+    }
+
+    return result;
+}
+
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+{
+    status_t result = kStatus_Success;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    /* Wait until the data register is ready for transmit. */
+    while (!(base->S & kI2C_TransferCompleteFlag))
+    {
+    }
+
+    /* Clear the IICIF flag. */
+    base->S = kI2C_IntPendingFlag;
+
+    /* Setup the I2C peripheral to receive data. */
+    base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+    /* If rxSize equals 1, configure to send NAK. */
+    if (rxSize == 1)
+    {
+        /* Issue NACK on read. */
+        base->C1 |= I2C_C1_TXAK_MASK;
+    }
+
+    /* Do dummy read. */
+    dummy = base->D;
+
+    while ((rxSize--))
+    {
+        /* Wait until data transfer complete. */
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Single byte use case. */
+        if (rxSize == 0)
+        {
+            /* Read the final byte. */
+            result = I2C_MasterStop(base);
+        }
+
+        if (rxSize == 1)
+        {
+            /* Issue NACK on read. */
+            base->C1 |= I2C_C1_TXAK_MASK;
+        }
+
+        /* Read from the data register. */
+        *rxBuff++ = base->D;
+    }
+
+    return result;
+}
+
+status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
+{
+    assert(xfer);
+
+    i2c_direction_t direction = xfer->direction;
+    status_t result = kStatus_Success;
+
+    /* Clear all status before transfer. */
+    I2C_MasterClearStatusFlags(base, kClearFlags);
+
+    /* Wait until ready to complete. */
+    while (!(base->S & kI2C_TransferCompleteFlag))
+    {
+    }
+
+    /* Change to send write address when it's a read operation with command. */
+    if ((xfer->subaddressSize > 0) && (xfer->direction == kI2C_Read))
+    {
+        direction = kI2C_Write;
+    }
+
+    /* If repeated start is requested, send repeated start. */
+    if (xfer->flags & kI2C_TransferRepeatedStartFlag)
+    {
+        result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, direction);
+    }
+    else /* For normal transfer, send start. */
+    {
+        result = I2C_MasterStart(base, xfer->slaveAddress, direction);
+    }
+
+    /* Return if error. */
+    if (result)
+    {
+        return result;
+    }
+
+    /* Send subaddress. */
+    if (xfer->subaddressSize)
+    {
+        do
+        {
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Clear interrupt pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+            xfer->subaddressSize--;
+            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
+
+        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
+
+        if (xfer->direction == kI2C_Read)
+        {
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Clear pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+            /* Send repeated start and slave address. */
+            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
+
+            /* Return if error. */
+            if (result)
+            {
+                return result;
+            }
+        }
+    }
+
+    /* Wait until address + command transfer complete. */
+    while (!(base->S & kI2C_IntPendingFlag))
+    {
+    }
+
+    /* Check if there's transfer error. */
+    result = I2C_CheckAndClearError(base, base->S);
+
+    /* Return if error. */
+    if (result)
+    {
+        if (result == kStatus_I2C_Nak)
+        {
+            I2C_MasterStop(base);
+        }
+
+        return result;
+    }
+
+    /* Transmit data. */
+    if ((xfer->direction == kI2C_Write) && (xfer->dataSize > 0))
+    {
+        /* Send Data. */
+        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize);
+
+        if (((result == kStatus_Success) && (!(xfer->flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
+        {
+            /* Clear the IICIF flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Send stop. */
+            result = I2C_MasterStop(base);
+        }
+    }
+
+    /* Receive Data. */
+    if ((xfer->direction == kI2C_Read) && (xfer->dataSize > 0))
+    {
+        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize);
+    }
+
+    return result;
+}
+
+void I2C_MasterTransferCreateHandle(I2C_Type *base,
+                                    i2c_master_handle_t *handle,
+                                    i2c_master_transfer_callback_t callback,
+                                    void *userData)
+{
+    assert(handle);
+
+    uint32_t instance = I2C_GetInstance(base);
+
+    /* Zero handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    /* Set callback and userData. */
+    handle->completionCallback = callback;
+    handle->userData = userData;
+
+    /* Save the context in global variables to support the double weak mechanism. */
+    s_i2cHandle[instance] = handle;
+
+    /* Save master interrupt handler. */
+    s_i2cMasterIsr = I2C_MasterTransferHandleIRQ;
+
+    /* Enable NVIC interrupt. */
+    EnableIRQ(s_i2cIrqs[instance]);
+}
+
+status_t I2C_MasterTransferNonBlocking(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
+{
+    assert(handle);
+    assert(xfer);
+
+    status_t result = kStatus_Success;
+
+    /* Check if the I2C bus is idle - if not return busy status. */
+    if (handle->state != kIdleState)
+    {
+        result = kStatus_I2C_Busy;
+    }
+    else
+    {
+        /* Start up the master transfer state machine. */
+        result = I2C_InitTransferStateMachine(base, handle, xfer);
+
+        if (result == kStatus_Success)
+        {
+            /* Enable the I2C interrupts. */
+            I2C_EnableInterrupts(base, kI2C_GlobalInterruptEnable);
+        }
+    }
+
+    return result;
+}
+
+void I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle)
+{
+    assert(handle);
+
+    /* Disable interrupt. */
+    I2C_DisableInterrupts(base, kI2C_GlobalInterruptEnable);
+
+    /* Reset the state to idle. */
+    handle->state = kIdleState;
+}
+
+status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    *count = handle->transferSize - handle->transfer.dataSize;
+
+    return kStatus_Success;
+}
+
+void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
+{
+    assert(i2cHandle);
+
+    i2c_master_handle_t *handle = (i2c_master_handle_t *)i2cHandle;
+    status_t result = kStatus_Success;
+    bool isDone;
+
+    /* Clear the interrupt flag. */
+    base->S = kI2C_IntPendingFlag;
+
+    /* Check transfer complete flag. */
+    result = I2C_MasterTransferRunStateMachine(base, handle, &isDone);
+
+    if (isDone || result)
+    {
+        /* Send stop command if transfer done or received Nak. */
+        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak))
+        {
+            /* Ensure stop command is a need. */
+            if ((base->C1 & I2C_C1_MST_MASK))
+            {
+                if (I2C_MasterStop(base) != kStatus_Success)
+                {
+                    result = kStatus_I2C_Timeout;
+                }
+            }
+        }
+
+        /* Restore handle to idle state. */
+        handle->state = kIdleState;
+
+        /* Disable interrupt. */
+        I2C_DisableInterrupts(base, kI2C_GlobalInterruptEnable);
+
+        /* Call the callback function after the function has completed. */
+        if (handle->completionCallback)
+        {
+            handle->completionCallback(base, handle, result, handle->userData);
+        }
+    }
+}
+
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
+{
+    assert(slaveConfig);
+
+    uint8_t tmpReg;
+
+    CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+
+    /* Configure addressing mode. */
+    switch (slaveConfig->addressingMode)
+    {
+        case kI2C_Address7bit:
+            base->A1 = ((uint32_t)(slaveConfig->slaveAddress)) << 1U;
+            break;
+
+        case kI2C_RangeMatch:
+            assert(slaveConfig->slaveAddress < slaveConfig->upperAddress);
+            base->A1 = ((uint32_t)(slaveConfig->slaveAddress)) << 1U;
+            base->RA = ((uint32_t)(slaveConfig->upperAddress)) << 1U;
+            base->C2 |= I2C_C2_RMEN_MASK;
+            break;
+
+        default:
+            break;
+    }
+
+    /* Configure low power wake up feature. */
+    tmpReg = base->C1;
+    tmpReg &= ~I2C_C1_WUEN_MASK;
+    base->C1 = tmpReg | I2C_C1_WUEN(slaveConfig->enableWakeUp) | I2C_C1_IICEN(slaveConfig->enableSlave);
+
+    /* Configure general call & baud rate control & high drive feature. */
+    tmpReg = base->C2;
+    tmpReg &= ~(I2C_C2_SBRC_MASK | I2C_C2_GCAEN_MASK);
+    tmpReg |= I2C_C2_SBRC(slaveConfig->enableBaudRateCtl) | I2C_C2_GCAEN(slaveConfig->enableGeneralCall);
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    tmpReg &= ~I2C_C2_HDRS_MASK;
+    tmpReg |= I2C_C2_HDRS(slaveConfig->enableHighDrive);
+#endif
+    base->C2 = tmpReg;
+}
+
+void I2C_SlaveDeinit(I2C_Type *base)
+{
+    /* Disable I2C module. */
+    I2C_Enable(base, false);
+
+    /* Disable I2C clock. */
+    CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+}
+
+void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
+{
+    assert(slaveConfig);
+
+    /* By default slave is addressed with 7-bit address. */
+    slaveConfig->addressingMode = kI2C_Address7bit;
+
+    /* General call mode is disabled by default. */
+    slaveConfig->enableGeneralCall = false;
+
+    /* Slave address match waking up MCU from low power mode is disabled. */
+    slaveConfig->enableWakeUp = false;
+
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    /* Default pin high drive is disabled. */
+    slaveConfig->enableHighDrive = false;
+#endif
+
+    /* Independent slave mode baud rate at maximum frequency is disabled. */
+    slaveConfig->enableBaudRateCtl = false;
+
+    /* Enable the I2C peripheral. */
+    slaveConfig->enableSlave = true;
+}
+
+status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+{
+    return I2C_MasterWriteBlocking(base, txBuff, txSize);
+}
+
+void I2C_SlaveReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+{
+    /* Clear the IICIF flag. */
+    base->S = kI2C_IntPendingFlag;
+
+    /* Wait until the data register is ready for receive. */
+    while (!(base->S & kI2C_TransferCompleteFlag))
+    {
+    }
+
+    /* Setup the I2C peripheral to receive data. */
+    base->C1 &= ~(I2C_C1_TX_MASK);
+
+    while (rxSize--)
+    {
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Read from the data register. */
+        *rxBuff++ = base->D;
+
+        /* Wait until data transfer complete. */
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+    }
+}
+
+void I2C_SlaveTransferCreateHandle(I2C_Type *base,
+                                   i2c_slave_handle_t *handle,
+                                   i2c_slave_transfer_callback_t callback,
+                                   void *userData)
+{
+    assert(handle);
+
+    uint32_t instance = I2C_GetInstance(base);
+
+    /* Zero handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    /* Set callback and userData. */
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* Save the context in global variables to support the double weak mechanism. */
+    s_i2cHandle[instance] = handle;
+
+    /* Save slave interrupt handler. */
+    s_i2cSlaveIsr = I2C_SlaveTransferHandleIRQ;
+
+    /* Enable NVIC interrupt. */
+    EnableIRQ(s_i2cIrqs[instance]);
+}
+
+status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle, uint32_t eventMask)
+{
+    assert(handle);
+
+    /* Check if the I2C bus is idle - if not return busy status. */
+    if (handle->isBusy)
+    {
+        return kStatus_I2C_Busy;
+    }
+    else
+    {
+        /* Disable LPI2C IRQ sources while we configure stuff. */
+        I2C_DisableInterrupts(base, kIrqFlags);
+
+        /* Clear transfer in handle. */
+        memset(&handle->transfer, 0, sizeof(handle->transfer));
+
+        /* Record that we're busy. */
+        handle->isBusy = true;
+
+        /* Set up event mask. tx and rx are always enabled. */
+        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent;
+
+        /* Clear all flags. */
+        I2C_SlaveClearStatusFlags(base, kClearFlags);
+
+        /* Enable I2C internal IRQ sources. NVIC IRQ was enabled in CreateHandle() */
+        I2C_EnableInterrupts(base, kIrqFlags);
+    }
+
+    return kStatus_Success;
+}
+
+void I2C_SlaveTransferAbort(I2C_Type *base, i2c_slave_handle_t *handle)
+{
+    assert(handle);
+
+    if (handle->isBusy)
+    {
+        /* Disable interrupts. */
+        I2C_DisableInterrupts(base, kIrqFlags);
+
+        /* Reset transfer info. */
+        memset(&handle->transfer, 0, sizeof(handle->transfer));
+
+        /* Reset the state to idle. */
+        handle->isBusy = false;
+    }
+}
+
+status_t I2C_SlaveTransferGetCount(I2C_Type *base, i2c_slave_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Catch when there is not an active transfer. */
+    if (!handle->isBusy)
+    {
+        *count = 0;
+        return kStatus_NoTransferInProgress;
+    }
+
+    /* For an active transfer, just return the count from the handle. */
+    *count = handle->transfer.transferredCount;
+
+    return kStatus_Success;
+}
+
+void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
+{
+    assert(i2cHandle);
+
+    uint16_t status;
+    bool doTransmit = false;
+    i2c_slave_handle_t *handle = (i2c_slave_handle_t *)i2cHandle;
+    i2c_slave_transfer_t *xfer;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    status = I2C_SlaveGetStatusFlags(base);
+    xfer = &(handle->transfer);
+
+#ifdef I2C_HAS_STOP_DETECT
+    /* Check stop flag. */
+    if (status & kI2C_StopDetectFlag)
+    {
+        I2C_MasterClearStatusFlags(base, kI2C_StopDetectFlag);
+
+        /* Clear the interrupt flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Call slave callback if this is the STOP of the transfer. */
+        if (handle->isBusy)
+        {
+            xfer->event = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_Success;
+            handle->isBusy = false;
+
+            if ((handle->eventMask & xfer->event) && (handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+        }
+
+        return;
+    }
+#endif /* I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Check start flag. */
+    if (status & kI2C_StartDetectFlag)
+    {
+        I2C_MasterClearStatusFlags(base, kI2C_StartDetectFlag);
+
+        /* Clear the interrupt flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        xfer->event = kI2C_SlaveRepeatedStartEvent;
+
+        if ((handle->eventMask & xfer->event) && (handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
+        }
+
+        if (!(status & kI2C_AddressMatchFlag))
+        {
+            return;
+        }
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+    /* Clear the interrupt flag. */
+    base->S = kI2C_IntPendingFlag;
+
+    /* Check NAK */
+    if (status & kI2C_ReceiveNakFlag)
+    {
+        /* Set receive mode. */
+        base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+        /* Read dummy. */
+        dummy = base->D;
+
+        if (handle->transfer.dataSize != 0)
+        {
+            xfer->event = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_I2C_Nak;
+            handle->isBusy = false;
+
+            if ((handle->eventMask & xfer->event) && (handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+        }
+        else
+        {
+#ifndef I2C_HAS_STOP_DETECT
+            xfer->event = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_Success;
+            handle->isBusy = false;
+
+            if ((handle->eventMask & xfer->event) && (handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+#endif /* !FSL_FEATURE_I2C_HAS_START_STOP_DETECT or !FSL_FEATURE_I2C_HAS_STOP_DETECT */
+        }
+    }
+    /* Check address match. */
+    else if (status & kI2C_AddressMatchFlag)
+    {
+        handle->isBusy = true;
+        xfer->event = kI2C_SlaveAddressMatchEvent;
+
+        if ((handle->eventMask & xfer->event) && (handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
+        }
+
+        /* Slave transmit, master reading from slave. */
+        if (status & kI2C_TransferDirectionFlag)
+        {
+            /* Change direction to send data. */
+            base->C1 |= I2C_C1_TX_MASK;
+
+            /* If we're out of data, invoke callback to get more. */
+            if ((!xfer->data) || (!xfer->dataSize))
+            {
+                xfer->event = kI2C_SlaveTransmitEvent;
+
+                if (handle->callback)
+                {
+                    handle->callback(base, xfer, handle->userData);
+                }
+
+                /* Clear the transferred count now that we have a new buffer. */
+                xfer->transferredCount = 0;
+            }
+
+            doTransmit = true;
+        }
+        else
+        {
+            /* Slave receive, master writing to slave. */
+            base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+            /* If we're out of data, invoke callback to get more. */
+            if ((!xfer->data) || (!xfer->dataSize))
+            {
+                xfer->event = kI2C_SlaveReceiveEvent;
+
+                if (handle->callback)
+                {
+                    handle->callback(base, xfer, handle->userData);
+                }
+
+                /* Clear the transferred count now that we have a new buffer. */
+                xfer->transferredCount = 0;
+            }
+
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+        }
+    }
+    /* Check transfer complete flag. */
+    else if (status & kI2C_TransferCompleteFlag)
+    {
+        /* Slave transmit, master reading from slave. */
+        if (status & kI2C_TransferDirectionFlag)
+        {
+            doTransmit = true;
+        }
+        else
+        {
+            /* Slave receive, master writing to slave. */
+            uint8_t data = base->D;
+
+            if (handle->transfer.dataSize)
+            {
+                /* Receive data. */
+                *handle->transfer.data++ = data;
+                handle->transfer.dataSize--;
+                xfer->transferredCount++;
+                if (!handle->transfer.dataSize)
+                {
+#ifndef I2C_HAS_STOP_DETECT
+                    xfer->event = kI2C_SlaveCompletionEvent;
+                    xfer->completionStatus = kStatus_Success;
+                    handle->isBusy = false;
+
+                    /* Proceed receive complete event. */
+                    if ((handle->eventMask & xfer->event) && (handle->callback))
+                    {
+                        handle->callback(base, xfer, handle->userData);
+                    }
+#endif /* !FSL_FEATURE_I2C_HAS_START_STOP_DETECT or !FSL_FEATURE_I2C_HAS_STOP_DETECT */
+                }
+            }
+        }
+    }
+    else
+    {
+        /* Read dummy to release bus. */
+        dummy = base->D;
+    }
+
+    /* Send data if there is the need. */
+    if (doTransmit)
+    {
+        if (handle->transfer.dataSize)
+        {
+            /* Send data. */
+            base->D = *handle->transfer.data++;
+            handle->transfer.dataSize--;
+            xfer->transferredCount++;
+        }
+        else
+        {
+            /* Switch to receive mode. */
+            base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+            /* Read dummy to release bus. */
+            dummy = base->D;
+
+#ifndef I2C_HAS_STOP_DETECT
+            xfer->event = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_Success;
+            handle->isBusy = false;
+
+            /* Proceed txdone event. */
+            if ((handle->eventMask & xfer->event) && (handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+#endif /* !FSL_FEATURE_I2C_HAS_START_STOP_DETECT or !FSL_FEATURE_I2C_HAS_STOP_DETECT */
+        }
+    }
+}
+
+void I2C0_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C0, s_i2cHandle[0]);
+}
+
+#if (FSL_FEATURE_SOC_I2C_COUNT > 1)
+void I2C1_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C1, s_i2cHandle[1]);
+}
+#endif /* I2C COUNT > 1 */
+
+#if (FSL_FEATURE_SOC_I2C_COUNT > 2)
+void I2C2_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C2, s_i2cHandle[2]);
+}
+#endif /* I2C COUNT > 2 */
+#if (FSL_FEATURE_SOC_I2C_COUNT > 3)
+void I2C3_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C3, s_i2cHandle[3]);
+}
+#endif /* I2C COUNT > 3 */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c.h
@@ -1,0 +1,781 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_I2C_H_
+#define _FSL_I2C_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup i2c_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief I2C driver version 2.0.0. */
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+#if (defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT || \
+     defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT)
+#define I2C_HAS_STOP_DETECT
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT / FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+/*! @brief  I2C status return codes. */
+enum _i2c_status
+{
+    kStatus_I2C_Busy = MAKE_STATUS(kStatusGroup_I2C, 0),            /*!< I2C is busy with current transfer. */
+    kStatus_I2C_Idle = MAKE_STATUS(kStatusGroup_I2C, 1),            /*!< Bus is Idle. */
+    kStatus_I2C_Nak = MAKE_STATUS(kStatusGroup_I2C, 2),             /*!< NAK received during transfer. */
+    kStatus_I2C_ArbitrationLost = MAKE_STATUS(kStatusGroup_I2C, 3), /*!< Arbitration lost during transfer. */
+    kStatus_I2C_Timeout = MAKE_STATUS(kStatusGroup_I2C, 4),         /*!< Wait event timeout. */
+};
+
+/*!
+ * @brief I2C peripheral flags
+ *
+ * The following status register flags can be cleared:
+ * - #kI2C_ArbitrationLostFlag
+ * - #kI2C_IntPendingFlag
+ * - #kI2C_StartDetectFlag
+ * - #kI2C_StopDetectFlag
+ *
+ * @note These enumerations are meant to be OR'd together to form a bit mask.
+ *
+ */
+enum _i2c_flags
+{
+    kI2C_ReceiveNakFlag = I2C_S_RXAK_MASK,       /*!< I2C receive NAK flag. */
+    kI2C_IntPendingFlag = I2C_S_IICIF_MASK,      /*!< I2C interrupt pending flag. */
+    kI2C_TransferDirectionFlag = I2C_S_SRW_MASK, /*!< I2C transfer direction flag. */
+    kI2C_RangeAddressMatchFlag = I2C_S_RAM_MASK, /*!< I2C range address match flag. */
+    kI2C_ArbitrationLostFlag = I2C_S_ARBL_MASK,  /*!< I2C arbitration lost flag. */
+    kI2C_BusBusyFlag = I2C_S_BUSY_MASK,          /*!< I2C bus busy flag. */
+    kI2C_AddressMatchFlag = I2C_S_IAAS_MASK,     /*!< I2C address match flag. */
+    kI2C_TransferCompleteFlag = I2C_S_TCF_MASK,  /*!< I2C transfer complete flag. */
+#ifdef I2C_HAS_STOP_DETECT
+    kI2C_StopDetectFlag = I2C_FLT_STOPF_MASK << 8, /*!< I2C stop detect flag. */
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT / FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kI2C_StartDetectFlag = I2C_FLT_STARTF_MASK << 8, /*!< I2C start detect flag. */
+#endif                                               /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+};
+
+/*! @brief I2C feature interrupt source. */
+enum _i2c_interrupt_enable
+{
+    kI2C_GlobalInterruptEnable = I2C_C1_IICIE_MASK, /*!< I2C global interrupt. */
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    kI2C_StopDetectInterruptEnable = I2C_FLT_STOPIE_MASK, /*!< I2C stop detect interrupt. */
+#endif                                                    /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kI2C_StartStopDetectInterruptEnable = I2C_FLT_SSIE_MASK, /*!< I2C start&stop detect interrupt. */
+#endif                                                       /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+};
+
+/*! @brief Direction of master and slave transfers. */
+typedef enum _i2c_direction
+{
+    kI2C_Write = 0x0U, /*!< Master transmit to slave. */
+    kI2C_Read = 0x1U,  /*!< Master receive from slave. */
+} i2c_direction_t;
+
+/*! @brief Addressing mode. */
+typedef enum _i2c_slave_address_mode
+{
+    kI2C_Address7bit = 0x0U, /*!< 7-bit addressing mode. */
+    kI2C_RangeMatch = 0X2U,  /*!< Range address match addressing mode. */
+} i2c_slave_address_mode_t;
+
+/*! @brief I2C transfer control flag. */
+enum _i2c_master_transfer_flags
+{
+    kI2C_TransferDefaultFlag = 0x0U,       /*!< Transfer starts with a start signal, stops with a stop signal. */
+    kI2C_TransferNoStartFlag = 0x1U,       /*!< Transfer starts without a start signal. */
+    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< Transfer starts with a repeated start signal. */
+    kI2C_TransferNoStopFlag = 0x4U,        /*!< Transfer ends without a stop signal. */
+};
+
+/*!
+ * @brief Set of events sent to the callback for nonblocking slave transfers.
+ *
+ * These event enumerations are used for two related purposes. First, a bit mask created by OR'ing together
+ * events is passed to I2C_SlaveTransferNonBlocking() in order to specify which events to enable.
+ * Then, when the slave callback is invoked, it is passed the current event through its @a transfer
+ * parameter.
+ *
+ * @note These enumerations are meant to be OR'd together to form a bit mask of events.
+ */
+typedef enum _i2c_slave_transfer_event
+{
+    kI2C_SlaveAddressMatchEvent = 0x01U, /*!< Received the slave address after a start or repeated start. */
+    kI2C_SlaveTransmitEvent = 0x02U,     /*!< Callback is requested to provide data to transmit
+                                                (slave-transmitter role). */
+    kI2C_SlaveReceiveEvent = 0x04U,      /*!< Callback is requested to provide a buffer in which to place received
+                                                 data (slave-receiver role). */
+    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< Callback needs to either transmit an ACK or NACK. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kI2C_SlaveRepeatedStartEvent = 0x10U, /*!< A repeated start was detected. */
+#endif
+    kI2C_SlaveCompletionEvent = 0x20U, /*!< A stop was detected or finished transfer, completing the transfer. */
+
+    /*! Bit mask of all available events. */
+    kI2C_SlaveAllEvents = kI2C_SlaveAddressMatchEvent | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent |
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+                          kI2C_SlaveRepeatedStartEvent |
+#endif
+                          kI2C_SlaveCompletionEvent,
+} i2c_slave_transfer_event_t;
+
+/*! @brief I2C master user configuration. */
+typedef struct _i2c_master_config
+{
+    bool enableMaster; /*!< Enables the I2C peripheral at initialization time. */
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
+#endif
+#if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
+    bool enableStopHold; /*!< Controls the stop hold enable. */
+#endif
+    uint32_t baudRate_Bps;     /*!< Baud rate configuration of I2C peripheral. */
+    uint8_t glitchFilterWidth; /*!< Controls the width of the glitch. */
+} i2c_master_config_t;
+
+/*! @brief I2C slave user configuration. */
+typedef struct _i2c_slave_config
+{
+    bool enableSlave;       /*!< Enables the I2C peripheral at initialization time. */
+    bool enableGeneralCall; /*!< Enable general call addressing mode. */
+    bool enableWakeUp;      /*!< Enables/disables waking up MCU from low power mode. */
+#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
+    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
+#endif
+    bool enableBaudRateCtl; /*!< Enables/disables independent slave baud rate on SCL in very fast I2C modes. */
+    uint16_t slaveAddress;  /*!< Slave address configuration. */
+    uint16_t upperAddress;  /*!< Maximum boundary slave address used in range matching mode. */
+    i2c_slave_address_mode_t addressingMode; /*!< Addressing mode configuration of i2c_slave_address_mode_config_t. */
+} i2c_slave_config_t;
+
+/*! @brief I2C master handle typedef. */
+typedef struct _i2c_master_handle i2c_master_handle_t;
+
+/*! @brief I2C master transfer callback typedef. */
+typedef void (*i2c_master_transfer_callback_t)(I2C_Type *base,
+                                               i2c_master_handle_t *handle,
+                                               status_t status,
+                                               void *userData);
+
+/*! @brief I2C slave handle typedef. */
+typedef struct _i2c_slave_handle i2c_slave_handle_t;
+
+/*! @brief I2C master transfer structure. */
+typedef struct _i2c_master_transfer
+{
+    uint32_t flags;            /*!< Transfer flag which controls the transfer. */
+    uint8_t slaveAddress;      /*!< 7-bit slave address. */
+    i2c_direction_t direction; /*!< Transfer direction, read or write. */
+    uint32_t subaddress;       /*!< Sub address. Transferred MSB first. */
+    uint8_t subaddressSize;    /*!< Size of command buffer. */
+    uint8_t *volatile data;    /*!< Transfer buffer. */
+    volatile size_t dataSize;  /*!< Transfer size. */
+} i2c_master_transfer_t;
+
+/*! @brief I2C master handle structure. */
+struct _i2c_master_handle
+{
+    i2c_master_transfer_t transfer;                    /*!< I2C master transfer copy. */
+    size_t transferSize;                               /*!< Total bytes to be transferred. */
+    uint8_t state;                                     /*!< Transfer state maintained during transfer. */
+    i2c_master_transfer_callback_t completionCallback; /*!< Callback function called when transfer finished. */
+    void *userData;                                    /*!< Callback parameter passed to callback function. */
+};
+
+/*! @brief I2C slave transfer structure. */
+typedef struct _i2c_slave_transfer
+{
+    i2c_slave_transfer_event_t event; /*!< Reason the callback is being invoked. */
+    uint8_t *volatile data;           /*!< Transfer buffer. */
+    volatile size_t dataSize;         /*!< Transfer size. */
+    status_t completionStatus;        /*!< Success or error code describing how the transfer completed. Only applies for
+                                         #kI2C_SlaveCompletionEvent. */
+    size_t transferredCount;          /*!< Number of bytes actually transferred since start or last repeated start. */
+} i2c_slave_transfer_t;
+
+/*! @brief I2C slave transfer callback typedef. */
+typedef void (*i2c_slave_transfer_callback_t)(I2C_Type *base, i2c_slave_transfer_t *xfer, void *userData);
+
+/*! @brief I2C slave handle structure. */
+struct _i2c_slave_handle
+{
+    bool isBusy;                            /*!< Whether transfer is busy. */
+    i2c_slave_transfer_t transfer;          /*!< I2C slave transfer copy. */
+    uint32_t eventMask;                     /*!< Mask of enabled events. */
+    i2c_slave_transfer_callback_t callback; /*!< Callback function called at transfer event. */
+    void *userData;                         /*!< Callback parameter passed to callback. */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /*_cplusplus. */
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
+ * and configure the I2C with master configuration.
+ *
+ * @note This API should be called at the beginning of the application to use
+ * the I2C driver, or any operation to the I2C module could cause hard fault
+ * because clock is not enabled. The configuration structure can be filled by user
+ * from scratch, or be set with default values by I2C_MasterGetDefaultConfig().
+ * After calling this API, the master is ready to transfer.
+ * Example:
+ * @code
+ * i2c_master_config_t config = {
+ * .enableMaster = true,
+ * .enableStopHold = false,
+ * .highDrive = false,
+ * .baudRate_Bps = 100000,
+ * .glitchFilterWidth = 0
+ * };
+ * I2C_MasterInit(I2C0, &config, 12000000U);
+ * @endcode
+ *
+ * @param base I2C base pointer
+ * @param masterConfig pointer to master configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
+ */
+void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
+ * and initializes the I2C with slave configuration.
+ *
+ * @note This API should be called at the beginning of the application to use
+ * the I2C driver, or any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can partly be set
+ * with default values by I2C_SlaveGetDefaultConfig(), or can be filled by the user.
+ * Example
+ * @code
+ * i2c_slave_config_t config = {
+ * .enableSlave = true,
+ * .enableGeneralCall = false,
+ * .addressingMode = kI2C_Address7bit,
+ * .slaveAddress = 0x1DU,
+ * .enableWakeUp = false,
+ * .enablehighDrive = false,
+ * .enableBaudRateCtl = false
+ * };
+ * I2C_SlaveInit(I2C0, &config);
+ * @endcode
+ *
+ * @param base I2C base pointer
+ * @param slaveConfig pointer to slave configuration structure
+ */
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig);
+
+/*!
+ * @brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
+ * The I2C master module can't work unless the I2C_MasterInit is called.
+ * @param base I2C base pointer
+ */
+void I2C_MasterDeinit(I2C_Type *base);
+
+/*!
+ * @brief De-initializes the I2C slave peripheral. Calling this API gates the I2C clock.
+ * The I2C slave module can't work unless the I2C_SlaveInit is called to enable the clock.
+ * @param base I2C base pointer
+ */
+void I2C_SlaveDeinit(I2C_Type *base);
+
+/*!
+ * @brief  Sets the I2C master configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
+ * Use the initialized structure unchanged in I2C_MasterConfigure(), or modify some fields of
+ * the structure before calling I2C_MasterConfigure().
+ * Example:
+ * @code
+ * i2c_master_config_t config;
+ * I2C_MasterGetDefaultConfig(&config);
+ * @endcode
+ * @param masterConfig Pointer to the master configuration structure.
+*/
+void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig);
+
+/*!
+ * @brief  Sets the I2C slave configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in I2C_SlaveConfigure().
+ * Modify fields of the structure before calling the I2C_SlaveConfigure().
+ * Example:
+ * @code
+ * i2c_slave_config_t config;
+ * I2C_SlaveGetDefaultConfig(&config);
+ * @endcode
+ * @param slaveConfig Pointer to the slave configuration structure.
+ */
+void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
+
+/*!
+ * @brief Enables or disabless the I2C peripheral operation.
+ *
+ * @param base I2C base pointer
+ * @param enable pass true to enable module, false to disable module
+ */
+static inline void I2C_Enable(I2C_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C1 |= I2C_C1_IICEN_MASK;
+    }
+    else
+    {
+        base->C1 &= ~I2C_C1_IICEN_MASK;
+    }
+}
+
+/* @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Gets the I2C status flags.
+ *
+ * @param base I2C base pointer
+ * @return status flag, use status flag to AND #_i2c_flags could get the related status.
+ */
+uint32_t I2C_MasterGetStatusFlags(I2C_Type *base);
+
+/*!
+ * @brief Gets the I2C status flags.
+ *
+ * @param base I2C base pointer
+ * @return status flag, use status flag to AND #_i2c_flags could get the related status.
+ */
+static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
+{
+    return I2C_MasterGetStatusFlags(base);
+}
+
+/*!
+ * @brief Clears the I2C status flag state.
+ *
+ * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ *
+ * @param base I2C base pointer
+ * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
+ *      The parameter could be any combination of the following values:
+ *          @arg kI2C_StartDetectFlag (if available)
+ *          @arg kI2C_StopDetectFlag (if available)
+ *          @arg kI2C_ArbitrationLostFlag
+ *          @arg kI2C_IntPendingFlagFlag
+ */
+static inline void I2C_MasterClearStatusFlags(I2C_Type *base, uint32_t statusMask)
+{
+/* Must clear the STARTF / STOPF bits prior to clearing IICIF */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    if (statusMask & kI2C_StartDetectFlag)
+    {
+        /* Shift the odd-ball flags back into place. */
+        base->FLT |= (uint8_t)(statusMask >> 8U);
+    }
+#endif
+
+#ifdef I2C_HAS_STOP_DETECT
+    if (statusMask & kI2C_StopDetectFlag)
+    {
+        /* Shift the odd-ball flags back into place. */
+        base->FLT |= (uint8_t)(statusMask >> 8U);
+    }
+#endif
+
+    base->S = (uint8_t)statusMask;
+}
+
+/*!
+ * @brief Clears the I2C status flag state.
+ *
+ * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ *
+  * @param base I2C base pointer
+  * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
+ *      The parameter could be any combination of the following values:
+ *          @arg kI2C_StartDetectFlag (if available)
+ *          @arg kI2C_StopDetectFlag (if available)
+ *          @arg kI2C_ArbitrationLostFlag
+ *          @arg kI2C_IntPendingFlagFlag
+ */
+static inline void I2C_SlaveClearStatusFlags(I2C_Type *base, uint32_t statusMask)
+{
+    I2C_MasterClearStatusFlags(base, statusMask);
+}
+
+/* @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enables I2C interrupt requests.
+ *
+ * @param base I2C base pointer
+ * @param mask interrupt source
+ *     The parameter can be combination of the following source if defined:
+ *     @arg kI2C_GlobalInterruptEnable
+ *     @arg kI2C_StopDetectInterruptEnable/kI2C_StartDetectInterruptEnable
+ *     @arg kI2C_SdaTimeoutInterruptEnable
+ */
+void I2C_EnableInterrupts(I2C_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables I2C interrupt requests.
+ *
+ * @param base I2C base pointer
+ * @param mask interrupt source
+ *     The parameter can be combination of the following source if defined:
+ *     @arg kI2C_GlobalInterruptEnable
+ *     @arg kI2C_StopDetectInterruptEnable/kI2C_StartDetectInterruptEnable
+ *     @arg kI2C_SdaTimeoutInterruptEnable
+ */
+void I2C_DisableInterrupts(I2C_Type *base, uint32_t mask);
+
+/*!
+ * @name DMA Control
+ * @{
+ */
+#if defined(FSL_FEATURE_I2C_HAS_DMA_SUPPORT) && FSL_FEATURE_I2C_HAS_DMA_SUPPORT
+/*!
+ * @brief Enables/disables the I2C DMA interrupt.
+ *
+ * @param base I2C base pointer
+ * @param enable true to enable, false to disable
+*/
+static inline void I2C_EnableDMA(I2C_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C1 |= I2C_C1_DMAEN_MASK;
+    }
+    else
+    {
+        base->C1 &= ~I2C_C1_DMAEN_MASK;
+    }
+}
+
+#endif /* FSL_FEATURE_I2C_HAS_DMA_SUPPORT */
+
+/*!
+ * @brief  Gets the I2C tx/rx data register address. This API is used to provide a transfer address
+ * for I2C DMA transfer configuration.
+ *
+ * @param base I2C base pointer
+ * @return data register address
+ */
+static inline uint32_t I2C_GetDataRegAddr(I2C_Type *base)
+{
+    return (uint32_t)(&(base->D));
+}
+
+/* @} */
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Sets the I2C master transfer baud rate.
+ *
+ * @param base I2C base pointer
+ * @param baudRate_Bps the baud rate value in bps
+ * @param srcClock_Hz Source clock
+ */
+void I2C_MasterSetBaudRate(I2C_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Sends a START on the I2C bus.
+ *
+ * This function is used to initiate a new master mode transfer by sending the START signal.
+ * The slave address is sent following the I2C START signal.
+ *
+ * @param base I2C peripheral base pointer
+ * @param address 7-bit slave device address.
+ * @param direction Master transfer directions(transmit/receive).
+ * @retval kStatus_Success Successfully send the start signal.
+ * @retval kStatus_I2C_Busy Current bus is busy.
+ */
+status_t I2C_MasterStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
+
+/*!
+ * @brief Sends a STOP signal on the I2C bus.
+ *
+ * @retval kStatus_Success Successfully send the stop signal.
+ * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
+ */
+status_t I2C_MasterStop(I2C_Type *base);
+
+/*!
+ * @brief Sends a REPEATED START on the I2C bus.
+ *
+ * @param base I2C peripheral base pointer
+ * @param address 7-bit slave device address.
+ * @param direction Master transfer directions(transmit/receive).
+ * @retval kStatus_Success Successfully send the start signal.
+ * @retval kStatus_I2C_Busy Current bus is busy but not occupied by current I2C master.
+ */
+status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
+
+/*!
+ * @brief Performs a polling send transaction on the I2C bus without a STOP signal.
+ *
+ * @param base  The I2C peripheral base pointer.
+ * @param txBuff The pointer to the data to be transferred.
+ * @param txSize The length in bytes of the data to be transferred.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+
+/*!
+ * @brief Performs a polling receive transaction on the I2C bus with a STOP signal.
+ *
+ * @note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
+ * Without stopping the bus prior for the final read, the bus issues another read, resulting
+ * in garbage data being read into the data register.
+ *
+ * @param base I2C peripheral base pointer.
+ * @param rxBuff The pointer to the data to store the received data.
+ * @param rxSize The length in bytes of the data to be received.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
+ */
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+
+/*!
+ * @brief Performs a polling send transaction on the I2C bus.
+ *
+ * @param base  The I2C peripheral base pointer.
+ * @param txBuff The pointer to the data to be transferred.
+ * @param txSize The length in bytes of the data to be transferred.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+
+/*!
+ * @brief Performs a polling receive transaction on the I2C bus.
+ *
+ * @param base I2C peripheral base pointer.
+ * @param rxBuff The pointer to the data to store the received data.
+ * @param rxSize The length in bytes of the data to be received.
+ */
+void I2C_SlaveReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+
+/*!
+ * @brief Performs a master polling transfer on the I2C bus.
+ *
+ * @note The API does not return until the transfer succeeds or fails due
+ * to arbitration lost or receiving a NAK.
+ *
+ * @param base I2C peripheral base address.
+ * @param xfer Pointer to the transfer structure.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_Busy Previous transmission still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer);
+
+/* @} */
+
+/*!
+ * @name Transactional
+ * @{
+ */
+
+/*!
+ * @brief Initializes the I2C handle which is used in transactional functions.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure to store the transfer state.
+ * @param callback pointer to user callback function.
+ * @param userData user paramater passed to the callback function.
+ */
+void I2C_MasterTransferCreateHandle(I2C_Type *base,
+                                    i2c_master_handle_t *handle,
+                                    i2c_master_transfer_callback_t callback,
+                                    void *userData);
+
+/*!
+ * @brief Performs a master interrupt non-blocking transfer on the I2C bus.
+ *
+ * @note Calling the API will return immediately after transfer initiates, user needs
+ * to call I2C_MasterGetTransferCount to poll the transfer status to check whether
+ * the transfer is finished, if the return status is not kStatus_I2C_Busy, the transfer
+ * is finished.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * @param xfer pointer to i2c_master_transfer_t structure.
+ * @retval kStatus_Success Sucessully start the data transmission.
+ * @retval kStatus_I2C_Busy Previous transmission still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ */
+status_t I2C_MasterTransferNonBlocking(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer);
+
+/*!
+ * @brief Gets the master transfer status during a interrupt non-blocking transfer.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @retval kStatus_InvalidArgument count is Invalid.
+ * @retval kStatus_Success Successfully return the count.
+ */
+status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Aborts an interrupt non-blocking transfer early.
+ *
+ * @note This API can be called at any time when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ */
+void I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle);
+
+/*!
+ * @brief Master interrupt handler.
+ *
+ * @param base I2C base pointer.
+ * @param i2cHandle pointer to i2c_master_handle_t structure.
+ */
+void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle);
+
+/*!
+ * @brief Initializes the I2C handle which is used in transactional functions.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_slave_handle_t structure to store the transfer state.
+ * @param callback pointer to user callback function.
+ * @param userData user parameter passed to the callback function.
+ */
+void I2C_SlaveTransferCreateHandle(I2C_Type *base,
+                                   i2c_slave_handle_t *handle,
+                                   i2c_slave_transfer_callback_t callback,
+                                   void *userData);
+
+/*!
+ * @brief Starts accepting slave transfers.
+ *
+ * Call this API after calling the I2C_SlaveInit() and I2C_SlaveTransferCreateHandle() to start processing
+ * transactions driven by an I2C master. The slave monitors the I2C bus and passes events to the
+ * callback that was passed into the call to I2C_SlaveTransferCreateHandle(). The callback is always invoked
+ * from the interrupt context.
+ *
+ * The set of events received by the callback is customizable. To do so, set the @a eventMask parameter to
+ * the OR'd combination of #i2c_slave_transfer_event_t enumerators for the events you wish to receive.
+ * The #kI2C_SlaveTransmitEvent and #kLPI2C_SlaveReceiveEvent events are always enabled and do not need
+ * to be included in the mask. Alternatively, pass 0 to get a default set of only the transmit and
+ * receive events that are always enabled. In addition, the #kI2C_SlaveAllEvents constant is provided as
+ * a convenient way to enable all events.
+ *
+ * @param base The I2C peripheral base address.
+ * @param handle Pointer to #i2c_slave_handle_t structure which stores the transfer state.
+ * @param eventMask Bit mask formed by OR'ing together #i2c_slave_transfer_event_t enumerators to specify
+ *      which events to send to the callback. Other accepted values are 0 to get a default set of
+ *      only the transmit and receive events, and #kI2C_SlaveAllEvents to enable all events.
+ *
+ * @retval #kStatus_Success Slave transfers were successfully started.
+ * @retval #kStatus_I2C_Busy Slave transfers have already been started on this handle.
+ */
+status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle, uint32_t eventMask);
+
+/*!
+ * @brief Aborts the slave transfer.
+ *
+ * @note This API can be called at any time to stop slave for handling the bus events.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_slave_handle_t structure which stores the transfer state.
+ */
+void I2C_SlaveTransferAbort(I2C_Type *base, i2c_slave_handle_t *handle);
+
+/*!
+ * @brief Gets the slave transfer remaining bytes during a interrupt non-blocking transfer.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_slave_handle_t structure.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @retval kStatus_InvalidArgument count is Invalid.
+ * @retval kStatus_Success Successfully return the count.
+ */
+status_t I2C_SlaveTransferGetCount(I2C_Type *base, i2c_slave_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Slave interrupt handler.
+ *
+ * @param base I2C base pointer.
+ * @param i2cHandle pointer to i2c_slave_handle_t structure which stores the transfer state
+ */
+void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle);
+
+/* @} */
+#if defined(__cplusplus)
+}
+#endif /*_cplusplus. */
+/*@}*/
+
+#endif /* _FSL_I2C_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c_edma.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c_edma.c
@@ -1,0 +1,526 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_i2c_edma.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*<! @breif Structure definition for i2c_master_edma_private_handle_t. The structure is private. */
+typedef struct _i2c_master_edma_private_handle
+{
+    I2C_Type *base;
+    i2c_master_edma_handle_t *handle;
+} i2c_master_edma_private_handle_t;
+
+/*! @brief i2c master DMA transfer state. */
+enum _i2c_master_dma_transfer_states
+{
+    kIdleState = 0x0U,         /*!< I2C bus idle. */
+    kTransferDataState = 0x1U, /*!< 7-bit address check state. */
+};
+
+/*! @brief Common sets of flags used by the driver. */
+enum _i2c_flag_constants
+{
+/*! All flags which are cleared by the driver upon starting a transfer. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag | kI2C_StartDetectFlag | kI2C_StopDetectFlag,
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag | kI2C_StopDetectFlag,
+#else
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag,
+#endif
+};
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief EDMA callback for I2C master EDMA driver.
+ *
+ * @param handle EDMA handler for I2C master EDMA driver
+ * @param userData user param passed to the callback function
+ */
+static void I2C_MasterTransferCallbackEDMA(edma_handle_t *handle, void *userData, bool transferDone, uint32_t tcds);
+
+/*!
+ * @brief Check and clear status operation.
+ *
+ * @param base I2C peripheral base address.
+ * @param status current i2c hardware status.
+ * @retval kStatus_Success No error found.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStatus_I2C_Nak Received Nak error.
+ */
+static status_t I2C_CheckAndClearError(I2C_Type *base, uint32_t status);
+
+/*!
+ * @brief EDMA config for I2C master driver.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_edma_handle_t structure which stores the transfer state
+ */
+static void I2C_MasterTransferEDMAConfig(I2C_Type *base, i2c_master_edma_handle_t *handle);
+
+/*!
+ * @brief Set up master transfer, send slave address and sub address(if any), wait until the
+ * wait until address sent status return.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_edma_handle_t structure which stores the transfer state
+ * @param xfer pointer to i2c_master_transfer_t structure
+ */
+static status_t I2C_InitTransferStateMachineEDMA(I2C_Type *base,
+                                                 i2c_master_edma_handle_t *handle,
+                                                 i2c_master_transfer_t *xfer);
+
+/*!
+ * @brief Get the I2C instance from peripheral base address.
+ *
+ * @param base I2C peripheral base address.
+ * @return I2C instance.
+ */
+extern uint32_t I2C_GetInstance(I2C_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*<! Private handle only used for internally. */
+static i2c_master_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2C_COUNT];
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+
+static void I2C_MasterTransferCallbackEDMA(edma_handle_t *handle, void *userData, bool transferDone, uint32_t tcds)
+{
+    i2c_master_edma_private_handle_t *i2cPrivateHandle = (i2c_master_edma_private_handle_t *)userData;
+    status_t result = kStatus_Success;
+
+    /* Disable DMA. */
+    I2C_EnableDMA(i2cPrivateHandle->base, false);
+
+    /* Send stop if kI2C_TransferNoStop flag is not asserted. */
+    if (!(i2cPrivateHandle->handle->transfer.flags & kI2C_TransferNoStopFlag))
+    {
+        if (i2cPrivateHandle->handle->transfer.direction == kI2C_Read)
+        {
+            /* Change to send NAK at the last byte. */
+            i2cPrivateHandle->base->C1 |= I2C_C1_TXAK_MASK;
+
+            /* Wait the last data to be received. */
+            while (!(i2cPrivateHandle->base->S & kI2C_TransferCompleteFlag))
+            {
+            }
+
+            /* Send stop signal. */
+            result = I2C_MasterStop(i2cPrivateHandle->base);
+
+            /* Read the last data byte. */
+            *(i2cPrivateHandle->handle->transfer.data + i2cPrivateHandle->handle->transfer.dataSize - 1) =
+                i2cPrivateHandle->base->D;
+        }
+        else
+        {
+            /* Wait the last data to be sent. */
+            while (!(i2cPrivateHandle->base->S & kI2C_TransferCompleteFlag))
+            {
+            }
+
+            /* Send stop signal. */
+            result = I2C_MasterStop(i2cPrivateHandle->base);
+        }
+    }
+
+    i2cPrivateHandle->handle->state = kIdleState;
+
+    if (i2cPrivateHandle->handle->completionCallback)
+    {
+        i2cPrivateHandle->handle->completionCallback(i2cPrivateHandle->base, i2cPrivateHandle->handle, result,
+                                                     i2cPrivateHandle->handle->userData);
+    }
+}
+
+static status_t I2C_CheckAndClearError(I2C_Type *base, uint32_t status)
+{
+    status_t result = kStatus_Success;
+
+    /* Check arbitration lost. */
+    if (status & kI2C_ArbitrationLostFlag)
+    {
+        /* Clear arbitration lost flag. */
+        base->S = kI2C_ArbitrationLostFlag;
+        result = kStatus_I2C_ArbitrationLost;
+    }
+    /* Check NAK */
+    else if (status & kI2C_ReceiveNakFlag)
+    {
+        result = kStatus_I2C_Nak;
+    }
+    else
+    {
+    }
+
+    return result;
+}
+
+static status_t I2C_InitTransferStateMachineEDMA(I2C_Type *base,
+                                                 i2c_master_edma_handle_t *handle,
+                                                 i2c_master_transfer_t *xfer)
+{
+    assert(handle);
+    assert(xfer);
+
+    status_t result = kStatus_Success;
+    uint16_t timeout = UINT16_MAX;
+
+    if (handle->state != kIdleState)
+    {
+        return kStatus_I2C_Busy;
+    }
+    else
+    {
+        i2c_direction_t direction = xfer->direction;
+
+        /* Init the handle member. */
+        handle->transfer = *xfer;
+
+        /* Save total transfer size. */
+        handle->transferSize = xfer->dataSize;
+
+        handle->state = kTransferDataState;
+
+        /* Wait until ready to complete. */
+        while ((!(base->S & kI2C_TransferCompleteFlag)) && (--timeout))
+        {
+        }
+
+        /* Failed to start the transfer. */
+        if (timeout == 0)
+        {
+            return kStatus_I2C_Timeout;
+        }
+        /* Clear all status before transfer. */
+        I2C_MasterClearStatusFlags(base, kClearFlags);
+
+        /* Change to send write address when it's a read operation with command. */
+        if ((xfer->subaddressSize > 0) && (xfer->direction == kI2C_Read))
+        {
+            direction = kI2C_Write;
+        }
+
+        /* If repeated start is requested, send repeated start. */
+        if (handle->transfer.flags & kI2C_TransferRepeatedStartFlag)
+        {
+            result = I2C_MasterRepeatedStart(base, handle->transfer.slaveAddress, direction);
+        }
+        else /* For normal transfer, send start. */
+        {
+            result = I2C_MasterStart(base, handle->transfer.slaveAddress, direction);
+        }
+
+        /* Send subaddress. */
+        if (handle->transfer.subaddressSize)
+        {
+            do
+            {
+                /* Wait until data transfer complete. */
+                while (!(base->S & kI2C_IntPendingFlag))
+                {
+                }
+
+                /* Clear interrupt pending flag. */
+                base->S = kI2C_IntPendingFlag;
+
+                handle->transfer.subaddressSize--;
+                base->D = ((handle->transfer.subaddress) >> (8 * handle->transfer.subaddressSize));
+
+                /* Check if there's transfer error. */
+                result = I2C_CheckAndClearError(base, base->S);
+
+                if (result)
+                {
+                    return result;
+                }
+
+            } while ((handle->transfer.subaddressSize > 0) && (result == kStatus_Success));
+
+            if (handle->transfer.direction == kI2C_Read)
+            {
+                /* Wait until data transfer complete. */
+                while (!(base->S & kI2C_IntPendingFlag))
+                {
+                }
+
+                /* Clear pending flag. */
+                base->S = kI2C_IntPendingFlag;
+
+                /* Send repeated start and slave address. */
+                result = I2C_MasterRepeatedStart(base, handle->transfer.slaveAddress, kI2C_Read);
+            }
+        }
+
+        if (result)
+        {
+            return result;
+        }
+
+        /* Wait until data transfer complete. */
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+
+        /* Clear pending flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Check if there's transfer error. */
+        result = I2C_CheckAndClearError(base, base->S);
+    }
+
+    return result;
+}
+
+static void I2C_MasterTransferEDMAConfig(I2C_Type *base, i2c_master_edma_handle_t *handle)
+{
+    edma_transfer_config_t transfer_config;
+
+    if (handle->transfer.direction == kI2C_Read)
+    {
+        transfer_config.srcAddr = (uint32_t)I2C_GetDataRegAddr(base);
+        transfer_config.destAddr = (uint32_t)(handle->transfer.data);
+
+        /* Send stop if kI2C_TransferNoStop flag is not asserted. */
+        if (!(handle->transfer.flags & kI2C_TransferNoStopFlag))
+        {
+            transfer_config.majorLoopCounts = (handle->transfer.dataSize - 1);
+        }
+        else
+        {
+            transfer_config.majorLoopCounts = handle->transfer.dataSize;
+        }
+
+        transfer_config.srcTransferSize = kEDMA_TransferSize1Bytes;
+        transfer_config.srcOffset = 0;
+        transfer_config.destTransferSize = kEDMA_TransferSize1Bytes;
+        transfer_config.destOffset = 1;
+        transfer_config.minorLoopBytes = 1;
+    }
+    else
+    {
+        transfer_config.srcAddr = (uint32_t)(handle->transfer.data + 1);
+        transfer_config.destAddr = (uint32_t)I2C_GetDataRegAddr(base);
+        transfer_config.majorLoopCounts = (handle->transfer.dataSize - 1);
+        transfer_config.srcTransferSize = kEDMA_TransferSize1Bytes;
+        transfer_config.srcOffset = 1;
+        transfer_config.destTransferSize = kEDMA_TransferSize1Bytes;
+        transfer_config.destOffset = 0;
+        transfer_config.minorLoopBytes = 1;
+    }
+
+    EDMA_SubmitTransfer(handle->dmaHandle, &transfer_config);
+    EDMA_StartTransfer(handle->dmaHandle);
+}
+
+void I2C_MasterCreateEDMAHandle(I2C_Type *base,
+                                i2c_master_edma_handle_t *handle,
+                                i2c_master_edma_transfer_callback_t callback,
+                                void *userData,
+                                edma_handle_t *edmaHandle)
+{
+    assert(handle);
+    assert(edmaHandle);
+
+    uint32_t instance = I2C_GetInstance(base);
+
+    /* Zero handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    /* Set the user callback and userData. */
+    handle->completionCallback = callback;
+    handle->userData = userData;
+
+    /* Set the base for the handle. */
+    base = base;
+
+    /* Set the handle for EDMA. */
+    handle->dmaHandle = edmaHandle;
+
+    s_edmaPrivateHandle[instance].base = base;
+    s_edmaPrivateHandle[instance].handle = handle;
+
+    EDMA_SetCallback(edmaHandle, (edma_callback)I2C_MasterTransferCallbackEDMA, &s_edmaPrivateHandle[instance]);
+}
+
+status_t I2C_MasterTransferEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, i2c_master_transfer_t *xfer)
+{
+    assert(handle);
+    assert(xfer);
+
+    status_t result;
+    uint8_t tmpReg;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    /* Disable dma xfer. */
+    I2C_EnableDMA(base, false);
+
+    /* Send address and command buffer(if there is), until senddata phase or receive data phase. */
+    result = I2C_InitTransferStateMachineEDMA(base, handle, xfer);
+
+    if (result)
+    {
+        /* Send stop if received Nak. */
+        if (result == kStatus_I2C_Nak)
+        {
+            if (I2C_MasterStop(base) != kStatus_Success)
+            {
+                result = kStatus_I2C_Timeout;
+            }
+        }
+
+        /* Reset the state to idle state. */
+        handle->state = kIdleState;
+
+        return result;
+    }
+
+    /* Configure dma transfer. */
+    /* For i2c send, need to send 1 byte first to trigger the dma, for i2c read,
+    need to send stop before reading the last byte, so the dma transfer size should
+    be (xSize - 1). */
+    if (handle->transfer.dataSize > 1)
+    {
+        I2C_MasterTransferEDMAConfig(base, handle);
+        if (handle->transfer.direction == kI2C_Read)
+        {
+            /* Change direction for receive. */
+            base->C1 &= ~I2C_C1_TX_MASK;
+
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+
+            /* Enabe dma transfer. */
+            I2C_EnableDMA(base, true);
+        }
+        else
+        {
+            /* Enabe dma transfer. */
+            I2C_EnableDMA(base, true);
+
+            /* Send the first data. */
+            base->D = *handle->transfer.data;
+        }
+    }
+    else /* If transfer size is 1, use polling method. */
+    {
+        if (handle->transfer.direction == kI2C_Read)
+        {
+            tmpReg = base->C1;
+
+            /* Change direction to Rx. */
+            tmpReg &= ~I2C_C1_TX_MASK;
+
+            /* Configure send NAK */
+            tmpReg |= I2C_C1_TXAK_MASK;
+
+            base->C1 = tmpReg;
+
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+        }
+        else
+        {
+            base->D = *handle->transfer.data;
+        }
+
+        /* Wait until data transfer complete. */
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+
+        /* Clear pending flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Send stop if kI2C_TransferNoStop flag is not asserted. */
+        if (!(handle->transfer.flags & kI2C_TransferNoStopFlag))
+        {
+            result = I2C_MasterStop(base);
+        }
+
+        /* Read the last byte of data. */
+        if (handle->transfer.direction == kI2C_Read)
+        {
+            *handle->transfer.data = base->D;
+        }
+
+        /* Reset the state to idle. */
+        handle->state = kIdleState;
+    }
+
+    return result;
+}
+
+status_t I2C_MasterTransferGetCountEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, size_t *count)
+{
+    assert(handle->dmaHandle);
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    if (kIdleState != handle->state)
+    {
+        *count = (handle->transferSize - EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+    }
+    else
+    {
+        *count = handle->transferSize;
+    }
+
+    return kStatus_Success;
+}
+
+void I2C_MasterTransferAbortEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle)
+{
+    EDMA_AbortTransfer(handle->dmaHandle);
+
+    /* Disable dma transfer. */
+    I2C_EnableDMA(base, false);
+
+    /* Reset the state to idle. */
+    handle->state = kIdleState;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c_edma.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_i2c_edma.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_I2C_DMA_H_
+#define _FSL_I2C_DMA_H_
+
+#include "fsl_i2c.h"
+#include "fsl_dmamux.h"
+#include "fsl_edma.h"
+
+/*!
+ * @addtogroup i2c_edma_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief I2C master edma handle typedef. */
+typedef struct _i2c_master_edma_handle i2c_master_edma_handle_t;
+
+/*! @brief I2C master edma transfer callback typedef. */
+typedef void (*i2c_master_edma_transfer_callback_t)(I2C_Type *base,
+                                                    i2c_master_edma_handle_t *handle,
+                                                    status_t status,
+                                                    void *userData);
+
+/*! @brief I2C master edma transfer structure. */
+struct _i2c_master_edma_handle
+{
+    i2c_master_transfer_t transfer; /*!< I2C master transfer struct. */
+    size_t transferSize;            /*!< Total bytes to be transferred. */
+    uint8_t state;                  /*!< I2C master transfer status. */
+    edma_handle_t *dmaHandle;       /*!< The eDMA handler used. */
+    i2c_master_edma_transfer_callback_t
+        completionCallback; /*!< Callback function called after edma transfer finished. */
+    void *userData;         /*!< Callback parameter passed to callback function. */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /*_cplusplus. */
+
+/*!
+ * @name I2C Block EDMA Transfer Operation
+ * @{
+ */
+
+/*!
+ * @brief Init the I2C handle which is used in transcational functions.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param callback pointer to user callback function.
+ * @param userData user param passed to the callback function.
+ * @param edmaHandle EDMA handle pointer.
+ */
+void I2C_MasterCreateEDMAHandle(I2C_Type *base,
+                                i2c_master_edma_handle_t *handle,
+                                i2c_master_edma_transfer_callback_t callback,
+                                void *userData,
+                                edma_handle_t *edmaHandle);
+
+/*!
+ * @brief Performs a master edma non-blocking transfer on the I2C bus.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param xfer pointer to transfer structure of i2c_master_transfer_t.
+ * @retval kStatus_Success Sucessully complete the data transmission.
+ * @retval kStatus_I2C_Busy Previous transmission still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive Nak during transfer.
+ */
+status_t I2C_MasterTransferEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, i2c_master_transfer_t *xfer);
+
+/*!
+ * @brief Get master transfer status during a edma non-blocking transfer.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ */
+status_t I2C_MasterTransferGetCountEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Abort a master edma non-blocking transfer in a early time.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_edma_handle_t structure.
+ */
+void I2C_MasterTransferAbortEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle);
+
+/* @} */
+#if defined(__cplusplus)
+}
+#endif /*_cplusplus. */
+/*@}*/
+#endif /*_FSL_I2C_DMA_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_llwu.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_llwu.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_llwu.h"
+
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN)
+void LLWU_SetExternalWakeupPinMode(LLWU_Type *base, uint32_t pinIndex, llwu_external_pin_mode_t pinMode)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    volatile uint32_t *regBase;
+    uint32_t regOffset;
+    uint32_t reg;
+
+    switch (pinIndex >> 4U)
+    {
+        case 0U:
+            regBase = &base->PE1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+        case 1U:
+            regBase = &base->PE2;
+            break;
+#endif
+        default:
+            regBase = NULL;
+            break;
+    }
+#else
+    volatile uint8_t *regBase;
+    uint8_t regOffset;
+    uint8_t reg;
+    switch (pinIndex >> 2U)
+    {
+        case 0U:
+            regBase = &base->PE1;
+            break;
+        case 1U:
+            regBase = &base->PE2;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 8))
+        case 2U:
+            regBase = &base->PE3;
+            break;
+#endif
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 12))
+        case 3U:
+            regBase = &base->PE4;
+            break;
+#endif
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+        case 4U:
+            regBase = &base->PE5;
+            break;
+#endif
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 20))
+        case 5U:
+            regBase = &base->PE6;
+            break;
+#endif
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 24))
+        case 6U:
+            regBase = &base->PE7;
+            break;
+#endif
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 28))
+        case 7U:
+            regBase = &base->PE8;
+            break;
+#endif
+        default:
+            regBase = NULL;
+            break;
+    }
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH == 32 */
+
+    if (regBase)
+    {
+        reg = *regBase;
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+        regOffset = ((pinIndex & 0x0FU) << 1U);
+#else
+        regOffset = ((pinIndex & 0x03U) << 1U);
+#endif
+        reg &= ~(0x3U << regOffset);
+        reg |= ((uint32_t)pinMode << regOffset);
+        *regBase = reg;
+    }
+}
+
+bool LLWU_GetExternalWakeupPinFlag(LLWU_Type *base, uint32_t pinIndex)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    return (bool)(base->PF & (1U << pinIndex));
+#else
+    volatile uint8_t *regBase;
+
+    switch (pinIndex >> 3U)
+    {
+#if (defined(FSL_FEATURE_LLWU_HAS_PF) && FSL_FEATURE_LLWU_HAS_PF)
+        case 0U:
+            regBase = &base->PF1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 8))
+        case 1U:
+            regBase = &base->PF2;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+        case 2U:
+            regBase = &base->PF3;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 24))
+        case 3U:
+            regBase = &base->PF4;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#else
+        case 0U:
+            regBase = &base->F1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 8))
+        case 1U:
+            regBase = &base->F2;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+        case 2U:
+            regBase = &base->F3;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 24))
+        case 3U:
+            regBase = &base->F4;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#endif /* FSL_FEATURE_LLWU_HAS_PF */
+        default:
+            regBase = NULL;
+            break;
+    }
+
+    if (regBase)
+    {
+        return (bool)(*regBase & (1U << pinIndex % 8));
+    }
+    else
+    {
+        return false;
+    }
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH */
+}
+
+void LLWU_ClearExternalWakeupPinFlag(LLWU_Type *base, uint32_t pinIndex)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    base->PF = (1U << pinIndex);
+#else
+    volatile uint8_t *regBase;
+    switch (pinIndex >> 3U)
+    {
+#if (defined(FSL_FEATURE_LLWU_HAS_PF) && FSL_FEATURE_LLWU_HAS_PF)
+        case 0U:
+            regBase = &base->PF1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 8))
+        case 1U:
+            regBase = &base->PF2;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+        case 2U:
+            regBase = &base->PF3;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 24))
+        case 3U:
+            regBase = &base->PF4;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#else
+        case 0U:
+            regBase = &base->F1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 8))
+        case 1U:
+            regBase = &base->F2;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+        case 2U:
+            regBase = &base->F3;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 24))
+        case 3U:
+            regBase = &base->F4;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#endif /* FSL_FEATURE_LLWU_HAS_PF */
+        default:
+            regBase = NULL;
+            break;
+    }
+    if (regBase)
+    {
+        *regBase = (1U << pinIndex % 8U);
+    }
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH */
+}
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && FSL_FEATURE_LLWU_HAS_PIN_FILTER)
+void LLWU_SetPinFilterMode(LLWU_Type *base, uint32_t filterIndex, llwu_external_pin_filter_mode_t filterMode)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    uint32_t reg;
+
+    reg = base->FILT;
+    reg &= ~((LLWU_FILT_FILTSEL1_MASK | LLWU_FILT_FILTE1_MASK) << (filterIndex * 8U - 1U));
+    reg |= (((filterMode.pinIndex << LLWU_FILT_FILTSEL1_SHIFT) | (filterMode.filterMode << LLWU_FILT_FILTE1_SHIFT)
+             /* Clear the Filter Detect Flag */
+             | LLWU_FILT_FILTF1_MASK)
+            << (filterIndex * 8U - 1U));
+    base->FILT = reg;
+#else
+    volatile uint8_t *regBase;
+    uint8_t reg;
+
+    switch (filterIndex)
+    {
+        case 1:
+            regBase = &base->FILT1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 1))
+        case 2:
+            regBase = &base->FILT2;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 2))
+        case 3:
+            regBase = &base->FILT3;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 3))
+        case 4:
+            regBase = &base->FILT4;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+        default:
+            regBase = NULL;
+            break;
+    }
+
+    if (regBase)
+    {
+        reg = *regBase;
+        reg &= ~(LLWU_FILT1_FILTSEL_MASK | LLWU_FILT1_FILTE_MASK);
+        reg |= ((uint32_t)filterMode.pinIndex << LLWU_FILT1_FILTSEL_SHIFT);
+        reg |= ((uint32_t)filterMode.filterMode << LLWU_FILT1_FILTE_SHIFT);
+        /* Clear the Filter Detect Flag */
+        reg |= LLWU_FILT1_FILTF_MASK;
+        *regBase = reg;
+    }
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH */
+}
+
+bool LLWU_GetPinFilterFlag(LLWU_Type *base, uint32_t filterIndex)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    return (bool)(base->FILT & (1U << (filterIndex * 8U - 1)));
+#else
+    bool status = false;
+
+    switch (filterIndex)
+    {
+        case 1:
+            status = (base->FILT1 & LLWU_FILT1_FILTF_MASK);
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 1))
+        case 2:
+            status = (base->FILT2 & LLWU_FILT2_FILTF_MASK);
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 2))
+        case 3:
+            status = (base->FILT3 & LLWU_FILT3_FILTF_MASK);
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 3))
+        case 4:
+            status = (base->FILT4 & LLWU_FILT4_FILTF_MASK);
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+        default:
+            break;
+    }
+
+    return status;
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH */
+}
+
+void LLWU_ClearPinFilterFlag(LLWU_Type *base, uint32_t filterIndex)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    uint32_t reg;
+
+    reg = base->FILT;
+    switch (filterIndex)
+    {
+        case 1:
+            reg |= LLWU_FILT_FILTF1_MASK;
+            break;
+        case 2:
+            reg |= LLWU_FILT_FILTF2_MASK;
+            break;
+        case 3:
+            reg |= LLWU_FILT_FILTF3_MASK;
+            break;
+        case 4:
+            reg |= LLWU_FILT_FILTF4_MASK;
+            break;
+        default:
+            break;
+    }
+    base->FILT = reg;
+#else
+    volatile uint8_t *regBase;
+    uint8_t reg;
+
+    switch (filterIndex)
+    {
+        case 1:
+            regBase = &base->FILT1;
+            break;
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 1))
+        case 2:
+            regBase = &base->FILT2;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 2))
+        case 3:
+            regBase = &base->FILT3;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && (FSL_FEATURE_LLWU_HAS_PIN_FILTER > 3))
+        case 4:
+            regBase = &base->FILT4;
+            break;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+        default:
+            regBase = NULL;
+            break;
+    }
+
+    if (regBase)
+    {
+        reg = *regBase;
+        reg |= LLWU_FILT1_FILTF_MASK;
+        *regBase = reg;
+    }
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH */
+}
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_RESET_ENABLE) && FSL_FEATURE_LLWU_HAS_RESET_ENABLE)
+void LLWU_SetResetPinMode(LLWU_Type *base, bool pinEnable, bool enableInLowLeakageMode)
+{
+    uint8_t reg;
+
+    reg = base->RST;
+    reg &= ~(LLWU_RST_LLRSTE_MASK | LLWU_RST_RSTFILT_MASK);
+    reg |=
+        (((uint32_t)pinEnable << LLWU_RST_LLRSTE_SHIFT) | ((uint32_t)enableInLowLeakageMode << LLWU_RST_RSTFILT_SHIFT));
+    base->RST = reg;
+}
+#endif /* FSL_FEATURE_LLWU_HAS_RESET_ENABLE */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_llwu.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_llwu.h
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_LLWU_H_
+#define _FSL_LLWU_H_
+
+#include "fsl_common.h"
+
+/*! @addtogroup llwu */
+/*! @{ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief LLWU driver version 2.0.1. */
+#define FSL_LLWU_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*!
+ * @brief External input pin control modes
+ */
+typedef enum _llwu_external_pin_mode
+{
+    kLLWU_ExternalPinDisable = 0U,     /*!< Pin disabled as wakeup input.           */
+    kLLWU_ExternalPinRisingEdge = 1U,  /*!< Pin enabled with rising edge detection. */
+    kLLWU_ExternalPinFallingEdge = 2U, /*!< Pin enabled with falling edge detection.*/
+    kLLWU_ExternalPinAnyEdge = 3U      /*!< Pin enabled with any change detection.  */
+} llwu_external_pin_mode_t;
+
+/*!
+ * @brief Digital filter control modes
+ */
+typedef enum _llwu_pin_filter_mode
+{
+    kLLWU_PinFilterDisable = 0U,     /*!< Filter disabled.               */
+    kLLWU_PinFilterRisingEdge = 1U,  /*!< Filter positive edge detection.*/
+    kLLWU_PinFilterFallingEdge = 2U, /*!< Filter negative edge detection.*/
+    kLLWU_PinFilterAnyEdge = 3U      /*!< Filter any edge detection.     */
+} llwu_pin_filter_mode_t;
+
+#if (defined(FSL_FEATURE_LLWU_HAS_VERID) && FSL_FEATURE_LLWU_HAS_VERID)
+/*!
+ * @brief IP version ID definition.
+ */
+typedef struct _llwu_version_id
+{
+    uint16_t feature; /*!< Feature Specification Number. */
+    uint8_t minor;    /*!< Minor version number.         */
+    uint8_t major;    /*!< Major version number.         */
+} llwu_version_id_t;
+#endif /* FSL_FEATURE_LLWU_HAS_VERID */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_PARAM) && FSL_FEATURE_LLWU_HAS_PARAM)
+/*!
+ * @brief IP parameter definition.
+ */
+typedef struct _llwu_param
+{
+    uint8_t filters; /*!< Number of pin filter.      */
+    uint8_t dmas;    /*!< Number of wakeup DMA.      */
+    uint8_t modules; /*!< Number of wakeup module.   */
+    uint8_t pins;    /*!< Number of wake up pin.     */
+} llwu_param_t;
+#endif /* FSL_FEATURE_LLWU_HAS_PARAM */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && FSL_FEATURE_LLWU_HAS_PIN_FILTER)
+/*!
+ * @brief External input pin filter control structure
+ */
+typedef struct _llwu_external_pin_filter_mode
+{
+    uint32_t pinIndex;                 /*!< Pin number  */
+    llwu_pin_filter_mode_t filterMode; /*!< Filter mode */
+} llwu_external_pin_filter_mode_t;
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Low-Leakage Wakeup Unit Control APIs
+ * @{
+ */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_VERID) && FSL_FEATURE_LLWU_HAS_VERID)
+/*!
+ * @brief Gets the LLWU version ID.
+ *
+ * This function gets the LLWU version ID, including major version number,
+ * minor version number, and feature specification number.
+ *
+ * @param base LLWU peripheral base address.
+ * @param versionId     Pointer to version ID structure.
+ */
+static inline void LLWU_GetVersionId(LLWU_Type *base, llwu_version_id_t *versionId)
+{
+    *((uint32_t *)versionId) = base->VERID;
+}
+#endif /* FSL_FEATURE_LLWU_HAS_VERID */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_PARAM) && FSL_FEATURE_LLWU_HAS_PARAM)
+/*!
+ * @brief Gets the LLWU parameter.
+ *
+ * This function gets the LLWU parameter, including wakeup pin number, module
+ * number, DMA number, and pin filter number.
+ *
+ * @param base LLWU peripheral base address.
+ * @param param         Pointer to LLWU param structure.
+ */
+static inline void LLWU_GetParam(LLWU_Type *base, llwu_param_t *param)
+{
+    *((uint32_t *)param) = base->PARAM;
+}
+#endif /* FSL_FEATURE_LLWU_HAS_PARAM */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN)
+/*!
+ * @brief Sets the external input pin source mode.
+ *
+ * This function sets the external input pin source mode that is used
+ * as a wake up source.
+ *
+ * @param base LLWU peripheral base address.
+ * @param pinIndex pin index which to be enabled as external wakeup source, start from 1.
+ * @param pinMode pin configuration mode defined in llwu_external_pin_modes_t
+ */
+void LLWU_SetExternalWakeupPinMode(LLWU_Type *base, uint32_t pinIndex, llwu_external_pin_mode_t pinMode);
+
+/*!
+ * @brief Gets the external wakeup source flag.
+ *
+ * This function checks the external pin flag to detect whether the MCU is
+ * woke up by the specific pin.
+ *
+ * @param base LLWU peripheral base address.
+ * @param pinIndex     pin index, start from 1.
+ * @return true if the specific pin is wake up source.
+ */
+bool LLWU_GetExternalWakeupPinFlag(LLWU_Type *base, uint32_t pinIndex);
+
+/*!
+ * @brief Clears the external wakeup source flag.
+ *
+ * This function clears the external wakeup source flag for a specific pin.
+ *
+ * @param base LLWU peripheral base address.
+ * @param pinIndex pin index, start from 1.
+ */
+void LLWU_ClearExternalWakeupPinFlag(LLWU_Type *base, uint32_t pinIndex);
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE) && FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE)
+/*!
+ * @brief Enables/disables the internal module source.
+ *
+ * This function enables/disables the internal module source mode that is used
+ * as a wake up source.
+ *
+ * @param base LLWU peripheral base address.
+ * @param moduleIndex   module index which to be enabled as internal wakeup source, start from 1.
+ * @param enable        enable or disable setting
+ */
+static inline void LLWU_EnableInternalModuleInterruptWakup(LLWU_Type *base, uint32_t moduleIndex, bool enable)
+{
+    if (enable)
+    {
+        base->ME |= 1U << moduleIndex;
+    }
+    else
+    {
+        base->ME &= ~(1U << moduleIndex);
+    }
+}
+
+/*!
+ * @brief Gets the external wakeup source flag.
+ *
+ * This function checks the external pin flag to detect whether the system is
+ * woke up by the specific pin.
+ *
+ * @param base LLWU peripheral base address.
+ * @param moduleIndex  module index, start from 1.
+ * @return true if the specific pin is wake up source.
+ */
+static inline bool LLWU_GetInternalWakeupModuleFlag(LLWU_Type *base, uint32_t moduleIndex)
+{
+#if (defined(FSL_FEATURE_LLWU_REG_BITWIDTH) && (FSL_FEATURE_LLWU_REG_BITWIDTH == 32))
+    return (bool)(base->MF & (1U << moduleIndex));
+#else
+#if (defined(FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN) && (FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN > 16))
+#if (defined(FSL_FEATURE_LLWU_HAS_PF) && FSL_FEATURE_LLWU_HAS_PF)
+    return (bool)(base->MF5 & (1U << moduleIndex));
+#else
+    return (bool)(base->F5 & (1U << moduleIndex));
+#endif /* FSL_FEATURE_LLWU_HAS_PF */
+#else
+#if (defined(FSL_FEATURE_LLWU_HAS_PF) && FSL_FEATURE_LLWU_HAS_PF)
+    return (bool)(base->PF3 & (1U << moduleIndex));
+#else
+    return (bool)(base->F3 & (1U << moduleIndex));
+#endif
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+#endif /* FSL_FEATURE_LLWU_REG_BITWIDTH */
+}
+#endif /* FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_DMA_ENABLE_REG) && FSL_FEATURE_LLWU_HAS_DMA_ENABLE_REG)
+/*!
+ * @brief Enables/disables the internal module DMA wakeup source.
+ *
+ * This function enables/disables the internal DMA that is used as a wake up source.
+ *
+ * @param base LLWU peripheral base address.
+ * @param moduleIndex   Internal module index which used as DMA request source, start from 1.
+ * @param enable        Enable or disable DMA request source
+ */
+static inline void LLWU_EnableInternalModuleDmaRequestWakup(LLWU_Type *base, uint32_t moduleIndex, bool enable)
+{
+    if (enable)
+    {
+        base->DE |= 1U << moduleIndex;
+    }
+    else
+    {
+        base->DE &= ~(1U << moduleIndex);
+    }
+}
+#endif /* FSL_FEATURE_LLWU_HAS_DMA_ENABLE_REG */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_PIN_FILTER) && FSL_FEATURE_LLWU_HAS_PIN_FILTER)
+/*!
+ * @brief Sets the pin filter configuration.
+ *
+ * This function sets the pin filter configuration.
+ *
+ * @param base LLWU peripheral base address.
+ * @param filterIndex pin filter index which used to enable/disable the digital filter, start from 1.
+ * @param filterMode filter mode configuration
+ */
+void LLWU_SetPinFilterMode(LLWU_Type *base, uint32_t filterIndex, llwu_external_pin_filter_mode_t filterMode);
+
+/*!
+ * @brief Gets the pin filter configuration.
+ *
+ * This function gets the pin filter flag.
+ *
+ * @param base LLWU peripheral base address.
+ * @param filterIndex pin filter index, start from 1.
+ * @return true if the flag is a source of existing a low-leakage power mode.
+ */
+bool LLWU_GetPinFilterFlag(LLWU_Type *base, uint32_t filterIndex);
+
+/*!
+ * @brief Clear the pin filter configuration.
+ *
+ * This function clear the pin filter flag.
+ *
+ * @param base LLWU peripheral base address.
+ * @param filterIndex pin filter index which to be clear the flag, start from 1.
+ */
+void LLWU_ClearPinFilterFlag(LLWU_Type *base, uint32_t filterIndex);
+
+#endif /* FSL_FEATURE_LLWU_HAS_PIN_FILTER */
+
+#if (defined(FSL_FEATURE_LLWU_HAS_RESET_ENABLE) && FSL_FEATURE_LLWU_HAS_RESET_ENABLE)
+/*!
+ * @brief Sets the reset pin mode.
+ *
+ * This function sets how the reset pin is used as a low leakage mode exit source.
+ *
+ * @param pinEnable       Enable reset pin filter
+ * @param pinFilterEnable Specify whether pin filter is enabled in Low-Leakage power mode.
+ */
+void LLWU_SetResetPinMode(LLWU_Type *base, bool pinEnable, bool enableInLowLeakageMode);
+#endif /* FSL_FEATURE_LLWU_HAS_RESET_ENABLE */
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+#endif /* _FSL_LLWU_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_lptmr.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_lptmr.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_lptmr.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Gets the instance from the base address to be used to gate or ungate the module clock
+ *
+ * @param base LPTMR peripheral base address
+ *
+ * @return The LPTMR instance
+ */
+static uint32_t LPTMR_GetInstance(LPTMR_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to LPTMR bases for each instance. */
+static LPTMR_Type *const s_lptmrBases[] = LPTMR_BASE_PTRS;
+
+/*! @brief Pointers to LPTMR clocks for each instance. */
+static const clock_ip_name_t s_lptmrClocks[] = LPTMR_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t LPTMR_GetInstance(LPTMR_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_LPTMR_COUNT; instance++)
+    {
+        if (s_lptmrBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_LPTMR_COUNT);
+
+    return instance;
+}
+
+void LPTMR_Init(LPTMR_Type *base, const lptmr_config_t *config)
+{
+    assert(config);
+
+    /* Ungate the LPTMR clock*/
+    CLOCK_EnableClock(s_lptmrClocks[LPTMR_GetInstance(base)]);
+
+    /* Configure the timers operation mode and input pin setup */
+    base->CSR = (LPTMR_CSR_TMS(config->timerMode) | LPTMR_CSR_TFC(config->enableFreeRunning) |
+                 LPTMR_CSR_TPP(config->pinPolarity) | LPTMR_CSR_TPS(config->pinSelect));
+
+    /* Configure the prescale value and clock source */
+    base->PSR = (LPTMR_PSR_PRESCALE(config->value) | LPTMR_PSR_PBYP(config->bypassPrescaler) |
+                 LPTMR_PSR_PCS(config->prescalerClockSource));
+}
+
+void LPTMR_Deinit(LPTMR_Type *base)
+{
+    /* Disable the LPTMR and reset the internal logic */
+    base->CSR &= ~LPTMR_CSR_TEN_MASK;
+    /* Gate the LPTMR clock*/
+    CLOCK_DisableClock(s_lptmrClocks[LPTMR_GetInstance(base)]);
+}
+
+void LPTMR_GetDefaultConfig(lptmr_config_t *config)
+{
+    assert(config);
+
+    /* Use time counter mode */
+    config->timerMode = kLPTMR_TimerModeTimeCounter;
+    /* Use input 0 as source in pulse counter mode */
+    config->pinSelect = kLPTMR_PinSelectInput_0;
+    /* Pulse input pin polarity is active-high */
+    config->pinPolarity = kLPTMR_PinPolarityActiveHigh;
+    /* Counter resets whenever TCF flag is set */
+    config->enableFreeRunning = false;
+    /* Bypass the prescaler */
+    config->bypassPrescaler = true;
+    /* LPTMR clock source */
+    config->prescalerClockSource = kLPTMR_PrescalerClock_1;
+    /* Divide the prescaler clock by 2 */
+    config->value = kLPTMR_Prescale_Glitch_0;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_lptmr.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_lptmr.h
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_LPTMR_H_
+#define _FSL_LPTMR_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup lptmr_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_LPTMR_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0 */
+/*@}*/
+
+/*! @brief LPTMR pin selection, used in pulse counter mode.*/
+typedef enum _lptmr_pin_select
+{
+    kLPTMR_PinSelectInput_0 = 0x0U, /*!< Pulse counter input 0 is selected */
+    kLPTMR_PinSelectInput_1 = 0x1U, /*!< Pulse counter input 1 is selected */
+    kLPTMR_PinSelectInput_2 = 0x2U, /*!< Pulse counter input 2 is selected */
+    kLPTMR_PinSelectInput_3 = 0x3U  /*!< Pulse counter input 3 is selected */
+} lptmr_pin_select_t;
+
+/*! @brief LPTMR pin polarity, used in pulse counter mode.*/
+typedef enum _lptmr_pin_polarity
+{
+    kLPTMR_PinPolarityActiveHigh = 0x0U, /*!< Pulse Counter input source is active-high */
+    kLPTMR_PinPolarityActiveLow = 0x1U   /*!< Pulse Counter input source is active-low */
+} lptmr_pin_polarity_t;
+
+/*! @brief LPTMR timer mode selection.*/
+typedef enum _lptmr_timer_mode
+{
+    kLPTMR_TimerModeTimeCounter = 0x0U, /*!< Time Counter mode */
+    kLPTMR_TimerModePulseCounter = 0x1U /*!< Pulse Counter mode */
+} lptmr_timer_mode_t;
+
+/*! @brief LPTMR prescaler/glitch filter values*/
+typedef enum _lptmr_prescaler_glitch_value
+{
+    kLPTMR_Prescale_Glitch_0 = 0x0U,  /*!< Prescaler divide 2, glitch filter does not support this setting */
+    kLPTMR_Prescale_Glitch_1 = 0x1U,  /*!< Prescaler divide 4, glitch filter 2 */
+    kLPTMR_Prescale_Glitch_2 = 0x2U,  /*!< Prescaler divide 8, glitch filter 4 */
+    kLPTMR_Prescale_Glitch_3 = 0x3U,  /*!< Prescaler divide 16, glitch filter 8 */
+    kLPTMR_Prescale_Glitch_4 = 0x4U,  /*!< Prescaler divide 32, glitch filter 16 */
+    kLPTMR_Prescale_Glitch_5 = 0x5U,  /*!< Prescaler divide 64, glitch filter 32 */
+    kLPTMR_Prescale_Glitch_6 = 0x6U,  /*!< Prescaler divide 128, glitch filter 64 */
+    kLPTMR_Prescale_Glitch_7 = 0x7U,  /*!< Prescaler divide 256, glitch filter 128 */
+    kLPTMR_Prescale_Glitch_8 = 0x8U,  /*!< Prescaler divide 512, glitch filter 256 */
+    kLPTMR_Prescale_Glitch_9 = 0x9U,  /*!< Prescaler divide 1024, glitch filter 512*/
+    kLPTMR_Prescale_Glitch_10 = 0xAU, /*!< Prescaler divide 2048 glitch filter 1024 */
+    kLPTMR_Prescale_Glitch_11 = 0xBU, /*!< Prescaler divide 4096, glitch filter 2048 */
+    kLPTMR_Prescale_Glitch_12 = 0xCU, /*!< Prescaler divide 8192, glitch filter 4096 */
+    kLPTMR_Prescale_Glitch_13 = 0xDU, /*!< Prescaler divide 16384, glitch filter 8192 */
+    kLPTMR_Prescale_Glitch_14 = 0xEU, /*!< Prescaler divide 32768, glitch filter 16384 */
+    kLPTMR_Prescale_Glitch_15 = 0xFU  /*!< Prescaler divide 65536, glitch filter 32768 */
+} lptmr_prescaler_glitch_value_t;
+
+/*!
+ * @brief LPTMR prescaler/glitch filter clock select.
+ * @note Clock connections are SoC-specific
+ */
+typedef enum _lptmr_prescaler_clock_select
+{
+    kLPTMR_PrescalerClock_0 = 0x0U, /*!< Prescaler/glitch filter clock 0 selected. */
+    kLPTMR_PrescalerClock_1 = 0x1U, /*!< Prescaler/glitch filter clock 1 selected. */
+    kLPTMR_PrescalerClock_2 = 0x2U, /*!< Prescaler/glitch filter clock 2 selected. */
+    kLPTMR_PrescalerClock_3 = 0x3U, /*!< Prescaler/glitch filter clock 3 selected. */
+} lptmr_prescaler_clock_select_t;
+
+/*! @brief List of LPTMR interrupts */
+typedef enum _lptmr_interrupt_enable
+{
+    kLPTMR_TimerInterruptEnable = LPTMR_CSR_TIE_MASK, /*!< Timer interrupt enable */
+} lptmr_interrupt_enable_t;
+
+/*! @brief List of LPTMR status flags */
+typedef enum _lptmr_status_flags
+{
+    kLPTMR_TimerCompareFlag = LPTMR_CSR_TCF_MASK, /*!< Timer compare flag */
+} lptmr_status_flags_t;
+
+/*!
+ * @brief LPTMR config structure
+ *
+ * This structure holds the configuration settings for the LPTMR peripheral. To initialize this
+ * structure to reasonable defaults, call the LPTMR_GetDefaultConfig() function and pass a
+ * pointer to your config structure instance.
+ *
+ * The config struct can be made const so it resides in flash
+ */
+typedef struct _lptmr_config
+{
+    lptmr_timer_mode_t timerMode;     /*!< Time counter mode or pulse counter mode */
+    lptmr_pin_select_t pinSelect;     /*!< LPTMR pulse input pin select; used only in pulse counter mode */
+    lptmr_pin_polarity_t pinPolarity; /*!< LPTMR pulse input pin polarity; used only in pulse counter mode */
+    bool enableFreeRunning;           /*!< true: enable free running, counter is reset on overflow
+                                           false: counter is reset when the compare flag is set */
+    bool bypassPrescaler;             /*!< true: bypass prescaler; false: use clock from prescaler */
+    lptmr_prescaler_clock_select_t prescalerClockSource; /*!< LPTMR clock source */
+    lptmr_prescaler_glitch_value_t value;                /*!< Prescaler or glitch filter value */
+} lptmr_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Ungate the LPTMR clock and configures the peripheral for basic operation.
+ *
+ * @note This API should be called at the beginning of the application using the LPTMR driver.
+ *
+ * @param base   LPTMR peripheral base address
+ * @param config Pointer to user's LPTMR config structure.
+ */
+void LPTMR_Init(LPTMR_Type *base, const lptmr_config_t *config);
+
+/*!
+ * @brief Gate the LPTMR clock
+ *
+ * @param base LPTMR peripheral base address
+ */
+void LPTMR_Deinit(LPTMR_Type *base);
+
+/*!
+ * @brief Fill in the LPTMR config struct with the default settings
+ *
+ * The default values are:
+ * @code
+ *    config->timerMode = kLPTMR_TimerModeTimeCounter;
+ *    config->pinSelect = kLPTMR_PinSelectInput_0;
+ *    config->pinPolarity = kLPTMR_PinPolarityActiveHigh;
+ *    config->enableFreeRunning = false;
+ *    config->bypassPrescaler = true;
+ *    config->prescalerClockSource = kLPTMR_PrescalerClock_1;
+ *    config->value = kLPTMR_Prescale_Glitch_0;
+ * @endcode
+ * @param config Pointer to user's LPTMR config structure.
+ */
+void LPTMR_GetDefaultConfig(lptmr_config_t *config);
+
+/*! @}*/
+
+/*!
+ * @name Interrupt Interface
+ * @{
+ */
+
+/*!
+ * @brief Enables the selected LPTMR interrupts.
+ *
+ * @param base LPTMR peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::lptmr_interrupt_enable_t
+ */
+static inline void LPTMR_EnableInterrupts(LPTMR_Type *base, uint32_t mask)
+{
+    base->CSR |= mask;
+}
+
+/*!
+ * @brief Disables the selected LPTMR interrupts.
+ *
+ * @param base LPTMR peripheral base address
+ * @param mask The interrupts to disable. This is a logical OR of members of the
+ *             enumeration ::lptmr_interrupt_enable_t
+ */
+static inline void LPTMR_DisableInterrupts(LPTMR_Type *base, uint32_t mask)
+{
+    base->CSR &= ~mask;
+}
+
+/*!
+ * @brief Gets the enabled LPTMR interrupts.
+ *
+ * @param base LPTMR peripheral base address
+ *
+ * @return The enabled interrupts. This is the logical OR of members of the
+ *         enumeration ::lptmr_interrupt_enable_t
+ */
+static inline uint32_t LPTMR_GetEnabledInterrupts(LPTMR_Type *base)
+{
+    return (base->CSR & LPTMR_CSR_TIE_MASK);
+}
+
+/*! @}*/
+
+/*!
+ * @name Status Interface
+ * @{
+ */
+
+/*!
+ * @brief Gets the LPTMR status flags
+ *
+ * @param base LPTMR peripheral base address
+ *
+ * @return The status flags. This is the logical OR of members of the
+ *         enumeration ::lptmr_status_flags_t
+ */
+static inline uint32_t LPTMR_GetStatusFlags(LPTMR_Type *base)
+{
+    return (base->CSR & LPTMR_CSR_TCF_MASK);
+}
+
+/*!
+ * @brief  Clears the LPTMR status flags
+ *
+ * @param base LPTMR peripheral base address
+ * @param mask The status flags to clear. This is a logical OR of members of the
+ *             enumeration ::lptmr_status_flags_t
+ */
+static inline void LPTMR_ClearStatusFlags(LPTMR_Type *base, uint32_t mask)
+{
+    base->CSR |= mask;
+}
+
+/*! @}*/
+
+/*!
+ * @name Read and Write the timer period
+ * @{
+ */
+
+/*!
+ * @brief Sets the timer period in units of count.
+ *
+ * Timers counts from 0 till it equals the count value set here. The count value is written to
+ * the CMR register.
+ *
+ * @note
+ * 1. The TCF flag is set with the CNR equals the count provided here and then increments.
+ * 2. User can call the utility macros provided in fsl_common.h to convert to ticks
+ *
+ * @param base  LPTMR peripheral base address
+ * @param ticks Timer period in units of ticks
+ */
+static inline void LPTMR_SetTimerPeriod(LPTMR_Type *base, uint16_t ticks)
+{
+    base->CMR = ticks;
+}
+
+/*!
+ * @brief Reads the current timer counting value.
+ *
+ * This function returns the real-time timer counting value, in a range from 0 to a
+ * timer period.
+ *
+ * @note User can call the utility macros provided in fsl_common.h to convert ticks to usec or msec
+ *
+ * @param base LPTMR peripheral base address
+ *
+ * @return Current counter value in ticks
+ */
+static inline uint16_t LPTMR_GetCurrentTimerCount(LPTMR_Type *base)
+{
+    /* Must first write any value to the CNR. This will synchronize and register the current value
+     * of the CNR into a temporary register which can then be read
+     */
+    base->CNR = 0U;
+    return (uint16_t)base->CNR;
+}
+
+/*! @}*/
+
+/*!
+ * @name Timer Start and Stop
+ * @{
+ */
+
+/*!
+ * @brief Starts the timer counting.
+ *
+ * After calling this function, the timer counts up to the CMR register value.
+ * Each time the timer reaches CMR value and then increments, it generates a
+ * trigger pulse and sets the timeout interrupt flag. An interrupt will also be
+ * triggered if the timer interrupt is enabled.
+ *
+ * @param base LPTMR peripheral base address
+ */
+static inline void LPTMR_StartTimer(LPTMR_Type *base)
+{
+    base->CSR |= LPTMR_CSR_TEN_MASK;
+}
+
+/*!
+ * @brief Stops the timer counting.
+ *
+ * This function stops the timer counting and resets the timer's counter register
+ *
+ * @param base LPTMR peripheral base address
+ */
+static inline void LPTMR_StopTimer(LPTMR_Type *base)
+{
+    base->CSR &= ~LPTMR_CSR_TEN_MASK;
+}
+
+/*! @}*/
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_LPTMR_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_mpu.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_mpu.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_mpu.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Defines the register numbers of the region descriptor configure. */
+#define MPU_REGIONDESCRIPTOR_WROD_REGNUM (4U)
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+const clock_ip_name_t g_mpuClock[FSL_FEATURE_SOC_MPU_COUNT] = MPU_CLOCKS;
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+
+void MPU_Init(MPU_Type *base, const mpu_config_t *config)
+{
+    assert(config);
+    uint8_t count;
+
+    /* Un-gate MPU clock */
+    CLOCK_EnableClock(g_mpuClock[0]);
+
+    /* Initializes the regions. */
+    for (count = 1; count < FSL_FEATURE_MPU_DESCRIPTOR_COUNT; count++)
+    {
+        base->WORD[count][3] = 0; /* VLD/VID+PID. */
+        base->WORD[count][0] = 0; /* Start address. */
+        base->WORD[count][1] = 0; /* End address. */
+        base->WORD[count][2] = 0; /* Access rights. */
+        base->RGDAAC[count] = 0;  /* Alternate access rights. */
+    }
+
+    /* MPU configure. */
+    while (config)
+    {
+        MPU_SetRegionConfig(base, &(config->regionConfig));
+        config = config->next;
+    }
+    /* Enable MPU. */
+    MPU_Enable(base, true);
+}
+
+void MPU_Deinit(MPU_Type *base)
+{
+    /* Disable MPU. */
+    MPU_Enable(base, false);
+
+    /* Gate the clock. */
+    CLOCK_DisableClock(g_mpuClock[0]);
+}
+
+void MPU_GetHardwareInfo(MPU_Type *base, mpu_hardware_info_t *hardwareInform)
+{
+    assert(hardwareInform);
+
+    uint32_t cesReg = base->CESR;
+
+    hardwareInform->hardwareRevisionLevel = (cesReg & MPU_CESR_HRL_MASK) >> MPU_CESR_HRL_SHIFT;
+    hardwareInform->slavePortsNumbers = (cesReg & MPU_CESR_NSP_MASK) >> MPU_CESR_NSP_SHIFT;
+    hardwareInform->regionsNumbers = (mpu_region_total_num_t)((cesReg & MPU_CESR_NRGD_MASK) >> MPU_CESR_NRGD_SHIFT);
+}
+
+void MPU_SetRegionConfig(MPU_Type *base, const mpu_region_config_t *regionConfig)
+{
+    assert(regionConfig);
+
+    uint32_t wordReg = 0;
+    uint8_t count;
+    uint8_t number = regionConfig->regionNum;
+
+    /* The start and end address of the region descriptor. */
+    base->WORD[number][0] = regionConfig->startAddress;
+    base->WORD[number][1] = regionConfig->endAddress;
+
+    /* The region descriptor access rights control. */
+    for (count = 0; count < MPU_REGIONDESCRIPTOR_WROD_REGNUM; count++)
+    {
+        wordReg |= MPU_WORD_LOW_MASTER(count, (((uint32_t)regionConfig->accessRights1[count].superAccessRights << 3U) |
+                                               (uint8_t)regionConfig->accessRights1[count].userAccessRights)) |
+                   MPU_WORD_HIGH_MASTER(count, ((uint32_t)regionConfig->accessRights2[count].readEnable << 1U |
+                                                (uint8_t)regionConfig->accessRights2[count].writeEnable));
+
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+        wordReg |= MPU_WORD_MASTER_PE(count, regionConfig->accessRights1[count].processIdentifierEnable);
+#endif /* FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER */
+    }
+
+    /* Set region descriptor access rights. */
+    base->WORD[number][2] = wordReg;
+
+    wordReg = MPU_WORD_VLD(1);
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    wordReg |= MPU_WORD_PID(regionConfig->processIdentifier) | MPU_WORD_PIDMASK(regionConfig->processIdMask);
+#endif /* FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER */
+
+    base->WORD[number][3] = wordReg;
+}
+
+void MPU_SetRegionAddr(MPU_Type *base, mpu_region_num_t regionNum, uint32_t startAddr, uint32_t endAddr)
+{
+    base->WORD[regionNum][0] = startAddr;
+    base->WORD[regionNum][1] = endAddr;
+}
+
+void MPU_SetRegionLowMasterAccessRights(MPU_Type *base,
+                                        mpu_region_num_t regionNum,
+                                        mpu_master_t masterNum,
+                                        const mpu_low_masters_access_rights_t *accessRights)
+{
+    assert(accessRights);
+#if FSL_FEATURE_MPU_HAS_MASTER4
+    assert(masterNum < kMPU_Master4);
+#endif
+    uint32_t mask = MPU_WORD_LOW_MASTER_MASK(masterNum);
+    uint32_t right = base->RGDAAC[regionNum];
+
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    mask |= MPU_LOW_MASTER_PE_MASK(masterNum);
+#endif
+
+    /* Build rights control value. */
+    right &= ~mask;
+    right |= MPU_WORD_LOW_MASTER(masterNum,
+                                 ((uint32_t)(accessRights->superAccessRights << 3U) | accessRights->userAccessRights));
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    right |= MPU_WORD_MASTER_PE(masterNum, accessRights->processIdentifierEnable);
+#endif /* FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER */
+
+    /* Set low master region access rights. */
+    base->RGDAAC[regionNum] = right;
+}
+
+void MPU_SetRegionHighMasterAccessRights(MPU_Type *base,
+                                         mpu_region_num_t regionNum,
+                                         mpu_master_t masterNum,
+                                         const mpu_high_masters_access_rights_t *accessRights)
+{
+    assert(accessRights);
+#if FSL_FEATURE_MPU_HAS_MASTER3
+    assert(masterNum > kMPU_Master3);
+#endif
+    uint32_t mask = MPU_WORD_HIGH_MASTER_MASK(masterNum);
+    uint32_t right = base->RGDAAC[regionNum];
+
+    /* Build rights control value. */
+    right &= ~mask;
+    right |= MPU_WORD_HIGH_MASTER((masterNum - (uint8_t)kMPU_RegionNum04),
+                                  (((uint32_t)accessRights->readEnable << 1U) | accessRights->writeEnable));
+    /* Set low master region access rights. */
+    base->RGDAAC[regionNum] = right;
+}
+
+bool MPU_GetSlavePortErrorStatus(MPU_Type *base, mpu_slave_t slaveNum)
+{
+    uint8_t sperr;
+
+    sperr = ((base->CESR & MPU_CESR_SPERR_MASK) >> MPU_CESR_SPERR_SHIFT) & (0x1U << slaveNum);
+
+    return (sperr != 0) ? true : false;
+}
+
+void MPU_GetDetailErrorAccessInfo(MPU_Type *base, mpu_slave_t slaveNum, mpu_access_err_info_t *errInform)
+{
+    assert(errInform);
+
+    uint16_t value;
+
+    /* Error address. */
+    errInform->address = base->SP[slaveNum].EAR;
+
+    /* Error detail information. */
+    value = (base->SP[slaveNum].EDR & MPU_EDR_EACD_MASK) >> MPU_EDR_EACD_SHIFT;
+    if (!value)
+    {
+        errInform->accessControl = kMPU_NoRegionHit;
+    }
+    else if (!(value & (uint16_t)(value - 1)))
+    {
+        errInform->accessControl = kMPU_NoneOverlappRegion;
+    }
+    else
+    {
+        errInform->accessControl = kMPU_OverlappRegion;
+    }
+
+    value = base->SP[slaveNum].EDR;
+    errInform->master = (mpu_master_t)((value & MPU_EDR_EMN_MASK) >> MPU_EDR_EMN_SHIFT);
+    errInform->attributes = (mpu_err_attributes_t)((value & MPU_EDR_EATTR_MASK) >> MPU_EDR_EATTR_SHIFT);
+    errInform->accessType = (mpu_err_access_type_t)((value & MPU_EDR_ERW_MASK) >> MPU_EDR_ERW_SHIFT);
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    errInform->processorIdentification = (uint8_t)((value & MPU_EDR_EPID_MASK) >> MPU_EDR_EPID_SHIFT);
+#endif
+
+    /*!< Clears error slave port bit. */
+    value = (base->CESR & ~MPU_CESR_SPERR_MASK) | (0x1U << slaveNum);
+    base->CESR = value;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_mpu.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_mpu.h
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_MPU_H_
+#define _FSL_MPU_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup mpu
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief MPU driver version 2.0.0. */
+#define FSL_MPU_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*! @brief MPU low master bit shift. */
+#define MPU_WORD_LOW_MASTER_SHIFT(n) (n * 6)
+
+/*! @brief MPU low master bit mask. */
+#define MPU_WORD_LOW_MASTER_MASK(n) (0x1Fu << MPU_WORD_LOW_MASTER_SHIFT(n))
+
+/*! @brief MPU low master bit width. */
+#define MPU_WORD_LOW_MASTER_WIDTH 5
+
+/*! @brief MPU low master priority setting. */
+#define MPU_WORD_LOW_MASTER(n, x) \
+    (((uint32_t)(((uint32_t)(x)) << MPU_WORD_LOW_MASTER_SHIFT(n))) & MPU_WORD_LOW_MASTER_MASK(n))
+
+/*! @brief MPU low master process enable bit shift. */
+#define MPU_LOW_MASTER_PE_SHIFT(n) (n * 6 + 5)
+
+/*! @brief MPU low master process enable bit mask. */
+#define MPU_LOW_MASTER_PE_MASK(n) (0x1u << MPU_LOW_MASTER_PE_SHIFT(n))
+
+/*! @brief MPU low master process enable width. */
+#define MPU_WORD_MASTER_PE_WIDTH 1
+
+/*! @brief MPU low master process enable setting. */
+#define MPU_WORD_MASTER_PE(n, x) \
+    (((uint32_t)(((uint32_t)(x)) << MPU_LOW_MASTER_PE_SHIFT(n))) & MPU_LOW_MASTER_PE_MASK(n))
+
+/*! @brief MPU high master bit shift. */
+#define MPU_WORD_HIGH_MASTER_SHIFT(n) (n * 2 + 24)
+
+/*! @brief MPU high master bit mask. */
+#define MPU_WORD_HIGH_MASTER_MASK(n) (0x03u << MPU_WORD_HIGH_MASTER_SHIFT(n))
+
+/*! @brief MPU high master bit width. */
+#define MPU_WORD_HIGH_MASTER_WIDTH 2
+
+/*! @brief MPU high master priority setting. */
+#define MPU_WORD_HIGH_MASTER(n, x) \
+    (((uint32_t)(((uint32_t)(x)) << MPU_WORD_HIGH_MASTER_SHIFT(n))) & MPU_WORD_HIGH_MASTER_MASK(n))
+
+/*! @brief MPU region number. */
+typedef enum _mpu_region_num
+{
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 0U
+    kMPU_RegionNum00 = 0U, /*!< MPU region number 0. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 1U
+    kMPU_RegionNum01 = 1U, /*!< MPU region number 1. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 2U
+    kMPU_RegionNum02 = 2U, /*!< MPU region number 2. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 3U
+    kMPU_RegionNum03 = 3U, /*!< MPU region number 3. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 4U
+    kMPU_RegionNum04 = 4U, /*!< MPU region number 4. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 5U
+    kMPU_RegionNum05 = 5U, /*!< MPU region number 5. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 6U
+    kMPU_RegionNum06 = 6U, /*!< MPU region number 6. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 7U
+    kMPU_RegionNum07 = 7U, /*!< MPU region number 7. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 8U
+    kMPU_RegionNum08 = 8U, /*!< MPU region number 8. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 9U
+    kMPU_RegionNum09 = 9U, /*!< MPU region number 9. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 10U
+    kMPU_RegionNum10 = 10U, /*!< MPU region number 10. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 11U
+    kMPU_RegionNum11 = 11U, /*!< MPU region number 11. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 12U
+    kMPU_RegionNum12 = 12U, /*!< MPU region number 12. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 13U
+    kMPU_RegionNum13 = 13U, /*!< MPU region number 13. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 14U
+    kMPU_RegionNum14 = 14U, /*!< MPU region number 14. */
+#endif
+#if FSL_FEATURE_MPU_DESCRIPTOR_COUNT > 15U
+    kMPU_RegionNum15 = 15U, /*!< MPU region number 15. */
+#endif
+} mpu_region_num_t;
+
+/*! @brief MPU master number. */
+typedef enum _mpu_master
+{
+#if FSL_FEATURE_MPU_HAS_MASTER0
+    kMPU_Master0 = 0U, /*!< MPU master core. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER1
+    kMPU_Master1 = 1U, /*!< MPU master defined in SoC. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER2
+    kMPU_Master2 = 2U, /*!< MPU master defined in SoC. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER3
+    kMPU_Master3 = 3U, /*!< MPU master defined in SoC. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER4
+    kMPU_Master4 = 4U, /*!< MPU master defined in SoC. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER5
+    kMPU_Master5 = 5U, /*!< MPU master defined in SoC. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER6
+    kMPU_Master6 = 6U, /*!< MPU master defined in SoC. */
+#endif
+#if FSL_FEATURE_MPU_HAS_MASTER7
+    kMPU_Master7 = 7U /*!< MPU master defined in SoC. */
+#endif
+} mpu_master_t;
+
+/*! @brief Describes the number of MPU regions. */
+typedef enum _mpu_region_total_num
+{
+    kMPU_8Regions = 0x0U,  /*!< MPU supports 8 regions.  */
+    kMPU_12Regions = 0x1U, /*!< MPU supports 12 regions. */
+    kMPU_16Regions = 0x2U  /*!< MPU supports 16 regions. */
+} mpu_region_total_num_t;
+
+/*! @brief MPU slave port number. */
+typedef enum _mpu_slave
+{
+    kMPU_Slave0 = 4U, /*!< MPU slave port 0. */
+    kMPU_Slave1 = 3U, /*!< MPU slave port 1. */
+    kMPU_Slave2 = 2U, /*!< MPU slave port 2. */
+    kMPU_Slave3 = 1U, /*!< MPU slave port 3. */
+    kMPU_Slave4 = 0U  /*!< MPU slave port 4. */
+} mpu_slave_t;
+
+/*! @brief MPU error access control detail. */
+typedef enum _mpu_err_access_control
+{
+    kMPU_NoRegionHit = 0U,        /*!< No region hit error. */
+    kMPU_NoneOverlappRegion = 1U, /*!< Access single region error. */
+    kMPU_OverlappRegion = 2U      /*!< Access overlapping region error. */
+} mpu_err_access_control_t;
+
+/*! @brief MPU error access type. */
+typedef enum _mpu_err_access_type
+{
+    kMPU_ErrTypeRead = 0U, /*!< MPU error access type --- read.  */
+    kMPU_ErrTypeWrite = 1U /*!< MPU error access type --- write. */
+} mpu_err_access_type_t;
+
+/*! @brief MPU access error attributes.*/
+typedef enum _mpu_err_attributes
+{
+    kMPU_InstructionAccessInUserMode = 0U,       /*!< Access instruction error in user mode. */
+    kMPU_DataAccessInUserMode = 1U,              /*!< Access data error in user mode. */
+    kMPU_InstructionAccessInSupervisorMode = 2U, /*!< Access instruction error in supervisor mode. */
+    kMPU_DataAccessInSupervisorMode = 3U         /*!< Access data error in supervisor mode. */
+} mpu_err_attributes_t;
+
+/*! @brief MPU access rights in supervisor mode for master port 0 ~ port 3. */
+typedef enum _mpu_supervisor_access_rights
+{
+    kMPU_SupervisorReadWriteExecute = 0U, /*!< Read write and execute operations are allowed in supervisor mode. */
+    kMPU_SupervisorReadExecute = 1U,      /*!< Read and execute operations are allowed in supervisor mode. */
+    kMPU_SupervisorReadWrite = 2U,        /*!< Read write operations are allowed in supervisor mode. */
+    kMPU_SupervisorEqualToUsermode = 3U   /*!< Access permission equal to user mode. */
+} mpu_supervisor_access_rights_t;
+
+/*! @brief MPU access rights in user mode for master port 0 ~ port 3. */
+typedef enum _mpu_user_access_rights
+{
+    kMPU_UserNoAccessRights = 0U,  /*!< No access allowed in user mode.  */
+    kMPU_UserExecute = 1U,         /*!< Execute operation is allowed in user mode. */
+    kMPU_UserWrite = 2U,           /*!< Write operation is allowed in user mode. */
+    kMPU_UserWriteExecute = 3U,    /*!< Write and execute operations are allowed in user mode. */
+    kMPU_UserRead = 4U,            /*!< Read is allowed in user mode. */
+    kMPU_UserReadExecute = 5U,     /*!< Read and execute operations are allowed in user mode. */
+    kMPU_UserReadWrite = 6U,       /*!< Read and write operations are allowed in user mode. */
+    kMPU_UserReadWriteExecute = 7U /*!< Read write and execute operations are allowed in user mode. */
+} mpu_user_access_rights_t;
+
+/*! @brief MPU hardware basic information. */
+typedef struct _mpu_hardware_info
+{
+    uint8_t hardwareRevisionLevel;         /*!< Specifies the MPU's hardware and definition reversion level. */
+    uint8_t slavePortsNumbers;             /*!< Specifies the number of slave ports connected to MPU. */
+    mpu_region_total_num_t regionsNumbers; /*!< Indicates the number of region descriptors implemented. */
+} mpu_hardware_info_t;
+
+/*! @brief MPU detail error access information. */
+typedef struct _mpu_access_err_info
+{
+    mpu_master_t master;                    /*!< Access error master. */
+    mpu_err_attributes_t attributes;        /*!< Access error attributes. */
+    mpu_err_access_type_t accessType;       /*!< Access error type. */
+    mpu_err_access_control_t accessControl; /*!< Access error control. */
+    uint32_t address;                       /*!< Access error address. */
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    uint8_t processorIdentification; /*!< Access error processor identification. */
+#endif                               /* FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER */
+} mpu_access_err_info_t;
+
+/*! @brief MPU access rights for low master master port 0 ~ port 3. */
+typedef struct _mpu_low_masters_access_rights
+{
+    mpu_supervisor_access_rights_t superAccessRights; /*!< Master access rights in supervisor mode. */
+    mpu_user_access_rights_t userAccessRights;        /*!< Master access rights in user mode. */
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    bool processIdentifierEnable; /*!< Enables or disables process identifier. */
+#endif                            /* FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER */
+} mpu_low_masters_access_rights_t;
+
+/*! @brief MPU access rights mode for high master port 4 ~ port 7. */
+typedef struct _mpu_high_masters_access_rights
+{
+    bool writeEnable; /*!< Enables or disables write permission. */
+    bool readEnable;  /*!< Enables or disables read permission.  */
+} mpu_high_masters_access_rights_t;
+
+/*!
+ * @brief MPU region configuration structure.
+ *
+ * This structure is used to configure the regionNum region.
+ * The accessRights1[0] ~ accessRights1[3] are used to configure the four low master
+ * numbers: master 0 ~ master 3.   The accessRights2[0] ~ accessRights2[3] are
+ * used to configure the four high master numbers: master 4 ~ master 7.
+ * The master port assignment is the chip configuration. Normally, the core is the
+ * master 0, debugger is the master 1.
+ * Note: MPU assigns a priority scheme where the debugger is treated as the highest
+ * priority master followed by the core and then all the remaining masters.
+ * MPU protection does not allow writes from the core to affect the "regionNum 0" start
+ * and end address nor the permissions associated with the debugger. It can only write
+ * the permission fields associated with the other masters. This protection guarantee
+ * the debugger always has access to the entire address space and those rights can't
+ * be changed by the core or any other bus master. Prepare
+ * the region configuration when regionNum is kMPU_RegionNum00.
+ */
+typedef struct _mpu_region_config
+{
+    mpu_region_num_t regionNum; /*!< MPU region number. */
+    uint32_t startAddress; /*!< Memory region start address. Note: bit0 ~ bit4 always be marked as 0 by MPU. The actual
+                              start address is 0-modulo-32 byte address.  */
+    uint32_t endAddress; /*!< Memory region end address. Note: bit0 ~ bit4 always be marked as 1 by MPU. The actual end
+                            address is 31-modulo-32 byte address. */
+    mpu_low_masters_access_rights_t accessRights1[4];  /*!< Low masters access permission.  */
+    mpu_high_masters_access_rights_t accessRights2[4]; /*!< High masters access permission. */
+#if FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER
+    uint8_t processIdentifier; /*!< Process identifier used when "processIdentifierEnable" set with true. */
+    uint8_t
+        processIdMask; /*!< Process identifier mask. The setting bit will ignore the same bit in process identifier. */
+#endif                 /* FSL_FEATURE_MPU_HAS_PROCESS_IDENTIFIER */
+} mpu_region_config_t;
+
+/*!
+ * @brief The configuration structure for the MPU initialization.
+ *
+ * This structure is used when calling the MPU_Init function.
+ */
+typedef struct _mpu_config
+{
+    mpu_region_config_t regionConfig; /*!< region access permission. */
+    struct _mpu_config *next;         /*!< pointer to the next structure. */
+} mpu_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* _cplusplus */
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the MPU with the user configuration structure.
+ *
+ * This function configures the MPU module with the user-defined configuration.
+ *
+ * @param base     MPU peripheral base address.
+ * @param config   The pointer to the configuration structure.
+ */
+void MPU_Init(MPU_Type *base, const mpu_config_t *config);
+
+/*!
+ * @brief Deinitializes the MPU regions.
+ *
+ * @param base     MPU peripheral base address.
+ */
+void MPU_Deinit(MPU_Type *base);
+
+/* @}*/
+
+/*!
+ * @name Basic Control Operations
+ * @{
+ */
+
+/*!
+ * @brief Enables/disables the MPU globally.
+ *
+ * Call this API to enable or disable the MPU module.
+ *
+ * @param base     MPU peripheral base address.
+ * @param enable   True enable MPU, false disable MPU.
+ */
+static inline void MPU_Enable(MPU_Type *base, bool enable)
+{
+    if (enable)
+    {
+        /* Enable the MPU globally. */
+        base->CESR |= MPU_CESR_VLD_MASK;
+    }
+    else
+    { /* Disable the MPU globally. */
+        base->CESR &= ~MPU_CESR_VLD_MASK;
+    }
+}
+
+/*!
+ * @brief Enables/disables the MPU for a special region.
+ *
+ * When MPU is enabled, call this API to disable an unused region
+ * of an enabled MPU. Call this API to minimize the power dissipation.
+ *
+ * @param base     MPU peripheral base address.
+ * @param number   MPU region number.
+ * @param enable   True enable the special region MPU, false disable the special region MPU.
+ */
+static inline void MPU_RegionEnable(MPU_Type *base, mpu_region_num_t number, bool enable)
+{
+    if (enable)
+    {
+        /* Enable the #number region MPU. */
+        base->WORD[number][3] |= MPU_WORD_VLD_MASK;
+    }
+    else
+    { /* Disable the #number region MPU. */
+        base->WORD[number][3] &= ~MPU_WORD_VLD_MASK;
+    }
+}
+
+/*!
+ * @brief Gets the MPU basic hardware information.
+ *
+ * @param base           MPU peripheral base address.
+ * @param hardwareInform The pointer to the MPU hardware information structure. See "mpu_hardware_info_t".
+ */
+void MPU_GetHardwareInfo(MPU_Type *base, mpu_hardware_info_t *hardwareInform);
+
+/*!
+ * @brief Sets the MPU region.
+ *
+ * Note: Due to the MPU protection, the kMPU_RegionNum00 does not allow writes from the
+ * core to affect the start and end address nor the permissions associated with
+ * the debugger. It can only write the permission fields associated
+ * with the other masters.
+ *
+ * @param base          MPU peripheral base address.
+ * @param regionConfig  The pointer to the MPU user configuration structure. See "mpu_region_config_t".
+ */
+void MPU_SetRegionConfig(MPU_Type *base, const mpu_region_config_t *regionConfig);
+
+/*!
+ * @brief Sets the region start and end address.
+ *
+ * Memory region start address. Note: bit0 ~ bit4 is always marked as 0 by MPU.
+ * The actual start address by MPU is 0-modulo-32 byte address.
+ * Memory region end address. Note: bit0 ~ bit4 always be marked as 1 by MPU.
+ * The actual end address used by MPU is 31-modulo-32 byte address.
+ * Note: Due to the MPU protection, the startAddr and endAddr can't be
+ * changed by the core when regionNum is "kMPU_RegionNum00".
+ *
+ * @param base          MPU peripheral base address.
+ * @param regionNum     MPU region number.
+ * @param startAddr     Region start address.
+ * @param endAddr       Region end address.
+ */
+void MPU_SetRegionAddr(MPU_Type *base, mpu_region_num_t regionNum, uint32_t startAddr, uint32_t endAddr);
+
+/*!
+ * @brief Sets the MPU region access rights for low master port 0 ~ port 3.
+ * This can be used to change the region access rights for any master port for any region.
+ *
+ * @param base          MPU peripheral base address.
+ * @param regionNum     MPU region number.
+ * @param masterNum     MPU master number. Should range from kMPU_Master0 ~ kMPU_Master3.
+ * @param accessRights  The pointer to the MPU access rights configuration. See "mpu_low_masters_access_rights_t".
+ */
+void MPU_SetRegionLowMasterAccessRights(MPU_Type *base,
+                                        mpu_region_num_t regionNum,
+                                        mpu_master_t masterNum,
+                                        const mpu_low_masters_access_rights_t *accessRights);
+
+/*!
+ * @brief Sets the MPU region access rights for high master port 4 ~ port 7.
+ * This can be used to change the region access rights for any master port for any region.
+ *
+ * @param base          MPU peripheral base address.
+ * @param regionNum     MPU region number.
+ * @param masterNum     MPU master number. Should range from kMPU_Master4 ~ kMPU_Master7.
+ * @param accessRights  The pointer to the MPU access rights configuration. See "mpu_high_masters_access_rights_t".
+ */
+void MPU_SetRegionHighMasterAccessRights(MPU_Type *base,
+                                         mpu_region_num_t regionNum,
+                                         mpu_master_t masterNum,
+                                         const mpu_high_masters_access_rights_t *accessRights);
+
+/*!
+ * @brief Gets the numbers of slave ports where errors occur.
+ *
+ * @param base       MPU peripheral base address.
+ * @param slaveNum   MPU slave port number.
+ * @return The slave ports error status.
+ *         true  - error happens in this slave port.
+ *         false - error didn't happen in this slave port.
+ */
+bool MPU_GetSlavePortErrorStatus(MPU_Type *base, mpu_slave_t slaveNum);
+
+/*!
+ * @brief Gets the MPU detailed error access information.
+ *
+ * @param base       MPU peripheral base address.
+ * @param slaveNum   MPU slave port number.
+ * @param errInform  The pointer to the MPU access error information. See "mpu_access_err_info_t".
+ */
+void MPU_GetDetailErrorAccessInfo(MPU_Type *base, mpu_slave_t slaveNum, mpu_access_err_info_t *errInform);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_MPU_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pdb.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pdb.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_pdb.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get instance number for PDB module.
+ *
+ * @param base PDB peripheral base address
+ */
+static uint32_t PDB_GetInstance(PDB_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to PDB bases for each instance. */
+static PDB_Type *const s_pdbBases[] = PDB_BASE_PTRS;
+/*! @brief Pointers to PDB clocks for each instance. */
+const clock_ip_name_t s_pdbClocks[] = PDB_CLOCKS;
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+static uint32_t PDB_GetInstance(PDB_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_PDB_COUNT; instance++)
+    {
+        if (s_pdbBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_PDB_COUNT);
+
+    return instance;
+}
+
+void PDB_Init(PDB_Type *base, const pdb_config_t *config)
+{
+    assert(NULL != config);
+
+    uint32_t tmp32;
+
+    /* Enable the clock. */
+    CLOCK_EnableClock(s_pdbClocks[PDB_GetInstance(base)]);
+
+    /* Configure. */
+    /* PDBx_SC. */
+    tmp32 = base->SC &
+            ~(PDB_SC_LDMOD_MASK | PDB_SC_PRESCALER_MASK | PDB_SC_TRGSEL_MASK | PDB_SC_MULT_MASK | PDB_SC_CONT_MASK);
+
+    tmp32 |= PDB_SC_LDMOD(config->loadValueMode) | PDB_SC_PRESCALER(config->prescalerDivider) |
+             PDB_SC_TRGSEL(config->triggerInputSource) | PDB_SC_MULT(config->dividerMultiplicationFactor);
+    if (config->enableContinuousMode)
+    {
+        tmp32 |= PDB_SC_CONT_MASK;
+    }
+    base->SC = tmp32;
+
+    PDB_Enable(base, true); /* Enable the PDB module. */
+}
+
+void PDB_Deinit(PDB_Type *base)
+{
+    PDB_Enable(base, false); /* Disable the PDB module. */
+
+    /* Disable the clock. */
+    CLOCK_DisableClock(s_pdbClocks[PDB_GetInstance(base)]);
+}
+
+void PDB_GetDefaultConfig(pdb_config_t *config)
+{
+    assert(NULL != config);
+
+    config->loadValueMode = kPDB_LoadValueImmediately;
+    config->prescalerDivider = kPDB_PrescalerDivider1;
+    config->dividerMultiplicationFactor = kPDB_DividerMultiplicationFactor1;
+    config->triggerInputSource = kPDB_TriggerSoftware;
+    config->enableContinuousMode = false;
+}
+
+#if defined(FSL_FEATURE_PDB_HAS_DAC) && FSL_FEATURE_PDB_HAS_DAC
+void PDB_SetDACTriggerConfig(PDB_Type *base, uint32_t channel, pdb_dac_trigger_config_t *config)
+{
+    assert(channel < PDB_INTC_COUNT);
+    assert(NULL != config);
+
+    uint32_t tmp32 = 0U;
+
+    /* PDBx_DACINTC. */
+    if (config->enableExternalTriggerInput)
+    {
+        tmp32 |= PDB_INTC_EXT_MASK;
+    }
+    if (config->enableIntervalTrigger)
+    {
+        tmp32 |= PDB_INTC_TOE_MASK;
+    }
+    base->DAC[channel].INTC = tmp32;
+}
+#endif /* FSL_FEATURE_PDB_HAS_DAC */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pdb.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pdb.h
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_PDB_H_
+#define _FSL_PDB_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup pdb
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief PDB driver version 2.0.1. */
+#define FSL_PDB_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*!
+ * @brief PDB flags.
+ */
+enum _pdb_status_flags
+{
+    kPDB_LoadOKFlag = PDB_SC_LDOK_MASK,      /*!< This flag is automatically cleared when the values in buffers are
+                                                  loaded into the internal registers after the LDOK bit is set or the
+                                                  PDBEN is cleared. */
+    kPDB_DelayEventFlag = PDB_SC_PDBIF_MASK, /*!< PDB timer delay event flag. */
+};
+
+/*!
+ * @brief PDB ADC PreTrigger channel flags.
+ */
+enum _pdb_adc_pretrigger_flags
+{
+    /* PDB PreTrigger channel match flags. */
+    kPDB_ADCPreTriggerChannel0Flag = PDB_S_CF(1U << 0), /*!< Pre-Trigger 0 flag. */
+    kPDB_ADCPreTriggerChannel1Flag = PDB_S_CF(1U << 1), /*!< Pre-Trigger 1 flag. */
+#if (PDB_DLY_COUNT > 2)
+    kPDB_ADCPreTriggerChannel2Flag = PDB_S_CF(1U << 2), /*!< Pre-Trigger 2 flag. */
+    kPDB_ADCPreTriggerChannel3Flag = PDB_S_CF(1U << 3), /*!< Pre-Trigger 3 flag. */
+#endif                                                  /* PDB_DLY_COUNT > 2 */
+#if (PDB_DLY_COUNT > 4)
+    kPDB_ADCPreTriggerChannel4Flag = PDB_S_CF(1U << 4), /*!< Pre-Trigger 4 flag. */
+    kPDB_ADCPreTriggerChannel5Flag = PDB_S_CF(1U << 5), /*!< Pre-Trigger 5 flag. */
+    kPDB_ADCPreTriggerChannel6Flag = PDB_S_CF(1U << 6), /*!< Pre-Trigger 6 flag. */
+    kPDB_ADCPreTriggerChannel7Flag = PDB_S_CF(1U << 7), /*!< Pre-Trigger 7 flag. */
+#endif                                                  /* PDB_DLY_COUNT > 4 */
+
+    /* PDB PreTrigger channel error flags. */
+    kPDB_ADCPreTriggerChannel0ErrorFlag = PDB_S_ERR(1U << 0), /*!< Pre-Trigger 0 Error. */
+    kPDB_ADCPreTriggerChannel1ErrorFlag = PDB_S_ERR(1U << 1), /*!< Pre-Trigger 1 Error. */
+#if (PDB_DLY_COUNT > 2)
+    kPDB_ADCPreTriggerChannel2ErrorFlag = PDB_S_ERR(1U << 2), /*!< Pre-Trigger 2 Error. */
+    kPDB_ADCPreTriggerChannel3ErrorFlag = PDB_S_ERR(1U << 3), /*!< Pre-Trigger 3 Error. */
+#endif                                                        /* PDB_DLY_COUNT > 2 */
+#if (PDB_DLY_COUNT > 4)
+    kPDB_ADCPreTriggerChannel4ErrorFlag = PDB_S_ERR(1U << 4), /*!< Pre-Trigger 4 Error. */
+    kPDB_ADCPreTriggerChannel5ErrorFlag = PDB_S_ERR(1U << 5), /*!< Pre-Trigger 5 Error. */
+    kPDB_ADCPreTriggerChannel6ErrorFlag = PDB_S_ERR(1U << 6), /*!< Pre-Trigger 6 Error. */
+    kPDB_ADCPreTriggerChannel7ErrorFlag = PDB_S_ERR(1U << 7), /*!< Pre-Trigger 7 Error. */
+#endif                                                        /* PDB_DLY_COUNT > 4 */
+};
+
+/*!
+ * @brief PDB buffer interrupts.
+ */
+enum _pdb_interrupt_enable
+{
+    kPDB_SequenceErrorInterruptEnable = PDB_SC_PDBEIE_MASK, /*!< PDB sequence error interrupt enable. */
+    kPDB_DelayInterruptEnable = PDB_SC_PDBIE_MASK,          /*!< PDB delay interrupt enable. */
+};
+
+/*!
+ * @brief PDB load value mode.
+ *
+ * Selects the mode to load the internal values after doing the load operation (write 1 to PDBx_SC[LDOK]).
+ * These values are for:
+ *  - PDB counter (PDBx_MOD, PDBx_IDLY)
+ *  - ADC trigger (PDBx_CHnDLYm)
+ *  - DAC trigger (PDBx_DACINTx)
+ *  - CMP trigger (PDBx_POyDLY)
+ */
+typedef enum _pdb_load_value_mode
+{
+    kPDB_LoadValueImmediately = 0U,                     /*!< Load immediately after 1 is written to LDOK. */
+    kPDB_LoadValueOnCounterOverflow = 1U,               /*!< Load when the PDB counter overflows (reaches the MOD
+                                                             register value). */
+    kPDB_LoadValueOnTriggerInput = 2U,                  /*!< Load a trigger input event is detected. */
+    kPDB_LoadValueOnCounterOverflowOrTriggerInput = 3U, /*!< Load either when the PDB counter overflows or a trigger
+                                                             input is detected. */
+} pdb_load_value_mode_t;
+
+/*!
+ * @brief Prescaler divider.
+ *
+ * Counting uses the peripheral clock divided by multiplication factor selected by times of MULT.
+ */
+typedef enum _pdb_prescaler_divider
+{
+    kPDB_PrescalerDivider1 = 0U,   /*!< Divider x1. */
+    kPDB_PrescalerDivider2 = 1U,   /*!< Divider x2. */
+    kPDB_PrescalerDivider4 = 2U,   /*!< Divider x4. */
+    kPDB_PrescalerDivider8 = 3U,   /*!< Divider x8. */
+    kPDB_PrescalerDivider16 = 4U,  /*!< Divider x16. */
+    kPDB_PrescalerDivider32 = 5U,  /*!< Divider x32. */
+    kPDB_PrescalerDivider64 = 6U,  /*!< Divider x64. */
+    kPDB_PrescalerDivider128 = 7U, /*!< Divider x128. */
+} pdb_prescaler_divider_t;
+
+/*!
+ * @brief Multiplication factor select for prescaler.
+ *
+ * Selects the multiplication factor of the prescaler divider for the counter clock.
+ */
+typedef enum _pdb_divider_multiplication_factor
+{
+    kPDB_DividerMultiplicationFactor1 = 0U,  /*!< Multiplication factor is 1. */
+    kPDB_DividerMultiplicationFactor10 = 1U, /*!< Multiplication factor is 10. */
+    kPDB_DividerMultiplicationFactor20 = 2U, /*!< Multiplication factor is 20. */
+    kPDB_DividerMultiplicationFactor40 = 3U, /*!< Multiplication factor is 40. */
+} pdb_divider_multiplication_factor_t;
+
+/*!
+ * @brief Trigger input source
+ *
+ * Selects the trigger input source for the PDB. The trigger input source can be internal or external (EXTRG pin), or
+ * the software trigger. Refer to chip configuration details for the actual PDB input trigger connections.
+ */
+typedef enum _pdb_trigger_input_source
+{
+    kPDB_TriggerInput0 = 0U,    /*!< Trigger-In 0. */
+    kPDB_TriggerInput1 = 1U,    /*!< Trigger-In 1. */
+    kPDB_TriggerInput2 = 2U,    /*!< Trigger-In 2. */
+    kPDB_TriggerInput3 = 3U,    /*!< Trigger-In 3. */
+    kPDB_TriggerInput4 = 4U,    /*!< Trigger-In 4. */
+    kPDB_TriggerInput5 = 5U,    /*!< Trigger-In 5. */
+    kPDB_TriggerInput6 = 6U,    /*!< Trigger-In 6. */
+    kPDB_TriggerInput7 = 7U,    /*!< Trigger-In 7. */
+    kPDB_TriggerInput8 = 8U,    /*!< Trigger-In 8. */
+    kPDB_TriggerInput9 = 9U,    /*!< Trigger-In 9. */
+    kPDB_TriggerInput10 = 10U,  /*!< Trigger-In 10. */
+    kPDB_TriggerInput11 = 11U,  /*!< Trigger-In 11. */
+    kPDB_TriggerInput12 = 12U,  /*!< Trigger-In 12. */
+    kPDB_TriggerInput13 = 13U,  /*!< Trigger-In 13. */
+    kPDB_TriggerInput14 = 14U,  /*!< Trigger-In 14. */
+    kPDB_TriggerSoftware = 15U, /*!< Trigger-In 15. */
+} pdb_trigger_input_source_t;
+
+/*!
+ * @brief PDB module configuration.
+ */
+typedef struct _pdb_config
+{
+    pdb_load_value_mode_t loadValueMode;                             /*!< Select the load value mode. */
+    pdb_prescaler_divider_t prescalerDivider;                        /*!< Select the prescaler divider. */
+    pdb_divider_multiplication_factor_t dividerMultiplicationFactor; /*!< Multiplication factor select for prescaler. */
+    pdb_trigger_input_source_t triggerInputSource;                   /*!< Select the trigger input source. */
+    bool enableContinuousMode;                                       /*!< Enable the PDB operation in Continuous mode.*/
+} pdb_config_t;
+
+/*!
+ * @brief PDB ADC Pre-Trigger configuration.
+ */
+typedef struct _pdb_adc_pretrigger_config
+{
+    uint32_t enablePreTriggerMask;          /*!< PDB Channel Pre-Trigger Enable. */
+    uint32_t enableOutputMask;              /*!< PDB Channel Pre-Trigger Output Select.
+                                                 PDB channel's corresponding pre-trigger asserts when the counter
+                                                 reaches the channel delay register. */
+    uint32_t enableBackToBackOperationMask; /*!< PDB Channel Pre-Trigger Back-to-Back Operation Enable.
+                                                 Back-to-back operation enables the ADC conversions complete to trigger
+                                                 the next PDB channel pre-trigger and trigger output, so that the ADC
+                                                 conversions can be triggered on next set of configuration and results
+                                                 registers.*/
+} pdb_adc_pretrigger_config_t;
+
+/*!
+ * @brief PDB DAC trigger configuration.
+ */
+typedef struct _pdb_dac_trigger_config
+{
+    bool enableExternalTriggerInput; /*!< Enables the external trigger for DAC interval counter. */
+    bool enableIntervalTrigger;      /*!< Enables the DAC interval trigger. */
+} pdb_dac_trigger_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes  the PDB module.
+ *
+ * This function is to make the initialization for PDB module. The operations includes are:
+ *  - Enable the clock for PDB instance.
+ *  - Configure the PDB module.
+ *  - Enable the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ * @param config Pointer to configuration structure. See "pdb_config_t".
+ */
+void PDB_Init(PDB_Type *base, const pdb_config_t *config);
+
+/*!
+ * @brief De-initializes  the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ */
+void PDB_Deinit(PDB_Type *base);
+
+/*!
+ * @brief Initializes the PDB user configure structure.
+ *
+ * This function initializes the user configure structure to default value. the default value are:
+ * @code
+ *   config->loadValueMode = kPDB_LoadValueImmediately;
+ *   config->prescalerDivider = kPDB_PrescalerDivider1;
+ *   config->dividerMultiplicationFactor = kPDB_DividerMultiplicationFactor1;
+ *   config->triggerInputSource = kPDB_TriggerSoftware;
+ *   config->enableContinuousMode = false;
+ * @endcode
+ * @param config Pointer to configuration structure. See "pdb_config_t".
+ */
+void PDB_GetDefaultConfig(pdb_config_t *config);
+
+/*!
+ * @brief Enables the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ * @param enable Enable the module or not.
+ */
+static inline void PDB_Enable(PDB_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->SC |= PDB_SC_PDBEN_MASK;
+    }
+    else
+    {
+        base->SC &= ~PDB_SC_PDBEN_MASK;
+    }
+}
+
+/* @} */
+
+/*!
+ * @name Basic Counter
+ * @{
+ */
+
+/*!
+ * @brief Triggers the PDB counter by software.
+ *
+ * @param base PDB peripheral base address.
+ */
+static inline void PDB_DoSoftwareTrigger(PDB_Type *base)
+{
+    base->SC |= PDB_SC_SWTRIG_MASK;
+}
+
+/*!
+ * @brief Loads the counter values.
+ *
+ * This function is to load the counter values from their internal buffer.
+ * See "pdb_load_value_mode_t" about PDB's load mode.
+ *
+ * @param base PDB peripheral base address.
+ */
+static inline void PDB_DoLoadValues(PDB_Type *base)
+{
+    base->SC |= PDB_SC_LDOK_MASK;
+}
+
+/*!
+ * @brief Enables the DMA for the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ * @param enable Enable the feature or not.
+ */
+static inline void PDB_EnableDMA(PDB_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->SC |= PDB_SC_DMAEN_MASK;
+    }
+    else
+    {
+        base->SC &= ~PDB_SC_DMAEN_MASK;
+    }
+}
+
+/*!
+ * @brief Enables the interrupts for the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ * @param mask Mask value for interrupts. See "_pdb_interrupt_enable".
+ */
+static inline void PDB_EnableInterrupts(PDB_Type *base, uint32_t mask)
+{
+    assert(0U == (mask & ~(PDB_SC_PDBEIE_MASK | PDB_SC_PDBIE_MASK)));
+
+    base->SC |= mask;
+}
+
+/*!
+ * @brief Disables the interrupts for the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ * @param mask Mask value for interrupts. See "_pdb_interrupt_enable".
+ */
+static inline void PDB_DisableInterrupts(PDB_Type *base, uint32_t mask)
+{
+    assert(0U == (mask & ~(PDB_SC_PDBEIE_MASK | PDB_SC_PDBIE_MASK)));
+
+    base->SC &= ~mask;
+}
+
+/*!
+ * @brief  Gets the status flags of the PDB module.
+ *
+ * @param  base PDB peripheral base address.
+ *
+ * @return      Mask value for asserted flags. See "_pdb_status_flags".
+ */
+static inline uint32_t PDB_GetStatusFlags(PDB_Type *base)
+{
+    return base->SC & (PDB_SC_PDBIF_MASK | PDB_SC_LDOK_MASK);
+}
+
+/*!
+ * @brief Clears the status flags of the PDB module.
+ *
+ * @param base PDB peripheral base address.
+ * @param mask Mask value of flags. See "_pdb_status_flags".
+ */
+static inline void PDB_ClearStatusFlags(PDB_Type *base, uint32_t mask)
+{
+    assert(0U == (mask & ~PDB_SC_PDBIF_MASK));
+
+    base->SC &= ~mask;
+}
+
+/*!
+ * @brief  Specifies the period of the counter.
+ *
+ * @param  base  PDB peripheral base address.
+ * @param  value Setting value for the modulus. 16-bit is available.
+ */
+static inline void PDB_SetModulusValue(PDB_Type *base, uint32_t value)
+{
+    base->MOD = PDB_MOD_MOD(value);
+}
+
+/*!
+ * @brief  Gets the PDB counter's current value.
+ *
+ * @param  base PDB peripheral base address.
+ *
+ * @return      PDB counter's current value.
+ */
+static inline uint32_t PDB_GetCounterValue(PDB_Type *base)
+{
+    return base->CNT;
+}
+
+/*!
+ * @brief Sets the value for PDB counter delay event.
+ *
+ * @param base  PDB peripheral base address.
+ * @param value Setting value for PDB counter delay event. 16-bit is available.
+ */
+static inline void PDB_SetCounterDelayValue(PDB_Type *base, uint32_t value)
+{
+    base->IDLY = PDB_IDLY_IDLY(value);
+}
+/* @} */
+
+/*!
+ * @name ADC Pre-Trigger
+ * @{
+ */
+
+/*!
+ * @brief Configures the ADC PreTrigger in PDB module.
+ *
+ * @param base    PDB peripheral base address.
+ * @param channel Channel index for ADC instance.
+ * @param config  Pointer to configuration structure. See "pdb_adc_pretrigger_config_t".
+ */
+static inline void PDB_SetADCPreTriggerConfig(PDB_Type *base, uint32_t channel, pdb_adc_pretrigger_config_t *config)
+{
+    assert(channel < PDB_C1_COUNT);
+    assert(NULL != config);
+
+    base->CH[channel].C1 = PDB_C1_BB(config->enableBackToBackOperationMask) | PDB_C1_TOS(config->enableOutputMask) |
+                           PDB_C1_EN(config->enableOutputMask);
+}
+
+/*!
+ * @brief Sets the value for ADC Pre-Trigger delay event.
+ *
+ * This function is to set the value for ADC Pre-Trigger delay event. IT Specifies the delay value for the channel's
+ * corresponding pre-trigger. The pre-trigger asserts when the PDB counter is equal to the setting value here.
+ *
+ * @param base       PDB peripheral base address.
+ * @param channel    Channel index for ADC instance.
+ * @param preChannel Channel group index for ADC instance.
+ * @param value      Setting value for ADC Pre-Trigger delay event. 16-bit is available.
+ */
+static inline void PDB_SetADCPreTriggerDelayValue(PDB_Type *base, uint32_t channel, uint32_t preChannel, uint32_t value)
+{
+    assert(channel < PDB_C1_COUNT);
+    assert(preChannel < PDB_DLY_COUNT);
+
+    base->CH[channel].DLY[preChannel] = PDB_DLY_DLY(value);
+}
+
+/*!
+ * @brief  Gets the ADC Pre-Trigger's status flags.
+ *
+ * @param  base    PDB peripheral base address.
+ * @param  channel Channel index for ADC instance.
+ *
+ * @return         Mask value for asserted flags. See "_pdb_adc_pretrigger_flags".
+ */
+static inline uint32_t PDB_GetADCPreTriggerStatusFlags(PDB_Type *base, uint32_t channel)
+{
+    assert(channel < PDB_C1_COUNT);
+
+    return base->CH[channel].S;
+}
+
+/*!
+ * @brief Clears the ADC Pre-Trigger's status flags.
+ *
+ * @param base    PDB peripheral base address.
+ * @param channel Channel index for ADC instance.
+ * @param mask    Mask value for flags. See "_pdb_adc_pretrigger_flags".
+ */
+static inline void PDB_ClearADCPreTriggerStatusFlags(PDB_Type *base, uint32_t channel, uint32_t mask)
+{
+    assert(channel < PDB_C1_COUNT);
+
+    base->CH[channel].S &= ~mask;
+}
+
+/* @} */
+
+#if defined(FSL_FEATURE_PDB_HAS_DAC) && FSL_FEATURE_PDB_HAS_DAC
+/*!
+ * @name DAC Interval Trigger
+ * @{
+ */
+
+/*!
+ * @brief Configures the DAC trigger in PDB module.
+ *
+ * @param base    PDB peripheral base address.
+ * @param channel Channel index for DAC instance.
+ * @param config  Pointer to configuration structure. See "pdb_dac_trigger_config_t".
+ */
+void PDB_SetDACTriggerConfig(PDB_Type *base, uint32_t channel, pdb_dac_trigger_config_t *config);
+
+/*!
+ * @brief Sets the value for the DAC interval event.
+ *
+ * This fucntion is to set the value for DAC interval event. DAC interval trigger would trigger the DAC module to update
+ * buffer when the DAC interval counter is equal to the setting value here.
+ *
+ * @param base    PDB peripheral base address.
+ * @param channel Channel index for DAC instance.
+ * @param value   Setting value for the DAC interval event.
+ */
+static inline void PDB_SetDACTriggerIntervalValue(PDB_Type *base, uint32_t channel, uint32_t value)
+{
+    assert(channel < PDB_INT_COUNT);
+
+    base->DAC[channel].INT = PDB_INT_INT(value);
+}
+
+/* @} */
+#endif /* FSL_FEATURE_PDB_HAS_DAC */
+
+/*!
+ * @name Pulse-Out Trigger
+ * @{
+ */
+
+/*!
+ * @brief Enables the pulse out trigger channels.
+ *
+ * @param base        PDB peripheral base address.
+ * @param channelMask Channel mask value for multiple pulse out trigger channel.
+ * @param enable Enable the feature or not.
+ */
+static inline void PDB_EnablePulseOutTrigger(PDB_Type *base, uint32_t channelMask, bool enable)
+{
+    if (enable)
+    {
+        base->POEN |= PDB_POEN_POEN(channelMask);
+    }
+    else
+    {
+        base->POEN &= ~(PDB_POEN_POEN(channelMask));
+    }
+}
+
+/*!
+ * @brief Sets event values for pulse out trigger.
+ *
+ * This function is used to set event values for pulse output trigger.
+ * These pulse output trigger delay values specify the delay for the PDB Pulse-Out. Pulse-Out goes high when the PDB
+ * counter is equal to the pulse output high value (value1). Pulse-Out goes low when the PDB counter is equal to the
+ * pulse output low value (value2).
+ *
+ * @param base    PDB peripheral base address.
+ * @param channel Channel index for pulse out trigger channel.
+ * @param value1  Setting value for pulse out high.
+ * @param value2  Setting value for pulse out low.
+ */
+static inline void PDB_SetPulseOutTriggerDelayValue(PDB_Type *base, uint32_t channel, uint32_t value1, uint32_t value2)
+{
+    assert(channel < PDB_PODLY_COUNT);
+
+    base->PODLY[channel] = PDB_PODLY_DLY1(value1) | PDB_PODLY_DLY2(value2);
+}
+
+/* @} */
+#if defined(__cplusplus)
+}
+#endif
+/*!
+ * @}
+ */
+#endif /* _FSL_PDB_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pit.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pit.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_pit.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Gets the instance from the base address to be used to gate or ungate the module clock
+ *
+ * @param base PIT peripheral base address
+ *
+ * @return The PIT instance
+ */
+static uint32_t PIT_GetInstance(PIT_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to PIT bases for each instance. */
+static PIT_Type *const s_pitBases[] = PIT_BASE_PTRS;
+
+/*! @brief Pointers to PIT clocks for each instance. */
+static const clock_ip_name_t s_pitClocks[] = PIT_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t PIT_GetInstance(PIT_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_PIT_COUNT; instance++)
+    {
+        if (s_pitBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_PIT_COUNT);
+
+    return instance;
+}
+
+void PIT_Init(PIT_Type *base, const pit_config_t *config)
+{
+    assert(config);
+
+    /* Ungate the PIT clock*/
+    CLOCK_EnableClock(s_pitClocks[PIT_GetInstance(base)]);
+
+    /* Enable PIT timers */
+    base->MCR &= ~PIT_MCR_MDIS_MASK;
+
+    /* Config timer operation when in debug mode */
+    if (config->enableRunInDebug)
+    {
+        base->MCR &= ~PIT_MCR_FRZ_MASK;
+    }
+    else
+    {
+        base->MCR |= PIT_MCR_FRZ_MASK;
+    }
+}
+
+void PIT_Deinit(PIT_Type *base)
+{
+    /* Disable PIT timers */
+    base->MCR |= PIT_MCR_MDIS_MASK;
+
+    /* Gate the PIT clock*/
+    CLOCK_DisableClock(s_pitClocks[PIT_GetInstance(base)]);
+}
+
+#if defined(FSL_FEATURE_PIT_HAS_LIFETIME_TIMER) && FSL_FEATURE_PIT_HAS_LIFETIME_TIMER
+
+uint64_t PIT_GetLifetimeTimerCount(PIT_Type *base)
+{
+    uint32_t valueH = 0U;
+    uint32_t valueL = 0U;
+
+    /* LTMR64H should be read before LTMR64L */
+    valueH = base->LTMR64H;
+    valueL = base->LTMR64L;
+
+    return (((uint64_t)valueH << 32U) + (uint64_t)(valueL));
+}
+
+#endif /* FSL_FEATURE_PIT_HAS_LIFETIME_TIMER */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pit.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pit.h
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_PIT_H_
+#define _FSL_PIT_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup pit_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_PIT_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0 */
+/*@}*/
+
+/*!
+ * @brief List of PIT channels
+ * @note Actual number of available channels is SoC dependent
+ */
+typedef enum _pit_chnl
+{
+    kPIT_Chnl_0 = 0U, /*!< PIT channel number 0*/
+    kPIT_Chnl_1,      /*!< PIT channel number 1 */
+    kPIT_Chnl_2,      /*!< PIT channel number 2 */
+    kPIT_Chnl_3,      /*!< PIT channel number 3 */
+} pit_chnl_t;
+
+/*! @brief List of PIT interrupts */
+typedef enum _pit_interrupt_enable
+{
+    kPIT_TimerInterruptEnable = PIT_TCTRL_TIE_MASK, /*!< Timer interrupt enable*/
+} pit_interrupt_enable_t;
+
+/*! @brief List of PIT status flags */
+typedef enum _pit_status_flags
+{
+    kPIT_TimerFlag = PIT_TFLG_TIF_MASK, /*!< Timer flag */
+} pit_status_flags_t;
+
+/*!
+ * @brief PIT config structure
+ *
+ * This structure holds the configuration settings for the PIT peripheral. To initialize this
+ * structure to reasonable defaults, call the PIT_GetDefaultConfig() function and pass a
+ * pointer to your config structure instance.
+ *
+ * The config struct can be made const so it resides in flash
+ */
+typedef struct _pit_config
+{
+    bool enableRunInDebug; /*!< true: Timers run in debug mode; false: Timers stop in debug mode */
+} pit_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Ungates the PIT clock, enables the PIT module and configures the peripheral for basic operation.
+ *
+ * @note This API should be called at the beginning of the application using the PIT driver.
+ *
+ * @param base   PIT peripheral base address
+ * @param config Pointer to user's PIT config structure
+ */
+void PIT_Init(PIT_Type *base, const pit_config_t *config);
+
+/*!
+ * @brief Gate the PIT clock and disable the PIT module
+ *
+ * @param base PIT peripheral base address
+ */
+void PIT_Deinit(PIT_Type *base);
+
+/*!
+ * @brief Fill in the PIT config struct with the default settings
+ *
+ * The default values are:
+ * @code
+ *     config->enableRunInDebug = false;
+ * @endcode
+ * @param config Pointer to user's PIT config structure.
+ */
+static inline void PIT_GetDefaultConfig(pit_config_t *config)
+{
+    assert(config);
+
+    /* Timers are stopped in Debug mode */
+    config->enableRunInDebug = false;
+}
+
+#if defined(FSL_FEATURE_PIT_HAS_CHAIN_MODE) && FSL_FEATURE_PIT_HAS_CHAIN_MODE
+
+/*!
+ * @brief Enables or disables chaining a timer with the previous timer.
+ *
+ * When a timer has a chain mode enabled, it only counts after the previous
+ * timer has expired. If the timer n-1 has counted down to 0, counter n
+ * decrements the value by one. Each timer is 32-bits, this allows the developers
+ * to chain timers together and form a longer timer (64-bits and larger). The first timer
+ * (timer 0) cannot be chained to any other timer.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number which is chained with the previous timer
+ * @param enable  Enable or disable chain.
+ *                true:  Current timer is chained with the previous timer.
+ *                false: Timer doesn't chain with other timers.
+ */
+static inline void PIT_SetTimerChainMode(PIT_Type *base, pit_chnl_t channel, bool enable)
+{
+    if (enable)
+    {
+        base->CHANNEL[channel].TCTRL |= PIT_TCTRL_CHN_MASK;
+    }
+    else
+    {
+        base->CHANNEL[channel].TCTRL &= ~PIT_TCTRL_CHN_MASK;
+    }
+}
+
+#endif /* FSL_FEATURE_PIT_HAS_CHAIN_MODE */
+
+/*! @}*/
+
+/*!
+ * @name Interrupt Interface
+ * @{
+ */
+
+/*!
+ * @brief Enables the selected PIT interrupts.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ * @param mask    The interrupts to enable. This is a logical OR of members of the
+ *                enumeration ::pit_interrupt_enable_t
+ */
+static inline void PIT_EnableInterrupts(PIT_Type *base, pit_chnl_t channel, uint32_t mask)
+{
+    base->CHANNEL[channel].TCTRL |= mask;
+}
+
+/*!
+ * @brief Disables the selected PIT interrupts.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ * @param mask    The interrupts to disable. This is a logical OR of members of the
+ *                enumeration ::pit_interrupt_enable_t
+ */
+static inline void PIT_DisableInterrupts(PIT_Type *base, pit_chnl_t channel, uint32_t mask)
+{
+    base->CHANNEL[channel].TCTRL &= ~mask;
+}
+
+/*!
+ * @brief Gets the enabled PIT interrupts.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ *
+ * @return The enabled interrupts. This is the logical OR of members of the
+ *         enumeration ::pit_interrupt_enable_t
+ */
+static inline uint32_t PIT_GetEnabledInterrupts(PIT_Type *base, pit_chnl_t channel)
+{
+    return (base->CHANNEL[channel].TCTRL & PIT_TCTRL_TIE_MASK);
+}
+
+/*! @}*/
+
+/*!
+ * @name Status Interface
+ * @{
+ */
+
+/*!
+ * @brief Gets the PIT status flags
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ *
+ * @return The status flags. This is the logical OR of members of the
+ *         enumeration ::pit_status_flags_t
+ */
+static inline uint32_t PIT_GetStatusFlags(PIT_Type *base, pit_chnl_t channel)
+{
+    return (base->CHANNEL[channel].TFLG & PIT_TFLG_TIF_MASK);
+}
+
+/*!
+ * @brief  Clears the PIT status flags.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ * @param mask    The status flags to clear. This is a logical OR of members of the
+ *                enumeration ::pit_status_flags_t
+ */
+static inline void PIT_ClearStatusFlags(PIT_Type *base, pit_chnl_t channel, uint32_t mask)
+{
+    base->CHANNEL[channel].TFLG = mask;
+}
+
+/*! @}*/
+
+/*!
+ * @name Read and Write the timer period
+ * @{
+ */
+
+/*!
+ * @brief Sets the timer period in units of count.
+ *
+ * Timers begin counting from the value set by this function until it reaches 0,
+ * then it will generate an interrupt and load this regiter value again.
+ * Writing a new value to this register will not restart the timer; instead the value
+ * will be loaded after the timer expires.
+ *
+ * @note User can call the utility macros provided in fsl_common.h to convert to ticks
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ * @param count   Timer period in units of ticks
+ */
+static inline void PIT_SetTimerPeriod(PIT_Type *base, pit_chnl_t channel, uint32_t count)
+{
+    base->CHANNEL[channel].LDVAL = count;
+}
+
+/*!
+ * @brief Reads the current timer counting value.
+ *
+ * This function returns the real-time timer counting value, in a range from 0 to a
+ * timer period.
+ *
+ * @note User can call the utility macros provided in fsl_common.h to convert ticks to usec or msec
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number
+ *
+ * @return Current timer counting value in ticks
+ */
+static inline uint32_t PIT_GetCurrentTimerCount(PIT_Type *base, pit_chnl_t channel)
+{
+    return base->CHANNEL[channel].CVAL;
+}
+
+/*! @}*/
+
+/*!
+ * @name Timer Start and Stop
+ * @{
+ */
+
+/*!
+ * @brief Starts the timer counting.
+ *
+ * After calling this function, timers load period value, count down to 0 and
+ * then load the respective start value again. Each time a timer reaches 0,
+ * it generates a trigger pulse and sets the timeout interrupt flag.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number.
+ */
+static inline void PIT_StartTimer(PIT_Type *base, pit_chnl_t channel)
+{
+    base->CHANNEL[channel].TCTRL |= PIT_TCTRL_TEN_MASK;
+}
+
+/*!
+ * @brief Stops the timer counting.
+ *
+ * This function stops every timer counting. Timers reload their periods
+ * respectively after the next time they call the PIT_DRV_StartTimer.
+ *
+ * @param base    PIT peripheral base address
+ * @param channel Timer channel number.
+ */
+static inline void PIT_StopTimer(PIT_Type *base, pit_chnl_t channel)
+{
+    base->CHANNEL[channel].TCTRL &= ~PIT_TCTRL_TEN_MASK;
+}
+
+/*! @}*/
+
+#if defined(FSL_FEATURE_PIT_HAS_LIFETIME_TIMER) && FSL_FEATURE_PIT_HAS_LIFETIME_TIMER
+
+/*!
+ * @brief Reads the current lifetime counter value.
+ *
+ * The lifetime timer is a 64-bit timer which chains timer 0 and timer 1 together.
+ * Timer 0 and 1 are chained by calling the PIT_SetTimerChainMode before using this timer.
+ * The period of lifetime timer is equal to the "period of timer 0 * period of timer 1".
+ * For the 64-bit value, the higher 32-bit has the value of timer 1, and the lower 32-bit
+ * has the value of timer 0.
+ *
+ * @param base PIT peripheral base address
+ *
+ * @return Current lifetime timer value
+ */
+uint64_t PIT_GetLifetimeTimerCount(PIT_Type *base);
+
+#endif /* FSL_FEATURE_PIT_HAS_LIFETIME_TIMER */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_PIT_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pmc.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pmc.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "fsl_pmc.h"
+
+#if (defined(FSL_FEATURE_PMC_HAS_PARAM) && FSL_FEATURE_PMC_HAS_PARAM)
+void PMC_GetParam(PMC_Type *base, pmc_param_t *param)
+{
+    uint32_t reg = base->PARAM;
+    ;
+    param->vlpoEnable = (bool)(reg & PMC_PARAM_VLPOE_MASK);
+    param->hvdEnable = (bool)(reg & PMC_PARAM_HVDE_MASK);
+}
+#endif /* FSL_FEATURE_PMC_HAS_PARAM */
+
+void PMC_ConfigureLowVoltDetect(PMC_Type *base, const pmc_low_volt_detect_config_t *config)
+{
+    base->LVDSC1 = (0U |
+#if (defined(FSL_FEATURE_PMC_HAS_LVDV) && FSL_FEATURE_PMC_HAS_LVDV)
+                    ((uint32_t)config->voltSelect << PMC_LVDSC1_LVDV_SHIFT) |
+#endif
+                    ((uint32_t)config->enableInt << PMC_LVDSC1_LVDIE_SHIFT) |
+                    ((uint32_t)config->enableReset << PMC_LVDSC1_LVDRE_SHIFT)
+                    /* Clear the Low Voltage Detect Flag with previouse power detect setting */
+                    | PMC_LVDSC1_LVDACK_MASK);
+}
+
+void PMC_ConfigureLowVoltWarning(PMC_Type *base, const pmc_low_volt_warning_config_t *config)
+{
+    base->LVDSC2 = (0U |
+#if (defined(FSL_FEATURE_PMC_HAS_LVWV) && FSL_FEATURE_PMC_HAS_LVWV)
+                    ((uint32_t)config->voltSelect << PMC_LVDSC2_LVWV_SHIFT) |
+#endif
+                    ((uint32_t)config->enableInt << PMC_LVDSC2_LVWIE_SHIFT)
+                    /* Clear the Low Voltage Warning Flag with previouse power detect setting */
+                    | PMC_LVDSC2_LVWACK_MASK);
+}
+
+#if (defined(FSL_FEATURE_PMC_HAS_HVDSC1) && FSL_FEATURE_PMC_HAS_HVDSC1)
+void PMC_ConfigureHighVoltDetect(PMC_Type *base, const pmc_high_volt_detect_config_t *config)
+{
+    base->HVDSC1 = (((uint32_t)config->voltSelect << PMC_HVDSC1_HVDV_SHIFT) |
+                    ((uint32_t)config->enableInt << PMC_HVDSC1_HVDIE_SHIFT) |
+                    ((uint32_t)config->enableReset << PMC_HVDSC1_HVDRE_SHIFT)
+                    /* Clear the High Voltage Detect Flag with previouse power detect setting */
+                    | PMC_HVDSC1_HVDACK_MASK);
+}
+#endif /* FSL_FEATURE_PMC_HAS_HVDSC1 */
+
+#if ((defined(FSL_FEATURE_PMC_HAS_BGBE) && FSL_FEATURE_PMC_HAS_BGBE) || \
+     (defined(FSL_FEATURE_PMC_HAS_BGEN) && FSL_FEATURE_PMC_HAS_BGEN) || \
+     (defined(FSL_FEATURE_PMC_HAS_BGBDS) && FSL_FEATURE_PMC_HAS_BGBDS))
+void PMC_ConfigureBandgapBuffer(PMC_Type *base, const pmc_bandgap_buffer_config_t *config)
+{
+    base->REGSC = (0U
+#if (defined(FSL_FEATURE_PMC_HAS_BGBE) && FSL_FEATURE_PMC_HAS_BGBE)
+                   | ((uint32_t)config->enable << PMC_REGSC_BGBE_SHIFT)
+#endif /* FSL_FEATURE_PMC_HAS_BGBE */
+#if (defined(FSL_FEATURE_PMC_HAS_BGEN) && FSL_FEATURE_PMC_HAS_BGEN)
+                   | (((uint32_t)config->enableInLowPowerMode << PMC_REGSC_BGEN_SHIFT))
+#endif /* FSL_FEATURE_PMC_HAS_BGEN */
+#if (defined(FSL_FEATURE_PMC_HAS_BGBDS) && FSL_FEATURE_PMC_HAS_BGBDS)
+                   | ((uint32_t)config->drive << PMC_REGSC_BGBDS_SHIFT)
+#endif /* FSL_FEATURE_PMC_HAS_BGBDS */
+                       );
+}
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pmc.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_pmc.h
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_PMC_H_
+#define _FSL_PMC_H_
+
+#include "fsl_common.h"
+
+/*! @addtogroup pmc */
+/*! @{ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief PMC driver version */
+#define FSL_PMC_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0. */
+/*@}*/
+
+#if (defined(FSL_FEATURE_PMC_HAS_LVDV) && FSL_FEATURE_PMC_HAS_LVDV)
+/*!
+ * @brief Low-Voltage Detect Voltage Select
+ */
+typedef enum _pmc_low_volt_detect_volt_select
+{
+    kPMC_LowVoltDetectLowTrip = 0U, /*!< Low trip point selected (VLVD = VLVDL )*/
+    kPMC_LowVoltDetectHighTrip = 1U /*!< High trip point selected (VLVD = VLVDH )*/
+} pmc_low_volt_detect_volt_select_t;
+#endif
+
+#if (defined(FSL_FEATURE_PMC_HAS_LVWV) && FSL_FEATURE_PMC_HAS_LVWV)
+/*!
+ * @brief Low-Voltage Warning Voltage Select
+ */
+typedef enum _pmc_low_volt_warning_volt_select
+{
+    kPMC_LowVoltWarningLowTrip = 0U,  /*!< Low trip point selected (VLVW = VLVW1)*/
+    kPMC_LowVoltWarningMid1Trip = 1U, /*!< Mid 1 trip point selected (VLVW = VLVW2)*/
+    kPMC_LowVoltWarningMid2Trip = 2U, /*!< Mid 2 trip point selected (VLVW = VLVW3)*/
+    kPMC_LowVoltWarningHighTrip = 3U  /*!< High trip point selected (VLVW = VLVW4)*/
+} pmc_low_volt_warning_volt_select_t;
+#endif
+
+#if (defined(FSL_FEATURE_PMC_HAS_HVDSC1) && FSL_FEATURE_PMC_HAS_HVDSC1)
+/*!
+ * @brief High-Voltage Detect Voltage Select
+ */
+typedef enum _pmc_high_volt_detect_volt_select
+{
+    kPMC_HighVoltDetectLowTrip = 0U, /*!< Low trip point selected (VHVD = VHVDL )*/
+    kPMC_HighVoltDetectHighTrip = 1U /*!< High trip point selected (VHVD = VHVDH )*/
+} pmc_high_volt_detect_volt_select_t;
+#endif /* FSL_FEATURE_PMC_HAS_HVDSC1 */
+
+#if (defined(FSL_FEATURE_PMC_HAS_BGBDS) && FSL_FEATURE_PMC_HAS_BGBDS)
+/*!
+ * @brief Bandgap Buffer Drive Select.
+ */
+typedef enum _pmc_bandgap_buffer_drive_select
+{
+    kPMC_BandgapBufferDriveLow = 0U, /*!< Low drive.  */
+    kPMC_BandgapBufferDriveHigh = 1U /*!< High drive. */
+} pmc_bandgap_buffer_drive_select_t;
+#endif /* FSL_FEATURE_PMC_HAS_BGBDS */
+
+#if (defined(FSL_FEATURE_PMC_HAS_VLPO) && FSL_FEATURE_PMC_HAS_VLPO)
+/*!
+ * @brief VLPx Option
+ */
+typedef enum _pmc_vlp_freq_option
+{
+    kPMC_FreqRestrict = 0U,  /*!< Frequency is restricted in VLPx mode. */
+    kPMC_FreqUnrestrict = 1U /*!< Frequency is unrestricted in VLPx mode. */
+} pmc_vlp_freq_mode_t;
+#endif /* FSL_FEATURE_PMC_HAS_VLPO */
+
+#if (defined(FSL_FEATURE_PMC_HAS_VERID) && FSL_FEATURE_PMC_HAS_VERID)
+/*!
+ @brief IP version ID definition.
+ */
+typedef struct _pmc_version_id
+{
+    uint16_t feature; /*!< Feature Specification Number. */
+    uint8_t minor;    /*!< Minor version number.         */
+    uint8_t major;    /*!< Major version number.         */
+} pmc_version_id_t;
+#endif /* FSL_FEATURE_PMC_HAS_VERID */
+
+#if (defined(FSL_FEATURE_PMC_HAS_PARAM) && FSL_FEATURE_PMC_HAS_PARAM)
+/*! @brief IP parameter definition. */
+typedef struct _pmc_param
+{
+    bool vlpoEnable; /*!< VLPO enable. */
+    bool hvdEnable;  /*!< HVD enable.  */
+} pmc_param_t;
+#endif /* FSL_FEATURE_PMC_HAS_PARAM */
+
+/*!
+ * @brief Low-Voltage Detect Configuration Structure
+ */
+typedef struct _pmc_low_volt_detect_config
+{
+    bool enableInt;   /*!< Enable interrupt when low voltage detect*/
+    bool enableReset; /*!< Enable system reset when low voltage detect*/
+#if (defined(FSL_FEATURE_PMC_HAS_LVDV) && FSL_FEATURE_PMC_HAS_LVDV)
+    pmc_low_volt_detect_volt_select_t voltSelect; /*!< Low voltage detect trip point voltage selection*/
+#endif
+} pmc_low_volt_detect_config_t;
+
+/*!
+ * @brief Low-Voltage Warning Configuration Structure
+ */
+typedef struct _pmc_low_volt_warning_config
+{
+    bool enableInt; /*!< Enable interrupt when low voltage warning*/
+#if (defined(FSL_FEATURE_PMC_HAS_LVWV) && FSL_FEATURE_PMC_HAS_LVWV)
+    pmc_low_volt_warning_volt_select_t voltSelect; /*!< Low voltage warning trip point voltage selection*/
+#endif
+} pmc_low_volt_warning_config_t;
+
+#if (defined(FSL_FEATURE_PMC_HAS_HVDSC1) && FSL_FEATURE_PMC_HAS_HVDSC1)
+/*!
+ * @brief High-Voltage Detect Configuration Structure
+ */
+typedef struct _pmc_high_volt_detect_config
+{
+    bool enableInt;                                /*!< Enable interrupt when high voltage detect*/
+    bool enableReset;                              /*!< Enable system reset when high voltage detect*/
+    pmc_high_volt_detect_volt_select_t voltSelect; /*!< High voltage detect trip point voltage selection*/
+} pmc_high_volt_detect_config_t;
+#endif /* FSL_FEATURE_PMC_HAS_HVDSC1 */
+
+#if ((defined(FSL_FEATURE_PMC_HAS_BGBE) && FSL_FEATURE_PMC_HAS_BGBE) || \
+     (defined(FSL_FEATURE_PMC_HAS_BGEN) && FSL_FEATURE_PMC_HAS_BGEN) || \
+     (defined(FSL_FEATURE_PMC_HAS_BGBDS) && FSL_FEATURE_PMC_HAS_BGBDS))
+/*!
+ * @brief Bandgap Buffer configuration.
+ */
+typedef struct _pmc_bandgap_buffer_config
+{
+#if (defined(FSL_FEATURE_PMC_HAS_BGBE) && FSL_FEATURE_PMC_HAS_BGBE)
+    bool enable; /*!< Enable bandgap buffer.                   */
+#endif
+#if (defined(FSL_FEATURE_PMC_HAS_BGEN) && FSL_FEATURE_PMC_HAS_BGEN)
+    bool enableInLowPowerMode; /*!< Enable bandgap buffer in low power mode. */
+#endif                         /* FSL_FEATURE_PMC_HAS_BGEN */
+#if (defined(FSL_FEATURE_PMC_HAS_BGBDS) && FSL_FEATURE_PMC_HAS_BGBDS)
+    pmc_bandgap_buffer_drive_select_t drive; /*!< Bandgap buffer drive select.             */
+#endif                                       /* FSL_FEATURE_PMC_HAS_BGBDS */
+} pmc_bandgap_buffer_config_t;
+#endif
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*! @name Power Management Controller Control APIs*/
+/*@{*/
+
+#if (defined(FSL_FEATURE_PMC_HAS_VERID) && FSL_FEATURE_PMC_HAS_VERID)
+/*!
+ * @brief Gets the PMC version ID.
+ *
+ * This function gets the PMC version ID, including major version number,
+ * minor version number and feature specification number.
+ *
+ * @param base PMC peripheral base address.
+ * @param versionId     Pointer to version ID structure.
+ */
+static inline void PMC_GetVersionId(PMC_Type *base, pmc_version_id_t *versionId)
+{
+    *((uint32_t *)versionId) = base->VERID;
+}
+#endif /* FSL_FEATURE_PMC_HAS_VERID */
+
+#if (defined(FSL_FEATURE_PMC_HAS_PARAM) && FSL_FEATURE_PMC_HAS_PARAM)
+/*!
+ * @brief Gets the PMC parameter.
+ *
+ * This function gets the PMC parameter, including VLPO enable and HVD enable.
+ *
+ * @param base PMC peripheral base address.
+ * @param param         Pointer to PMC param structure.
+ */
+void PMC_GetParam(PMC_Type *base, pmc_param_t *param);
+#endif
+
+/*!
+ * @brief Configure the low voltage detect setting.
+ *
+ * This function configures the low voltage detect setting, including the trip
+ * point voltage setting, enable interrupt or not, enable system reset or not.
+ *
+ * @param base PMC peripheral base address.
+ * @param config  Low-Voltage detect configuration structure.
+ */
+void PMC_ConfigureLowVoltDetect(PMC_Type *base, const pmc_low_volt_detect_config_t *config);
+
+/*!
+ * @brief Get Low-Voltage Detect Flag status
+ *
+ * This function  reads the current LVDF status. If it returns 1, a low
+ * voltage event is detected.
+ *
+ * @param base PMC peripheral base address.
+ * @return Current low voltage detect flag
+ *                - true: Low-Voltage detected
+ *                - false: Low-Voltage not detected
+ */
+static inline bool PMC_GetLowVoltDetectFlag(PMC_Type *base)
+{
+    return (bool)(base->LVDSC1 & PMC_LVDSC1_LVDF_MASK);
+}
+
+/*!
+ * @brief Acknowledge to clear the Low-Voltage Detect flag
+ *
+ * This function acknowledges the low voltage detection errors (write 1 to
+ * clear LVDF).
+ *
+ * @param base PMC peripheral base address.
+ */
+static inline void PMC_ClearLowVoltDetectFlag(PMC_Type *base)
+{
+    base->LVDSC1 |= PMC_LVDSC1_LVDACK_MASK;
+}
+
+/*!
+ * @brief Configure the low voltage warning setting.
+ *
+ * This function configures the low voltage warning setting, including the trip
+ * point voltage setting and enable interrupt or not.
+ *
+ * @param base PMC peripheral base address.
+ * @param config  Low-Voltage warning configuration structure.
+ */
+void PMC_ConfigureLowVoltWarning(PMC_Type *base, const pmc_low_volt_warning_config_t *config);
+
+/*!
+ * @brief Get Low-Voltage Warning Flag status
+ *
+ * This function polls the current LVWF status. When 1 is returned, it
+ * indicates a low-voltage warning event. LVWF is set when V Supply transitions
+ * below the trip point or after reset and V Supply is already below the V LVW.
+ *
+ * @param base PMC peripheral base address.
+ * @return Current LVWF status
+ *                  - true: Low-Voltage Warning Flag is set.
+ *                  - false: the  Low-Voltage Warning does not happen.
+ */
+static inline bool PMC_GetLowVoltWarningFlag(PMC_Type *base)
+{
+    return (bool)(base->LVDSC2 & PMC_LVDSC2_LVWF_MASK);
+}
+
+/*!
+ * @brief Acknowledge to Low-Voltage Warning flag
+ *
+ * This function acknowledges the low voltage warning errors (write 1 to
+ * clear LVWF).
+ *
+ * @param base PMC peripheral base address.
+ */
+static inline void PMC_ClearLowVoltWarningFlag(PMC_Type *base)
+{
+    base->LVDSC2 |= PMC_LVDSC2_LVWACK_MASK;
+}
+
+#if (defined(FSL_FEATURE_PMC_HAS_HVDSC1) && FSL_FEATURE_PMC_HAS_HVDSC1)
+/*!
+ * @brief Configure the high voltage detect setting.
+ *
+ * This function configures the high voltage detect setting, including the trip
+ * point voltage setting, enable interrupt or not, enable system reset or not.
+ *
+ * @param base PMC peripheral base address.
+ * @param config  High-Voltage detect configuration structure.
+ */
+void PMC_ConfigureHighVoltDetect(PMC_Type *base, const pmc_high_volt_detect_config_t *config);
+
+/*!
+ * @brief Get High-Voltage Detect Flag status
+ *
+ * This function  reads the current HVDF status. If it returns 1, a low
+ * voltage event is detected.
+ *
+ * @param base PMC peripheral base address.
+ * @return Current high voltage detect flag
+ *                - true: High-Voltage detected
+ *                - false: High-Voltage not detected
+ */
+static inline bool PMC_GetHighVoltDetectFlag(PMC_Type *base)
+{
+    return (bool)(base->HVDSC1 & PMC_HVDSC1_HVDF_MASK);
+}
+
+/*!
+ * @brief Acknowledge to clear the High-Voltage Detect flag
+ *
+ * This function acknowledges the high voltage detection errors (write 1 to
+ * clear HVDF).
+ *
+ * @param base PMC peripheral base address.
+ */
+static inline void PMC_ClearHighVoltDetectFlag(PMC_Type *base)
+{
+    base->HVDSC1 |= PMC_HVDSC1_HVDACK_MASK;
+}
+#endif /* FSL_FEATURE_PMC_HAS_HVDSC1 */
+
+#if ((defined(FSL_FEATURE_PMC_HAS_BGBE) && FSL_FEATURE_PMC_HAS_BGBE) || \
+     (defined(FSL_FEATURE_PMC_HAS_BGEN) && FSL_FEATURE_PMC_HAS_BGEN) || \
+     (defined(FSL_FEATURE_PMC_HAS_BGBDS) && FSL_FEATURE_PMC_HAS_BGBDS))
+/*!
+ * @brief Configure the PMC bandgap
+ *
+ * This function configures the PMC bandgap, including the drive select and
+ * behavior in low power mode.
+ *
+ * @param base PMC peripheral base address.
+ * @param config Pointer to the configuration structure
+ */
+void PMC_ConfigureBandgapBuffer(PMC_Type *base, const pmc_bandgap_buffer_config_t *config);
+#endif
+
+#if (defined(FSL_FEATURE_PMC_HAS_ACKISO) && FSL_FEATURE_PMC_HAS_ACKISO)
+/*!
+ * @brief Gets the acknowledge Peripherals and I/O pads isolation flag.
+ *
+ * This function  reads the Acknowledge Isolation setting that indicates
+ * whether certain peripherals and the I/O pads are in a latched state as
+ * a result of having been in the VLLS mode.
+ *
+ * @param base PMC peripheral base address.
+ * @param base  Base address for current PMC instance.
+ * @return ACK isolation
+ *               0 - Peripherals and I/O pads are in a normal run state.
+ *               1 - Certain peripherals and I/O pads are in an isolated and
+ *                   latched state.
+ */
+static inline bool PMC_GetPeriphIOIsolationFlag(PMC_Type *base)
+{
+    return (bool)(base->REGSC & PMC_REGSC_ACKISO_MASK);
+}
+
+/*!
+ * @brief Acknowledge to Peripherals and I/O pads isolation flag.
+ *
+ * This function  clears the ACK Isolation flag. Writing one to this setting
+ * when it is set releases the I/O pads and certain peripherals to their normal
+ * run mode state.
+ *
+ * @param base PMC peripheral base address.
+ */
+static inline void PMC_ClearPeriphIOIsolationFlag(PMC_Type *base)
+{
+    base->REGSC |= PMC_REGSC_ACKISO_MASK;
+}
+#endif /* FSL_FEATURE_PMC_HAS_ACKISO */
+
+#if (defined(FSL_FEATURE_PMC_HAS_REGONS) && FSL_FEATURE_PMC_HAS_REGONS)
+/*!
+ * @brief Gets the Regulator regulation status.
+ *
+ * This function  returns the regulator to a run regulation status. It provides
+ * the current status of the internal voltage regulator.
+ *
+ * @param base PMC peripheral base address.
+ * @param base  Base address for current PMC instance.
+ * @return Regulation status
+ *               0 - Regulator is in a stop regulation or in transition to/from the regulation.
+ *               1 - Regulator is in a run regulation.
+ *
+ */
+static inline bool PMC_IsRegulatorInRunRegulation(PMC_Type *base)
+{
+    return (bool)(base->REGSC & PMC_REGSC_REGONS_MASK);
+}
+#endif /* FSL_FEATURE_PMC_HAS_REGONS */
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*! @}*/
+
+#endif /* _FSL_PMC_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_port.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_port.h
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SDRVL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_PORT_H_
+#define _FSL_PORT_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup port_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! Version 2.0.1. */
+#define FSL_PORT_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*! @brief Internal resistor pull feature selection */
+enum _port_pull
+{
+    kPORT_PullDisable = 0U, /*!< internal pull-up/down resistor is disabled. */
+    kPORT_PullDown = 2U,    /*!< internal pull-down resistor is enabled. */
+    kPORT_PullUp = 3U,      /*!< internal pull-up resistor is enabled. */
+};
+
+/*! @brief Slew rate selection */
+enum _port_slew_rate
+{
+    kPORT_FastSlewRate = 0U, /*!< fast slew rate is configured. */
+    kPORT_SlowSlewRate = 1U, /*!< slow slew rate is configured. */
+};
+
+#if defined(FSL_FEATURE_PORT_HAS_OPEN_DRAIN) && FSL_FEATURE_PORT_HAS_OPEN_DRAIN
+/*! @brief Internal resistor pull feature enable/disable */
+enum _port_open_drain_enable
+{
+    kPORT_OpenDrainDisable = 0U, /*!< internal pull-down resistor is disabled. */
+    kPORT_OpenDrainEnable = 1U,  /*!< internal pull-up resistor is enabled. */
+};
+#endif /* FSL_FEATURE_PORT_HAS_OPEN_DRAIN */
+
+/*! @brief Passive filter feature enable/disable */
+enum _port_passive_filter_enable
+{
+    kPORT_PassiveFilterDisable = 0U, /*!< fast slew rate is configured. */
+    kPORT_PassiveFilterEnable = 1U,  /*!< slow slew rate is configured. */
+};
+
+/*! @brief Configures the drive strength. */
+enum _port_drive_strength
+{
+    kPORT_LowDriveStrength = 0U,  /*!< low drive strength is configured. */
+    kPORT_HighDriveStrength = 1U, /*!< high drive strength is configured. */
+};
+
+#if defined(FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK) && FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK
+/*! @brief Unlock/lock the pin control register field[15:0] */
+enum _port_lock_register
+{
+    kPORT_UnlockRegister = 0U, /*!< Pin Control Register fields [15:0] are not locked. */
+    kPORT_LockRegister = 1U,   /*!< Pin Control Register fields [15:0] are locked. */
+};
+#endif /* FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK */
+
+/*! @brief Pin mux selection */
+typedef enum _port_mux
+{
+    kPORT_PinDisabledOrAnalog = 0U, /*!< corresponding pin is disabled, but is used as an analog pin. */
+    kPORT_MuxAsGpio = 1U,           /*!< corresponding pin is configured as GPIO. */
+    kPORT_MuxAlt2 = 2U,             /*!< chip-specific */
+    kPORT_MuxAlt3 = 3U,             /*!< chip-specific */
+    kPORT_MuxAlt4 = 4U,             /*!< chip-specific */
+    kPORT_MuxAlt5 = 5U,             /*!< chip-specific */
+    kPORT_MuxAlt6 = 6U,             /*!< chip-specific */
+    kPORT_MuxAlt7 = 7U,             /*!< chip-specific */
+} port_mux_t;
+
+/*! @brief Configures the interrupt generation condition. */
+typedef enum _port_interrupt
+{
+    kPORT_InterruptOrDMADisabled = 0x0U, /*!< Interrupt/DMA request is disabled. */
+#if defined(FSL_FEATURE_PORT_HAS_DMA_REQUEST) && FSL_FEATURE_PORT_HAS_DMA_REQUEST
+    kPORT_DMARisingEdge = 0x1U,  /*!< DMA request on rising edge. */
+    kPORT_DMAFallingEdge = 0x2U, /*!< DMA request on falling edge. */
+    kPORT_DMAEitherEdge = 0x3U,  /*!< DMA request on either edge. */
+#endif
+#if defined(FSL_FEATURE_PORT_HAS_IRQC_FLAG) && FSL_FEATURE_PORT_HAS_IRQC_FLAG
+    kPORT_FlagRisingEdge = 0x05U,  /*!< Flag sets on rising edge. */
+    kPORT_FlagFallingEdge = 0x06U, /*!< Flag sets on falling edge. */
+    kPORT_FlagEitherEdge = 0x07U,  /*!< Flag sets on either edge. */
+#endif
+    kPORT_InterruptLogicZero = 0x8U,   /*!< Interrupt when logic zero. */
+    kPORT_InterruptRisingEdge = 0x9U,  /*!< Interrupt on rising edge. */
+    kPORT_InterruptFallingEdge = 0xAU, /*!< Interrupt on falling edge. */
+    kPORT_InterruptEitherEdge = 0xBU,  /*!< Interrupt on either edge. */
+    kPORT_InterruptLogicOne = 0xCU,    /*!< Interrupt when logic one. */
+#if defined(FSL_FEATURE_PORT_HAS_IRQC_TRIGGER) && FSL_FEATURE_PORT_HAS_IRQC_TRIGGER
+    kPORT_ActiveHighTriggerOutputEnable = 0xDU, /*!< Enable active high trigger output. */
+    kPORT_ActiveLowTriggerOutputEnable = 0xEU,  /*!< Enable active low trigger output. */
+#endif
+} port_interrupt_t;
+
+#if defined(FSL_FEATURE_PORT_HAS_DIGITAL_FILTER) && FSL_FEATURE_PORT_HAS_DIGITAL_FILTER
+/*! @brief Digital filter clock source selection */
+typedef enum _port_digital_filter_clock_source
+{
+    kPORT_BusClock = 0U, /*!< Digital filters are clocked by the bus clock. */
+    kPORT_LpoClock = 1U, /*!< Digital filters are clocked by the 1 kHz LPO clock. */
+} port_digital_filter_clock_source_t;
+
+/*! @brief PORT digital filter feature configuration definition */
+typedef struct _port_digital_filter_config
+{
+    uint32_t digitalFilterWidth;                    /*!< Set digital filter width */
+    port_digital_filter_clock_source_t clockSource; /*!< Set digital filter clockSource */
+} port_digital_filter_config_t;
+#endif /* FSL_FEATURE_PORT_HAS_DIGITAL_FILTER */
+
+/*! @brief PORT pin config structure */
+typedef struct _port_pin_config
+{
+    uint16_t pullSelect : 2; /*!< no-pull/pull-down/pull-up select */
+    uint16_t slewRate : 1;   /*!< fast/slow slew rate Configure */
+    uint16_t : 1;
+    uint16_t passiveFilterEnable : 1; /*!< passive filter enable/disable */
+#if defined(FSL_FEATURE_PORT_HAS_OPEN_DRAIN) && FSL_FEATURE_PORT_HAS_OPEN_DRAIN
+    uint16_t openDrainEnable : 1; /*!< open drain enable/disable */
+#else
+    uint16_t : 1;
+#endif                          /* FSL_FEATURE_PORT_HAS_OPEN_DRAIN */
+    uint16_t driveStrength : 1; /*!< fast/slow drive strength configure */
+    uint16_t : 1;
+    uint16_t mux : 3; /*!< pin mux Configure */
+    uint16_t : 4;
+#if defined(FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK) && FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK
+    uint16_t lockRegister : 1; /*!< lock/unlock the pcr field[15:0] */
+#else
+    uint16_t : 1;
+#endif /* FSL_FEATURE_PORT_HAS_PIN_CONTROL_LOCK */
+} port_pin_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*! @name Configuration */
+/*@{*/
+
+/*!
+ * @brief Sets the port PCR register.
+ *
+ * This is an example to define an input pin or output pin PCR configuration:
+ * @code
+ * // Define a digital input pin PCR configuration
+ * port_pin_config_t config = {
+ *      kPORT_PullUp,
+ *      kPORT_FastSlewRate,
+ *      kPORT_PassiveFilterDisable,
+ *      kPORT_OpenDrainDisable,
+ *      kPORT_LowDriveStrength,
+ *      kPORT_MuxAsGpio,
+ *      kPORT_UnLockRegister,
+ * };
+ * @endcode
+ *
+ * @param base   PORT peripheral base pointer.
+ * @param pin    PORT pin number.
+ * @param config PORT PCR register configure structure.
+ */
+static inline void PORT_SetPinConfig(PORT_Type *base, uint32_t pin, const port_pin_config_t *config)
+{
+    assert(config);
+    uint32_t addr = (uint32_t)&base->PCR[pin];
+    *(volatile uint16_t *)(addr) = *((const uint16_t *)config);
+}
+
+/*!
+ * @brief Sets the port PCR register for multiple pins.
+ *
+ * This is an example to define input pins or output pins PCR configuration:
+ * @code
+ * // Define a digital input pin PCR configuration
+ * port_pin_config_t config = {
+ *      kPORT_PullUp ,
+ *      kPORT_PullEnable,
+ *      kPORT_FastSlewRate,
+ *      kPORT_PassiveFilterDisable,
+ *      kPORT_OpenDrainDisable,
+ *      kPORT_LowDriveStrength,
+ *      kPORT_MuxAsGpio,
+ *      kPORT_UnlockRegister,
+ * };
+ * @endcode
+ *
+ * @param base   PORT peripheral base pointer.
+ * @param mask   PORT pins' numbers macro.
+ * @param config PORT PCR register configure structure.
+ */
+static inline void PORT_SetMultiplePinsConfig(PORT_Type *base, uint32_t mask, const port_pin_config_t *config)
+{
+    assert(config);
+
+    uint16_t pcrl = *((const uint16_t *)config);
+
+    if (mask & 0xffffU)
+    {
+        base->GPCLR = ((mask & 0xffffU) << 16) | pcrl;
+    }
+    if (mask >> 16)
+    {
+        base->GPCHR = (mask & 0xffff0000U) | pcrl;
+    }
+}
+
+/*!
+ * @brief Configures the pin muxing.
+ *
+ * @param base  PORT peripheral base pointer.
+ * @param pin   PORT pin number.
+ * @param mux   pin muxing slot selection.
+ *        - #kPORT_PinDisabledOrAnalog: Pin disabled or work in analog function.
+ *        - #kPORT_MuxAsGpio          : Set as GPIO.
+ *        - #kPORT_MuxAlt2            : chip-specific.
+ *        - #kPORT_MuxAlt3            : chip-specific.
+ *        - #kPORT_MuxAlt4            : chip-specific.
+ *        - #kPORT_MuxAlt5            : chip-specific.
+ *        - #kPORT_MuxAlt6            : chip-specific.
+ *        - #kPORT_MuxAlt7            : chip-specific.
+ * @Note : This function is NOT recommended to use together with the PORT_SetPinsConfig, because
+ *         the PORT_SetPinsConfig need to configure the pin mux anyway (Otherwise the pin mux will
+ *         be reset to zero : kPORT_PinDisabledOrAnalog).
+ *         This function is recommended to use in the case you just need to reset the pin mux
+ *
+ */
+static inline void PORT_SetPinMux(PORT_Type *base, uint32_t pin, port_mux_t mux)
+{
+    base->PCR[pin] = (base->PCR[pin] & ~PORT_PCR_MUX_MASK) | PORT_PCR_MUX(mux);
+}
+
+#if defined(FSL_FEATURE_PORT_HAS_DIGITAL_FILTER) && FSL_FEATURE_PORT_HAS_DIGITAL_FILTER
+
+/*!
+ * @brief Enables the digital filter in one port, each bit of the 32-bit register represents one pin.
+ *
+ * @param base  PORT peripheral base pointer.
+ * @param mask  PORT pins' numbers macro.
+ */
+static inline void PORT_EnablePinsDigitalFilter(PORT_Type *base, uint32_t mask, bool enable)
+{
+    if (enable == true)
+    {
+        base->DFER |= mask;
+    }
+    else
+    {
+        base->DFER &= ~mask;
+    }
+}
+
+/*!
+ * @brief Sets the digital filter in one port, each bit of the 32-bit register represents one pin.
+ *
+ * @param base   PORT peripheral base pointer.
+ * @param config PORT digital filter configuration structure.
+ */
+static inline void PORT_SetDigitalFilterConfig(PORT_Type *base, const port_digital_filter_config_t *config)
+{
+    assert(config);
+
+    base->DFCR = PORT_DFCR_CS(config->clockSource);
+    base->DFWR = PORT_DFWR_FILT(config->digitalFilterWidth);
+}
+
+#endif /* FSL_FEATURE_PORT_HAS_DIGITAL_FILTER */
+
+/*@}*/
+
+/*! @name Interrupt */
+/*@{*/
+
+/*!
+ * @brief Configures the port pin interrupt/DMA request.
+ *
+ * @param base    PORT peripheral base pointer.
+ * @param pin     PORT pin number.
+ * @param config  PORT pin interrupt configuration.
+ *        - #kPORT_InterruptOrDMADisabled: Interrupt/DMA request disabled.
+ *        - #kPORT_DMARisingEdge : DMA request on rising edge(if the DMA requests exit).
+ *        - #kPORT_DMAFallingEdge: DMA request on falling edge(if the DMA requests exit).
+ *        - #kPORT_DMAEitherEdge : DMA request on either edge(if the DMA requests exit).
+ *        - #kPORT_FlagRisingEdge : Flag sets on rising edge(if the Flag states exit).
+ *        - #kPORT_FlagFallingEdge : Flag sets on falling edge(if the Flag states exit).
+ *        - #kPORT_FlagEitherEdge : Flag sets on either edge(if the Flag states exit).
+ *        - #kPORT_InterruptLogicZero  : Interrupt when logic zero.
+ *        - #kPORT_InterruptRisingEdge : Interrupt on rising edge.
+ *        - #kPORT_InterruptFallingEdge: Interrupt on falling edge.
+ *        - #kPORT_InterruptEitherEdge : Interrupt on either edge.
+ *        - #kPORT_InterruptLogicOne   : Interrupt when logic one.
+ *        - #kPORT_ActiveHighTriggerOutputEnable : Enable active high trigger output(if the trigger states exit).
+ *        - #kPORT_ActiveLowTriggerOutputEnable  : Enable active low trigger output(if the trigger states exit).
+ */
+static inline void PORT_SetPinInterruptConfig(PORT_Type *base, uint32_t pin, port_interrupt_t config)
+{
+    base->PCR[pin] = (base->PCR[pin] & ~PORT_PCR_IRQC_MASK) | PORT_PCR_IRQC(config);
+}
+
+/*!
+ * @brief Reads the whole port status flag.
+ *
+ * If a pin is configured to generate the DMA request,  the corresponding flag
+ * is cleared automatically at the completion of the requested DMA transfer.
+ * Otherwise, the flag remains set until a logic one is written to that flag.
+ * If configured for a level sensitive interrupt that remains asserted, the flag
+ * is set again immediately.
+ *
+ * @param  base PORT peripheral base pointer.
+ * @return Current port interrupt status flags, for example, 0x00010001 means the
+ *         pin 0 and 17 have the interrupt.
+ */
+static inline uint32_t PORT_GetPinsInterruptFlags(PORT_Type *base)
+{
+    return base->ISFR;
+}
+
+/*!
+ * @brief Clears the multiple pins' interrupt status flag.
+ *
+ * @param base PORT peripheral base pointer.
+ * @param mask PORT pins' numbers macro.
+ */
+static inline void PORT_ClearPinsInterruptFlags(PORT_Type *base, uint32_t mask)
+{
+    base->ISFR = mask;
+}
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_PORT_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rcm.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rcm.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_rcm.h"
+
+void RCM_ConfigureResetPinFilter(RCM_Type *base, const rcm_reset_pin_filter_config_t *config)
+{
+#if (defined(FSL_FEATURE_RCM_REG_WIDTH) && (FSL_FEATURE_RCM_REG_WIDTH == 32))
+    uint32_t reg;
+
+    reg = (((uint32_t)config->enableFilterInStop << RCM_RPC_RSTFLTSS_SHIFT) | (uint32_t)config->filterInRunWait);
+    if (config->filterInRunWait == kRCM_FilterBusClock)
+    {
+        reg |= ((uint32_t)config->busClockFilterCount << RCM_RPC_RSTFLTSEL_SHIFT);
+    }
+    base->RPC = reg;
+#else
+    base->RPFC = ((uint8_t)(config->enableFilterInStop << RCM_RPFC_RSTFLTSS_SHIFT) | (uint8_t)config->filterInRunWait);
+    if (config->filterInRunWait == kRCM_FilterBusClock)
+    {
+        base->RPFW = config->busClockFilterCount;
+    }
+#endif /* FSL_FEATURE_RCM_REG_WIDTH */
+}
+
+#if (defined(FSL_FEATURE_RCM_HAS_BOOTROM) && FSL_FEATURE_RCM_HAS_BOOTROM)
+void RCM_SetForceBootRomSource(RCM_Type *base, rcm_boot_rom_config_t config)
+{
+    uint32_t reg;
+
+    reg = base->FM;
+    reg &= ~RCM_FM_FORCEROM_MASK;
+    reg |= ((uint32_t)config << RCM_FM_FORCEROM_SHIFT);
+    base->FM = reg;
+}
+#endif /* #if FSL_FEATURE_RCM_HAS_BOOTROM */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rcm.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rcm.h
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_RCM_H_
+#define _FSL_RCM_H_
+
+#include "fsl_common.h"
+
+/*! @addtogroup rcm */
+/*! @{*/
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief RCM driver version 2.0.0. */
+#define FSL_RCM_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*!
+ * @brief System Reset Source Name definitions
+ */
+typedef enum _rcm_reset_source
+{
+#if (defined(FSL_FEATURE_RCM_REG_WIDTH) && (FSL_FEATURE_RCM_REG_WIDTH == 32))
+/* RCM register bit width is 32. */
+#if (defined(FSL_FEATURE_RCM_HAS_WAKEUP) && FSL_FEATURE_RCM_HAS_WAKEUP)
+    kRCM_SourceWakeup = RCM_SRS_WAKEUP_MASK, /*!< Low-leakage wakeup reset */
+#endif
+    kRCM_SourceLvd = RCM_SRS_LVD_MASK, /*!< low voltage detect reset */
+#if (defined(FSL_FEATURE_RCM_HAS_LOC) && FSL_FEATURE_RCM_HAS_LOC)
+    kRCM_SourceLoc = RCM_SRS_LOC_MASK, /*!< Loss of clock reset */
+#endif                                 /* FSL_FEATURE_RCM_HAS_LOC */
+#if (defined(FSL_FEATURE_RCM_HAS_LOL) && FSL_FEATURE_RCM_HAS_LOL)
+    kRCM_SourceLol = RCM_SRS_LOL_MASK,   /*!< Loss of lock reset */
+#endif                                   /* FSL_FEATURE_RCM_HAS_LOL */
+    kRCM_SourceWdog = RCM_SRS_WDOG_MASK, /*!< Watchdog reset */
+    kRCM_SourcePin = RCM_SRS_PIN_MASK,   /*!< External pin reset */
+    kRCM_SourcePor = RCM_SRS_POR_MASK,   /*!< Power on reset */
+#if (defined(FSL_FEATURE_RCM_HAS_JTAG) && FSL_FEATURE_RCM_HAS_JTAG)
+    kRCM_SourceJtag = RCM_SRS_JTAG_MASK,     /*!< JTAG generated reset */
+#endif                                       /* FSL_FEATURE_RCM_HAS_JTAG */
+    kRCM_SourceLockup = RCM_SRS_LOCKUP_MASK, /*!< Core lock up reset */
+    kRCM_SourceSw = RCM_SRS_SW_MASK,         /*!< Software reset */
+#if (defined(FSL_FEATURE_RCM_HAS_MDM_AP) && FSL_FEATURE_RCM_HAS_MDM_AP)
+    kRCM_SourceMdmap = RCM_SRS_MDM_AP_MASK, /*!< MDM-AP system reset */
+#endif                                      /* FSL_FEATURE_RCM_HAS_MDM_AP */
+#if (defined(FSL_FEATURE_RCM_HAS_EZPORT) && FSL_FEATURE_RCM_HAS_EZPORT)
+    kRCM_SourceEzpt = RCM_SRS_EZPT_MASK,       /*!< EzPort reset */
+#endif                                         /* FSL_FEATURE_RCM_HAS_EZPORT */
+    kRCM_SourceSackerr = RCM_SRS_SACKERR_MASK, /*!< Parameter could get all reset flags */
+
+#else /* (FSL_FEATURE_RCM_REG_WIDTH == 32) */
+/* RCM register bit width is 8. */
+#if (defined(FSL_FEATURE_RCM_HAS_WAKEUP) && FSL_FEATURE_RCM_HAS_WAKEUP)
+    kRCM_SourceWakeup = RCM_SRS0_WAKEUP_MASK, /*!< Low-leakage wakeup reset */
+#endif
+    kRCM_SourceLvd = RCM_SRS0_LVD_MASK, /*!< low voltage detect reset */
+#if (defined(FSL_FEATURE_RCM_HAS_LOC) && FSL_FEATURE_RCM_HAS_LOC)
+    kRCM_SourceLoc = RCM_SRS0_LOC_MASK,   /*!< Loss of clock reset */
+#endif /* FSL_FEATURE_RCM_HAS_LOC */
+#if (defined(FSL_FEATURE_RCM_HAS_LOL) && FSL_FEATURE_RCM_HAS_LOL)
+    kRCM_SourceLol = RCM_SRS0_LOL_MASK,   /*!< Loss of lock reset */
+#endif /* FSL_FEATURE_RCM_HAS_LOL */
+    kRCM_SourceWdog = RCM_SRS0_WDOG_MASK, /*!< Watchdog reset */
+    kRCM_SourcePin = RCM_SRS0_PIN_MASK,   /*!< External pin reset */
+    kRCM_SourcePor = RCM_SRS0_POR_MASK, /*!< Power on reset */
+#if (defined(FSL_FEATURE_RCM_HAS_JTAG) && FSL_FEATURE_RCM_HAS_JTAG)
+    kRCM_SourceJtag = RCM_SRS1_JTAG_MASK << 8U,     /*!< JTAG generated reset */
+#endif /* FSL_FEATURE_RCM_HAS_JTAG */
+    kRCM_SourceLockup = RCM_SRS1_LOCKUP_MASK << 8U, /*!< Core lock up reset */
+    kRCM_SourceSw = RCM_SRS1_SW_MASK, /*!< Software reset */
+#if (defined(FSL_FEATURE_RCM_HAS_MDM_AP) && FSL_FEATURE_RCM_HAS_MDM_AP)
+    kRCM_SourceMdmap = RCM_SRS1_MDM_AP_MASK << 8U,    /*!< MDM-AP system reset */
+#endif /* FSL_FEATURE_RCM_HAS_MDM_AP */
+#if (defined(FSL_FEATURE_RCM_HAS_EZPORT) && FSL_FEATURE_RCM_HAS_EZPORT)
+    kRCM_SourceEzpt = RCM_SRS1_EZPT_MASK << 8U,       /*!< EzPort reset */
+#endif /* FSL_FEATURE_RCM_HAS_EZPORT */
+    kRCM_SourceSackerr = RCM_SRS1_SACKERR_MASK << 8U, /*!< Parameter could get all reset flags */
+#endif /* (FSL_FEATURE_RCM_REG_WIDTH == 32) */
+    kRCM_SourceAll = 0xffffffffU,
+} rcm_reset_source_t;
+
+/*!
+ * @brief Reset pin filter select in Run and Wait modes
+ */
+typedef enum _rcm_run_wait_filter_mode
+{
+    kRCM_FilterDisable = 0U,  /*!< All filtering disabled */
+    kRCM_FilterBusClock = 1U, /*!< Bus clock filter enabled */
+    kRCM_FilterLpoClock = 2U  /*!< LPO clock filter enabled */
+} rcm_run_wait_filter_mode_t;
+
+#if (defined(FSL_FEATURE_RCM_HAS_BOOTROM) && FSL_FEATURE_RCM_HAS_BOOTROM)
+/*!
+ * @brief Boot from ROM configuration.
+ */
+typedef enum _rcm_boot_rom_config
+{
+    kRCM_BootFlash = 0U,   /*!< Boot from flash */
+    kRCM_BootRomCfg0 = 1U, /*!< Boot from boot ROM due to BOOTCFG0 */
+    kRCM_BootRomFopt = 2U, /*!< Boot from boot ROM due to FOPT[7] */
+    kRCM_BootRomBoth = 3U  /*!< Boot from boot ROM due to both BOOTCFG0 and FOPT[7] */
+} rcm_boot_rom_config_t;
+#endif /* FSL_FEATURE_RCM_HAS_BOOTROM */
+
+#if (defined(FSL_FEATURE_RCM_HAS_SRIE) && FSL_FEATURE_RCM_HAS_SRIE)
+/*!
+ * @brief Max delay time from interrupt asserts to system reset.
+ */
+typedef enum _rcm_reset_delay
+{
+    kRCM_ResetDelay8Lpo = 0U,   /*!< Delay 8 LPO cycles.   */
+    kRCM_ResetDelay32Lpo = 1U,  /*!< Delay 32 LPO cycles.  */
+    kRCM_ResetDelay128Lpo = 2U, /*!< Delay 128 LPO cycles. */
+    kRCM_ResetDelay512Lpo = 3U  /*!< Delay 512 LPO cycles. */
+} rcm_reset_delay_t;
+
+/*!
+ * @brief System reset interrupt enable bit definitions.
+ */
+typedef enum _rcm_interrupt_enable
+{
+    kRCM_IntNone = 0U,                              /*!< No interrupt enabled.           */
+    kRCM_IntLossOfClk = RCM_SRIE_LOC_MASK,          /*!< Loss of clock interrupt.        */
+    kRCM_IntLossOfLock = RCM_SRIE_LOL_MASK,         /*!< Loss of lock interrupt.         */
+    kRCM_IntWatchDog = RCM_SRIE_WDOG_MASK,          /*!< Watch dog interrupt.            */
+    kRCM_IntExternalPin = RCM_SRIE_PIN_MASK,        /*!< External pin interrupt.         */
+    kRCM_IntGlobal = RCM_SRIE_GIE_MASK,             /*!< Global interrupts.              */
+    kRCM_IntCoreLockup = RCM_SRIE_LOCKUP_MASK,      /*!< Core lock up interrupt           */
+    kRCM_IntSoftware = RCM_SRIE_SW_MASK,            /*!< software interrupt              */
+    kRCM_IntStopModeAckErr = RCM_SRIE_SACKERR_MASK, /*!< Stop mode ACK error interrupt.  */
+#if (defined(FSL_FEATURE_RCM_HAS_CORE1) && FSL_FEATURE_RCM_HAS_CORE1)
+    kRCM_IntCore1 = RCM_SRIE_CORE1_MASK, /*!< Core 1 interrupt.               */
+#endif
+    kRCM_IntAll = RCM_SRIE_LOC_MASK /*!< Enable all interrupts.          */
+                  |
+                  RCM_SRIE_LOL_MASK | RCM_SRIE_WDOG_MASK | RCM_SRIE_PIN_MASK | RCM_SRIE_GIE_MASK |
+                  RCM_SRIE_LOCKUP_MASK | RCM_SRIE_SW_MASK | RCM_SRIE_SACKERR_MASK
+#if (defined(FSL_FEATURE_RCM_HAS_CORE1) && FSL_FEATURE_RCM_HAS_CORE1)
+                  |
+                  RCM_SRIE_CORE1_MASK
+#endif
+} rcm_interrupt_enable_t;
+#endif /* FSL_FEATURE_RCM_HAS_SRIE */
+
+#if (defined(FSL_FEATURE_RCM_HAS_VERID) && FSL_FEATURE_RCM_HAS_VERID)
+/*!
+ * @brief IP version ID definition.
+ */
+typedef struct _rcm_version_id
+{
+    uint16_t feature; /*!< Feature Specification Number. */
+    uint8_t minor;    /*!< Minor version number.         */
+    uint8_t major;    /*!< Major version number.         */
+} rcm_version_id_t;
+#endif
+
+/*!
+ * @brief Reset pin filter configuration
+ */
+typedef struct _rcm_reset_pin_filter_config
+{
+    bool enableFilterInStop;                    /*!< Reset pin filter select in stop mode. */
+    rcm_run_wait_filter_mode_t filterInRunWait; /*!< Reset pin filter in run/wait mode. */
+    uint8_t busClockFilterCount;                /*!< Reset pin bus clock filter width.  */
+} rcm_reset_pin_filter_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*! @name Reset Control Module APIs*/
+/*@{*/
+
+#if (defined(FSL_FEATURE_RCM_HAS_VERID) && FSL_FEATURE_RCM_HAS_VERID)
+/*!
+ * @brief Gets the RCM version ID.
+ *
+ * This function gets the RCM version ID including the major version number,
+ * the minor version number, and the feature specification number.
+ *
+ * @param base RCM peripheral base address.
+ * @param versionId     Pointer to version ID structure.
+ */
+static inline void RCM_GetVersionId(RCM_Type *base, rcm_version_id_t *versionId)
+{
+    *((uint32_t *)versionId) = base->VERID;
+}
+#endif
+
+#if (defined(FSL_FEATURE_RCM_HAS_PARAM) && FSL_FEATURE_RCM_HAS_PARAM)
+/*!
+ * @brief Gets the reset source implemented status.
+ *
+ * This function gets the RCM parameter that indicates whether the corresponding reset source is implemented.
+ * Use source masks defined in the rcm_reset_source_t to get the desired source status.
+ *
+ * Example:
+   @code
+   uint32_t status;
+
+   // To test whether the MCU is reset using Watchdog.
+   status = RCM_GetResetSourceImplementedStatus(RCM) & (kRCM_SourceWdog | kRCM_SourcePin);
+   @endcode
+ *
+ * @param base RCM peripheral base address.
+ * @return All reset source implemented status bit map.
+ */
+static inline uint32_t RCM_GetResetSourceImplementedStatus(RCM_Type *base)
+{
+    return base->PARAM;
+}
+#endif /* FSL_FEATURE_RCM_HAS_PARAM */
+
+/*!
+ * @brief Gets the reset source status which caused a previous reset.
+ *
+ * This function gets the current reset source status. Use source masks
+ * defined in the rcm_reset_source_t to get the desired source status.
+ *
+ * Example:
+   @code
+   uint32_t resetStatus;
+
+   // To get all reset source statuses.
+   resetStatus = RCM_GetPreviousResetSources(RCM) & kRCM_SourceAll;
+
+   // To test whether the MCU is reset using Watchdog.
+   resetStatus = RCM_GetPreviousResetSources(RCM) & kRCM_SourceWdog;
+
+   // To test multiple reset sources.
+   resetStatus = RCM_GetPreviousResetSources(RCM) & (kRCM_SourceWdog | kRCM_SourcePin);
+   @endcode
+ *
+ * @param base RCM peripheral base address.
+ * @return All reset source status bit map.
+ */
+static inline uint32_t RCM_GetPreviousResetSources(RCM_Type *base)
+{
+#if (defined(FSL_FEATURE_RCM_REG_WIDTH) && (FSL_FEATURE_RCM_REG_WIDTH == 32))
+    return base->SRS;
+#else
+    return (uint32_t)((uint32_t)base->SRS0 | ((uint32_t)base->SRS1 << 8U));
+#endif /* (FSL_FEATURE_RCM_REG_WIDTH == 32) */
+}
+
+#if (defined(FSL_FEATURE_RCM_HAS_SSRS) && FSL_FEATURE_RCM_HAS_SSRS)
+/*!
+ * @brief Gets the sticky reset source status.
+ *
+ * This function gets the current reset source status that has not been cleared
+ * by software for some specific source.
+ *
+ * Example:
+   @code
+   uint32_t resetStatus;
+
+   // To get all reset source statuses.
+   resetStatus = RCM_GetStickyResetSources(RCM) & kRCM_SourceAll;
+
+   // To test whether the MCU is reset using Watchdog.
+   resetStatus = RCM_GetStickyResetSources(RCM) & kRCM_SourceWdog;
+
+   // To test multiple reset sources.
+   resetStatus = RCM_GetStickyResetSources(RCM) & (kRCM_SourceWdog | kRCM_SourcePin);
+   @endcode
+ *
+ * @param base RCM peripheral base address.
+ * @return All reset source status bit map.
+ */
+static inline uint32_t RCM_GetStickyResetSources(RCM_Type *base)
+{
+#if (defined(FSL_FEATURE_RCM_REG_WIDTH) && (FSL_FEATURE_RCM_REG_WIDTH == 32))
+    return base->SSRS;
+#else
+    return (base->SSRS0 | ((uint32_t)base->SSRS1 << 8U));
+#endif /* (FSL_FEATURE_RCM_REG_WIDTH == 32) */
+}
+
+/*!
+ * @brief Clears the sticky reset source status.
+ *
+ * This function clears the sticky system reset flags indicated by source masks.
+ *
+ * Example:
+   @code
+   // Clears multiple reset sources.
+   RCM_ClearStickyResetSources(kRCM_SourceWdog | kRCM_SourcePin);
+   @endcode
+ *
+ * @param base RCM peripheral base address.
+ * @param sourceMasks reset source status bit map
+ */
+static inline void RCM_ClearStickyResetSources(RCM_Type *base, uint32_t sourceMasks)
+{
+#if (defined(FSL_FEATURE_RCM_REG_WIDTH) && (FSL_FEATURE_RCM_REG_WIDTH == 32))
+    base->SSRS = sourceMasks;
+#else
+    base->SSRS0 = (sourceMasks & 0xffU);
+    base->SSRS1 = ((sourceMasks >> 8U) & 0xffU);
+#endif /* (FSL_FEATURE_RCM_REG_WIDTH == 32) */
+}
+#endif /* FSL_FEATURE_RCM_HAS_SSRS */
+
+/*!
+ * @brief Configures the reset pin filter.
+ *
+ * This function sets the reset pin filter including the filter source, filter
+ * width, and so on.
+ *
+ * @param base RCM peripheral base address.
+ * @param config Pointer to the configuration structure.
+ */
+void RCM_ConfigureResetPinFilter(RCM_Type *base, const rcm_reset_pin_filter_config_t *config);
+
+#if (defined(FSL_FEATURE_RCM_HAS_EZPMS) && FSL_FEATURE_RCM_HAS_EZPMS)
+/*!
+ * @brief Gets the EZP_MS_B pin assert status.
+ *
+ * This function gets the easy port mode status (EZP_MS_B) pin assert status.
+ *
+ * @param base RCM peripheral base address.
+ * @return status  true - asserted, false - reasserted
+ */
+static inline bool RCM_GetEasyPortModePinStatus(RCM_Type *base)
+{
+    return (bool)(base->MR & RCM_MR_EZP_MS_MASK);
+}
+#endif /* FSL_FEATURE_RCM_HAS_EZPMS */
+
+#if (defined(FSL_FEATURE_RCM_HAS_BOOTROM) && FSL_FEATURE_RCM_HAS_BOOTROM)
+/*!
+ * @brief Gets the ROM boot source.
+ *
+ * This function gets the ROM boot source during the last chip reset.
+ *
+ * @param base RCM peripheral base address.
+ * @return The ROM boot source.
+ */
+static inline rcm_boot_rom_config_t RCM_GetBootRomSource(RCM_Type *base)
+{
+    return (rcm_boot_rom_config_t)((base->MR & RCM_MR_BOOTROM_MASK) >> RCM_MR_BOOTROM_SHIFT);
+}
+
+/*!
+ * @brief Clears the ROM boot source flag.
+ *
+ * This function clears the ROM boot source flag.
+ *
+ * @param base     Register base address of RCM
+ */
+static inline void RCM_ClearBootRomSource(RCM_Type *base)
+{
+    base->MR |= RCM_MR_BOOTROM_MASK;
+}
+
+/*!
+ * @brief Forces the boot from ROM.
+ *
+ * This function forces booting from ROM during all subsequent system resets.
+ *
+ * @param base RCM peripheral base address.
+ * @param config   Boot configuration.
+ */
+void RCM_SetForceBootRomSource(RCM_Type *base, rcm_boot_rom_config_t config);
+#endif /* FSL_FEATURE_RCM_HAS_BOOTROM */
+
+#if (defined(FSL_FEATURE_RCM_HAS_SRIE) && FSL_FEATURE_RCM_HAS_SRIE)
+/*!
+ * @brief Sets the system reset interrupt configuration.
+ *
+ * For graceful shutdown, the RCM supports delaying the assertion of the system
+ * reset for a period of time when the reset interrupt is generated. This function
+ * can be used to enable the interrupt and the delay period. The interrupts
+ * are passed in as bit mask. See rcm_int_t for details. For example, to
+ * delay a reset for 512 LPO cycles after the WDOG timeout or loss-of-clock occurs,
+ * configure as follows:
+ * RCM_SetSystemResetInterruptConfig(kRCM_IntWatchDog | kRCM_IntLossOfClk, kRCM_ResetDelay512Lpo);
+ *
+ * @param base RCM peripheral base address.
+ * @param intMask   Bit mask of the system reset interrupts to enable. See
+ *                  rcm_interrupt_enable_t for details.
+ * @param Delay     Bit mask of the system reset interrupts to enable.
+ */
+static inline void RCM_SetSystemResetInterruptConfig(RCM_Type *base, uint32_t intMask, rcm_reset_delay_t delay)
+{
+    base->SRIE = (intMask | delay);
+}
+#endif /* FSL_FEATURE_RCM_HAS_SRIE */
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*! @}*/
+
+#endif /* _FSL_RCM_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rnga.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rnga.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_rnga.h"
+
+#if defined(FSL_FEATURE_SOC_RNG_COUNT) && FSL_FEATURE_SOC_RNG_COUNT
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*******************************************************************************
+ * RNG_CR - RNGA Control Register
+ ******************************************************************************/
+/*!
+ * @brief RNG_CR - RNGA Control Register (RW)
+ *
+ * Reset value: 0x00000000U
+ *
+ * Controls the operation of RNGA.
+ */
+/*!
+ * @name Constants and macros for entire RNG_CR register
+ */
+/*@{*/
+#define RNG_CR_REG(base) ((base)->CR)
+#define RNG_RD_CR(base) (RNG_CR_REG(base))
+#define RNG_WR_CR(base, value) (RNG_CR_REG(base) = (value))
+#define RNG_RMW_CR(base, mask, value) (RNG_WR_CR(base, (RNG_RD_CR(base) & ~(mask)) | (value)))
+/*@}*/
+
+/*!
+ * @name Register RNG_CR, field GO[0] (RW)
+ *
+ * Specifies whether random-data generation and loading (into OR[RANDOUT]) is
+ * enabled.This field is sticky. You must reset RNGA to stop RNGA from loading
+ * OR[RANDOUT] with data.
+ *
+ * Values:
+ * - 0b0 - Disabled
+ * - 0b1 - Enabled
+ */
+/*@{*/
+/*! @brief Read current value of the RNG_CR_GO field. */
+#define RNG_RD_CR_GO(base) ((RNG_CR_REG(base) & RNG_CR_GO_MASK) >> RNG_CR_GO_SHIFT)
+
+/*! @brief Set the GO field to a new value. */
+#define RNG_WR_CR_GO(base, value) (RNG_RMW_CR(base, RNG_CR_GO_MASK, RNG_CR_GO(value)))
+/*@}*/
+
+/*!
+ * @name Register RNG_CR, field SLP[4] (RW)
+ *
+ * Specifies whether RNGA is in Sleep or Normal mode. You can also enter Sleep
+ * mode by asserting the DOZE signal.
+ *
+ * Values:
+ * - 0b0 - Normal mode
+ * - 0b1 - Sleep (low-power) mode
+ */
+/*@{*/
+/*! @brief Read current value of the RNG_CR_SLP field. */
+#define RNG_RD_CR_SLP(base) ((RNG_CR_REG(base) & RNG_CR_SLP_MASK) >> RNG_CR_SLP_SHIFT)
+
+/*! @brief Set the SLP field to a new value. */
+#define RNG_WR_CR_SLP(base, value) (RNG_RMW_CR(base, RNG_CR_SLP_MASK, RNG_CR_SLP(value)))
+/*@}*/
+
+/*******************************************************************************
+ * RNG_SR - RNGA Status Register
+ ******************************************************************************/
+#define RNG_SR_REG(base) ((base)->SR)
+
+/*!
+ * @name Register RNG_SR, field OREG_LVL[15:8] (RO)
+ *
+ * Indicates the number of random-data words that are in OR[RANDOUT], which
+ * indicates whether OR[RANDOUT] is valid.If you read OR[RANDOUT] when SR[OREG_LVL]
+ * is not 0, then the contents of a random number contained in OR[RANDOUT] are
+ * returned, and RNGA writes 0 to both OR[RANDOUT] and SR[OREG_LVL].
+ *
+ * Values:
+ * - 0b00000000 - No words (empty)
+ * - 0b00000001 - One word (valid)
+ */
+/*@{*/
+/*! @brief Read current value of the RNG_SR_OREG_LVL field. */
+#define RNG_RD_SR_OREG_LVL(base) ((RNG_SR_REG(base) & RNG_SR_OREG_LVL_MASK) >> RNG_SR_OREG_LVL_SHIFT)
+/*@}*/
+
+/*!
+ * @name Register RNG_SR, field SLP[4] (RO)
+ *
+ * Specifies whether RNGA is in Sleep or Normal mode. You can also enter Sleep
+ * mode by asserting the DOZE signal.
+ *
+ * Values:
+ * - 0b0 - Normal mode
+ * - 0b1 - Sleep (low-power) mode
+ */
+/*@{*/
+/*! @brief Read current value of the RNG_SR_SLP field. */
+#define RNG_RD_SR_SLP(base) ((RNG_SR_REG(base) & RNG_SR_SLP_MASK) >> RNG_SR_SLP_SHIFT)
+/*@}*/
+
+/*******************************************************************************
+ * RNG_OR - RNGA Output Register
+ ******************************************************************************/
+/*!
+ * @brief RNG_OR - RNGA Output Register (RO)
+ *
+ * Reset value: 0x00000000U
+ *
+ * Stores a random-data word generated by RNGA.
+ */
+/*!
+ * @name Constants and macros for entire RNG_OR register
+ */
+/*@{*/
+#define RNG_OR_REG(base) ((base)->OR)
+#define RNG_RD_OR(base) (RNG_OR_REG(base))
+/*@}*/
+
+/*******************************************************************************
+ * RNG_ER - RNGA Entropy Register
+ ******************************************************************************/
+/*!
+ * @brief RNG_ER - RNGA Entropy Register (WORZ)
+ *
+ * Reset value: 0x00000000U
+ *
+ * Specifies an entropy value that RNGA uses in addition to its ring oscillators
+ * to seed its pseudorandom algorithm. This is a write-only register; reads
+ * return all zeros.
+ */
+/*!
+ * @name Constants and macros for entire RNG_ER register
+ */
+/*@{*/
+#define RNG_ER_REG(base) ((base)->ER)
+#define RNG_RD_ER(base) (RNG_ER_REG(base))
+#define RNG_WR_ER(base, value) (RNG_ER_REG(base) = (value))
+/*@}*/
+
+/*******************************************************************************
+ * Prototypes
+ *******************************************************************************/
+
+static uint32_t rnga_ReadEntropy(RNG_Type *base);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+void RNGA_Init(RNG_Type *base)
+{
+    /* Enable the clock gate. */
+    CLOCK_EnableClock(kCLOCK_Rnga0);
+    CLOCK_DisableClock(kCLOCK_Rnga0); /* To solve the release version on twrkm43z75m */
+    CLOCK_EnableClock(kCLOCK_Rnga0);
+
+    /* Reset the registers for RNGA module to reset state. */
+    RNG_WR_CR(base, 0);
+    /* Enables the RNGA random data generation and loading.*/
+    RNG_WR_CR_GO(base, 1);
+}
+
+void RNGA_Deinit(RNG_Type *base)
+{
+    /* Disable the clock for RNGA module.*/
+    CLOCK_DisableClock(kCLOCK_Rnga0);
+}
+
+/*!
+ * @brief Get a random data from RNGA.
+ *
+ * @param base RNGA base address
+ */
+static uint32_t rnga_ReadEntropy(RNG_Type *base)
+{
+    uint32_t data = 0;
+    if (RNGA_GetMode(base) == kRNGA_ModeNormal) /* Is in normal mode.*/
+    {
+        /* Wait for valid random-data.*/
+        while (RNG_RD_SR_OREG_LVL(base) == 0)
+        {
+        }
+        data = RNG_RD_OR(base);
+    }
+    /* Get random-data word generated by RNGA.*/
+    return data;
+}
+
+status_t RNGA_GetRandomData(RNG_Type *base, void *data, size_t data_size)
+{
+    status_t result = kStatus_Success;
+    uint32_t random_32;
+    uint8_t *random_p;
+    uint32_t random_size;
+    uint8_t *data_p = (uint8_t *)data;
+    uint32_t i;
+
+    /* Check input parameters.*/
+    if (base && data && data_size)
+    {
+        do
+        {
+            /* Read Entropy.*/
+            random_32 = rnga_ReadEntropy(base);
+
+            random_p = (uint8_t *)&random_32;
+
+            if (data_size < sizeof(random_32))
+            {
+                random_size = data_size;
+            }
+            else
+            {
+                random_size = sizeof(random_32);
+            }
+
+            for (i = 0; i < random_size; i++)
+            {
+                *data_p++ = *random_p++;
+            }
+
+            data_size -= random_size;
+        } while (data_size > 0);
+    }
+    else
+    {
+        result = kStatus_InvalidArgument;
+    }
+
+    return result;
+}
+
+void RNGA_SetMode(RNG_Type *base, rnga_mode_t mode)
+{
+    RNG_WR_CR_SLP(base, (uint32_t)mode);
+}
+
+rnga_mode_t RNGA_GetMode(RNG_Type *base)
+{
+    return (rnga_mode_t)RNG_RD_SR_SLP(base);
+}
+
+void RNGA_Seed(RNG_Type *base, uint32_t seed)
+{
+    /* Write to RNGA Entropy Register.*/
+    RNG_WR_ER(base, seed);
+}
+
+#endif /* FSL_FEATURE_SOC_RNG_COUNT */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rnga.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rnga.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_RNGA_DRIVER_H_
+#define _FSL_RNGA_DRIVER_H_
+
+#include "fsl_common.h"
+
+#if defined(FSL_FEATURE_SOC_RNG_COUNT) && FSL_FEATURE_SOC_RNG_COUNT
+/*!
+ * @addtogroup rnga_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief RNGA driver version 2.0.1. */
+#define FSL_RNGA_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*! @brief RNGA working mode */
+typedef enum _rnga_mode
+{
+    kRNGA_ModeNormal = 0U, /*!< Normal Mode. The ring-oscillator clocks are active; RNGA generates entropy
+                                           (randomness) from the clocks and stores it in shift registers.*/
+    kRNGA_ModeSleep = 1U,  /*!< Sleep Mode. The ring-oscillator clocks are inactive; RNGA does not generate entropy.*/
+} rnga_mode_t;
+
+/*******************************************************************************
+ * API
+ *******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @brief Initializes the RNGA.
+ *
+ * This function initializes the RNGA.
+ * When called, the RNGA entropy generation starts immediately.
+ *
+ * @param base RNGA base address
+ */
+void RNGA_Init(RNG_Type *base);
+
+/*!
+ * @brief Shuts down the RNGA.
+ *
+ * This function shuts down the RNGA.
+ *
+ * @param base RNGA base address
+ */
+void RNGA_Deinit(RNG_Type *base);
+
+/*!
+ * @brief Gets random data.
+ *
+ * This function gets random data from the RNGA.
+ *
+ * @param base RNGA base address
+ * @param data pointer to user buffer to be filled by random data
+ * @param data_size size of data in bytes
+ * @return RNGA status
+ */
+status_t RNGA_GetRandomData(RNG_Type *base, void *data, size_t data_size);
+
+/*!
+ * @brief Feeds the RNGA module.
+ *
+ * This function inputs an entropy value that the RNGA uses to seed its
+ * pseudo-random algorithm.
+ *
+ * @param base RNGA base address
+ * @param seed input seed value
+ */
+void RNGA_Seed(RNG_Type *base, uint32_t seed);
+
+/*!
+ * @brief Sets the RNGA in normal mode or sleep mode.
+ *
+ * This function sets the RNGA in sleep mode or normal mode.
+ *
+ * @param base RNGA base address
+ * @param mode normal mode or sleep mode
+ */
+void RNGA_SetMode(RNG_Type *base, rnga_mode_t mode);
+
+/*!
+ * @brief Gets the RNGA working mode.
+ *
+ * This function gets the RNGA working mode.
+ *
+ * @param base RNGA base address
+ * @return normal mode or sleep mode
+ */
+rnga_mode_t RNGA_GetMode(RNG_Type *base);
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* FSL_FEATURE_SOC_RNG_COUNT */
+#endif /* _FSL_RNGA_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rtc.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rtc.c
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_rtc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define SECONDS_IN_A_DAY (86400U)
+#define SECONDS_IN_A_HOUR (3600U)
+#define SECONDS_IN_A_MINUTE (60U)
+#define DAYS_IN_A_YEAR (365U)
+#define YEAR_RANGE_START (1970U)
+#define YEAR_RANGE_END (2099U)
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Checks whether the date and time passed in is valid
+ *
+ * @param datetime Pointer to structure where the date and time details are stored
+ *
+ * @return Returns false if the date & time details are out of range; true if in range
+ */
+static bool RTC_CheckDatetimeFormat(const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Converts time data from datetime to seconds
+ *
+ * @param datetime Pointer to datetime structure where the date and time details are stored
+ *
+ * @return The result of the conversion in seconds
+ */
+static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Converts time data from seconds to a datetime structure
+ *
+ * @param seconds  Seconds value that needs to be converted to datetime format
+ * @param datetime Pointer to the datetime structure where the result of the conversion is stored
+ */
+static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static bool RTC_CheckDatetimeFormat(const rtc_datetime_t *datetime)
+{
+    /* Table of days in a month for a non leap year. First entry in the table is not used,
+     * valid months start from 1
+     */
+    uint8_t daysPerMonth[] = {0U, 31U, 28U, 31U, 30U, 31U, 30U, 31U, 31U, 30U, 31U, 30U, 31U};
+
+    /* Check year, month, hour, minute, seconds */
+    if ((datetime->year < YEAR_RANGE_START) || (datetime->year > YEAR_RANGE_END) || (datetime->month > 12U) ||
+        (datetime->month < 1U) || (datetime->hour >= 24U) || (datetime->minute >= 60U) || (datetime->second >= 60U))
+    {
+        /* If not correct then error*/
+        return false;
+    }
+
+    /* Adjust the days in February for a leap year */
+    if (!(datetime->year & 3U))
+    {
+        daysPerMonth[2] = 29U;
+    }
+
+    /* Check the validity of the day */
+    if (datetime->day > daysPerMonth[datetime->month])
+    {
+        return false;
+    }
+
+    return true;
+}
+
+static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime)
+{
+    /* Number of days from begin of the non Leap-year*/
+    uint16_t monthDays[] = {0U, 0U, 31U, 59U, 90U, 120U, 151U, 181U, 212U, 243U, 273U, 304U, 334U};
+    uint32_t seconds;
+
+    /* Compute number of days from 1970 till given year*/
+    seconds = (datetime->year - 1970U) * DAYS_IN_A_YEAR;
+    /* Add leap year days */
+    seconds += ((datetime->year / 4) - (1970U / 4));
+    /* Add number of days till given month*/
+    seconds += monthDays[datetime->month];
+    /* Add days in given month. We subtract the current day as it is
+     * represented in the hours, minutes and seconds field*/
+    seconds += (datetime->day - 1);
+    /* For leap year if month less than or equal to Febraury, decrement day counter*/
+    if ((!(datetime->year & 3U)) && (datetime->month <= 2U))
+    {
+        seconds--;
+    }
+
+    seconds = (seconds * SECONDS_IN_A_DAY) + (datetime->hour * SECONDS_IN_A_HOUR) +
+              (datetime->minute * SECONDS_IN_A_MINUTE) + datetime->second;
+
+    return seconds;
+}
+
+static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime)
+{
+    uint32_t x;
+    uint32_t secondsRemaining, days;
+    uint16_t daysInYear;
+    /* Table of days in a month for a non leap year. First entry in the table is not used,
+     * valid months start from 1
+     */
+    uint8_t daysPerMonth[] = {0U, 31U, 28U, 31U, 30U, 31U, 30U, 31U, 31U, 30U, 31U, 30U, 31U};
+
+    /* Start with the seconds value that is passed in to be converted to date time format */
+    secondsRemaining = seconds;
+
+    /* Calcuate the number of days, we add 1 for the current day which is represented in the
+     * hours and seconds field
+     */
+    days = secondsRemaining / SECONDS_IN_A_DAY + 1;
+
+    /* Update seconds left*/
+    secondsRemaining = secondsRemaining % SECONDS_IN_A_DAY;
+
+    /* Calculate the datetime hour, minute and second fields */
+    datetime->hour = secondsRemaining / SECONDS_IN_A_HOUR;
+    secondsRemaining = secondsRemaining % SECONDS_IN_A_HOUR;
+    datetime->minute = secondsRemaining / 60U;
+    datetime->second = secondsRemaining % SECONDS_IN_A_MINUTE;
+
+    /* Calculate year */
+    daysInYear = DAYS_IN_A_YEAR;
+    datetime->year = YEAR_RANGE_START;
+    while (days > daysInYear)
+    {
+        /* Decrease day count by a year and increment year by 1 */
+        days -= daysInYear;
+        datetime->year++;
+
+        /* Adjust the number of days for a leap year */
+        if (datetime->year & 3U)
+        {
+            daysInYear = DAYS_IN_A_YEAR;
+        }
+        else
+        {
+            daysInYear = DAYS_IN_A_YEAR + 1;
+        }
+    }
+
+    /* Adjust the days in February for a leap year */
+    if (!(datetime->year & 3U))
+    {
+        daysPerMonth[2] = 29U;
+    }
+
+    for (x = 1U; x <= 12U; x++)
+    {
+        if (days <= daysPerMonth[x])
+        {
+            datetime->month = x;
+            break;
+        }
+        else
+        {
+            days -= daysPerMonth[x];
+        }
+    }
+
+    datetime->day = days;
+}
+
+void RTC_Init(RTC_Type *base, const rtc_config_t *config)
+{
+    assert(config);
+
+    uint32_t reg;
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Issue a software reset if timer is invalid */
+    if (RTC_GetStatusFlags(RTC) & kRTC_TimeInvalidFlag)
+    {
+        RTC_Reset(RTC);
+    }
+
+    reg = base->CR;
+    /* Setup the update mode and supervisor access mode */
+    reg &= ~(RTC_CR_UM_MASK | RTC_CR_SUP_MASK);
+    reg |= RTC_CR_UM(config->updateMode) | RTC_CR_SUP(config->supervisorAccess);
+#if defined(FSL_FEATURE_RTC_HAS_WAKEUP_PIN) && FSL_FEATURE_RTC_HAS_WAKEUP_PIN
+    /* Setup the wakeup pin select */
+    reg &= ~(RTC_CR_WPS_MASK);
+    reg |= RTC_CR_WPS(config->wakeupSelect);
+#endif /* FSL_FEATURE_RTC_HAS_WAKEUP_PIN */
+    base->CR = reg;
+
+    /* Configure the RTC time compensation register */
+    base->TCR = (RTC_TCR_CIR(config->compensationInterval) | RTC_TCR_TCR(config->compensationTime));
+}
+
+void RTC_GetDefaultConfig(rtc_config_t *config)
+{
+    assert(config);
+
+    /* Wakeup pin will assert if the RTC interrupt asserts or if the wakeup pin is turned on */
+    config->wakeupSelect = false;
+    /* Registers cannot be written when locked */
+    config->updateMode = false;
+    /* Non-supervisor mode write accesses are not supported and will generate a bus error */
+    config->supervisorAccess = false;
+    /* Compensation interval used by the crystal compensation logic */
+    config->compensationInterval = 0;
+    /* Compensation time used by the crystal compensation logic */
+    config->compensationTime = 0;
+}
+
+status_t RTC_SetDatetime(RTC_Type *base, const rtc_datetime_t *datetime)
+{
+    assert(datetime);
+
+    /* Return error if the time provided is not valid */
+    if (!(RTC_CheckDatetimeFormat(datetime)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Set time in seconds */
+    base->TSR = RTC_ConvertDatetimeToSeconds(datetime);
+
+    return kStatus_Success;
+}
+
+void RTC_GetDatetime(RTC_Type *base, rtc_datetime_t *datetime)
+{
+    assert(datetime);
+
+    uint32_t seconds = 0;
+
+    seconds = base->TSR;
+    RTC_ConvertSecondsToDatetime(seconds, datetime);
+}
+
+status_t RTC_SetAlarm(RTC_Type *base, const rtc_datetime_t *alarmTime)
+{
+    assert(alarmTime);
+
+    uint32_t alarmSeconds = 0;
+    uint32_t currSeconds = 0;
+
+    /* Return error if the alarm time provided is not valid */
+    if (!(RTC_CheckDatetimeFormat(alarmTime)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    alarmSeconds = RTC_ConvertDatetimeToSeconds(alarmTime);
+
+    /* Get the current time */
+    currSeconds = base->TSR;
+
+    /* Return error if the alarm time has passed */
+    if (alarmSeconds < currSeconds)
+    {
+        return kStatus_Fail;
+    }
+
+    /* Set alarm in seconds*/
+    base->TAR = alarmSeconds;
+
+    return kStatus_Success;
+}
+
+void RTC_GetAlarm(RTC_Type *base, rtc_datetime_t *datetime)
+{
+    assert(datetime);
+
+    uint32_t alarmSeconds = 0;
+
+    /* Get alarm in seconds  */
+    alarmSeconds = base->TAR;
+
+    RTC_ConvertSecondsToDatetime(alarmSeconds, datetime);
+}
+
+void RTC_ClearStatusFlags(RTC_Type *base, uint32_t mask)
+{
+    /* The alarm flag is cleared by writing to the TAR register */
+    if (mask & kRTC_AlarmFlag)
+    {
+        base->TAR = 0U;
+    }
+
+    /* The timer overflow flag is cleared by initializing the TSR register.
+     * The time counter should be disabled for this write to be successful
+     */
+    if (mask & kRTC_TimeOverflowFlag)
+    {
+        base->TSR = 1U;
+    }
+
+    /* The timer overflow flag is cleared by initializing the TSR register.
+     * The time counter should be disabled for this write to be successful
+     */
+    if (mask & kRTC_TimeInvalidFlag)
+    {
+        base->TSR = 1U;
+    }
+}
+
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+
+void RTC_GetMonotonicCounter(RTC_Type *base, uint64_t *counter)
+{
+    *counter = (((uint64_t)base->MCHR << 32) | ((uint64_t)base->MCLR));
+}
+
+void RTC_SetMonotonicCounter(RTC_Type *base, uint64_t counter)
+{
+    /* Prepare to initialize the register with the new value written */
+    base->MER &= ~RTC_MER_MCE_MASK;
+
+    base->MCHR = (uint32_t)((counter) >> 32);
+    base->MCLR = (uint32_t)(counter);
+}
+
+status_t RTC_IncrementMonotonicCounter(RTC_Type *base)
+{
+    if (base->SR & (RTC_SR_MOF_MASK | RTC_SR_TIF_MASK))
+    {
+        return kStatus_Fail;
+    }
+
+    /* Prepare to switch to increment mode */
+    base->MER |= RTC_MER_MCE_MASK;
+    /* Write anything so the counter increments*/
+    base->MCLR = 1U;
+
+    return kStatus_Success;
+}
+
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rtc.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_rtc.h
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_RTC_H_
+#define _FSL_RTC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup rtc_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_RTC_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0 */
+/*@}*/
+
+/*! @brief List of RTC interrupts */
+typedef enum _rtc_interrupt_enable
+{
+    kRTC_TimeInvalidInterruptEnable = RTC_IER_TIIE_MASK,  /*!< Time invalid interrupt.*/
+    kRTC_TimeOverflowInterruptEnable = RTC_IER_TOIE_MASK, /*!< Time overflow interrupt.*/
+    kRTC_AlarmInterruptEnable = RTC_IER_TAIE_MASK,        /*!< Alarm interrupt.*/
+    kRTC_SecondsInterruptEnable = RTC_IER_TSIE_MASK       /*!< Seconds interrupt.*/
+} rtc_interrupt_enable_t;
+
+/*! @brief List of RTC flags */
+typedef enum _rtc_status_flags
+{
+    kRTC_TimeInvalidFlag = RTC_SR_TIF_MASK,  /*!< Time invalid flag */
+    kRTC_TimeOverflowFlag = RTC_SR_TOF_MASK, /*!< Time overflow flag */
+    kRTC_AlarmFlag = RTC_SR_TAF_MASK         /*!< Alarm flag*/
+} rtc_status_flags_t;
+
+/*! @brief List of RTC Oscillator capacitor load settings */
+typedef enum _rtc_osc_cap_load
+{
+    kRTC_Capacitor_2p = RTC_CR_SC2P_MASK,  /*!< 2pF capacitor load */
+    kRTC_Capacitor_4p = RTC_CR_SC4P_MASK,  /*!< 4pF capacitor load */
+    kRTC_Capacitor_8p = RTC_CR_SC8P_MASK,  /*!< 8pF capacitor load */
+    kRTC_Capacitor_16p = RTC_CR_SC16P_MASK /*!< 16pF capacitor load */
+} rtc_osc_cap_load_t;
+
+/*! @brief Structure is used to hold the date and time */
+typedef struct _rtc_datetime
+{
+    uint16_t year;  /*!< Range from 1970 to 2099.*/
+    uint8_t month;  /*!< Range from 1 to 12.*/
+    uint8_t day;    /*!< Range from 1 to 31 (depending on month).*/
+    uint8_t hour;   /*!< Range from 0 to 23.*/
+    uint8_t minute; /*!< Range from 0 to 59.*/
+    uint8_t second; /*!< Range from 0 to 59.*/
+} rtc_datetime_t;
+
+/*!
+ * @brief RTC config structure
+ *
+ * This structure holds the configuration settings for the RTC peripheral. To initialize this
+ * structure to reasonable defaults, call the RTC_GetDefaultConfig() function and pass a
+ * pointer to your config structure instance.
+ *
+ * The config struct can be made const so it resides in flash
+ */
+typedef struct _rtc_config
+{
+    bool wakeupSelect;             /*!< true: Wakeup pin outputs the 32KHz clock;
+                                        false:Wakeup pin used to wakeup the chip  */
+    bool updateMode;               /*!< true: Registers can be written even when locked under certain
+                                        conditions, false: No writes allowed when registers are locked */
+    bool supervisorAccess;         /*!< true: Non-supervisor accesses are allowed;
+                                        false: Non-supervisor accesses are not supported */
+    uint32_t compensationInterval; /*!< Compensation interval that is written to the CIR field in RTC TCR Register */
+    uint32_t compensationTime;     /*!< Compensation time that is written to the TCR field in RTC TCR Register */
+} rtc_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Ungates the RTC clock and configures the peripheral for basic operation.
+ *
+ * This function will issue a software reset if the timer invalid flag is set.
+ *
+ * @note This API should be called at the beginning of the application using the RTC driver.
+ *
+ * @param base   RTC peripheral base address
+ * @param config Pointer to user's RTC config structure.
+ */
+void RTC_Init(RTC_Type *base, const rtc_config_t *config);
+
+/*!
+ * @brief Stop the timer and gate the RTC clock
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_Deinit(RTC_Type *base)
+{
+    /* Stop the RTC timer */
+    base->SR &= ~RTC_SR_TCE_MASK;
+
+    /* Gate the module clock */
+    CLOCK_DisableClock(kCLOCK_Rtc0);
+}
+
+/*!
+ * @brief Fill in the RTC config struct with the default settings
+ *
+ * The default values are:
+ * @code
+ *    config->wakeupSelect = false;
+ *    config->updateMode = false;
+ *    config->supervisorAccess = false;
+ *    config->compensationInterval = 0;
+ *    config->compensationTime = 0;
+ * @endcode
+ * @param config Pointer to user's RTC config structure.
+ */
+void RTC_GetDefaultConfig(rtc_config_t *config);
+
+/*! @}*/
+
+/*!
+ * @name Current Time & Alarm
+ * @{
+ */
+
+/*!
+ * @brief Sets the RTC date and time according to the given time structure.
+ *
+ * The RTC counter must be stopped prior to calling this function as writes to the RTC
+ * seconds register will fail if the RTC counter is running.
+ *
+ * @param base     RTC peripheral base address
+ * @param datetime Pointer to structure where the date and time details to set are stored
+ *
+ * @return kStatus_Success: Success in setting the time and starting the RTC
+ *         kStatus_InvalidArgument: Error because the datetime format is incorrect
+ */
+status_t RTC_SetDatetime(RTC_Type *base, const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Gets the RTC time and stores it in the given time structure.
+ *
+ * @param base     RTC peripheral base address
+ * @param datetime Pointer to structure where the date and time details are stored.
+ */
+void RTC_GetDatetime(RTC_Type *base, rtc_datetime_t *datetime);
+
+/*!
+ * @brief Sets the RTC alarm time
+ *
+ * The function checks whether the specified alarm time is greater than the present
+ * time. If not, the function does not set the alarm and returns an error.
+ *
+ * @param base      RTC peripheral base address
+ * @param alarmTime Pointer to structure where the alarm time is stored.
+ *
+ * @return kStatus_Success: success in setting the RTC alarm
+ *         kStatus_InvalidArgument: Error because the alarm datetime format is incorrect
+ *         kStatus_Fail: Error because the alarm time has already passed
+ */
+status_t RTC_SetAlarm(RTC_Type *base, const rtc_datetime_t *alarmTime);
+
+/*!
+ * @brief Returns the RTC alarm time.
+ *
+ * @param base     RTC peripheral base address
+ * @param datetime Pointer to structure where the alarm date and time details are stored.
+ */
+void RTC_GetAlarm(RTC_Type *base, rtc_datetime_t *datetime);
+
+/*! @}*/
+
+/*!
+ * @name Interrupt Interface
+ * @{
+ */
+
+/*!
+ * @brief Enables the selected RTC interrupts.
+ *
+ * @param base RTC peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::rtc_interrupt_enable_t
+ */
+static inline void RTC_EnableInterrupts(RTC_Type *base, uint32_t mask)
+{
+    base->IER |= mask;
+}
+
+/*!
+ * @brief Disables the selected RTC interrupts.
+ *
+ * @param base RTC peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::rtc_interrupt_enable_t
+ */
+static inline void RTC_DisableInterrupts(RTC_Type *base, uint32_t mask)
+{
+    base->IER &= ~mask;
+}
+
+/*!
+ * @brief Gets the enabled RTC interrupts.
+ *
+ * @param base RTC peripheral base address
+ *
+ * @return The enabled interrupts. This is the logical OR of members of the
+ *         enumeration ::rtc_interrupt_enable_t
+ */
+static inline uint32_t RTC_GetEnabledInterrupts(RTC_Type *base)
+{
+    return (base->IER & (RTC_IER_TIIE_MASK | RTC_IER_TOIE_MASK | RTC_IER_TAIE_MASK | RTC_IER_TSIE_MASK));
+}
+
+/*! @}*/
+
+/*!
+ * @name Status Interface
+ * @{
+ */
+
+/*!
+ * @brief Gets the RTC status flags
+ *
+ * @param base RTC peripheral base address
+ *
+ * @return The status flags. This is the logical OR of members of the
+ *         enumeration ::rtc_status_flags_t
+ */
+static inline uint32_t RTC_GetStatusFlags(RTC_Type *base)
+{
+    return (base->SR & (RTC_SR_TIF_MASK | RTC_SR_TOF_MASK | RTC_SR_TAF_MASK));
+}
+
+/*!
+ * @brief  Clears the RTC status flags.
+ *
+ * @param base RTC peripheral base address
+ * @param mask The status flags to clear. This is a logical OR of members of the
+ *             enumeration ::rtc_status_flags_t
+ */
+void RTC_ClearStatusFlags(RTC_Type *base, uint32_t mask);
+
+/*! @}*/
+
+/*!
+ * @name Timer Start and Stop
+ * @{
+ */
+
+/*!
+ * @brief Starts the RTC time counter.
+ *
+ * After calling this function, the timer counter increments once a second provided SR[TOF] or
+ * SR[TIF] are not set.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_StartTimer(RTC_Type *base)
+{
+    base->SR |= RTC_SR_TCE_MASK;
+}
+
+/*!
+ * @brief Stops the RTC time counter.
+ *
+ * RTC's seconds register can be written to only when the timer is stopped.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_StopTimer(RTC_Type *base)
+{
+    base->SR &= ~RTC_SR_TCE_MASK;
+}
+
+/*! @}*/
+
+/*!
+ * @brief This function sets the specified capacitor configuration for the RTC oscillator.
+ *
+ * @param base    RTC peripheral base address
+ * @param capLoad Oscillator loads to enable. This is a logical OR of members of the
+ *                enumeration ::rtc_osc_cap_load_t
+ */
+static inline void RTC_SetOscCapLoad(RTC_Type *base, uint32_t capLoad)
+{
+    uint32_t reg = base->CR;
+
+    reg &= ~(RTC_CR_SC2P_MASK | RTC_CR_SC4P_MASK | RTC_CR_SC8P_MASK | RTC_CR_SC16P_MASK);
+    reg |= capLoad;
+
+    base->CR = reg;
+}
+
+/*!
+ * @brief Performs a software reset on the RTC module.
+ *
+ * This resets all RTC registers except for the SWR bit and the RTC_WAR and RTC_RAR
+ * registers. The SWR bit is cleared by software explicitly clearing it.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_Reset(RTC_Type *base)
+{
+    base->CR |= RTC_CR_SWR_MASK;
+    base->CR &= ~RTC_CR_SWR_MASK;
+
+    /* Set TSR register to 0x1 to avoid the timer invalid (TIF) bit being set in the SR register */
+    base->TSR = 1U;
+}
+
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+
+/*!
+ * @name Monotonic counter functions
+ * @{
+ */
+
+/*!
+ * @brief Reads the values of the Monotonic Counter High and Monotonic Counter Low and returns
+ *        them as a single value.
+ *
+ * @param base    RTC peripheral base address
+ * @param counter Pointer to variable where the value is stored.
+ */
+void RTC_GetMonotonicCounter(RTC_Type *base, uint64_t *counter);
+
+/*!
+ * @brief Writes values Monotonic Counter High and Monotonic Counter Low by decomposing
+ *        the given single value.
+ *
+ * @param base    RTC peripheral base address
+ * @param counter Counter value
+ */
+void RTC_SetMonotonicCounter(RTC_Type *base, uint64_t counter);
+
+/*!
+ * @brief Increments the Monotonic Counter by one.
+ *
+ * Increments the Monotonic Counter (registers RTC_MCLR and RTC_MCHR accordingly) by setting
+ * the monotonic counter enable (MER[MCE]) and then writing to the RTC_MCLR register. A write to the
+ * monotonic counter low that causes it to overflow also increments the monotonic counter high.
+ *
+ * @param base RTC peripheral base address
+ *
+ * @return kStatus_Success: success
+ *         kStatus_Fail: error occurred, either time invalid or monotonic overflow flag was found
+ */
+status_t RTC_IncrementMonotonicCounter(RTC_Type *base);
+
+/*! @}*/
+
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_RTC_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai.c
@@ -1,0 +1,1048 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_sai.h"
+
+/*******************************************************************************
+ * Definitations
+ ******************************************************************************/
+enum _sai_transfer_state
+{
+    kSAI_Busy = 0x0U, /*!< SAI is busy */
+    kSAI_Idle,        /*!< Transfer is done. */
+    kSAI_Error        /*!< Transfer error occured. */
+};
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+#if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
+
+/*!
+ * @brief Set the master clock divider.
+ *
+ * This API will compute the master clock divider according to master clock frequency and master
+ * clock source clock source frequency.
+ *
+ * @param base SAI base pointer.
+ * @param mclk_Hz Mater clock frequency in Hz.
+ * @param mclkSrcClock_Hz Master clock source frequency in Hz.
+ */
+static void SAI_SetMasterClockDivider(I2S_Type *base, uint32_t mclk_Hz, uint32_t mclkSrcClock_Hz);
+#endif /* FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER */
+
+/*!
+ * @brief Get the instance number for SAI.
+ *
+ * @param base SAI base pointer.
+ */
+uint32_t SAI_GetInstance(I2S_Type *base);
+
+/*!
+ * @brief sends a piece of data in non-blocking way.
+ *
+ * @param base SAI base pointer
+ * @param channel Data channel used.
+ * @param bitWidth How many bits in a audio word, usually 8/16/24/32 bits.
+ * @param buffer Pointer to the data to be written.
+ * @param size Bytes to be written.
+ */
+static void SAI_WriteNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+
+/*!
+ * @brief Receive a piece of data in non-blocking way.
+ *
+ * @param base SAI base pointer
+ * @param channel Data channel used.
+ * @param bitWidth How many bits in a audio word, usually 8/16/24/32 bits.
+ * @param buffer Pointer to the data to be read.
+ * @param size Bytes to be read.
+ */
+static void SAI_ReadNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*!@brief SAI handle pointer */
+sai_handle_t *s_saiHandle[FSL_FEATURE_SOC_I2S_COUNT][2];
+/* Base pointer array */
+static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
+/* IRQ number array */
+static const IRQn_Type s_saiTxIRQ[] = I2S_TX_IRQS;
+static const IRQn_Type s_saiRxIRQ[] = I2S_RX_IRQS;
+/* Clock name array */
+static const clock_ip_name_t s_saiClock[] = SAI_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+#if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
+static void SAI_SetMasterClockDivider(I2S_Type *base, uint32_t mclk_Hz, uint32_t mclkSrcClock_Hz)
+{
+    uint32_t freq = mclkSrcClock_Hz;
+    uint16_t fract, divide;
+    uint32_t remaind = 0;
+    uint32_t current_remainder = 0xFFFFFFFFU;
+    uint16_t current_fract = 0;
+    uint16_t current_divide = 0;
+    uint32_t mul_freq = 0;
+    uint32_t max_fract = 256;
+
+    /*In order to prevent overflow */
+    freq /= 100;
+    mclk_Hz /= 100;
+
+    /* Compute the max fract number */
+    max_fract = mclk_Hz * 4096 / freq + 1;
+    if (max_fract > 256)
+    {
+        max_fract = 256;
+    }
+
+    /* Looking for the closet frequency */
+    for (fract = 1; fract < max_fract; fract++)
+    {
+        mul_freq = freq * fract;
+        remaind = mul_freq % mclk_Hz;
+        divide = mul_freq / mclk_Hz;
+
+        /* Find the exactly frequency */
+        if (remaind == 0)
+        {
+            current_fract = fract;
+            current_divide = mul_freq / mclk_Hz;
+            break;
+        }
+
+        /* Closer to next one, set the closest to next data */
+        if (remaind > mclk_Hz / 2)
+        {
+            remaind = mclk_Hz - remaind;
+            divide += 1;
+        }
+
+        /* Update the closest div and fract */
+        if (remaind < current_remainder)
+        {
+            current_fract = fract;
+            current_divide = divide;
+            current_remainder = remaind;
+        }
+    }
+
+    /* Fill the computed fract and divider to registers */
+    base->MDR = I2S_MDR_DIVIDE(current_divide - 1) | I2S_MDR_FRACT(current_fract - 1);
+
+    /* Waiting for the divider updated */
+    while (base->MCR & I2S_MCR_DUF_MASK)
+    {
+    }
+}
+#endif /* FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER */
+
+uint32_t SAI_GetInstance(I2S_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_I2S_COUNT; instance++)
+    {
+        if (s_saiBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_I2S_COUNT);
+
+    return instance;
+}
+
+static void SAI_WriteNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+{
+    uint32_t i = 0;
+    uint8_t j = 0;
+    uint8_t bytesPerWord = bitWidth / 8U;
+    uint32_t data = 0;
+    uint32_t temp = 0;
+
+    for (i = 0; i < size / bytesPerWord; i++)
+    {
+        for (j = 0; j < bytesPerWord; j++)
+        {
+            temp = (uint32_t)(*buffer);
+            data |= (temp << (8U * j));
+            buffer++;
+        }
+        base->TDR[channel] = data;
+        data = 0;
+    }
+}
+
+static void SAI_ReadNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+{
+    uint32_t i = 0;
+    uint8_t j = 0;
+    uint8_t bytesPerWord = bitWidth / 8U;
+    uint32_t data = 0;
+
+    for (i = 0; i < size / bytesPerWord; i++)
+    {
+        data = base->RDR[channel];
+        for (j = 0; j < bytesPerWord; j++)
+        {
+            *buffer = (data >> (8U * j)) & 0xFF;
+            buffer++;
+        }
+    }
+}
+
+void SAI_TxInit(I2S_Type *base, const sai_config_t *config)
+{
+    uint32_t val = 0;
+
+    /* Enable the SAI clock */
+    CLOCK_EnableClock(s_saiClock[SAI_GetInstance(base)]);
+
+#if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+    /* Configure Master clock output enable */
+    base->MCR = I2S_MCR_MOE(config->mclkOutputEnable);
+
+    /* Master clock source setting */
+    val = (base->MCR & ~I2S_MCR_MICS_MASK);
+    base->MCR = (val | I2S_MCR_MICS(config->mclkSource));
+#endif /* FSL_FEATURE_SAI_HAS_MCR */
+
+    /* Configure audio protocol */
+    switch (config->protocol)
+    {
+        case kSAI_BusLeftJustified:
+            base->TCR2 |= I2S_TCR2_BCP_MASK;
+            base->TCR3 &= ~I2S_TCR3_WDFL_MASK;
+            base->TCR4 = I2S_TCR4_MF(1U) | I2S_TCR4_SYWD(31U) | I2S_TCR4_FSE(0U) | I2S_TCR4_FSP(0U) | I2S_TCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusRightJustified:
+            base->TCR2 |= I2S_TCR2_BCP_MASK;
+            base->TCR3 &= ~I2S_TCR3_WDFL_MASK;
+            base->TCR4 = I2S_TCR4_MF(1U) | I2S_TCR4_SYWD(31U) | I2S_TCR4_FSE(0U) | I2S_TCR4_FSP(0U) | I2S_TCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusI2S:
+            base->TCR2 |= I2S_TCR2_BCP_MASK;
+            base->TCR3 &= ~I2S_TCR3_WDFL_MASK;
+            base->TCR4 = I2S_TCR4_MF(1U) | I2S_TCR4_SYWD(31U) | I2S_TCR4_FSE(1U) | I2S_TCR4_FSP(1U) | I2S_TCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusPCMA:
+            base->TCR2 &= ~I2S_TCR2_BCP_MASK;
+            base->TCR3 &= ~I2S_TCR3_WDFL_MASK;
+            base->TCR4 = I2S_TCR4_MF(1U) | I2S_TCR4_SYWD(0U) | I2S_TCR4_FSE(1U) | I2S_TCR4_FSP(0U) | I2S_TCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusPCMB:
+            base->TCR2 &= ~I2S_TCR2_BCP_MASK;
+            base->TCR3 &= ~I2S_TCR3_WDFL_MASK;
+            base->TCR4 = I2S_TCR4_MF(1U) | I2S_TCR4_SYWD(0U) | I2S_TCR4_FSE(0U) | I2S_TCR4_FSP(0U) | I2S_TCR4_FRSZ(1U);
+            break;
+
+        default:
+            break;
+    }
+
+    /* Set master or slave */
+    if (config->masterSlave == kSAI_Master)
+    {
+        base->TCR2 |= I2S_TCR2_BCD_MASK;
+        base->TCR4 |= I2S_TCR4_FSD_MASK;
+
+        /* Bit clock source setting */
+        val = base->TCR2 & (~I2S_TCR2_MSEL_MASK);
+        base->TCR2 = (val | I2S_TCR2_MSEL(config->bclkSource));
+    }
+    else
+    {
+        base->TCR2 &= ~I2S_TCR2_BCD_MASK;
+        base->TCR4 &= ~I2S_TCR4_FSD_MASK;
+    }
+
+    /* Set Sync mode */
+    switch (config->syncMode)
+    {
+        case kSAI_ModeAsync:
+            val = base->TCR2;
+            val &= ~I2S_TCR2_SYNC_MASK;
+            base->TCR2 = (val | I2S_TCR2_SYNC(0U));
+            break;
+        case kSAI_ModeSync:
+            val = base->TCR2;
+            val &= ~I2S_TCR2_SYNC_MASK;
+            base->TCR2 = (val | I2S_TCR2_SYNC(1U));
+            /* If sync with Rx, should set Rx to async mode */
+            val = base->RCR2;
+            val &= ~I2S_RCR2_SYNC_MASK;
+            base->RCR2 = (val | I2S_RCR2_SYNC(0U));
+            break;
+        case kSAI_ModeSyncWithOtherTx:
+            val = base->TCR2;
+            val &= ~I2S_TCR2_SYNC_MASK;
+            base->TCR2 = (val | I2S_TCR2_SYNC(2U));
+            break;
+        case kSAI_ModeSyncWithOtherRx:
+            val = base->TCR2;
+            val &= ~I2S_TCR2_SYNC_MASK;
+            base->TCR2 = (val | I2S_TCR2_SYNC(3U));
+            break;
+        default:
+            break;
+    }
+}
+
+void SAI_RxInit(I2S_Type *base, const sai_config_t *config)
+{
+    uint32_t val = 0;
+
+    /* Enable SAI clock first. */
+    CLOCK_EnableClock(s_saiClock[SAI_GetInstance(base)]);
+
+#if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+    /* Configure Master clock output enable */
+    base->MCR = I2S_MCR_MOE(config->mclkOutputEnable);
+
+    /* Master clock source setting */
+    val = (base->MCR & ~I2S_MCR_MICS_MASK);
+    base->MCR = (val | I2S_MCR_MICS(config->mclkSource));
+#endif /* FSL_FEATURE_SAI_HAS_MCR */
+
+    /* Configure audio protocol */
+    switch (config->protocol)
+    {
+        case kSAI_BusLeftJustified:
+            base->RCR2 |= I2S_RCR2_BCP_MASK;
+            base->RCR3 &= ~I2S_RCR3_WDFL_MASK;
+            base->RCR4 = I2S_RCR4_MF(1U) | I2S_RCR4_SYWD(31U) | I2S_RCR4_FSE(0U) | I2S_RCR4_FSP(0U) | I2S_RCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusRightJustified:
+            base->RCR2 |= I2S_RCR2_BCP_MASK;
+            base->RCR3 &= ~I2S_RCR3_WDFL_MASK;
+            base->RCR4 = I2S_RCR4_MF(1U) | I2S_RCR4_SYWD(31U) | I2S_RCR4_FSE(0U) | I2S_RCR4_FSP(0U) | I2S_RCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusI2S:
+            base->RCR2 |= I2S_RCR2_BCP_MASK;
+            base->RCR3 &= ~I2S_RCR3_WDFL_MASK;
+            base->RCR4 = I2S_RCR4_MF(1U) | I2S_RCR4_SYWD(31U) | I2S_RCR4_FSE(1U) | I2S_RCR4_FSP(1U) | I2S_RCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusPCMA:
+            base->RCR2 &= ~I2S_RCR2_BCP_MASK;
+            base->RCR3 &= ~I2S_RCR3_WDFL_MASK;
+            base->RCR4 = I2S_RCR4_MF(1U) | I2S_RCR4_SYWD(0U) | I2S_RCR4_FSE(1U) | I2S_RCR4_FSP(0U) | I2S_RCR4_FRSZ(1U);
+            break;
+
+        case kSAI_BusPCMB:
+            base->RCR2 &= ~I2S_RCR2_BCP_MASK;
+            base->RCR3 &= ~I2S_RCR3_WDFL_MASK;
+            base->RCR4 = I2S_RCR4_MF(1U) | I2S_RCR4_SYWD(0U) | I2S_RCR4_FSE(0U) | I2S_RCR4_FSP(0U) | I2S_RCR4_FRSZ(1U);
+            break;
+
+        default:
+            break;
+    }
+
+    /* Set master or slave */
+    if (config->masterSlave == kSAI_Master)
+    {
+        base->RCR2 |= I2S_RCR2_BCD_MASK;
+        base->RCR4 |= I2S_RCR4_FSD_MASK;
+
+        /* Bit clock source setting */
+        val = base->RCR2 & (~I2S_RCR2_MSEL_MASK);
+        base->RCR2 = (val | I2S_RCR2_MSEL(config->bclkSource));
+    }
+    else
+    {
+        base->RCR2 &= ~I2S_RCR2_BCD_MASK;
+        base->RCR4 &= ~I2S_RCR4_FSD_MASK;
+    }
+
+    /* Set Sync mode */
+    switch (config->syncMode)
+    {
+        case kSAI_ModeAsync:
+            val = base->RCR2;
+            val &= ~I2S_RCR2_SYNC_MASK;
+            base->RCR2 = (val | I2S_RCR2_SYNC(0U));
+            break;
+        case kSAI_ModeSync:
+            val = base->RCR2;
+            val &= ~I2S_RCR2_SYNC_MASK;
+            base->RCR2 = (val | I2S_RCR2_SYNC(1U));
+            /* If sync with Tx, should set Tx to async mode */
+            val = base->TCR2;
+            val &= ~I2S_TCR2_SYNC_MASK;
+            base->TCR2 = (val | I2S_TCR2_SYNC(0U));
+            break;
+        case kSAI_ModeSyncWithOtherTx:
+            val = base->RCR2;
+            val &= ~I2S_RCR2_SYNC_MASK;
+            base->RCR2 = (val | I2S_RCR2_SYNC(2U));
+            break;
+        case kSAI_ModeSyncWithOtherRx:
+            val = base->RCR2;
+            val &= ~I2S_RCR2_SYNC_MASK;
+            base->RCR2 = (val | I2S_RCR2_SYNC(3U));
+            break;
+        default:
+            break;
+    }
+}
+
+void SAI_Deinit(I2S_Type *base)
+{
+    SAI_TxEnable(base, false);
+    SAI_RxEnable(base, false);
+    CLOCK_DisableClock(s_saiClock[SAI_GetInstance(base)]);
+}
+
+void SAI_TxGetDefaultConfig(sai_config_t *config)
+{
+    config->bclkSource = kSAI_BclkSourceMclkDiv;
+    config->masterSlave = kSAI_Master;
+    config->mclkSource = kSAI_MclkSourceSysclk;
+    config->protocol = kSAI_BusLeftJustified;
+    config->syncMode = kSAI_ModeAsync;
+#if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+    config->mclkOutputEnable = true;
+#endif /* FSL_FEATURE_SAI_HAS_MCR */
+}
+
+void SAI_RxGetDefaultConfig(sai_config_t *config)
+{
+    config->bclkSource = kSAI_BclkSourceMclkDiv;
+    config->masterSlave = kSAI_Master;
+    config->mclkSource = kSAI_MclkSourceSysclk;
+    config->protocol = kSAI_BusLeftJustified;
+    config->syncMode = kSAI_ModeSync;
+#if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+    config->mclkOutputEnable = true;
+#endif /* FSL_FEATURE_SAI_HAS_MCR */
+}
+
+void SAI_TxReset(I2S_Type *base)
+{
+    /* Set the software reset and FIFO reset to clear internal state */
+    base->TCSR = I2S_TCSR_SR_MASK | I2S_TCSR_FR_MASK;
+
+    /* Clear software reset bit, this should be done by software */
+    base->TCSR &= ~I2S_TCSR_SR_MASK;
+
+    /* Reset all Tx register values */
+    base->TCR2 = 0;
+    base->TCR3 = 0;
+    base->TCR4 = 0;
+    base->TCR5 = 0;
+    base->TMR = 0;
+}
+
+void SAI_RxReset(I2S_Type *base)
+{
+    /* Set the software reset and FIFO reset to clear internal state */
+    base->RCSR = I2S_RCSR_SR_MASK | I2S_RCSR_FR_MASK;
+
+    /* Clear software reset bit, this should be done by software */
+    base->RCSR &= ~I2S_RCSR_SR_MASK;
+
+    /* Reset all Rx register values */
+    base->RCR2 = 0;
+    base->RCR3 = 0;
+    base->RCR4 = 0;
+    base->RCR5 = 0;
+    base->RMR = 0;
+}
+
+void SAI_TxEnable(I2S_Type *base, bool enable)
+{
+    if (enable)
+    {
+        /* If clock is sync with Rx, should enable RE bit. */
+        if (((base->TCR2 & I2S_TCR2_SYNC_MASK) >> I2S_TCR2_SYNC_SHIFT) == 0x1U)
+        {
+            base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | I2S_RCSR_RE_MASK);
+        }
+        base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | I2S_TCSR_TE_MASK);
+    }
+    else
+    {
+        /* Should not close RE even sync with Rx */
+        base->TCSR = ((base->TCSR & 0xFFE3FFFFU) & (~I2S_TCSR_TE_MASK));
+    }
+}
+
+void SAI_RxEnable(I2S_Type *base, bool enable)
+{
+    if (enable)
+    {
+        /* If clock is sync with Tx, should enable TE bit. */
+        if (((base->RCR2 & I2S_RCR2_SYNC_MASK) >> I2S_RCR2_SYNC_SHIFT) == 0x1U)
+        {
+            base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | I2S_TCSR_TE_MASK);
+        }
+        base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | I2S_RCSR_RE_MASK);
+    }
+    else
+    {
+        base->RCSR = ((base->RCSR & 0xFFE3FFFFU) & (~I2S_RCSR_RE_MASK));
+    }
+}
+
+void SAI_TxSetFormat(I2S_Type *base,
+                     sai_transfer_format_t *format,
+                     uint32_t mclkSourceClockHz,
+                     uint32_t bclkSourceClockHz)
+{
+    uint32_t bclk = format->sampleRate_Hz * 32U * 2U;
+
+/* Compute the mclk */
+#if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
+    /* Check if master clock divider enabled, then set master clock divider */
+    if (base->MCR & I2S_MCR_MOE_MASK)
+    {
+        SAI_SetMasterClockDivider(base, format->masterClockHz, mclkSourceClockHz);
+    }
+#endif /* FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER */
+
+    /* Set bclk if needed */
+    if (base->TCR2 & I2S_TCR2_BCD_MASK)
+    {
+        base->TCR2 &= ~I2S_TCR2_DIV_MASK;
+        base->TCR2 |= I2S_TCR2_DIV((bclkSourceClockHz / bclk) / 2U - 1U);
+    }
+
+    /* Set bitWidth */
+    if (format->protocol == kSAI_BusRightJustified)
+    {
+        base->TCR5 = I2S_TCR5_WNW(31U) | I2S_TCR5_W0W(31U) | I2S_TCR5_FBT(31U);
+    }
+    else
+    {
+        base->TCR5 = I2S_TCR5_WNW(31U) | I2S_TCR5_W0W(31U) | I2S_TCR5_FBT(format->bitWidth - 1);
+    }
+
+    /* Set mono or stereo */
+    base->TMR = (uint32_t)format->stereo;
+
+    /* Set data channel */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
+    base->TCR3 |= I2S_TCR3_TCE(1U << format->channel);
+
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    /* Set watermark */
+    base->TCR1 = format->watermark;
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT  */
+}
+
+void SAI_RxSetFormat(I2S_Type *base,
+                     sai_transfer_format_t *format,
+                     uint32_t mclkSourceClockHz,
+                     uint32_t bclkSourceClockHz)
+{
+    uint32_t bclk = format->sampleRate_Hz * 32U * 2U;
+
+/* Compute the mclk */
+#if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
+    /* Check if master clock divider enabled */
+    if (base->MCR & I2S_MCR_MOE_MASK)
+    {
+        SAI_SetMasterClockDivider(base, format->masterClockHz, mclkSourceClockHz);
+    }
+#endif /* FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER */
+
+    /* Set bclk if needed */
+    if (base->RCR2 & I2S_RCR2_BCD_MASK)
+    {
+        base->RCR2 &= ~I2S_RCR2_DIV_MASK;
+        base->RCR2 |= I2S_RCR2_DIV((bclkSourceClockHz / bclk) / 2U - 1U);
+    }
+
+    /* Set bitWidth */
+    if (format->protocol == kSAI_BusRightJustified)
+    {
+        base->RCR5 = I2S_RCR5_WNW(31U) | I2S_RCR5_W0W(31U) | I2S_RCR5_FBT(31U);
+    }
+    else
+    {
+        base->RCR5 = I2S_RCR5_WNW(31U) | I2S_RCR5_W0W(31U) | I2S_RCR5_FBT(format->bitWidth - 1);
+    }
+
+    /* Set mono or stereo */
+    base->RMR = (uint32_t)format->stereo;
+
+    /* Set data channel */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
+    base->RCR3 |= I2S_RCR3_RCE(1U << format->channel);
+
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    /* Set watermark */
+    base->RCR1 = format->watermark;
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT  */
+}
+
+void SAI_WriteBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+{
+    uint32_t i = 0;
+    uint8_t bytesPerWord = bitWidth / 8U;
+
+    for (i = 0; i < size; i++)
+    {
+        /* Wait until it can write data */
+        while (!(base->TCSR & I2S_TCSR_FWF_MASK))
+        {
+        }
+
+        SAI_WriteNonBlocking(base, channel, bitWidth, buffer, bytesPerWord);
+        buffer += bytesPerWord;
+    }
+
+    /* Wait until the last data is sent */
+    while (!(base->TCSR & I2S_TCSR_FWF_MASK))
+    {
+    }
+}
+
+void SAI_ReadBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+{
+    uint32_t i = 0;
+    uint8_t bytesPerWord = bitWidth / 8U;
+
+    for (i = 0; i < size; i++)
+    {
+        /* Wait until data is received */
+        while (!(base->RCSR & I2S_RCSR_FWF_MASK))
+        {
+        }
+
+        SAI_ReadNonBlocking(base, channel, bitWidth, buffer, bytesPerWord);
+        buffer += bytesPerWord;
+    }
+}
+
+void SAI_TransferTxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transfer_callback_t callback, void *userData)
+{
+    assert(handle);
+
+    s_saiHandle[SAI_GetInstance(base)][0] = handle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* Enable Tx irq */
+    EnableIRQ(s_saiTxIRQ[SAI_GetInstance(base)]);
+}
+
+void SAI_TransferRxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transfer_callback_t callback, void *userData)
+{
+    assert(handle);
+
+    s_saiHandle[SAI_GetInstance(base)][1] = handle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* Enable Rx irq */
+    EnableIRQ(s_saiRxIRQ[SAI_GetInstance(base)]);
+}
+
+status_t SAI_TransferTxSetFormat(I2S_Type *base,
+                                 sai_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz)
+{
+    assert(handle);
+
+    if ((mclkSourceClockHz < format->sampleRate_Hz) || (bclkSourceClockHz < format->sampleRate_Hz))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Copy format to handle */
+    handle->bitWidth = format->bitWidth;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    handle->watermark = format->watermark;
+#endif
+    handle->channel = format->channel;
+
+    SAI_TxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
+
+    return kStatus_Success;
+}
+
+status_t SAI_TransferRxSetFormat(I2S_Type *base,
+                                 sai_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz)
+{
+    assert(handle);
+
+    if ((mclkSourceClockHz < format->sampleRate_Hz) || (bclkSourceClockHz < format->sampleRate_Hz))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Copy format to handle */
+    handle->bitWidth = format->bitWidth;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    handle->watermark = format->watermark;
+#endif
+    handle->channel = format->channel;
+
+    SAI_RxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
+
+    return kStatus_Success;
+}
+
+status_t SAI_TransferSendNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_transfer_t *xfer)
+{
+    assert(handle);
+
+    /* Check if the queue is full */
+    if (handle->saiQueue[handle->queueUser].data)
+    {
+        return kStatus_SAI_QueueFull;
+    }
+
+    /* Add into queue */
+    handle->transferSize[handle->queueUser] = xfer->dataSize;
+    handle->saiQueue[handle->queueUser].data = xfer->data;
+    handle->saiQueue[handle->queueUser].dataSize = xfer->dataSize;
+    handle->queueUser = (handle->queueUser + 1) % SAI_XFER_QUEUE_SIZE;
+
+    /* Set the state to busy */
+    handle->state = kSAI_Busy;
+
+/* Enable interrupt */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    /* Use FIFO request interrupt and fifo error*/
+    SAI_TxEnableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFORequestInterruptEnable);
+#else
+    SAI_TxEnableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFOWarningInterruptEnable);
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    /* Enable Tx transfer */
+    SAI_TxEnable(base, true);
+
+    return kStatus_Success;
+}
+
+status_t SAI_TransferReceiveNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_transfer_t *xfer)
+{
+    assert(handle);
+
+    /* Check if the queue is full */
+    if (handle->saiQueue[handle->queueUser].data)
+    {
+        return kStatus_SAI_QueueFull;
+    }
+
+    /* Add into queue */
+    handle->transferSize[handle->queueUser] = xfer->dataSize;
+    handle->saiQueue[handle->queueUser].data = xfer->data;
+    handle->saiQueue[handle->queueUser].dataSize = xfer->dataSize;
+    handle->queueUser = (handle->queueUser + 1) % SAI_XFER_QUEUE_SIZE;
+
+    /* Set state to busy */
+    handle->state = kSAI_Busy;
+
+/* Enable interrupt */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    /* Use FIFO request interrupt and fifo error*/
+    SAI_RxEnableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFORequestInterruptEnable);
+#else
+    SAI_RxEnableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFOWarningInterruptEnable);
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    /* Enable Rx transfer */
+    SAI_RxEnable(base, true);
+
+    return kStatus_Success;
+}
+
+status_t SAI_TransferGetSendCount(I2S_Type *base, sai_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    status_t status = kStatus_Success;
+
+    if (handle->state != kSAI_Busy)
+    {
+        status = kStatus_NoTransferInProgress;
+    }
+    else
+    {
+        *count = (handle->transferSize[handle->queueDriver] - handle->saiQueue[handle->queueDriver].dataSize);
+    }
+
+    return status;
+}
+
+status_t SAI_TransferGetReceiveCount(I2S_Type *base, sai_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    status_t status = kStatus_Success;
+
+    if (handle->state != kSAI_Busy)
+    {
+        status = kStatus_NoTransferInProgress;
+    }
+    else
+    {
+        *count = (handle->transferSize[handle->queueDriver] - handle->saiQueue[handle->queueDriver].dataSize);
+    }
+
+    return status;
+}
+
+void SAI_TransferAbortSend(I2S_Type *base, sai_handle_t *handle)
+{
+    assert(handle);
+
+    /* Stop Tx transfer and disable interrupt */
+    SAI_TxEnable(base, false);
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    /* Use FIFO request interrupt and fifo error */
+    SAI_TxDisableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFORequestInterruptEnable);
+#else
+    SAI_TxDisableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFOWarningInterruptEnable);
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    handle->state = kSAI_Idle;
+
+    /* Clear the queue */
+    memset(handle->saiQueue, 0, sizeof(sai_transfer_t) * SAI_XFER_QUEUE_SIZE);
+    handle->queueDriver = 0;
+    handle->queueUser = 0;
+}
+
+void SAI_TransferAbortReceive(I2S_Type *base, sai_handle_t *handle)
+{
+    assert(handle);
+
+    /* Stop Tx transfer and disable interrupt */
+    SAI_RxEnable(base, false);
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    /* Use FIFO request interrupt and fifo error */
+    SAI_RxDisableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFORequestInterruptEnable);
+#else
+    SAI_RxDisableInterrupts(base, kSAI_FIFOErrorInterruptEnable | kSAI_FIFOWarningInterruptEnable);
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    handle->state = kSAI_Idle;
+
+    /* Clear the queue */
+    memset(handle->saiQueue, 0, sizeof(sai_transfer_t) * SAI_XFER_QUEUE_SIZE);
+    handle->queueDriver = 0;
+    handle->queueUser = 0;
+}
+
+void SAI_TransferTxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
+{
+    assert(handle);
+
+    uint8_t *buffer = handle->saiQueue[handle->queueDriver].data;
+    uint8_t dataSize = handle->bitWidth / 8U;
+
+    /* Handle Error */
+    if (base->TCSR & I2S_TCSR_FEF_MASK)
+    {
+        /* Clear FIFO error flag to continue transfer */
+        SAI_TxClearStatusFlags(base, kSAI_FIFOErrorFlag);
+
+        /* Call the callback */
+        if (handle->callback)
+        {
+            (handle->callback)(base, handle, kStatus_SAI_TxError, handle->userData);
+        }
+    }
+
+/* Handle transfer */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if (base->TCSR & I2S_TCSR_FRF_MASK)
+    {
+        /* Judge if the data need to transmit is less than space */
+        uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize),
+                           (size_t)((FSL_FEATURE_SAI_FIFO_COUNT - handle->watermark) * dataSize));
+
+        /* Copy the data from sai buffer to FIFO */
+        SAI_WriteNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+
+        /* Update the internal counter */
+        handle->saiQueue[handle->queueDriver].dataSize -= size;
+        handle->saiQueue[handle->queueDriver].data += size;
+    }
+#else
+    if (base->TCSR & I2S_TCSR_FWF_MASK)
+    {
+        uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize), dataSize);
+
+        SAI_WriteNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+
+        /* Update internal counter */
+        handle->saiQueue[handle->queueDriver].dataSize -= size;
+        handle->saiQueue[handle->queueDriver].data += size;
+    }
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    /* If finished a blcok, call the callback function */
+    if (handle->saiQueue[handle->queueDriver].dataSize == 0U)
+    {
+        memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+        handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
+        if (handle->callback)
+        {
+            (handle->callback)(base, handle, kStatus_SAI_TxIdle, handle->userData);
+        }
+    }
+
+    /* If all data finished, just stop the transfer */
+    if (handle->saiQueue[handle->queueDriver].data == NULL)
+    {
+        SAI_TransferAbortSend(base, handle);
+    }
+}
+
+void SAI_TransferRxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
+{
+    assert(handle);
+
+    uint8_t *buffer = handle->saiQueue[handle->queueDriver].data;
+    uint8_t dataSize = handle->bitWidth / 8U;
+
+    /* Handle Error */
+    if (base->RCSR & I2S_RCSR_FEF_MASK)
+    {
+        /* Clear FIFO error flag to continue transfer */
+        SAI_RxClearStatusFlags(base, kSAI_FIFOErrorFlag);
+
+        /* Call the callback */
+        if (handle->callback)
+        {
+            (handle->callback)(base, handle, kStatus_SAI_RxError, handle->userData);
+        }
+    }
+
+/* Handle transfer */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if (base->RCSR & I2S_RCSR_FRF_MASK)
+    {
+        /* Judge if the data need to transmit is less than space */
+        uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize), (handle->watermark * dataSize));
+
+        /* Copy the data from sai buffer to FIFO */
+        SAI_ReadNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+
+        /* Update the internal counter */
+        handle->saiQueue[handle->queueDriver].dataSize -= size;
+        handle->saiQueue[handle->queueDriver].data += size;
+    }
+#else
+    if (base->RCSR & I2S_RCSR_FWF_MASK)
+    {
+        uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize), dataSize);
+
+        SAI_ReadNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+
+        /* Update internal state */
+        handle->saiQueue[handle->queueDriver].dataSize -= size;
+        handle->saiQueue[handle->queueDriver].data += size;
+    }
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    /* If finished a blcok, call the callback function */
+    if (handle->saiQueue[handle->queueDriver].dataSize == 0U)
+    {
+        memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+        handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
+        if (handle->callback)
+        {
+            (handle->callback)(base, handle, kStatus_SAI_RxIdle, handle->userData);
+        }
+    }
+
+    /* If all data finished, just stop the transfer */
+    if (handle->saiQueue[handle->queueDriver].data == NULL)
+    {
+        SAI_TransferAbortReceive(base, handle);
+    }
+}
+
+#if defined(I2S0)
+#if defined(FSL_FEATURE_SAI_INT_SOURCE_NUM) && (FSL_FEATURE_SAI_INT_SOURCE_NUM == 1)
+void I2S0_DriverIRQHandler(void)
+{
+    if ((s_saiHandle[0][1]) && ((I2S0->RCSR & kSAI_FIFOWarningFlag) || (I2S0->RCSR & kSAI_FIFOErrorFlag)))
+    {
+        SAI_TransferRxHandleIRQ(I2S0, s_saiHandle[0][1]);
+    }
+    if ((s_saiHandle[0][0]) && ((I2S0->TCSR & kSAI_FIFOWarningFlag) || (I2S0->TCSR & kSAI_FIFOErrorFlag)))
+    {
+        SAI_TransferTxHandleIRQ(I2S0, s_saiHandle[0][0]);
+    }
+}
+#else
+void I2S0_Tx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[0][0]);
+    SAI_TransferTxHandleIRQ(I2S0, s_saiHandle[0][0]);
+}
+
+void I2S0_Rx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[0][1]);
+    SAI_TransferRxHandleIRQ(I2S0, s_saiHandle[0][1]);
+}
+#endif /* FSL_FEATURE_SAI_INT_SOURCE_NUM */
+#endif /* I2S0*/
+
+#if defined(I2S1)
+void I2S1_Tx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[1][0]);
+    SAI_TransferTxHandleIRQ(I2S1, s_saiHandle[1][0]);
+}
+
+void I2S1_Rx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[1][1]);
+    SAI_TransferRxHandleIRQ(I2S1, s_saiHandle[1][1]);
+}
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai.h
@@ -1,0 +1,850 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_SAI_H_
+#define _FSL_SAI_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup sai
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_SAI_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0 */
+/*@}*/
+
+/*! @brief SAI return status*/
+enum _sai_status_t
+{
+    kStatus_SAI_TxBusy = MAKE_STATUS(kStatusGroup_SAI, 0),    /*!< SAI Tx is busy. */
+    kStatus_SAI_RxBusy = MAKE_STATUS(kStatusGroup_SAI, 1),    /*!< SAI Rx is busy. */
+    kStatus_SAI_TxError = MAKE_STATUS(kStatusGroup_SAI, 2),   /*!< SAI Tx FIFO error. */
+    kStatus_SAI_RxError = MAKE_STATUS(kStatusGroup_SAI, 3),   /*!< SAI Rx FIFO error. */
+    kStatus_SAI_QueueFull = MAKE_STATUS(kStatusGroup_SAI, 4), /*!< SAI transfer queue is full. */
+    kStatus_SAI_TxIdle = MAKE_STATUS(kStatusGroup_SAI, 5),    /*!< SAI Tx is idle */
+    kStatus_SAI_RxIdle = MAKE_STATUS(kStatusGroup_SAI, 6)     /*!< SAI Rx is idle */
+};
+
+/*! @brief Define the SAI bus type */
+typedef enum _sai_protocol
+{
+    kSAI_BusLeftJustified = 0x0U, /*!< Uses left justified format.*/
+    kSAI_BusRightJustified,       /*!< Uses right justified format. */
+    kSAI_BusI2S,                  /*!< Uses I2S format. */
+    kSAI_BusPCMA,                 /*!< Uses I2S PCM A format.*/
+    kSAI_BusPCMB                  /*!< Uses I2S PCM B format. */
+} sai_protocol_t;
+
+/*! @brief Master or slave mode */
+typedef enum _sai_master_slave
+{
+    kSAI_Master = 0x0U, /*!< Master mode */
+    kSAI_Slave = 0x1U   /*!< Slave mode */
+} sai_master_slave_t;
+
+/*! @brief Mono or stereo audio format */
+typedef enum _sai_mono_stereo
+{
+    kSAI_Stereo = 0x0U, /*!< Stereo sound. */
+    kSAI_MonoLeft,      /*!< Only left channel have sound. */
+    kSAI_MonoRight      /*!< Only Right channel have sound. */
+} sai_mono_stereo_t;
+
+/*! @brief Synchronous or asynchronous mode */
+typedef enum _sai_sync_mode
+{
+    kSAI_ModeAsync = 0x0U,    /*!< Asynchronous mode */
+    kSAI_ModeSync,            /*!< Synchronous mode (with receiver or transmit) */
+    kSAI_ModeSyncWithOtherTx, /*!< Synchronous with another SAI transmit */
+    kSAI_ModeSyncWithOtherRx  /*!< Synchronous with another SAI receiver */
+} sai_sync_mode_t;
+
+/*! @brief Mater clock source */
+typedef enum _sai_mclk_source
+{
+    kSAI_MclkSourceSysclk = 0x0U, /*!< Master clock from the system clock */
+    kSAI_MclkSourceSelect1,       /*!< Master clock from source 1 */
+    kSAI_MclkSourceSelect2,       /*!< Master clock from source 2 */
+    kSAI_MclkSourceSelect3        /*!< Master clock from source 3 */
+} sai_mclk_source_t;
+
+/*! @brief Bit clock source */
+typedef enum _sai_bclk_source
+{
+    kSAI_BclkSourceBusclk = 0x0U, /*!< Bit clock using bus clock */
+    kSAI_BclkSourceMclkDiv,       /*!< Bit clock using master clock divider */
+    kSAI_BclkSourceOtherSai0,     /*!< Bit clock from other SAI device  */
+    kSAI_BclkSourceOtherSai1      /*!< Bit clock from other SAI device */
+} sai_bclk_source_t;
+
+/*! @brief The SAI interrupt enable flag */
+enum _sai_interrupt_enable_t
+{
+    kSAI_WordStartInterruptEnable =
+        I2S_TCSR_WSIE_MASK, /*!< Word start flag, means the first word in a frame detected */
+    kSAI_SyncErrorInterruptEnable = I2S_TCSR_SEIE_MASK,   /*!< Sync error flag, means the sync error is detected */
+    kSAI_FIFOWarningInterruptEnable = I2S_TCSR_FWIE_MASK, /*!< FIFO warning flag, means the FIFO is empty */
+    kSAI_FIFOErrorInterruptEnable = I2S_TCSR_FEIE_MASK,   /*!< FIFO error flag */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    kSAI_FIFORequestInterruptEnable = I2S_TCSR_FRIE_MASK, /*!< FIFO request, means reached watermark */
+#endif                                                    /* FSL_FEATURE_SAI_FIFO_COUNT */
+};
+
+/*! @brief The DMA request sources */
+enum _sai_dma_enable_t
+{
+    kSAI_FIFOWarningDMAEnable = I2S_TCSR_FWDE_MASK, /*!< FIFO warning caused by the DMA request */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    kSAI_FIFORequestDMAEnable = I2S_TCSR_FRDE_MASK, /*!< FIFO request caused by the DMA request */
+#endif                                              /* FSL_FEATURE_SAI_FIFO_COUNT */
+};
+
+/*! @brief The SAI status flag */
+enum _sai_flags
+{
+    kSAI_WordStartFlag = I2S_TCSR_WSF_MASK, /*!< Word start flag, means the first word in a frame detected */
+    kSAI_SyncErrorFlag = I2S_TCSR_SEF_MASK, /*!< Sync error flag, means the sync error is detected */
+    kSAI_FIFOErrorFlag = I2S_TCSR_FEF_MASK, /*!< FIFO error flag */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    kSAI_FIFORequestFlag = I2S_TCSR_FRF_MASK, /*!< FIFO request flag. */
+#endif                                        /* FSL_FEATURE_SAI_FIFO_COUNT */
+    kSAI_FIFOWarningFlag = I2S_TCSR_FWF_MASK, /*!< FIFO warning flag */
+};
+
+/*! @brief The reset type */
+typedef enum _sai_reset_type
+{
+    kSAI_ResetTypeSoftware = I2S_TCSR_SR_MASK,          /*!< Software reset, reset the logic state */
+    kSAI_ResetTypeFIFO = I2S_TCSR_FR_MASK,              /*!< FIFO reset, reset the FIFO read and write pointer */
+    kSAI_ResetAll = I2S_TCSR_SR_MASK | I2S_TCSR_FR_MASK /*!< All reset. */
+} sai_reset_type_t;
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_PACKING) && FSL_FEATURE_SAI_HAS_FIFO_PACKING
+/*!
+ * @brief The SAI packing mode
+ * The mode includes 8 bit and 16 bit packing.
+ */
+typedef enum _sai_fifo_packing
+{
+    kSAI_FifoPackingDisabled = 0x0U, /*!< Packing disabled */
+    kSAI_FifoPacking8bit = 0x2U,     /*!< 8 bit packing enabled */
+    kSAI_FifoPacking16bit = 0x3U     /*!< 16bit packing enabled */
+} sai_fifo_packing_t;
+#endif /* FSL_FEATURE_SAI_HAS_FIFO_PACKING */
+
+/*! @brief SAI user configure structure */
+typedef struct _sai_config
+{
+    sai_protocol_t protocol;  /*!< Audio bus protocol in SAI */
+    sai_sync_mode_t syncMode; /*!< SAI sync mode, control Tx/Rx clock sync */
+#if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+    bool mclkOutputEnable;          /*!< Master clock output enable, true means master clock divider enabled */
+#endif                              /* FSL_FEATURE_SAI_HAS_MCR */
+    sai_mclk_source_t mclkSource;   /*!< Master Clock source */
+    sai_bclk_source_t bclkSource;   /*!< Bit Clock source */
+    sai_master_slave_t masterSlave; /*!< Master or slave */
+} sai_config_t;
+
+/*!@brief SAI transfer queue size, user can refine it according to use case. */
+#define SAI_XFER_QUEUE_SIZE (4)
+
+/*! @brief Audio sample rate */
+typedef enum _sai_sample_rate
+{
+    kSAI_SampleRate8KHz = 8000U,     /*!< Sample rate 8000Hz */
+    kSAI_SampleRate11025Hz = 11025U, /*!< Sample rate 11025Hz */
+    kSAI_SampleRate12KHz = 12000U,   /*!< Sample rate 12000Hz */
+    kSAI_SampleRate16KHz = 16000U,   /*!< Sample rate 16000Hz */
+    kSAI_SampleRate22050Hz = 22050U, /*!< Sample rate 22050Hz */
+    kSAI_SampleRate24KHz = 24000U,   /*!< Sample rate 24000Hz */
+    kSAI_SampleRate32KHz = 32000U,   /*!< Sample rate 32000Hz */
+    kSAI_SampleRate44100Hz = 44100U, /*!< Sample rate 44100Hz */
+    kSAI_SampleRate48KHz = 48000U,   /*!< Sample rate 48000Hz */
+    kSAI_SampleRate96KHz = 96000U    /*!< Sample rate 96000Hz */
+} sai_sample_rate_t;
+
+/*! @brief Audio word width */
+typedef enum _sai_word_width
+{
+    kSAI_WordWidth8bits = 8U,   /*!< Audio data width 8 bits */
+    kSAI_WordWidth16bits = 16U, /*!< Audio data width 16 bits */
+    kSAI_WordWidth24bits = 24U, /*!< Audio data width 24 bits */
+    kSAI_WordWidth32bits = 32U  /*!< Audio data width 32 bits */
+} sai_word_width_t;
+
+/*! @brief sai transfer format */
+typedef struct _sai_transfer_format
+{
+    uint32_t sampleRate_Hz;   /*!< Sample rate of audio data */
+    uint32_t bitWidth;        /*!< Data length of audio data, usually 8/16/24/32bits */
+    sai_mono_stereo_t stereo; /*!< Mono or stereo */
+    uint32_t masterClockHz;   /*!< Master clock frequency in Hz */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    uint8_t watermark;       /*!< Watermark value */
+#endif                       /* FSL_FEATURE_SAI_FIFO_COUNT */
+    uint8_t channel;         /*!< Data channel used in transfer.*/
+    sai_protocol_t protocol; /*!< Which audio protocol used */
+} sai_transfer_format_t;
+
+/*! @brief SAI transfer structure */
+typedef struct _sai_transfer
+{
+    uint8_t *data;   /*!< Data start address to transfer. */
+    size_t dataSize; /*!< Transfer size. */
+} sai_transfer_t;
+
+typedef struct _sai_handle sai_handle_t;
+
+/*! @brief SAI transfer callback prototype */
+typedef void (*sai_transfer_callback_t)(I2S_Type *base, sai_handle_t *handle, status_t status, void *userData);
+
+/*! @brief SAI handle structure */
+struct _sai_handle
+{
+    uint32_t state;                               /*!< Transfer status */
+    sai_transfer_callback_t callback;             /*!< Callback function called at transfer event*/
+    void *userData;                               /*!< Callback parameter passed to callback function*/
+    uint8_t bitWidth;                             /*!< Bit width for transfer, 8/16/24/32bits */
+    uint8_t channel;                              /*!< Transfer channel */
+    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE]; /*!< Transfer queue storing queued transfer */
+    size_t transferSize[SAI_XFER_QUEUE_SIZE];     /*!< Data bytes need to transfer */
+    volatile uint8_t queueUser;                   /*!< Index for user to queue transfer */
+    volatile uint8_t queueDriver;                 /*!< Index for driver to get the transfer data and size */
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    uint8_t watermark; /*!< Watermark value */
+#endif
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /*_cplusplus*/
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the SAI Tx peripheral.
+ *
+ * Ungates the SAI clock, resets the module, and configures SAI Tx with a configuration structure.
+ * The configuration structure can be custom filled or set with default values by
+ * SAI_TxGetDefaultConfig().
+ *
+ * @note  This API should be called at the beginning of the application to use
+ * the SAI driver. Otherwise, accessing the SAIM module can cause a hard fault
+ * because the clock is not enabled.
+ *
+ * @param base SAI base pointer
+ * @param config SAI configure structure.
+*/
+void SAI_TxInit(I2S_Type *base, const sai_config_t *config);
+
+/*!
+ * @brief Initializes the the SAI Rx peripheral.
+ *
+ * Ungates the SAI clock, resets the module, and configures the SAI Rx with a configuration structure.
+ * The configuration structure can be custom filled or set with default values by
+ * SAI_RxGetDefaultConfig().
+ *
+ * @note  This API should be called at the beginning of the application to use
+ * the SAI driver. Otherwise, accessing the SAI module can cause a hard fault
+ * because the clock is not enabled.
+ *
+ * @param base SAI base pointer
+ * @param config SAI configure structure.
+ */
+void SAI_RxInit(I2S_Type *base, const sai_config_t *config);
+
+/*!
+ * @brief  Sets the SAI Tx configuration structure to default values.
+ *
+ * This API initializes the configuration structure for use in SAI_TxConfig().
+ * The initialized structure can remain unchanged in SAI_TxConfig(), or it can be modified
+ *  before calling SAI_TxConfig().
+ * Example:
+   @code
+   sai_config_t config;
+   SAI_TxGetDefaultConfig(&config);
+   @endcode
+ *
+ * @param config pointer to master configuration structure
+ */
+void SAI_TxGetDefaultConfig(sai_config_t *config);
+
+/*!
+ * @brief  Sets the SAI Rx configuration structure to default values.
+ *
+ * This API initializes the configuration structure for use in SAI_RxConfig().
+ * The initialized structure can remain unchanged in SAI_RxConfig() or it can be modified
+ *  before calling SAI_RxConfig().
+ * Example:
+   @code
+   sai_config_t config;
+   SAI_RxGetDefaultConfig(&config);
+   @endcode
+ *
+ * @param config pointer to master configuration structure
+ */
+void SAI_RxGetDefaultConfig(sai_config_t *config);
+
+/*!
+ * @brief De-initializes the SAI peripheral.
+ *
+ * This API gates the SAI clock. The SAI module can't operate unless SAI_TxInit
+ * or SAI_RxInit is called to enable the clock.
+ *
+ * @param base SAI base pointer
+*/
+void SAI_Deinit(I2S_Type *base);
+
+/*!
+ * @brief Resets the SAI Tx.
+ *
+ * This function enables the software reset and FIFO reset of SAI Tx. After reset, clear the reset bit.
+ *
+ * @param base SAI base pointer
+ */
+void SAI_TxReset(I2S_Type *base);
+
+/*!
+ * @brief Resets the SAI Rx.
+ *
+ * This function enables the software reset and FIFO reset of SAI Rx. After reset, clear the reset bit.
+ *
+ * @param base SAI base pointer
+ */
+void SAI_RxReset(I2S_Type *base);
+
+/*!
+ * @brief Enables/disables SAI Tx.
+ *
+ * @param base SAI base pointer
+ * @param enable True means enable SAI Tx, false means disable.
+ */
+void SAI_TxEnable(I2S_Type *base, bool enable);
+
+/*!
+ * @brief Enables/disables SAI Rx.
+ *
+ * @param base SAI base pointer
+ * @param enable True means enable SAI Rx, false means disable.
+ */
+void SAI_RxEnable(I2S_Type *base, bool enable);
+
+/*! @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Gets the SAI Tx status flag state.
+ *
+ * @param base SAI base pointer
+ * @return SAI Tx status flag value. Use the Status Mask to get the status value needed.
+ */
+static inline uint32_t SAI_TxGetStatusFlag(I2S_Type *base)
+{
+    return base->TCSR;
+}
+
+/*!
+ * @brief Clears the SAI Tx status flag state.
+ *
+ * @param base SAI base pointer
+ * @param mask State mask. It can be a combination of the following source if defined:
+ *        @arg kSAI_WordStartFlag
+ *        @arg kSAI_SyncErrorFlag
+ *        @arg kSAI_FIFOErrorFlag
+ */
+static inline void SAI_TxClearStatusFlags(I2S_Type *base, uint32_t mask)
+{
+    base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | mask);
+}
+
+/*!
+ * @brief Gets the SAI Tx status flag state.
+ *
+ * @param base SAI base pointer
+ * @return SAI Rx status flag value. Use the Status Mask to get the status value needed.
+ */
+static inline uint32_t SAI_RxGetStatusFlag(I2S_Type *base)
+{
+    return base->RCSR;
+}
+
+/*!
+ * @brief Clears the SAI Rx status flag state.
+ *
+ * @param base SAI base pointer
+ * @param mask State mask. It can be a combination of the following source if defined:
+ *        @arg kSAI_WordStartFlag
+ *        @arg kSAI_SyncErrorFlag
+ *        @arg kSAI_FIFOErrorFlag
+ */
+static inline void SAI_RxClearStatusFlags(I2S_Type *base, uint32_t mask)
+{
+    base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | mask);
+}
+
+/*! @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enables SAI Tx interrupt requests.
+ *
+ * @param base SAI base pointer
+ * @param mask interrupt source
+ *     The parameter can be a combination of the following source if defined:
+ *     @arg kSAI_WordStartInterruptEnable
+ *     @arg kSAI_SyncErrorInterruptEnable
+ *     @arg kSAI_FIFOWarningInterruptEnable
+ *     @arg kSAI_FIFORequestInterruptEnable
+ *     @arg kSAI_FIFOErrorInterruptEnable
+ */
+static inline void SAI_TxEnableInterrupts(I2S_Type *base, uint32_t mask)
+{
+    base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | mask);
+}
+
+/*!
+ * @brief Enables SAI Rx interrupt requests.
+ *
+ * @param base SAI base pointer
+ * @param mask interrupt source
+ *     The parameter can be a combination of the following source if defined:
+ *     @arg kSAI_WordStartInterruptEnable
+ *     @arg kSAI_SyncErrorInterruptEnable
+ *     @arg kSAI_FIFOWarningInterruptEnable
+ *     @arg kSAI_FIFORequestInterruptEnable
+ *     @arg kSAI_FIFOErrorInterruptEnable
+ */
+static inline void SAI_RxEnableInterrupts(I2S_Type *base, uint32_t mask)
+{
+    base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | mask);
+}
+
+/*!
+ * @brief Disables SAI Tx interrupt requests.
+ *
+ * @param base SAI base pointer
+ * @param mask interrupt source
+ *     The parameter can be a combination of the following source if defined:
+ *     @arg kSAI_WordStartInterruptEnable
+ *     @arg kSAI_SyncErrorInterruptEnable
+ *     @arg kSAI_FIFOWarningInterruptEnable
+ *     @arg kSAI_FIFORequestInterruptEnable
+ *     @arg kSAI_FIFOErrorInterruptEnable
+ */
+static inline void SAI_TxDisableInterrupts(I2S_Type *base, uint32_t mask)
+{
+    base->TCSR = ((base->TCSR & 0xFFE3FFFFU) & (~mask));
+}
+
+/*!
+ * @brief Disables SAI Rx interrupt requests.
+ *
+ * @param base SAI base pointer
+ * @param mask interrupt source
+ *     The parameter can be a combination of the following source if defined:
+ *     @arg kSAI_WordStartInterruptEnable
+ *     @arg kSAI_SyncErrorInterruptEnable
+ *     @arg kSAI_FIFOWarningInterruptEnable
+ *     @arg kSAI_FIFORequestInterruptEnable
+ *     @arg kSAI_FIFOErrorInterruptEnable
+ */
+static inline void SAI_RxDisableInterrupts(I2S_Type *base, uint32_t mask)
+{
+    base->RCSR = ((base->RCSR & 0xFFE3FFFFU) & (~mask));
+}
+
+/*! @} */
+
+/*!
+ * @name DMA Control
+ * @{
+ */
+
+/*!
+ * @brief Enables/disables SAI Tx DMA requests.
+ * @param base SAI base pointer
+ * @param mask DMA source
+ *     The parameter can be combination of the following source if defined:
+ *     @arg kSAI_FIFOWarningDMAEnable
+ *     @arg kSAI_FIFORequestDMAEnable
+ * @param enable True means enable DMA, false means disable DMA.
+ */
+static inline void SAI_TxEnableDMA(I2S_Type *base, uint32_t mask, bool enable)
+{
+    if (enable)
+    {
+        base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | mask);
+    }
+    else
+    {
+        base->TCSR = ((base->TCSR & 0xFFE3FFFFU) & (~mask));
+    }
+}
+
+/*!
+ * @brief Enables/disables SAI Rx DMA requests.
+ * @param base SAI base pointer
+ * @param mask DMA source
+ *     The parameter can be a combination of the following source if defined:
+ *     @arg kSAI_FIFOWarningDMAEnable
+ *     @arg kSAI_FIFORequestDMAEnable
+ * @param enable True means enable DMA, false means disable DMA.
+ */
+static inline void SAI_RxEnableDMA(I2S_Type *base, uint32_t mask, bool enable)
+{
+    if (enable)
+    {
+        base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | mask);
+    }
+    else
+    {
+        base->RCSR = ((base->RCSR & 0xFFE3FFFFU) & (~mask));
+    }
+}
+
+/*!
+ * @brief  Gets the SAI Tx data register address.
+ *
+ * This API is used to provide a transfer address for SAI DMA transfer configuration.
+ *
+ * @param base SAI base pointer.
+ * @param channel Which data channel used.
+ * @return data register address.
+ */
+static inline uint32_t SAI_TxGetDataRegisterAddress(I2S_Type *base, uint32_t channel)
+{
+    return (uint32_t)(&(base->TDR)[channel]);
+}
+
+/*!
+ * @brief  Gets the SAI Rx data register address.
+ *
+ * This API is used to provide a transfer address for SAI DMA transfer configuration.
+ *
+ * @param base SAI base pointer.
+ * @param channel Which data channel used.
+ * @return data register address.
+ */
+static inline uint32_t SAI_RxGetDataRegisterAddress(I2S_Type *base, uint32_t channel)
+{
+    return (uint32_t)(&(base->RDR)[channel]);
+}
+
+/*! @} */
+
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * @param base SAI base pointer.
+ * @param format Pointer to SAI audio data format structure.
+ * @param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * @param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+*/
+void SAI_TxSetFormat(I2S_Type *base,
+                     sai_transfer_format_t *format,
+                     uint32_t mclkSourceClockHz,
+                     uint32_t bclkSourceClockHz);
+
+/*!
+ * @brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * @param base SAI base pointer.
+ * @param format Pointer to SAI audio data format structure.
+ * @param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * @param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+*/
+void SAI_RxSetFormat(I2S_Type *base,
+                     sai_transfer_format_t *format,
+                     uint32_t mclkSourceClockHz,
+                     uint32_t bclkSourceClockHz);
+
+/*!
+ * @brief Sends data using a blocking method.
+ *
+ * @note This function blocks by polling until data is ready to be sent.
+ *
+ * @param base SAI base pointer.
+ * @param channel Data channel used.
+ * @param bitWidth How many bits in a audio word, usually 8/16/24/32 bits.
+ * @param buffer Pointer to the data to be written.
+ * @param size Bytes to be written.
+ */
+void SAI_WriteBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+
+/*!
+ * @brief Writes data into SAI FIFO.
+ *
+ * @param base SAI base pointer.
+ * @param channel Data channel used.
+ * @param data Data needs to be written.
+ */
+static inline void SAI_WriteData(I2S_Type *base, uint32_t channel, uint32_t data)
+{
+    base->TDR[channel] = data;
+}
+
+/*!
+ * @brief Receives data using a blocking method.
+ *
+ * @note This function blocks by polling until data is ready to be sent.
+ *
+ * @param base SAI base pointer.
+ * @param channel Data channel used.
+ * @param bitWidth How many bits in a audio word, usually 8/16/24/32 bits.
+ * @param buffer Pointer to the data to be read.
+ * @param size Bytes to be read.
+ */
+void SAI_ReadBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+
+/*!
+ * @brief Reads data from SAI FIFO.
+ *
+ * @param base SAI base pointer.
+ * @param channel Data channel used.
+ * @return Data in SAI FIFO.
+ */
+static inline uint32_t SAI_ReadData(I2S_Type *base, uint32_t channel)
+{
+    return base->RDR[channel];
+}
+
+/*! @} */
+
+/*!
+ * @name Transactional
+ * @{
+ */
+
+/*!
+ * @brief Initializes the SAI Tx handle.
+ *
+ * This function initializes the Tx handle for SAI Tx transactional APIs. Call
+ * this function one time to get the handle initialized.
+ *
+ * @param base SAI base pointer
+ * @param handle SAI handle pointer.
+ * @param callback pointer to user callback function
+ * @param userData user parameter passed to the callback function
+ */
+void SAI_TransferTxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transfer_callback_t callback, void *userData);
+
+/*!
+ * @brief Initializes the SAI Rx handle.
+ *
+ * This function initializes the Rx handle for SAI Rx transactional APIs. Call
+ * this function one time to get the handle initialized.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI handle pointer.
+ * @param callback pointer to user callback function
+ * @param userData user parameter passed to the callback function
+ */
+void SAI_TransferRxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transfer_callback_t callback, void *userData);
+
+/*!
+ * @brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI handle pointer.
+ * @param format Pointer to SAI audio data format structure.
+ * @param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * @param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is a master
+ * clock, this value should equal to masterClockHz in format.
+ * @return Status of this function. Return value is one of status_t.
+*/
+status_t SAI_TransferTxSetFormat(I2S_Type *base,
+                                 sai_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz);
+
+/*!
+ * @brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI handle pointer.
+ * @param format Pointer to SAI audio data format structure.
+ * @param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * @param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+ * @return Status of this function. Return value is one of status_t.
+*/
+status_t SAI_TransferRxSetFormat(I2S_Type *base,
+                                 sai_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz);
+
+/*!
+ * @brief Performs an interrupt non-blocking send transfer on SAI.
+ *
+ * @note This API returns immediately after the transfer initiates.
+ * Call the SAI_TxGetTransferStatusIRQ to poll the transfer status and check whether
+ * the transfer is finished. If the return status is not kStatus_SAI_Busy, the transfer
+ * is finished.
+ *
+ * @param base SAI base pointer
+ * @param handle pointer to sai_handle_t structure which stores the transfer state
+ * @param xfer pointer to sai_transfer_t structure
+ * @retval kStatus_Success Successfully started the data receive.
+ * @retval kStatus_SAI_TxBusy Previous receive still not finished.
+ * @retval kStatus_InvalidArgument The input parameter is invalid.
+ */
+status_t SAI_TransferSendNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_transfer_t *xfer);
+
+/*!
+ * @brief Performs an interrupt non-blocking receive transfer on SAI.
+ *
+ * @note This API returns immediately after the transfer initiates.
+ * Call the SAI_RxGetTransferStatusIRQ to poll the transfer status and check whether
+ * the transfer is finished. If the return status is not kStatus_SAI_Busy, the transfer
+ * is finished.
+ *
+ * @param base SAI base pointer
+ * @param handle pointer to sai_handle_t structure which stores the transfer state
+ * @param xfer pointer to sai_transfer_t structure
+ * @retval kStatus_Success Successfully started the data receive.
+ * @retval kStatus_SAI_RxBusy Previous receive still not finished.
+ * @retval kStatus_InvalidArgument The input parameter is invalid.
+ */
+status_t SAI_TransferReceiveNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_transfer_t *xfer);
+
+/*!
+ * @brief Gets a set byte count.
+ *
+ * @param base SAI base pointer.
+ * @param handle pointer to sai_handle_t structure which stores the transfer state.
+ * @param count Bytes count sent.
+ * @retval kStatus_Success Succeed get the transfer count.
+ * @retval kStatus_NoTransferInProgress There is not a non-blocking transaction currently in progress.
+ */
+status_t SAI_TransferGetSendCount(I2S_Type *base, sai_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Gets a received byte count.
+ *
+ * @param base SAI base pointer.
+ * @param handle pointer to sai_handle_t structure which stores the transfer state.
+ * @param count Bytes count received.
+ * @retval kStatus_Success Succeed get the transfer count.
+ * @retval kStatus_NoTransferInProgress There is not a non-blocking transaction currently in progress.
+ */
+status_t SAI_TransferGetReceiveCount(I2S_Type *base, sai_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Aborts the current send.
+ *
+ * @note This API can be called any time when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * @param base SAI base pointer.
+ * @param handle pointer to sai_handle_t structure which stores the transfer state.
+ */
+void SAI_TransferAbortSend(I2S_Type *base, sai_handle_t *handle);
+
+/*!
+ * @brief Aborts the the current IRQ receive.
+ *
+ * @note This API can be called any time when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * @param base SAI base pointer
+ * @param handle pointer to sai_handle_t structure which stores the transfer state.
+ */
+void SAI_TransferAbortReceive(I2S_Type *base, sai_handle_t *handle);
+
+/*!
+ * @brief Tx interrupt handler.
+ *
+ * @param base SAI base pointer.
+ * @param handle pointer to sai_handle_t structure.
+ */
+void SAI_TransferTxHandleIRQ(I2S_Type *base, sai_handle_t *handle);
+
+/*!
+ * @brief Tx interrupt handler.
+ *
+ * @param base SAI base pointer.
+ * @param handle pointer to sai_handle_t structure.
+ */
+void SAI_TransferRxHandleIRQ(I2S_Type *base, sai_handle_t *handle);
+
+/*! @} */
+
+#if defined(__cplusplus)
+}
+#endif /*_cplusplus*/
+
+/*! @} */
+
+#endif /* _FSL_SAI_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai_edma.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai_edma.c
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_sai_edma.h"
+
+/*******************************************************************************
+ * Definitations
+ ******************************************************************************/
+/* Used for 32byte aligned */
+#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)address + 32) & ~0x1FU)
+
+/*<! Structure definition for uart_edma_private_handle_t. The structure is private. */
+typedef struct _sai_edma_private_handle
+{
+    I2S_Type *base;
+    sai_edma_handle_t *handle;
+} sai_edma_private_handle_t;
+
+enum _sai_edma_transfer_state
+{
+    kSAI_Busy = 0x0U, /*!< SAI is busy */
+    kSAI_Idle,        /*!< Transfer is done. */
+};
+
+/*<! Private handle only used for internally. */
+static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][2];
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get the instance number for SAI.
+ *
+ * @param base SAI base pointer.
+ */
+extern uint32_t SAI_GetInstance(I2S_Type *base);
+
+/*!
+ * @brief SAI EDMA callback for send.
+ *
+ * @param handle pointer to sai_edma_handle_t structure which stores the transfer state.
+ * @param userData Parameter for user callback.
+ * @param done If the DMA transfer finished.
+ * @param tcds The TCD index.
+ */
+static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds);
+
+/*!
+ * @brief SAI EDMA callback for receive.
+ *
+ * @param handle pointer to sai_edma_handle_t structure which stores the transfer state.
+ * @param userData Parameter for user callback.
+ * @param done If the DMA transfer finished.
+ * @param tcds The TCD index.
+ */
+static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds);
+
+/*******************************************************************************
+* Code
+******************************************************************************/
+static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds)
+{
+    sai_edma_private_handle_t *privHandle = (sai_edma_private_handle_t *)userData;
+    sai_edma_handle_t *saiHandle = privHandle->handle;
+
+    /* If finished a blcok, call the callback function */
+    memset(&saiHandle->saiQueue[saiHandle->queueDriver], 0, sizeof(sai_transfer_t));
+    saiHandle->queueDriver = (saiHandle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
+    if (saiHandle->callback)
+    {
+        (saiHandle->callback)(privHandle->base, saiHandle, kStatus_SAI_TxIdle, saiHandle->userData);
+    }
+
+    /* If all data finished, just stop the transfer */
+    if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
+    {
+        SAI_TransferAbortSendEDMA(privHandle->base, saiHandle);
+    }
+}
+
+static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds)
+{
+    sai_edma_private_handle_t *privHandle = (sai_edma_private_handle_t *)userData;
+    sai_edma_handle_t *saiHandle = privHandle->handle;
+
+    /* If finished a blcok, call the callback function */
+    memset(&saiHandle->saiQueue[saiHandle->queueDriver], 0, sizeof(sai_transfer_t));
+    saiHandle->queueDriver = (saiHandle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
+    if (saiHandle->callback)
+    {
+        (saiHandle->callback)(privHandle->base, saiHandle, kStatus_SAI_RxIdle, saiHandle->userData);
+    }
+
+    /* If all data finished, just stop the transfer */
+    if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
+    {
+        SAI_TransferAbortReceiveEDMA(privHandle->base, saiHandle);
+    }
+}
+
+void SAI_TransferTxCreateHandleEDMA(
+    I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
+{
+    assert(handle && dmaHandle);
+
+    uint32_t instance = SAI_GetInstance(base);
+
+    /* Set sai base to handle */
+    handle->dmaHandle = dmaHandle;
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* Set SAI state to idle */
+    handle->state = kSAI_Idle;
+
+    s_edmaPrivateHandle[instance][0].base = base;
+    s_edmaPrivateHandle[instance][0].handle = handle;
+
+    /* Need to use scatter gather */
+    EDMA_InstallTCDMemory(dmaHandle, STCD_ADDR(handle->tcd), SAI_XFER_QUEUE_SIZE);
+
+    /* Install callback for Tx dma channel */
+    EDMA_SetCallback(dmaHandle, SAI_TxEDMACallback, &s_edmaPrivateHandle[instance][0]);
+}
+
+void SAI_TransferRxCreateHandleEDMA(
+    I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
+{
+    assert(handle && dmaHandle);
+
+    uint32_t instance = SAI_GetInstance(base);
+
+    /* Set sai base to handle */
+    handle->dmaHandle = dmaHandle;
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* Set SAI state to idle */
+    handle->state = kSAI_Idle;
+
+    s_edmaPrivateHandle[instance][1].base = base;
+    s_edmaPrivateHandle[instance][1].handle = handle;
+
+    /* Need to use scatter gather */
+    EDMA_InstallTCDMemory(dmaHandle, STCD_ADDR(handle->tcd), SAI_XFER_QUEUE_SIZE);
+
+    /* Install callback for Tx dma channel */
+    EDMA_SetCallback(dmaHandle, SAI_RxEDMACallback, &s_edmaPrivateHandle[instance][1]);
+}
+
+void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
+                                 sai_edma_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz)
+{
+    assert(handle && format);
+
+    /* Configure the audio format to SAI registers */
+    SAI_TxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
+
+    /* Get the tranfer size from format, this should be used in EDMA configuration */
+    handle->bytesPerFrame = format->bitWidth / 8U;
+
+    /* Update the data channel SAI used */
+    handle->channel = format->channel;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    handle->count = FSL_FEATURE_SAI_FIFO_COUNT - format->watermark;
+#else
+    handle->count = 1U;
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+}
+
+void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
+                                 sai_edma_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz)
+{
+    assert(handle && format);
+
+    /* Configure the audio format to SAI registers */
+    SAI_RxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
+
+    /* Get the tranfer size from format, this should be used in EDMA configuration */
+    handle->bytesPerFrame = format->bitWidth / 8U;
+
+    /* Update the data channel SAI used */
+    handle->channel = format->channel;
+
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    handle->count = format->watermark;
+#else
+    handle->count = 1U;
+#endif /* FSL_FEATURE_SAI_FIFO_COUNT */
+}
+
+status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
+{
+    assert(handle && xfer);
+
+    edma_transfer_config_t config = {0};
+    uint32_t destAddr = SAI_TxGetDataRegisterAddress(base, handle->channel);
+
+    /* Check if input parameter invalid */
+    if ((xfer->data == NULL) || (xfer->dataSize == 0U))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    if (handle->saiQueue[handle->queueUser].data)
+    {
+        return kStatus_SAI_QueueFull;
+    }
+
+    /* Change the state of handle */
+    handle->state = kSAI_Busy;
+
+    /* Update the queue state */
+    handle->transferSize[handle->queueUser] = xfer->dataSize;
+    handle->saiQueue[handle->queueUser].data = xfer->data;
+    handle->saiQueue[handle->queueUser].dataSize = xfer->dataSize;
+    handle->queueUser = (handle->queueUser + 1) % SAI_XFER_QUEUE_SIZE;
+
+    /* Prepare edma configure */
+    EDMA_PrepareTransfer(&config, xfer->data, handle->bytesPerFrame, (void *)destAddr, handle->bytesPerFrame,
+                         handle->count * handle->bytesPerFrame, xfer->dataSize, kEDMA_MemoryToPeripheral);
+
+    EDMA_SubmitTransfer(handle->dmaHandle, &config);
+
+    /* Start DMA transfer */
+    EDMA_StartTransfer(handle->dmaHandle);
+
+    /* Enable DMA enable bit */
+    SAI_TxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
+
+    /* Enable SAI Tx clock */
+    SAI_TxEnable(base, true);
+
+    return kStatus_Success;
+}
+
+status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
+{
+    assert(handle && xfer);
+
+    edma_transfer_config_t config = {0};
+    uint32_t srcAddr = SAI_RxGetDataRegisterAddress(base, handle->channel);
+
+    /* Check if input parameter invalid */
+    if ((xfer->data == NULL) || (xfer->dataSize == 0U))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    if (handle->saiQueue[handle->queueUser].data)
+    {
+        return kStatus_SAI_QueueFull;
+    }
+
+    /* Change the state of handle */
+    handle->state = kSAI_Busy;
+
+    /* Update queue state  */
+    handle->transferSize[handle->queueUser] = xfer->dataSize;
+    handle->saiQueue[handle->queueUser].data = xfer->data;
+    handle->saiQueue[handle->queueUser].dataSize = xfer->dataSize;
+    handle->queueUser = (handle->queueUser + 1) % SAI_XFER_QUEUE_SIZE;
+
+    /* Prepare edma configure */
+    EDMA_PrepareTransfer(&config, (void *)srcAddr, handle->bytesPerFrame, xfer->data, handle->bytesPerFrame,
+                         handle->count * handle->bytesPerFrame, xfer->dataSize, kEDMA_PeripheralToMemory);
+
+    EDMA_SubmitTransfer(handle->dmaHandle, &config);
+
+    /* Start DMA transfer */
+    EDMA_StartTransfer(handle->dmaHandle);
+
+    /* Enable DMA enable bit */
+    SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
+
+    /* Enable SAI Rx clock */
+    SAI_RxEnable(base, true);
+
+    return kStatus_Success;
+}
+
+void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Disable dma */
+    EDMA_AbortTransfer(handle->dmaHandle);
+
+    /* Disable DMA enable bit */
+    SAI_TxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
+
+    /* Set the handle state */
+    handle->state = kSAI_Idle;
+}
+
+void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Disable dma */
+    EDMA_AbortTransfer(handle->dmaHandle);
+
+    /* Disable DMA enable bit */
+    SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
+
+    /* Set the handle state */
+    handle->state = kSAI_Idle;
+}
+
+status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    status_t status = kStatus_Success;
+
+    if (handle->state != kSAI_Busy)
+    {
+        status = kStatus_NoTransferInProgress;
+    }
+    else
+    {
+        *count = (handle->transferSize[handle->queueDriver] -
+                  EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+    }
+
+    return status;
+}
+
+status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
+{
+    assert(handle);
+
+    status_t status = kStatus_Success;
+
+    if (handle->state != kSAI_Busy)
+    {
+        status = kStatus_NoTransferInProgress;
+    }
+    else
+    {
+        *count = (handle->transferSize[handle->queueDriver] -
+                  EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+    }
+
+    return status;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai_edma.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sai_edma.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_SAI_EDMA_H_
+#define _FSL_SAI_EDMA_H_
+
+#include "fsl_sai.h"
+#include "fsl_edma.h"
+
+/*!
+ * @addtogroup sai_edma
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+typedef struct _sai_edma_handle sai_edma_handle_t;
+
+/*! @brief SAI eDMA transfer callback function for finish and error */
+typedef void (*sai_edma_callback_t)(I2S_Type *base, sai_edma_handle_t *handle, status_t status, void *userData);
+
+/*! @brief SAI DMA transfer handle, users should not touch the content of the handle.*/
+struct _sai_edma_handle
+{
+    edma_handle_t *dmaHandle;                     /*!< DMA handler for SAI send */
+    uint8_t bytesPerFrame;                        /*!< Bytes in a frame */
+    uint8_t channel;                              /*!< Which data channel */
+    uint8_t count;                                /*!< The transfer data count in a DMA request */
+    uint32_t state;                               /*!< Internal state for SAI eDMA transfer */
+    sai_edma_callback_t callback;                 /*!< Callback for users while transfer finish or error occurs */
+    void *userData;                               /*!< User callback parameter */
+    edma_tcd_t tcd[SAI_XFER_QUEUE_SIZE + 1U];     /*!< TCD pool for eDMA transfer. */
+    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE]; /*!< Transfer queue storing queued transfer. */
+    size_t transferSize[SAI_XFER_QUEUE_SIZE];     /*!< Data bytes need to transfer */
+    volatile uint8_t queueUser;                   /*!< Index for user to queue transfer. */
+    volatile uint8_t queueDriver;                 /*!< Index for driver to get the transfer data and size */
+};
+
+/*******************************************************************************
+ * APIs
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name eDMA Transactional
+ * @{
+ */
+
+/*!
+ * @brief Initializes the SAI eDMA handle.
+ *
+ * This function initializes the SAI master DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ * @param base SAI peripheral base address.
+ * @param callback Pointer to user callback function.
+ * @param userData User parameter passed to the callback function.
+ * @param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
+void SAI_TransferTxCreateHandleEDMA(
+    I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle);
+
+/*!
+ * @brief Initializes the SAI Rx eDMA handle.
+ *
+ * This function initializes the SAI slave DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ * @param base SAI peripheral base address.
+ * @param callback Pointer to user callback function.
+ * @param userData User parameter passed to the callback function.
+ * @param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
+void SAI_TransferRxCreateHandleEDMA(
+    I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle);
+
+/*!
+ * @brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ * @param format Pointer to SAI audio data format structure.
+ * @param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * @param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+ * @retval kStatus_Success Audio format set successfully.
+ * @retval kStatus_InvalidArgument The input argument is invalid.
+*/
+void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
+                                 sai_edma_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz);
+
+/*!
+ * @brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ * @param format Pointer to SAI audio data format structure.
+ * @param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * @param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is the master
+ * clock, this value should equal to masterClockHz in format.
+ * @retval kStatus_Success Audio format set successfully.
+ * @retval kStatus_InvalidArgument The input argument is invalid.
+*/
+void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
+                                 sai_edma_handle_t *handle,
+                                 sai_transfer_format_t *format,
+                                 uint32_t mclkSourceClockHz,
+                                 uint32_t bclkSourceClockHz);
+
+/*!
+ * @brief Performs a non-blocking SAI transfer using DMA.
+ *
+ * @note This interface returns immediately after the transfer initiates. Call
+ * SAI_GetTransferStatus to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ * @param xfer Pointer to the DMA transfer structure.
+ * @retval kStatus_Success Start a SAI eDMA send successfully.
+ * @retval kStatus_InvalidArgument The input argument is invalid.
+ * @retval kStatus_TxBusy SAI is busy sending data.
+ */
+status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking SAI receive using eDMA.
+ *
+ * @note This interface returns immediately after the transfer initiates. Call
+ * the SAI_GetReceiveRemainingBytes to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * @param base SAI base pointer
+ * @param handle SAI eDMA handle pointer.
+ * @param xfer Pointer to DMA transfer structure.
+ * @retval kStatus_Success Start a SAI eDMA receive successfully.
+ * @retval kStatus_InvalidArgument The input argument is invalid.
+ * @retval kStatus_RxBusy SAI is busy receiving data.
+ */
+status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer);
+
+/*!
+ * @brief Aborts a SAI transfer using eDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
+ * @brief Aborts a SAI receive using eDMA.
+ *
+ * @param base SAI base pointer
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
+ * @brief Gets byte count sent by SAI.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ * @param count Bytes count sent by SAI.
+ * @retval kStatus_Success Succeed get the transfer count.
+ * @retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
+status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Gets byte count received by SAI.
+ *
+ * @param base SAI base pointer
+ * @param handle SAI eDMA handle pointer.
+ * @param count Bytes count received by SAI.
+ * @retval kStatus_Success Succeed get the transfer count.
+ * @retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
+status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count);
+
+/*! @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*!
+ * @}
+ */
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sdhc.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sdhc.c
@@ -1,0 +1,1294 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this
+ * list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice,
+ * this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_sdhc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*! @brief Clock setting */
+/* Max SD clock divisor from base clock */
+#define SDHC_MAX_DVS ((SDHC_SYSCTL_DVS_MASK >> SDHC_SYSCTL_DVS_SHIFT) + 1U)
+#define SDHC_INITIAL_DVS (1U)   /* Initial value of SD clock divisor */
+#define SDHC_INITIAL_CLKFS (2U) /* Initial value of SD clock frequency selector */
+#define SDHC_NEXT_DVS(x) ((x) += 1U)
+#define SDHC_PREV_DVS(x) ((x) -= 1U)
+#define SDHC_MAX_CLKFS ((SDHC_SYSCTL_SDCLKFS_MASK >> SDHC_SYSCTL_SDCLKFS_SHIFT) + 1U)
+#define SDHC_NEXT_CLKFS(x) ((x) <<= 1U)
+#define SDHC_PREV_CLKFS(x) ((x) >>= 1U)
+
+/*! @brief ADMA table configuration */
+typedef struct _sdhc_adma_table_config
+{
+    uint32_t *admaTable;     /*!< ADMA table address, can't be null if transfer way is ADMA1/ADMA2 */
+    uint32_t admaTableWords; /*!< ADMA table length united as words, can't be 0 if transfer way is ADMA1/ADMA2 */
+} sdhc_adma_table_config_t;
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Get the instance.
+ *
+ * @param base SDHC peripheral base address.
+ * @return Instance number.
+ */
+static uint32_t SDHC_GetInstance(SDHC_Type *base);
+
+/*!
+ * @brief Set transfer interrupt.
+ *
+ * @param base SDHC peripheral base address.
+ * @param usingInterruptSignal True to use IRQ signal.
+ */
+static void SDHC_SetTransferInterrupt(SDHC_Type *base, bool usingInterruptSignal);
+
+/*!
+ * @brief Start transfer according to current transfer state
+ *
+ * @param base SDHC peripheral base address.
+ * @param command Command to be sent.
+ * @param data Data to be transferred.
+ */
+static void SDHC_StartTransfer(SDHC_Type *base, sdhc_command_t *command, sdhc_data_t *data);
+
+/*!
+ * @brief Receive command response
+ *
+ * @param base SDHC peripheral base address.
+ * @param command Command to be sent.
+ */
+static void SDHC_ReceiveCommandResponse(SDHC_Type *base, sdhc_command_t *command);
+
+/*!
+ * @brief Read DATAPORT when buffer enable bit is set.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data Data to be read.
+ * @param transferredWords The number of data words have been transferred last time transaction.
+ * @return The number of total data words have been transferred after this time transaction.
+ */
+static uint32_t SDHC_ReadDataPort(SDHC_Type *base, sdhc_data_t *data, uint32_t transferredWords);
+
+/*!
+ * @brief Read data by using DATAPORT polling way.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data Data to be read.
+ * @retval kStatus_Fail Read DATAPORT failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+static status_t SDHC_ReadByDataPortBlocking(SDHC_Type *base, sdhc_data_t *data);
+
+/*!
+ * @brief Write DATAPORT when buffer enable bit is set.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data Data to be read.
+ * @param transferredWords The number of data words have been transferred last time.
+ * @return The number of total data words have been transferred after this time transaction.
+ */
+static uint32_t SDHC_WriteDataPort(SDHC_Type *base, sdhc_data_t *data, uint32_t transferredWords);
+
+/*!
+ * @brief Write data by using DATAPORT polling way.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data Data to be transferred.
+ * @retval kStatus_Fail Write DATAPORT failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+static status_t SDHC_WriteByDataPortBlocking(SDHC_Type *base, sdhc_data_t *data);
+
+/*!
+ * @brief Send command by using polling way.
+ *
+ * @param base SDHC peripheral base address.
+ * @param command Command to be sent.
+ * @retval kStatus_Fail Send command failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+static status_t SDHC_SendCommandBlocking(SDHC_Type *base, sdhc_command_t *command);
+
+/*!
+ * @brief Transfer data by DATAPORT and polling way.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data Data to be transferred.
+ * @retval kStatus_Fail Transfer data failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+static status_t SDHC_TransferByDataPortBlocking(SDHC_Type *base, sdhc_data_t *data);
+
+/*!
+ * @brief Transfer data by ADMA2 and polling way.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data Data to be transferred.
+ * @retval kStatus_Fail Transfer data failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+static status_t SDHC_TransferByAdma2Blocking(SDHC_Type *base, sdhc_data_t *data);
+
+/*!
+ * @brief Transfer data by polling way.
+ *
+ * @param dmaMode DMA mode.
+ * @param base SDHC peripheral base address.
+ * @param data Data to be transferred.
+ * @retval kStatus_Fail Transfer data failed.
+ * @retval kStatus_InvalidArgument Argument is invalid.
+ * @retval kStatus_Success Operate successfully.
+ */
+static status_t SDHC_TransferDataBlocking(sdhc_dma_mode_t dmaMode, SDHC_Type *base, sdhc_data_t *data);
+
+/*!
+ * @brief Handle card detect interrupt.
+ *
+ * @param handle SDHC handle.
+ * @param interruptFlags Card detect related interrupt flags.
+ */
+static void SDHC_TransferHandleCardDetect(sdhc_handle_t *handle, uint32_t interruptFlags);
+
+/*!
+ * @brief Handle command interrupt.
+ *
+ * @param base SDHC peripheral base address.
+ * @param handle SDHC handle.
+ * @param interruptFlags Command related interrupt flags.
+ */
+static void SDHC_TransferHandleCommand(SDHC_Type *base, sdhc_handle_t *handle, uint32_t interruptFlags);
+
+/*!
+ * @brief Handle data interrupt.
+ *
+ * @param base SDHC peripheral base address.
+ * @param handle SDHC handle.
+ * @param interruptFlags Data related interrupt flags.
+ */
+static void SDHC_TransferHandleData(SDHC_Type *base, sdhc_handle_t *handle, uint32_t interruptFlags);
+
+/*!
+ * @brief Handle SDIO card interrupt signal.
+ *
+ * @param handle SDHC handle.
+ */
+static void SDHC_TransferHandleSdioInterrupt(sdhc_handle_t *handle);
+
+/*!
+ * @brief Handle SDIO block gap event.
+ *
+ * @param handle SDHC handle.
+ */
+static void SDHC_TransferHandleSdioBlockGap(sdhc_handle_t *handle);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief SDHC internal handle pointer array */
+static sdhc_handle_t *s_sdhcHandle[FSL_FEATURE_SOC_SDHC_COUNT];
+
+/*! @brief SDHC base pointer array */
+static SDHC_Type *const s_sdhcBase[] = SDHC_BASE_PTRS;
+
+/*! @brief SDHC IRQ name array */
+static const IRQn_Type s_sdhcIRQ[] = SDHC_IRQS;
+
+/*! @brief SDHC clock array name */
+static const clock_ip_name_t s_sdhcClock[] = SDHC_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t SDHC_GetInstance(SDHC_Type *base)
+{
+    uint8_t instance = 0;
+
+    while ((instance < FSL_FEATURE_SOC_SDHC_COUNT) && (s_sdhcBase[instance] != base))
+    {
+        instance++;
+    }
+
+    assert(instance < FSL_FEATURE_SOC_SDHC_COUNT);
+
+    return instance;
+}
+
+static void SDHC_SetTransferInterrupt(SDHC_Type *base, bool usingInterruptSignal)
+{
+    uint32_t interruptEnabled; /* The Interrupt status flags to be enabled */
+    sdhc_dma_mode_t dmaMode = (sdhc_dma_mode_t)((base->PROCTL & SDHC_PROCTL_DMAS_MASK) >> SDHC_PROCTL_DMAS_SHIFT);
+    bool cardDetectDat3 = (bool)(base->PROCTL & SDHC_PROCTL_D3CD_MASK);
+
+    /* Disable all interrupts */
+    SDHC_DisableInterruptStatus(base, (uint32_t)kSDHC_AllInterruptFlags);
+    SDHC_DisableInterruptSignal(base, (uint32_t)kSDHC_AllInterruptFlags);
+    DisableIRQ(s_sdhcIRQ[SDHC_GetInstance(base)]);
+
+    interruptEnabled =
+        (kSDHC_CommandIndexErrorFlag | kSDHC_CommandCrcErrorFlag | kSDHC_CommandEndBitErrorFlag |
+         kSDHC_CommandTimeoutFlag | kSDHC_CommandCompleteFlag | kSDHC_DataTimeoutFlag | kSDHC_DataCrcErrorFlag |
+         kSDHC_DataEndBitErrorFlag | kSDHC_DataCompleteFlag | kSDHC_AutoCommand12ErrorFlag);
+    if (cardDetectDat3)
+    {
+        interruptEnabled |= (kSDHC_CardInsertionFlag | kSDHC_CardRemovalFlag);
+    }
+    switch (dmaMode)
+    {
+        case kSDHC_DmaModeAdma1:
+        case kSDHC_DmaModeAdma2:
+            interruptEnabled |= (kSDHC_DmaErrorFlag | kSDHC_DmaCompleteFlag);
+            break;
+        case kSDHC_DmaModeNo:
+            interruptEnabled |= (kSDHC_BufferReadReadyFlag | kSDHC_BufferWriteReadyFlag);
+            break;
+        default:
+            break;
+    }
+
+    SDHC_EnableInterruptStatus(base, interruptEnabled);
+    if (usingInterruptSignal)
+    {
+        SDHC_EnableInterruptSignal(base, interruptEnabled);
+    }
+}
+
+static void SDHC_StartTransfer(SDHC_Type *base, sdhc_command_t *command, sdhc_data_t *data)
+{
+    assert(command);
+
+    uint32_t flags = 0U;
+    sdhc_transfer_config_t sdhcTransferConfig;
+    sdhc_dma_mode_t dmaMode;
+
+    /* Define the flag corresponding to each response type. */
+    switch (command->responseType)
+    {
+        case kSDHC_ResponseTypeNone:
+            break;
+        case kSDHC_ResponseTypeR1: /* Response 1 */
+            flags |= (kSDHC_ResponseLength48Flag | kSDHC_EnableCrcCheckFlag | kSDHC_EnableIndexCheckFlag);
+            break;
+        case kSDHC_ResponseTypeR1b: /* Response 1 with busy */
+            flags |= (kSDHC_ResponseLength48BusyFlag | kSDHC_EnableCrcCheckFlag | kSDHC_EnableIndexCheckFlag);
+            break;
+        case kSDHC_ResponseTypeR2: /* Response 2 */
+            flags |= (kSDHC_ResponseLength136Flag | kSDHC_EnableCrcCheckFlag);
+            break;
+        case kSDHC_ResponseTypeR3: /* Response 3 */
+            flags |= (kSDHC_ResponseLength48Flag);
+            break;
+        case kSDHC_ResponseTypeR4: /* Response 4 */
+            flags |= (kSDHC_ResponseLength48Flag);
+            break;
+        case kSDHC_ResponseTypeR5: /* Response 5 */
+            flags |= (kSDHC_ResponseLength48Flag | kSDHC_EnableCrcCheckFlag);
+            break;
+        case kSDHC_ResponseTypeR5b: /* Response 5 with busy */
+            flags |= (kSDHC_ResponseLength48BusyFlag | kSDHC_EnableCrcCheckFlag | kSDHC_EnableIndexCheckFlag);
+            break;
+        case kSDHC_ResponseTypeR6: /* Response 6 */
+            flags |= (kSDHC_ResponseLength48Flag | kSDHC_EnableCrcCheckFlag | kSDHC_EnableIndexCheckFlag);
+            break;
+        case kSDHC_ResponseTypeR7: /* Response 7 */
+            flags |= (kSDHC_ResponseLength48Flag | kSDHC_EnableCrcCheckFlag | kSDHC_EnableIndexCheckFlag);
+            break;
+        default:
+            break;
+    }
+    if (command->type == kSDHC_CommandTypeAbort)
+    {
+        flags |= kSDHC_CommandTypeAbortFlag;
+    }
+
+    if (data)
+    {
+        flags |= kSDHC_DataPresentFlag;
+        dmaMode = (sdhc_dma_mode_t)((base->PROCTL & SDHC_PROCTL_DMAS_MASK) >> SDHC_PROCTL_DMAS_SHIFT);
+        if (dmaMode != kSDHC_DmaModeNo)
+        {
+            flags |= kSDHC_EnableDmaFlag;
+        }
+        if (data->rxData)
+        {
+            flags |= kSDHC_DataReadFlag;
+        }
+        if (data->blockCount > 1U)
+        {
+            flags |= (kSDHC_MultipleBlockFlag | kSDHC_EnableBlockCountFlag);
+            if (data->enableAutoCommand12)
+            {
+                /* Enable Auto command 12. */
+                flags |= kSDHC_EnableAutoCommand12Flag;
+            }
+        }
+        if (data->blockCount > SDHC_MAX_BLOCK_COUNT)
+        {
+            sdhcTransferConfig.dataBlockSize = data->blockSize;
+            sdhcTransferConfig.dataBlockCount = SDHC_MAX_BLOCK_COUNT;
+
+            flags &= ~(uint32_t)kSDHC_EnableBlockCountFlag;
+        }
+        else
+        {
+            sdhcTransferConfig.dataBlockSize = data->blockSize;
+            sdhcTransferConfig.dataBlockCount = data->blockCount;
+        }
+    }
+    else
+    {
+        sdhcTransferConfig.dataBlockSize = 0U;
+        sdhcTransferConfig.dataBlockCount = 0U;
+    }
+
+    sdhcTransferConfig.commandArgument = command->argument;
+    sdhcTransferConfig.commandIndex = command->index;
+    sdhcTransferConfig.flags = flags;
+    SDHC_SetTransferConfig(base, &sdhcTransferConfig);
+}
+
+static void SDHC_ReceiveCommandResponse(SDHC_Type *base, sdhc_command_t *command)
+{
+    assert(command);
+
+    uint32_t i;
+
+    if (command->responseType != kSDHC_ResponseTypeNone)
+    {
+        command->response[0U] = SDHC_GetCommandResponse(base, 0U);
+        if (command->responseType == kSDHC_ResponseTypeR2)
+        {
+            command->response[1U] = SDHC_GetCommandResponse(base, 1U);
+            command->response[2U] = SDHC_GetCommandResponse(base, 2U);
+            command->response[3U] = SDHC_GetCommandResponse(base, 3U);
+
+            i = 4U;
+            /* R3-R2-R1-R0(lowest 8 bit is invalid bit) has the same format as R2 format in SD specification document
+            after removed internal CRC7 and end bit. */
+            do
+            {
+                command->response[i - 1U] <<= 8U;
+                if (i > 1U)
+                {
+                    command->response[i - 1U] |= ((command->response[i - 2U] & 0xFF000000U) >> 24U);
+                }
+            } while (i--);
+        }
+    }
+}
+
+static uint32_t SDHC_ReadDataPort(SDHC_Type *base, sdhc_data_t *data, uint32_t transferredWords)
+{
+    assert(data);
+
+    uint32_t i;
+    uint32_t totalWords;
+    uint32_t wordsCanBeRead; /* The words can be read at this time. */
+    uint32_t readWatermark = ((base->WML & SDHC_WML_RDWML_MASK) >> SDHC_WML_RDWML_SHIFT);
+
+    totalWords = ((data->blockCount * data->blockSize) / sizeof(uint32_t));
+
+    /* If watermark level is equal or bigger than totalWords, transfers totalWords data. */
+    if (readWatermark >= totalWords)
+    {
+        wordsCanBeRead = totalWords;
+    }
+    /* If watermark level is less than totalWords and left words to be sent is equal or bigger than readWatermark,
+    transfers watermark level words. */
+    else if ((readWatermark < totalWords) && ((totalWords - transferredWords) >= readWatermark))
+    {
+        wordsCanBeRead = readWatermark;
+    }
+    /* If watermark level is less than totalWords and left words to be sent is less than readWatermark, transfers left
+    words. */
+    else
+    {
+        wordsCanBeRead = (totalWords - transferredWords);
+    }
+
+    i = 0U;
+    while (i < wordsCanBeRead)
+    {
+        data->rxData[transferredWords++] = SDHC_ReadData(base);
+        i++;
+    }
+
+    return transferredWords;
+}
+
+static status_t SDHC_ReadByDataPortBlocking(SDHC_Type *base, sdhc_data_t *data)
+{
+    assert(data);
+
+    uint32_t totalWords;
+    uint32_t transferredWords = 0U;
+    status_t error = kStatus_Success;
+
+    totalWords = ((data->blockCount * data->blockSize) / sizeof(uint32_t));
+
+    while ((error == kStatus_Success) && (transferredWords < totalWords))
+    {
+        while (!(SDHC_GetInterruptStatusFlags(base) & (kSDHC_BufferReadReadyFlag | kSDHC_DataErrorFlag)))
+        {
+        }
+
+        if (SDHC_GetInterruptStatusFlags(base) & kSDHC_DataErrorFlag)
+        {
+            if (!(data->enableIgnoreError))
+            {
+                error = kStatus_Fail;
+            }
+        }
+        if (error == kStatus_Success)
+        {
+            transferredWords = SDHC_ReadDataPort(base, data, transferredWords);
+        }
+
+        /* Clear buffer enable flag to trigger transfer. Clear data error flag when SDHC encounter error */
+        SDHC_ClearInterruptStatusFlags(base, (kSDHC_BufferReadReadyFlag | kSDHC_DataErrorFlag));
+    }
+
+    /* Clear data complete flag after the last read operation. */
+    SDHC_ClearInterruptStatusFlags(base, kSDHC_DataCompleteFlag);
+
+    return error;
+}
+
+static uint32_t SDHC_WriteDataPort(SDHC_Type *base, sdhc_data_t *data, uint32_t transferredWords)
+{
+    assert(data);
+
+    uint32_t i;
+    uint32_t totalWords;
+    uint32_t wordsCanBeWrote; /* Words can be wrote at this time. */
+    uint32_t writeWatermark = ((base->WML & SDHC_WML_WRWML_MASK) >> SDHC_WML_WRWML_SHIFT);
+
+    totalWords = ((data->blockCount * data->blockSize) / sizeof(uint32_t));
+
+    /* If watermark level is equal or bigger than totalWords, transfers totalWords data.*/
+    if (writeWatermark >= totalWords)
+    {
+        wordsCanBeWrote = totalWords;
+    }
+    /* If watermark level is less than totalWords and left words to be sent is equal or bigger than watermark,
+    transfers watermark level words. */
+    else if ((writeWatermark < totalWords) && ((totalWords - transferredWords) >= writeWatermark))
+    {
+        wordsCanBeWrote = writeWatermark;
+    }
+    /* If watermark level is less than totalWords and left words to be sent is less than watermark, transfers left
+    words. */
+    else
+    {
+        wordsCanBeWrote = (totalWords - transferredWords);
+    }
+
+    i = 0U;
+    while (i < wordsCanBeWrote)
+    {
+        SDHC_WriteData(base, data->txData[transferredWords++]);
+        i++;
+    }
+
+    return transferredWords;
+}
+
+static status_t SDHC_WriteByDataPortBlocking(SDHC_Type *base, sdhc_data_t *data)
+{
+    assert(data);
+
+    uint32_t totalWords;
+    uint32_t transferredWords = 0U;
+    status_t error = kStatus_Success;
+
+    totalWords = (data->blockCount * data->blockSize) / sizeof(uint32_t);
+
+    while ((error == kStatus_Success) && (transferredWords < totalWords))
+    {
+        while (!(SDHC_GetInterruptStatusFlags(base) & (kSDHC_BufferWriteReadyFlag | kSDHC_DataErrorFlag)))
+        {
+        }
+
+        if (SDHC_GetInterruptStatusFlags(base) & kSDHC_DataErrorFlag)
+        {
+            if (!(data->enableIgnoreError))
+            {
+                error = kStatus_Fail;
+            }
+        }
+        if (error == kStatus_Success)
+        {
+            transferredWords = SDHC_WriteDataPort(base, data, transferredWords);
+        }
+
+        /* Clear buffer enable flag to trigger transfer. Clear error flag when SDHC encounter error. */
+        SDHC_ClearInterruptStatusFlags(base, (kSDHC_BufferWriteReadyFlag | kSDHC_DataErrorFlag));
+    }
+
+    /* Wait write data complete or data transfer error after the last writing operation. */
+    while (!(SDHC_GetInterruptStatusFlags(base) & (kSDHC_DataCompleteFlag | kSDHC_DataErrorFlag)))
+    {
+    }
+    if (SDHC_GetInterruptStatusFlags(base) & kSDHC_DataErrorFlag)
+    {
+        if (!(data->enableIgnoreError))
+        {
+            error = kStatus_Fail;
+        }
+    }
+    SDHC_ClearInterruptStatusFlags(base, (kSDHC_DataCompleteFlag | kSDHC_DataErrorFlag));
+
+    return error;
+}
+
+static status_t SDHC_SendCommandBlocking(SDHC_Type *base, sdhc_command_t *command)
+{
+    assert(command);
+
+    status_t error = kStatus_Success;
+
+    /* Wait command complete or SDHC encounters error. */
+    while (!(SDHC_GetInterruptStatusFlags(base) & (kSDHC_CommandCompleteFlag | kSDHC_CommandErrorFlag)))
+    {
+    }
+
+    if (SDHC_GetInterruptStatusFlags(base) & kSDHC_CommandErrorFlag)
+    {
+        error = kStatus_Fail;
+    }
+    /* Receive response when command completes successfully. */
+    if (error == kStatus_Success)
+    {
+        SDHC_ReceiveCommandResponse(base, command);
+    }
+
+    SDHC_ClearInterruptStatusFlags(base, (kSDHC_CommandCompleteFlag | kSDHC_CommandErrorFlag));
+
+    return error;
+}
+
+static status_t SDHC_TransferByDataPortBlocking(SDHC_Type *base, sdhc_data_t *data)
+{
+    assert(data);
+
+    status_t error = kStatus_Success;
+
+    if (data->rxData)
+    {
+        error = SDHC_ReadByDataPortBlocking(base, data);
+    }
+    else
+    {
+        error = SDHC_WriteByDataPortBlocking(base, data);
+    }
+
+    return error;
+}
+
+static status_t SDHC_TransferByAdma2Blocking(SDHC_Type *base, sdhc_data_t *data)
+{
+    status_t error = kStatus_Success;
+
+    /* Wait data complete or SDHC encounters error. */
+    while (!(SDHC_GetInterruptStatusFlags(base) & (kSDHC_DataCompleteFlag | kSDHC_DataErrorFlag | kSDHC_DmaErrorFlag)))
+    {
+    }
+    if (SDHC_GetInterruptStatusFlags(base) & (kSDHC_DataErrorFlag | kSDHC_DmaErrorFlag))
+    {
+        if (!(data->enableIgnoreError))
+        {
+            error = kStatus_Fail;
+        }
+    }
+    SDHC_ClearInterruptStatusFlags(
+        base, (kSDHC_DataCompleteFlag | kSDHC_DmaCompleteFlag | kSDHC_DataErrorFlag | kSDHC_DmaErrorFlag));
+    return error;
+}
+
+#if defined FSL_SDHC_ENABLE_ADMA1
+#define SDHC_TransferByAdma1Blocking(base, data) SDHC_TransferByAdma2Blocking(base, data)
+#endif /* FSL_SDHC_ENABLE_ADMA1 */
+
+static status_t SDHC_TransferDataBlocking(sdhc_dma_mode_t dmaMode, SDHC_Type *base, sdhc_data_t *data)
+{
+    status_t error = kStatus_Success;
+
+    switch (dmaMode)
+    {
+        case kSDHC_DmaModeNo:
+            error = SDHC_TransferByDataPortBlocking(base, data);
+            break;
+#if defined FSL_SDHC_ENABLE_ADMA1
+        case kSDHC_DmaModeAdma1:
+            error = SDHC_TransferByAdma1Blocking(base, data);
+            break;
+#endif /* FSL_SDHC_ENABLE_ADMA1 */
+        case kSDHC_DmaModeAdma2:
+            error = SDHC_TransferByAdma2Blocking(base, data);
+            break;
+        default:
+            error = kStatus_InvalidArgument;
+            break;
+    }
+
+    return error;
+}
+
+static void SDHC_TransferHandleCardDetect(sdhc_handle_t *handle, uint32_t interruptFlags)
+{
+    assert(interruptFlags & kSDHC_CardDetectFlag);
+
+    if (interruptFlags & kSDHC_CardInsertionFlag)
+    {
+        if (handle->callback.CardInserted)
+        {
+            handle->callback.CardInserted();
+        }
+    }
+    else
+    {
+        if (handle->callback.CardRemoved)
+        {
+            handle->callback.CardRemoved();
+        }
+    }
+}
+
+static void SDHC_TransferHandleCommand(SDHC_Type *base, sdhc_handle_t *handle, uint32_t interruptFlags)
+{
+    assert(interruptFlags & kSDHC_CommandFlag);
+
+    if ((interruptFlags & kSDHC_CommandErrorFlag) && (!(handle->data)) && (handle->callback.TransferComplete))
+    {
+        handle->callback.TransferComplete(base, handle, kStatus_SDHC_SendCommandFailed, handle->userData);
+    }
+    else
+    {
+        /* Receive response */
+        SDHC_ReceiveCommandResponse(base, handle->command);
+        if ((!(handle->data)) && (handle->callback.TransferComplete))
+        {
+            handle->callback.TransferComplete(base, handle, kStatus_Success, handle->userData);
+        }
+    }
+}
+
+static void SDHC_TransferHandleData(SDHC_Type *base, sdhc_handle_t *handle, uint32_t interruptFlags)
+{
+    assert(handle->data);
+    assert(interruptFlags & kSDHC_DataFlag);
+
+    if ((!(handle->data->enableIgnoreError)) && (interruptFlags & (kSDHC_DataErrorFlag | kSDHC_DmaErrorFlag)) &&
+        (handle->callback.TransferComplete))
+    {
+        handle->callback.TransferComplete(base, handle, kStatus_SDHC_TransferDataFailed, handle->userData);
+    }
+    else
+    {
+        if (interruptFlags & kSDHC_BufferReadReadyFlag)
+        {
+            handle->transferredWords = SDHC_ReadDataPort(base, handle->data, handle->transferredWords);
+        }
+        else if (interruptFlags & kSDHC_BufferWriteReadyFlag)
+        {
+            handle->transferredWords = SDHC_WriteDataPort(base, handle->data, handle->transferredWords);
+        }
+        else if ((interruptFlags & kSDHC_DataCompleteFlag) && (handle->callback.TransferComplete))
+        {
+            handle->callback.TransferComplete(base, handle, kStatus_Success, handle->userData);
+        }
+        else
+        {
+            /* Do nothing when DMA complete flag is set. Wait until data complete flag is set. */
+        }
+    }
+}
+
+static void SDHC_TransferHandleSdioInterrupt(sdhc_handle_t *handle)
+{
+    if (handle->callback.SdioInterrupt)
+    {
+        handle->callback.SdioInterrupt();
+    }
+}
+
+static void SDHC_TransferHandleSdioBlockGap(sdhc_handle_t *handle)
+{
+    if (handle->callback.SdioBlockGap)
+    {
+        handle->callback.SdioBlockGap();
+    }
+}
+
+void SDHC_Init(SDHC_Type *base, const sdhc_config_t *config)
+{
+    assert(config);
+#if !defined FSL_SDHC_ENABLE_ADMA1
+    assert(config->dmaMode != kSDHC_DmaModeAdma1);
+#endif /* FSL_SDHC_ENABLE_ADMA1 */
+
+    uint32_t proctl;
+    uint32_t wml;
+
+    /* Enable SDHC clock. */
+    CLOCK_EnableClock(s_sdhcClock[SDHC_GetInstance(base)]);
+
+    /* Reset SDHC. */
+    SDHC_Reset(base, kSDHC_ResetAll, 100);
+
+    proctl = base->PROCTL;
+    wml = base->WML;
+
+    proctl &= ~(SDHC_PROCTL_D3CD_MASK | SDHC_PROCTL_EMODE_MASK | SDHC_PROCTL_DMAS_MASK);
+    /* Set DAT3 as card detection pin */
+    if (config->cardDetectDat3)
+    {
+        proctl |= SDHC_PROCTL_D3CD_MASK;
+    }
+    /* Endian mode and DMA mode */
+    proctl |= (SDHC_PROCTL_EMODE(config->endianMode) | SDHC_PROCTL_DMAS(config->dmaMode));
+
+    /* Watermark level */
+    wml &= ~(SDHC_WML_RDWML_MASK | SDHC_WML_WRWML_MASK);
+    wml |= (SDHC_WML_RDWML(config->readWatermarkLevel) | SDHC_WML_WRWML(config->writeWatermarkLevel));
+
+    base->WML = wml;
+    base->PROCTL = proctl;
+
+    /* Disable all clock auto gated off feature because of DAT0 line logic(card buffer full status) can't be updated
+    correctly when clock auto gated off is enabled. */
+    base->SYSCTL |= (SDHC_SYSCTL_PEREN_MASK | SDHC_SYSCTL_HCKEN_MASK | SDHC_SYSCTL_IPGEN_MASK);
+
+    /* Enable interrupt status but doesn't enable interrupt signal. */
+    SDHC_SetTransferInterrupt(base, false);
+}
+
+void SDHC_Deinit(SDHC_Type *base)
+{
+    /* Disable clock. */
+    CLOCK_DisableClock(s_sdhcClock[SDHC_GetInstance(base)]);
+}
+
+bool SDHC_Reset(SDHC_Type *base, uint32_t mask, uint32_t timeout)
+{
+    base->SYSCTL |= (mask & (SDHC_SYSCTL_RSTA_MASK | SDHC_SYSCTL_RSTC_MASK | SDHC_SYSCTL_RSTD_MASK));
+    /* Delay some time to wait reset success. */
+    while ((base->SYSCTL & mask))
+    {
+        if (!timeout)
+        {
+            break;
+        }
+        timeout--;
+    }
+
+    return ((!timeout) ? false : true);
+}
+
+void SDHC_GetCapability(SDHC_Type *base, sdhc_capability_t *capability)
+{
+    assert(capability);
+
+    uint32_t htCapability;
+    uint32_t hostVer;
+    uint32_t maxBlockLength;
+
+    hostVer = base->HOSTVER;
+    htCapability = base->HTCAPBLT;
+
+    /* Get the capability of SDHC. */
+    capability->specVersion = ((hostVer & SDHC_HOSTVER_SVN_MASK) >> SDHC_HOSTVER_SVN_SHIFT);
+    capability->vendorVersion = ((hostVer & SDHC_HOSTVER_VVN_MASK) >> SDHC_HOSTVER_VVN_SHIFT);
+    maxBlockLength = ((htCapability & SDHC_HTCAPBLT_MBL_MASK) >> SDHC_HTCAPBLT_MBL_SHIFT);
+    capability->maxBlockLength = (512U << maxBlockLength);
+    /* Other attributes not in HTCAPBLT register. */
+    capability->maxBlockCount = SDHC_MAX_BLOCK_COUNT;
+    capability->flags = (htCapability & (kSDHC_SupportAdmaFlag | kSDHC_SupportHighSpeedFlag | kSDHC_SupportDmaFlag |
+                                         kSDHC_SupportSuspendResumeFlag | kSDHC_SupportV330Flag));
+#if defined FSL_FEATURE_SDHC_HAS_V300_SUPPORT && FSL_FEATURE_SDHC_HAS_V300_SUPPORT
+    capability->flags |= (htCapability & kSDHC_SupportV300Flag);
+#endif
+#if defined FSL_FEATURE_SDHC_HAS_V180_SUPPORT && FSL_FEATURE_SDHC_HAS_V180_SUPPORT
+    capability->flags |= (htCapability & kSDHC_SupportV180Flag);
+#endif
+    /* eSDHC on all kinetis boards will support 4/8 bit data bus width. */
+    capability->flags |= (kSDHC_Support4BitFlag | kSDHC_Support8BitFlag);
+}
+
+uint32_t SDHC_SetSdClock(SDHC_Type *base, uint32_t srcClock_Hz, uint32_t busClock_Hz)
+{
+    assert(busClock_Hz && (busClock_Hz < srcClock_Hz));
+
+    uint32_t divisor;
+    uint32_t prescaler;
+    uint32_t sysctl;
+    uint32_t nearestFrequency = 0;
+
+    divisor = SDHC_INITIAL_DVS;
+    prescaler = SDHC_INITIAL_CLKFS;
+
+    /* Disable SD clock. It should be disabled before changing the SD clock frequency.*/
+    base->SYSCTL &= ~SDHC_SYSCTL_SDCLKEN_MASK;
+
+    if (busClock_Hz > 0U)
+    {
+        while ((srcClock_Hz / prescaler / SDHC_MAX_DVS > busClock_Hz) && (prescaler < SDHC_MAX_CLKFS))
+        {
+            SDHC_NEXT_CLKFS(prescaler);
+        }
+        while ((srcClock_Hz / prescaler / divisor > busClock_Hz) && (divisor < SDHC_MAX_DVS))
+        {
+            SDHC_NEXT_DVS(divisor);
+        }
+        nearestFrequency = srcClock_Hz / prescaler / divisor;
+        SDHC_PREV_CLKFS(prescaler);
+        SDHC_PREV_DVS(divisor);
+
+        /* Set the SD clock frequency divisor, SD clock frequency select, data timeout counter value. */
+        sysctl = base->SYSCTL;
+        sysctl &= ~(SDHC_SYSCTL_DVS_MASK | SDHC_SYSCTL_SDCLKFS_MASK | SDHC_SYSCTL_DTOCV_MASK);
+        sysctl |= (SDHC_SYSCTL_DVS(divisor) | SDHC_SYSCTL_SDCLKFS(prescaler) | SDHC_SYSCTL_DTOCV(0xEU));
+        base->SYSCTL = sysctl;
+
+        /* Wait until the SD clock is stable. */
+        while (!(base->PRSSTAT & SDHC_PRSSTAT_SDSTB_MASK))
+        {
+        }
+        /* Enable the SD clock. */
+        base->SYSCTL |= SDHC_SYSCTL_SDCLKEN_MASK;
+    }
+
+    return nearestFrequency;
+}
+
+bool SDHC_SetCardActive(SDHC_Type *base, uint32_t timeout)
+{
+    base->SYSCTL |= SDHC_SYSCTL_INITA_MASK;
+    /* Delay some time to wait card become active state. */
+    while (!(base->SYSCTL & SDHC_SYSCTL_INITA_MASK))
+    {
+        if (!timeout)
+        {
+            break;
+        }
+        timeout--;
+    }
+
+    return ((!timeout) ? false : true);
+}
+
+void SDHC_SetTransferConfig(SDHC_Type *base, const sdhc_transfer_config_t *config)
+{
+    assert(config);
+
+    base->BLKATTR = ((base->BLKATTR & ~(SDHC_BLKATTR_BLKSIZE_MASK | SDHC_BLKATTR_BLKCNT_MASK)) |
+                     (SDHC_BLKATTR_BLKSIZE(config->dataBlockSize) | SDHC_BLKATTR_BLKCNT(config->dataBlockCount)));
+    base->CMDARG = config->commandArgument;
+    base->XFERTYP = (((config->commandIndex << SDHC_XFERTYP_CMDINX_SHIFT) & SDHC_XFERTYP_CMDINX_MASK) |
+                     (config->flags & (SDHC_XFERTYP_DMAEN_MASK | SDHC_XFERTYP_MSBSEL_MASK | SDHC_XFERTYP_DPSEL_MASK |
+                                       SDHC_XFERTYP_CMDTYP_MASK | SDHC_XFERTYP_BCEN_MASK | SDHC_XFERTYP_CICEN_MASK |
+                                       SDHC_XFERTYP_CCCEN_MASK | SDHC_XFERTYP_RSPTYP_MASK | SDHC_XFERTYP_DTDSEL_MASK |
+                                       SDHC_XFERTYP_AC12EN_MASK)));
+}
+
+void SDHC_EnableSdioControl(SDHC_Type *base, uint32_t mask, bool enable)
+{
+    uint32_t proctl = base->PROCTL;
+    uint32_t vendor = base->VENDOR;
+
+    if (enable)
+    {
+        if (mask & kSDHC_StopAtBlockGapFlag)
+        {
+            proctl |= SDHC_PROCTL_SABGREQ_MASK;
+        }
+        if (mask & kSDHC_ReadWaitControlFlag)
+        {
+            proctl |= SDHC_PROCTL_RWCTL_MASK;
+        }
+        if (mask & kSDHC_InterruptAtBlockGapFlag)
+        {
+            proctl |= SDHC_PROCTL_IABG_MASK;
+        }
+        if (mask & kSDHC_ExactBlockNumberReadFlag)
+        {
+            vendor |= SDHC_VENDOR_EXBLKNU_MASK;
+        }
+    }
+    else
+    {
+        if (mask & kSDHC_StopAtBlockGapFlag)
+        {
+            proctl &= ~SDHC_PROCTL_SABGREQ_MASK;
+        }
+        if (mask & kSDHC_ReadWaitControlFlag)
+        {
+            proctl &= ~SDHC_PROCTL_RWCTL_MASK;
+        }
+        if (mask & kSDHC_InterruptAtBlockGapFlag)
+        {
+            proctl &= ~SDHC_PROCTL_IABG_MASK;
+        }
+        if (mask & kSDHC_ExactBlockNumberReadFlag)
+        {
+            vendor &= ~SDHC_VENDOR_EXBLKNU_MASK;
+        }
+    }
+
+    base->PROCTL = proctl;
+    base->VENDOR = vendor;
+}
+
+void SDHC_SetMmcBootConfig(SDHC_Type *base, const sdhc_boot_config_t *config)
+{
+    assert(config);
+
+    uint32_t mmcboot;
+
+    mmcboot = base->MMCBOOT;
+    mmcboot |= (SDHC_MMCBOOT_DTOCVACK(config->ackTimeoutCount) | SDHC_MMCBOOT_BOOTMODE(config->bootMode) |
+                SDHC_MMCBOOT_BOOTBLKCNT(config->blockCount));
+    if (config->enableBootAck)
+    {
+        mmcboot |= SDHC_MMCBOOT_BOOTACK_MASK;
+    }
+    if (config->enableBoot)
+    {
+        mmcboot |= SDHC_MMCBOOT_BOOTEN_MASK;
+    }
+    if (config->enableAutoStopAtBlockGap)
+    {
+        mmcboot |= SDHC_MMCBOOT_AUTOSABGEN_MASK;
+    }
+    base->MMCBOOT = mmcboot;
+}
+
+status_t SDHC_SetAdmaTableConfig(SDHC_Type *base,
+                                 sdhc_dma_mode_t dmaMode,
+                                 uint32_t *table,
+                                 uint32_t tableWords,
+                                 const uint32_t *data,
+                                 uint32_t dataBytes)
+{
+    status_t error = kStatus_Success;
+    const uint32_t *startAddress;
+    uint32_t entries;
+    uint32_t i;
+#if defined FSL_SDHC_ENABLE_ADMA1
+    sdhc_adma1_descriptor_t *adma1EntryAddress;
+#endif
+    sdhc_adma2_descriptor_t *adma2EntryAddress;
+
+    if ((((!table) || (!tableWords)) && ((dmaMode == kSDHC_DmaModeAdma1) || (dmaMode == kSDHC_DmaModeAdma2))) ||
+        (!data) || (!dataBytes)
+#if !defined FSL_SDHC_ENABLE_ADMA1
+        || (dmaMode == kSDHC_DmaModeAdma1)
+#endif /* FSL_SDHC_ENABLE_ADMA1 */
+            )
+    {
+        error = kStatus_InvalidArgument;
+    }
+    else
+    {
+        switch (dmaMode)
+        {
+            case kSDHC_DmaModeNo:
+                break;
+#if defined FSL_SDHC_ENABLE_ADMA1
+            case kSDHC_DmaModeAdma1:
+                startAddress = data;
+                /* Check if ADMA descriptor's number is enough. */
+                entries = ((dataBytes / SDHC_ADMA1_DESCRIPTOR_MAX_LENGTH_PER_ENTRY) + 1U);
+                /* ADMA1 needs two descriptors to finish a transfer */
+                entries <<= 1U;
+                if (entries > ((tableWords * sizeof(uint32_t)) / sizeof(sdhc_adma1_descriptor_t)))
+                {
+                    error = kStatus_OutOfRange;
+                }
+                else
+                {
+                    adma1EntryAddress = (sdhc_adma1_descriptor_t *)(table);
+                    for (i = 0U; i < entries; i += 2U)
+                    {
+                        /* Each descriptor for ADMA1 is 32-bit in length */
+                        if ((dataBytes - sizeof(uint32_t) * (startAddress - data)) <=
+                            SDHC_ADMA1_DESCRIPTOR_MAX_LENGTH_PER_ENTRY)
+                        {
+                            /* The last piece of data, setting end flag in descriptor */
+                            adma1EntryAddress[i] = ((uint32_t)(dataBytes - sizeof(uint32_t) * (startAddress - data))
+                                                    << SDHC_ADMA1_DESCRIPTOR_LENGTH_SHIFT);
+                            adma1EntryAddress[i] |= kSDHC_Adma1DescriptorTypeSetLength;
+                            adma1EntryAddress[i + 1U] =
+                                ((uint32_t)(startAddress) << SDHC_ADMA1_DESCRIPTOR_ADDRESS_SHIFT);
+                            adma1EntryAddress[i + 1U] |=
+                                (SDHC_ADMA1_DESCRIPTOR_TYPE_TRANSFER | SDHC_ADMA1_DESCRIPTOR_END_MASK);
+                        }
+                        else
+                        {
+                            adma1EntryAddress[i] = ((uint32_t)SDHC_ADMA1_DESCRIPTOR_MAX_LENGTH_PER_ENTRY
+                                                    << SDHC_ADMA1_DESCRIPTOR_LENGTH_SHIFT);
+                            adma1EntryAddress[i] |= kSDHC_Adma1DescriptorTypeSetLength;
+                            adma1EntryAddress[i + 1U] =
+                                ((uint32_t)(startAddress) << SDHC_ADMA1_DESCRIPTOR_ADDRESS_SHIFT);
+                            adma1EntryAddress[i + 1U] |= kSDHC_Adma1DescriptorTypeTransfer;
+                            startAddress += SDHC_ADMA1_DESCRIPTOR_MAX_LENGTH_PER_ENTRY / sizeof(uint32_t);
+                        }
+                    }
+
+                    /* When use ADMA, disable simple DMA */
+                    base->DSADDR = 0U;
+                    base->ADSADDR = (uint32_t)table;
+                }
+                break;
+#endif /* FSL_SDHC_ENABLE_ADMA1 */
+            case kSDHC_DmaModeAdma2:
+                startAddress = data;
+                /* Check if ADMA descriptor's number is enough. */
+                entries = ((dataBytes / SDHC_ADMA2_DESCRIPTOR_MAX_LENGTH_PER_ENTRY) + 1U);
+                if (entries > ((tableWords * sizeof(uint32_t)) / sizeof(sdhc_adma2_descriptor_t)))
+                {
+                    error = kStatus_OutOfRange;
+                }
+                else
+                {
+                    adma2EntryAddress = (sdhc_adma2_descriptor_t *)(table);
+                    for (i = 0U; i < entries; i++)
+                    {
+                        /* Each descriptor for ADMA2 is 64-bit in length */
+                        if ((dataBytes - sizeof(uint32_t) * (startAddress - data)) <=
+                            SDHC_ADMA2_DESCRIPTOR_MAX_LENGTH_PER_ENTRY)
+                        {
+                            /* The last piece of data, setting end flag in descriptor */
+                            adma2EntryAddress[i].address = startAddress;
+                            adma2EntryAddress[i].attribute = ((dataBytes - sizeof(uint32_t) * (startAddress - data))
+                                                              << SDHC_ADMA2_DESCRIPTOR_LENGTH_SHIFT);
+                            adma2EntryAddress[i].attribute |=
+                                (kSDHC_Adma2DescriptorTypeTransfer | kSDHC_Adma2DescriptorEndFlag);
+                        }
+                        else
+                        {
+                            adma2EntryAddress[i].address = startAddress;
+                            adma2EntryAddress[i].attribute =
+                                (((SDHC_ADMA2_DESCRIPTOR_MAX_LENGTH_PER_ENTRY / sizeof(uint32_t)) * sizeof(uint32_t))
+                                 << SDHC_ADMA2_DESCRIPTOR_LENGTH_SHIFT);
+                            adma2EntryAddress[i].attribute |= kSDHC_Adma2DescriptorTypeTransfer;
+                            startAddress += (SDHC_ADMA2_DESCRIPTOR_MAX_LENGTH_PER_ENTRY / sizeof(uint32_t));
+                        }
+                    }
+
+                    /* When use ADMA, disable simple DMA */
+                    base->DSADDR = 0U;
+                    base->ADSADDR = (uint32_t)table;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    return error;
+}
+
+status_t SDHC_TransferBlocking(SDHC_Type *base, uint32_t *admaTable, uint32_t admaTableWords, sdhc_transfer_t *transfer)
+{
+    assert(transfer);
+    assert(transfer->command); /* Command must not be NULL, data can be NULL. */
+
+    status_t error = kStatus_Success;
+    sdhc_dma_mode_t dmaMode = (sdhc_dma_mode_t)((base->PROCTL & SDHC_PROCTL_DMAS_MASK) >> SDHC_PROCTL_DMAS_SHIFT);
+    sdhc_command_t *command = transfer->command;
+    sdhc_data_t *data = transfer->data;
+
+    /* DATA-PORT is 32-bit align, ADMA2 4 bytes align, ADMA1 is 4096 bytes align */
+    if ((!command) || (data && (data->blockSize % 4U)))
+    {
+        error = kStatus_InvalidArgument;
+    }
+    else
+    {
+        /* Wait until command/data bus out of busy status. */
+        while (SDHC_GetPresentStatusFlags(base) & kSDHC_CommandInhibitFlag)
+        {
+        }
+        while (data && (SDHC_GetPresentStatusFlags(base) & kSDHC_DataInhibitFlag))
+        {
+        }
+
+        /* Update ADMA descriptor table if data isn't NULL. */
+        if (data && (kStatus_Success != SDHC_SetAdmaTableConfig(base, dmaMode, admaTable, admaTableWords,
+                                                                (data->rxData ? data->rxData : data->txData),
+                                                                (data->blockCount * data->blockSize))))
+        {
+            error = kStatus_SDHC_PrepareAdmaDescriptorFailed;
+        }
+        else
+        {
+            SDHC_StartTransfer(base, command, data);
+
+            /* Send command and receive data. */
+            if (kStatus_Success != SDHC_SendCommandBlocking(base, command))
+            {
+                error = kStatus_SDHC_SendCommandFailed;
+            }
+            else if (data && (kStatus_Success != SDHC_TransferDataBlocking(dmaMode, base, data)))
+            {
+                error = kStatus_SDHC_TransferDataFailed;
+            }
+            else
+            {
+            }
+        }
+    }
+
+    return error;
+}
+
+void SDHC_TransferCreateHandle(SDHC_Type *base,
+                               sdhc_handle_t *handle,
+                               const sdhc_transfer_callback_t *callback,
+                               void *userData)
+{
+    assert(handle);
+    assert(callback);
+
+    /* Zero the handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    /* Set the callback. */
+    handle->callback.CardInserted = callback->CardInserted;
+    handle->callback.CardRemoved = callback->CardRemoved;
+    handle->callback.SdioInterrupt = callback->SdioInterrupt;
+    handle->callback.SdioBlockGap = callback->SdioBlockGap;
+    handle->callback.TransferComplete = callback->TransferComplete;
+    handle->userData = userData;
+
+    /* Save the handle in global variables to support the double weak mechanism. */
+    s_sdhcHandle[SDHC_GetInstance(base)] = handle;
+
+    /* Enable interrupt in NVIC. */
+    SDHC_SetTransferInterrupt(base, true);
+    EnableIRQ(s_sdhcIRQ[SDHC_GetInstance(base)]);
+}
+
+status_t SDHC_TransferNonBlocking(
+    SDHC_Type *base, sdhc_handle_t *handle, uint32_t *admaTable, uint32_t admaTableWords, sdhc_transfer_t *transfer)
+{
+    assert(transfer);
+
+    sdhc_dma_mode_t dmaMode = (sdhc_dma_mode_t)((base->PROCTL & SDHC_PROCTL_DMAS_MASK) >> SDHC_PROCTL_DMAS_SHIFT);
+    status_t error = kStatus_Success;
+    sdhc_command_t *command = transfer->command;
+    sdhc_data_t *data = transfer->data;
+
+    /* DATA-PORT is 32-bit align, ADMA2 4 bytes align, ADMA1 is 4096 bytes align */
+    if ((!(transfer->command)) || ((transfer->data) && (transfer->data->blockSize % 4U)))
+    {
+        error = kStatus_InvalidArgument;
+    }
+    else
+    {
+        /* Wait until command/data bus out of busy status. */
+        if ((SDHC_GetPresentStatusFlags(base) & kSDHC_CommandInhibitFlag) ||
+            (data && (SDHC_GetPresentStatusFlags(base) & kSDHC_DataInhibitFlag)))
+        {
+            error = kStatus_SDHC_BusyTransferring;
+        }
+        else
+        {
+            /* Update ADMA descriptor table and reset transferred words if data isn't NULL. */
+            if (data && (kStatus_Success != SDHC_SetAdmaTableConfig(base, dmaMode, admaTable, admaTableWords,
+                                                                    (data->rxData ? data->rxData : data->txData),
+                                                                    (data->blockCount * data->blockSize))))
+            {
+                error = kStatus_SDHC_PrepareAdmaDescriptorFailed;
+            }
+            else
+            {
+                /* Save command and data into handle before transferring. */
+                handle->command = command;
+                handle->data = data;
+                handle->interruptFlags = 0U;
+                /* transferredWords will only be updated in ISR when transfer way is DATAPORT. */
+                handle->transferredWords = 0U;
+                SDHC_StartTransfer(base, command, data);
+            }
+        }
+    }
+
+    return error;
+}
+
+void SDHC_TransferHandleIRQ(SDHC_Type *base, sdhc_handle_t *handle)
+{
+    assert(handle);
+
+    uint32_t interruptFlags;
+
+    interruptFlags = SDHC_GetInterruptStatusFlags(base);
+    handle->interruptFlags = interruptFlags;
+
+    if (interruptFlags & kSDHC_CardDetectFlag)
+    {
+        SDHC_TransferHandleCardDetect(handle, (interruptFlags & kSDHC_CardDetectFlag));
+    }
+    if (interruptFlags & kSDHC_CommandFlag)
+    {
+        SDHC_TransferHandleCommand(base, handle, (interruptFlags & kSDHC_CommandFlag));
+    }
+    if (interruptFlags & kSDHC_DataFlag)
+    {
+        SDHC_TransferHandleData(base, handle, (interruptFlags & kSDHC_DataFlag));
+    }
+    if (interruptFlags & kSDHC_CardInterruptFlag)
+    {
+        SDHC_TransferHandleSdioInterrupt(handle);
+    }
+    if (interruptFlags & kSDHC_BlockGapEventFlag)
+    {
+        SDHC_TransferHandleSdioBlockGap(handle);
+    }
+
+    SDHC_ClearInterruptStatusFlags(base, interruptFlags);
+}
+
+#if defined(SDHC)
+void SDHC_DriverIRQHandler(void)
+{
+    assert(s_sdhcHandle[0]);
+
+    SDHC_TransferHandleIRQ(SDHC, s_sdhcHandle[0]);
+}
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sdhc.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sdhc.h
@@ -1,0 +1,1082 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_SDHC_H_
+#define _FSL_SDHC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup sdhc
+ * @{
+ */
+
+/*! @file */
+
+/******************************************************************************
+ * Definitions.
+ *****************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief Driver version 2.0.0. */
+#define FSL_SDHC_DRIVER_VERSION (MAKE_VERSION(2U, 0U, 0U))
+/*@}*/
+
+/*! @brief Maximum block count can be set one time */
+#define SDHC_MAX_BLOCK_COUNT (SDHC_BLKATTR_BLKCNT_MASK >> SDHC_BLKATTR_BLKCNT_SHIFT)
+
+/*! @brief SDHC status */
+enum _sdhc_status
+{
+    kStatus_SDHC_BusyTransferring = MAKE_STATUS(kStatusGroup_SDHC, 0U),            /*!< Transfer is on-going */
+    kStatus_SDHC_PrepareAdmaDescriptorFailed = MAKE_STATUS(kStatusGroup_SDHC, 1U), /*!< Set DMA descriptor failed */
+    kStatus_SDHC_SendCommandFailed = MAKE_STATUS(kStatusGroup_SDHC, 2U),           /*!< Send command failed */
+    kStatus_SDHC_TransferDataFailed = MAKE_STATUS(kStatusGroup_SDHC, 3U),          /*!< Transfer data failed */
+};
+
+/*! @brief Host controller capabilities flag mask */
+enum _sdhc_capability_flag
+{
+    kSDHC_SupportAdmaFlag = SDHC_HTCAPBLT_ADMAS_MASK,        /*!< Support ADMA */
+    kSDHC_SupportHighSpeedFlag = SDHC_HTCAPBLT_HSS_MASK,     /*!< Support high-speed */
+    kSDHC_SupportDmaFlag = SDHC_HTCAPBLT_DMAS_MASK,          /*!< Support DMA */
+    kSDHC_SupportSuspendResumeFlag = SDHC_HTCAPBLT_SRS_MASK, /*!< Support suspend/resume */
+    kSDHC_SupportV330Flag = SDHC_HTCAPBLT_VS33_MASK,         /*!< Support voltage 3.3V */
+#if defined FSL_FEATURE_SDHC_HAS_V300_SUPPORT && FSL_FEATURE_SDHC_HAS_V300_SUPPORT
+    kSDHC_SupportV300Flag = SDHC_HTCAPBLT_VS30_MASK, /*!< Support voltage 3.0V */
+#endif
+#if defined FSL_FEATURE_SDHC_HAS_V180_SUPPORT && FSL_FEATURE_SDHC_HAS_V180_SUPPORT
+    kSDHC_SupportV180Flag = SDHC_HTCAPBLT_VS18_MASK, /*!< Support voltage 1.8V */
+#endif
+    /* Put additional two flags in HTCAPBLT_MBL's position. */
+    kSDHC_Support4BitFlag = (SDHC_HTCAPBLT_MBL_SHIFT << 0U), /*!< Support 4 bit mode */
+    kSDHC_Support8BitFlag = (SDHC_HTCAPBLT_MBL_SHIFT << 1U), /*!< Support 8 bit mode */
+};
+
+/*! @brief Wakeup event mask */
+enum _sdhc_wakeup_event
+{
+    kSDHC_WakeupEventOnCardInt = SDHC_PROCTL_WECINT_MASK,    /*!< Wakeup on card interrupt */
+    kSDHC_WakeupEventOnCardInsert = SDHC_PROCTL_WECINS_MASK, /*!< Wakeup on card insertion */
+    kSDHC_WakeupEventOnCardRemove = SDHC_PROCTL_WECRM_MASK,  /*!< Wakeup on card removal */
+
+    kSDHC_WakeupEventsAll = (kSDHC_WakeupEventOnCardInt | kSDHC_WakeupEventOnCardInsert |
+                             kSDHC_WakeupEventOnCardRemove), /*!< All wakeup events */
+};
+
+/*! @brief Reset type mask */
+enum _sdhc_reset
+{
+    kSDHC_ResetAll = SDHC_SYSCTL_RSTA_MASK,     /*!< Reset all except card detection */
+    kSDHC_ResetCommand = SDHC_SYSCTL_RSTC_MASK, /*!< Reset command line */
+    kSDHC_ResetData = SDHC_SYSCTL_RSTD_MASK,    /*!< Reset data line */
+
+    kSDHC_ResetsAll = (kSDHC_ResetAll | kSDHC_ResetCommand | kSDHC_ResetData), /*!< All reset types */
+};
+
+/*! @brief Transfer flag mask */
+enum _sdhc_transfer_flag
+{
+    kSDHC_EnableDmaFlag = SDHC_XFERTYP_DMAEN_MASK, /*!< Enable DMA */
+
+    kSDHC_CommandTypeSuspendFlag = (SDHC_XFERTYP_CMDTYP(1U)), /*!< Suspend command */
+    kSDHC_CommandTypeResumeFlag = (SDHC_XFERTYP_CMDTYP(2U)),  /*!< Resume command */
+    kSDHC_CommandTypeAbortFlag = (SDHC_XFERTYP_CMDTYP(3U)),   /*!< Abort command */
+
+    kSDHC_EnableBlockCountFlag = SDHC_XFERTYP_BCEN_MASK,      /*!< Enable block count */
+    kSDHC_EnableAutoCommand12Flag = SDHC_XFERTYP_AC12EN_MASK, /*!< Enable auto CMD12 */
+    kSDHC_DataReadFlag = SDHC_XFERTYP_DTDSEL_MASK,            /*!< Enable data read */
+    kSDHC_MultipleBlockFlag = SDHC_XFERTYP_MSBSEL_MASK,       /*!< Multiple block data read/write */
+
+    kSDHC_ResponseLength136Flag = SDHC_XFERTYP_RSPTYP(1U),    /*!< 136 bit response length */
+    kSDHC_ResponseLength48Flag = SDHC_XFERTYP_RSPTYP(2U),     /*!< 48 bit response length */
+    kSDHC_ResponseLength48BusyFlag = SDHC_XFERTYP_RSPTYP(3U), /*!< 48 bit response length with busy status */
+
+    kSDHC_EnableCrcCheckFlag = SDHC_XFERTYP_CCCEN_MASK,   /*!< Enable CRC check */
+    kSDHC_EnableIndexCheckFlag = SDHC_XFERTYP_CICEN_MASK, /*!< Enable index check */
+    kSDHC_DataPresentFlag = SDHC_XFERTYP_DPSEL_MASK,      /*!< Data present flag */
+};
+
+/*! @brief Present status flag mask */
+enum _sdhc_present_status_flag
+{
+    kSDHC_CommandInhibitFlag = SDHC_PRSSTAT_CIHB_MASK,     /*!< Command inhibit */
+    kSDHC_DataInhibitFlag = SDHC_PRSSTAT_CDIHB_MASK,       /*!< Data inhibit */
+    kSDHC_DataLineActiveFlag = SDHC_PRSSTAT_DLA_MASK,      /*!< Data line active */
+    kSDHC_SdClockStableFlag = SDHC_PRSSTAT_SDSTB_MASK,     /*!< SD bus clock stable */
+    kSDHC_WriteTransferActiveFlag = SDHC_PRSSTAT_WTA_MASK, /*!< Write transfer active */
+    kSDHC_ReadTransferActiveFlag = SDHC_PRSSTAT_RTA_MASK,  /*!< Read transfer active */
+    kSDHC_BufferWriteEnableFlag = SDHC_PRSSTAT_BWEN_MASK,  /*!< Buffer write enable */
+    kSDHC_BufferReadEnableFlag = SDHC_PRSSTAT_BREN_MASK,   /*!< Buffer read enable */
+    kSDHC_CardInsertedFlag = SDHC_PRSSTAT_CINS_MASK,       /*!< Card inserted */
+    kSDHC_CommandLineLevelFlag = SDHC_PRSSTAT_CLSL_MASK,   /*!< Command line signal level */
+    kSDHC_Data0LineLevelFlag = (1U << 24U),                /*!< Data0 line signal level */
+    kSDHC_Data1LineLevelFlag = (1U << 25U),                /*!< Data1 line signal level */
+    kSDHC_Data2LineLevelFlag = (1U << 26U),                /*!< Data2 line signal level */
+    kSDHC_Data3LineLevelFlag = (1U << 27U),                /*!< Data3 line signal level */
+    kSDHC_Data4LineLevelFlag = (1U << 28U),                /*!< Data4 line signal level */
+    kSDHC_Data5LineLevelFlag = (1U << 29U),                /*!< Data5 line signal level */
+    kSDHC_Data6LineLevelFlag = (1U << 30U),                /*!< Data6 line signal level */
+    kSDHC_Data7LineLevelFlag = (1U << 31U),                /*!< Data7 line signal level */
+};
+
+/*! @brief Interrupt status flag mask */
+enum _sdhc_interrupt_status_flag
+{
+    kSDHC_CommandCompleteFlag = SDHC_IRQSTAT_CC_MASK,       /*!< Command complete */
+    kSDHC_DataCompleteFlag = SDHC_IRQSTAT_TC_MASK,          /*!< Data complete */
+    kSDHC_BlockGapEventFlag = SDHC_IRQSTAT_BGE_MASK,        /*!< Block gap event */
+    kSDHC_DmaCompleteFlag = SDHC_IRQSTAT_DINT_MASK,         /*!< DMA interrupt */
+    kSDHC_BufferWriteReadyFlag = SDHC_IRQSTAT_BWR_MASK,     /*!< Buffer write ready */
+    kSDHC_BufferReadReadyFlag = SDHC_IRQSTAT_BRR_MASK,      /*!< Buffer read ready */
+    kSDHC_CardInsertionFlag = SDHC_IRQSTAT_CINS_MASK,       /*!< Card inserted */
+    kSDHC_CardRemovalFlag = SDHC_IRQSTAT_CRM_MASK,          /*!< Card removed */
+    kSDHC_CardInterruptFlag = SDHC_IRQSTAT_CINT_MASK,       /*!< Card interrupt */
+    kSDHC_CommandTimeoutFlag = SDHC_IRQSTAT_CTOE_MASK,      /*!< Command timeout error */
+    kSDHC_CommandCrcErrorFlag = SDHC_IRQSTAT_CCE_MASK,      /*!< Command CRC error */
+    kSDHC_CommandEndBitErrorFlag = SDHC_IRQSTAT_CEBE_MASK,  /*!< Command end bit error */
+    kSDHC_CommandIndexErrorFlag = SDHC_IRQSTAT_CIE_MASK,    /*!< Command index error */
+    kSDHC_DataTimeoutFlag = SDHC_IRQSTAT_DTOE_MASK,         /*!< Data timeout error */
+    kSDHC_DataCrcErrorFlag = SDHC_IRQSTAT_DCE_MASK,         /*!< Data CRC error */
+    kSDHC_DataEndBitErrorFlag = SDHC_IRQSTAT_DEBE_MASK,     /*!< Data end bit error */
+    kSDHC_AutoCommand12ErrorFlag = SDHC_IRQSTAT_AC12E_MASK, /*!< Auto CMD12 error */
+    kSDHC_DmaErrorFlag = SDHC_IRQSTAT_DMAE_MASK,            /*!< DMA error */
+
+    kSDHC_CommandErrorFlag = (kSDHC_CommandTimeoutFlag | kSDHC_CommandCrcErrorFlag | kSDHC_CommandEndBitErrorFlag |
+                              kSDHC_CommandIndexErrorFlag), /*!< Command error */
+    kSDHC_DataErrorFlag = (kSDHC_DataTimeoutFlag | kSDHC_DataCrcErrorFlag | kSDHC_DataEndBitErrorFlag |
+                           kSDHC_AutoCommand12ErrorFlag),                                  /*!< Data error */
+    kSDHC_ErrorFlag = (kSDHC_CommandErrorFlag | kSDHC_DataErrorFlag | kSDHC_DmaErrorFlag), /*!< All error */
+    kSDHC_DataFlag = (kSDHC_DataCompleteFlag | kSDHC_DmaCompleteFlag | kSDHC_BufferWriteReadyFlag |
+                      kSDHC_BufferReadReadyFlag | kSDHC_DataErrorFlag | kSDHC_DmaErrorFlag), /*!< Data interrupts */
+    kSDHC_CommandFlag = (kSDHC_CommandErrorFlag | kSDHC_CommandCompleteFlag),                /*!< Command interrupts */
+    kSDHC_CardDetectFlag = (kSDHC_CardInsertionFlag | kSDHC_CardRemovalFlag), /*!< Card detection interrupts */
+
+    kSDHC_AllInterruptFlags = (kSDHC_BlockGapEventFlag | kSDHC_CardInterruptFlag | kSDHC_CommandFlag | kSDHC_DataFlag |
+                               kSDHC_ErrorFlag), /*!< All flags mask */
+};
+
+/*! @brief Auto CMD12 error status flag mask */
+enum _sdhc_auto_command12_error_status_flag
+{
+    kSDHC_AutoCommand12NotExecutedFlag = SDHC_AC12ERR_AC12NE_MASK,  /*!< Not executed error */
+    kSDHC_AutoCommand12TimeoutFlag = SDHC_AC12ERR_AC12TOE_MASK,     /*!< Timeout error */
+    kSDHC_AutoCommand12EndBitErrorFlag = SDHC_AC12ERR_AC12EBE_MASK, /*!< End bit error */
+    kSDHC_AutoCommand12CrcErrorFlag = SDHC_AC12ERR_AC12CE_MASK,     /*!< CRC error */
+    kSDHC_AutoCommand12IndexErrorFlag = SDHC_AC12ERR_AC12IE_MASK,   /*!< Index error */
+    kSDHC_AutoCommand12NotIssuedFlag = SDHC_AC12ERR_CNIBAC12E_MASK, /*!< Not issued error */
+};
+
+/*! @brief ADMA error status flag mask */
+enum _sdhc_adma_error_status_flag
+{
+    kSDHC_AdmaLenghMismatchFlag = SDHC_ADMAES_ADMALME_MASK,   /*!< Length mismatch error */
+    kSDHC_AdmaDescriptorErrorFlag = SDHC_ADMAES_ADMADCE_MASK, /*!< Descriptor error */
+};
+
+/*!
+ * @brief ADMA error state
+ *
+ * This state is the detail state when ADMA error has occurred.
+ */
+typedef enum _sdhc_adma_error_state
+{
+    kSDHC_AdmaErrorStateStopDma = 0x00U,         /*!< Stop DMA */
+    kSDHC_AdmaErrorStateFetchDescriptor = 0x01U, /*!< Fetch descriptor */
+    kSDHC_AdmaErrorStateChangeAddress = 0x02U,   /*!< Change address */
+    kSDHC_AdmaErrorStateTransferData = 0x03U,    /*!< Transfer data */
+} sdhc_adma_error_state_t;
+
+/*! @brief Force event mask */
+enum _sdhc_force_event
+{
+    kSDHC_ForceEventAutoCommand12NotExecuted = SDHC_FEVT_AC12NE_MASK,  /*!< Auto CMD12 not executed error */
+    kSDHC_ForceEventAutoCommand12Timeout = SDHC_FEVT_AC12TOE_MASK,     /*!< Auto CMD12 timeout error */
+    kSDHC_ForceEventAutoCommand12CrcError = SDHC_FEVT_AC12CE_MASK,     /*!< Auto CMD12 CRC error */
+    kSDHC_ForceEventEndBitError = SDHC_FEVT_AC12EBE_MASK,              /*!< Auto CMD12 end bit error */
+    kSDHC_ForceEventAutoCommand12IndexError = SDHC_FEVT_AC12IE_MASK,   /*!< Auto CMD12 index error */
+    kSDHC_ForceEventAutoCommand12NotIssued = SDHC_FEVT_CNIBAC12E_MASK, /*!< Auto CMD12 not issued error */
+    kSDHC_ForceEventCommandTimeout = SDHC_FEVT_CTOE_MASK,              /*!< Command timeout error */
+    kSDHC_ForceEventCommandCrcError = SDHC_FEVT_CCE_MASK,              /*!< Command CRC error */
+    kSDHC_ForceEventCommandEndBitError = SDHC_FEVT_CEBE_MASK,          /*!< Command end bit error */
+    kSDHC_ForceEventCommandIndexError = SDHC_FEVT_CIE_MASK,            /*!< Command index error */
+    kSDHC_ForceEventDataTimeout = SDHC_FEVT_DTOE_MASK,                 /*!< Data timeout error */
+    kSDHC_ForceEventDataCrcError = SDHC_FEVT_DCE_MASK,                 /*!< Data CRC error */
+    kSDHC_ForceEventDataEndBitError = SDHC_FEVT_DEBE_MASK,             /*!< Data end bit error */
+    kSDHC_ForceEventAutoCommand12Error = SDHC_FEVT_AC12E_MASK,         /*!< Auto CMD12 error */
+    kSDHC_ForceEventCardInt = SDHC_FEVT_CINT_MASK,                     /*!< Card interrupt */
+    kSDHC_ForceEventDmaError = SDHC_FEVT_DMAE_MASK,                    /*!< Dma error */
+
+    kSDHC_ForceEventsAll =
+        (kSDHC_ForceEventAutoCommand12NotExecuted | kSDHC_ForceEventAutoCommand12Timeout |
+         kSDHC_ForceEventAutoCommand12CrcError | kSDHC_ForceEventEndBitError | kSDHC_ForceEventAutoCommand12IndexError |
+         kSDHC_ForceEventAutoCommand12NotIssued | kSDHC_ForceEventCommandTimeout | kSDHC_ForceEventCommandCrcError |
+         kSDHC_ForceEventCommandEndBitError | kSDHC_ForceEventCommandIndexError | kSDHC_ForceEventDataTimeout |
+         kSDHC_ForceEventDataCrcError | kSDHC_ForceEventDataEndBitError | kSDHC_ForceEventAutoCommand12Error |
+         kSDHC_ForceEventCardInt | kSDHC_ForceEventDmaError), /*!< All force event flags mask */
+};
+
+/*! @brief Data transfer width */
+typedef enum _sdhc_data_bus_width
+{
+    kSDHC_DataBusWidth1Bit = 0U, /*!< 1-bit mode */
+    kSDHC_DataBusWidth4Bit = 1U, /*!< 4-bit mode */
+    kSDHC_DataBusWidth8Bit = 2U, /*!< 8-bit mode */
+} sdhc_data_bus_width_t;
+
+/*! @brief Endian mode */
+typedef enum _sdhc_endian_mode
+{
+    kSDHC_EndianModeBig = 0U,         /*!< Big endian mode */
+    kSDHC_EndianModeHalfWordBig = 1U, /*!< Half word big endian mode */
+    kSDHC_EndianModeLittle = 2U,      /*!< Little endian mode */
+} sdhc_endian_mode_t;
+
+/*! @brief DMA mode */
+typedef enum _sdhc_dma_mode
+{
+    kSDHC_DmaModeNo = 0U,    /*!< No DMA */
+    kSDHC_DmaModeAdma1 = 1U, /*!< ADMA1 is selected */
+    kSDHC_DmaModeAdma2 = 2U, /*!< ADMA2 is selected */
+} sdhc_dma_mode_t;
+
+/*! @brief SDIO control flag mask */
+enum _sdhc_sdio_control_flag
+{
+    kSDHC_StopAtBlockGapFlag = 0x01,       /*!< Stop at block gap */
+    kSDHC_ReadWaitControlFlag = 0x02,      /*!< Read wait control */
+    kSDHC_InterruptAtBlockGapFlag = 0x04,  /*!< Interrupt at block gap */
+    kSDHC_ExactBlockNumberReadFlag = 0x08, /*!< Exact block number read */
+};
+
+/*! @brief MMC card boot mode */
+typedef enum _sdhc_boot_mode
+{
+    kSDHC_BootModeNormal = 0U,      /*!< Normal boot */
+    kSDHC_BootModeAlternative = 1U, /*!< Alternative boot */
+} sdhc_boot_mode_t;
+
+/*! @brief The command type */
+typedef enum _sdhc_command_type
+{
+    kSDHC_CommandTypeNormal = 0U,  /*!< Normal command */
+    kSDHC_CommandTypeSuspend = 1U, /*!< Suspend command */
+    kSDHC_CommandTypeResume = 2U,  /*!< Resume command */
+    kSDHC_CommandTypeAbort = 3U,   /*!< Abort command */
+} sdhc_command_type_t;
+
+/*!
+ * @brief The command response type.
+ *
+ * Define the command response type from card to host controller.
+ */
+typedef enum _sdhc_response_type
+{
+    kSDHC_ResponseTypeNone = 0U, /*!< Response type: none */
+    kSDHC_ResponseTypeR1 = 1U,   /*!< Response type: R1 */
+    kSDHC_ResponseTypeR1b = 2U,  /*!< Response type: R1b */
+    kSDHC_ResponseTypeR2 = 3U,   /*!< Response type: R2 */
+    kSDHC_ResponseTypeR3 = 4U,   /*!< Response type: R3 */
+    kSDHC_ResponseTypeR4 = 5U,   /*!< Response type: R4 */
+    kSDHC_ResponseTypeR5 = 6U,   /*!< Response type: R5 */
+    kSDHC_ResponseTypeR5b = 7U,  /*!< Response type: R5b */
+    kSDHC_ResponseTypeR6 = 8U,   /*!< Response type: R6 */
+    kSDHC_ResponseTypeR7 = 9U,   /*!< Response type: R7 */
+} sdhc_response_type_t;
+
+/*! @brief The alignment size for ADDRESS filed in ADMA1's descriptor */
+#define SDHC_ADMA1_ADDRESS_ALIGN (4096U)
+/*! @brief The alignment size for LENGTH field in ADMA1's descriptor */
+#define SDHC_ADMA1_LENGTH_ALIGN (4096U)
+/*! @brief The alignment size for ADDRESS field in ADMA2's descriptor */
+#define SDHC_ADMA2_ADDRESS_ALIGN (4U)
+/*! @brief The alignment size for LENGTH filed in ADMA2's descriptor */
+#define SDHC_ADMA2_LENGTH_ALIGN (4U)
+
+/* ADMA1 descriptor table
+ * |------------------------|---------|--------------------------|
+ * | Address/page field     |Reserved |         Attribute        |
+ * |------------------------|---------|--------------------------|
+ * |31                    12|11      6|05  |04  |03|02 |01 |00   |
+ * |------------------------|---------|----|----|--|---|---|-----|
+ * | address or data length | 000000  |Act2|Act1| 0|Int|End|Valid|
+ * |------------------------|---------|----|----|--|---|---|-----|
+ *
+ *
+ * |------|------|-----------------|-------|-------------|
+ * | Act2 | Act1 |     Comment     | 31-28 | 27 - 12     |
+ * |------|------|-----------------|---------------------|
+ * |   0  |   0  | No op           | Don't care          |
+ * |------|------|-----------------|-------|-------------|
+ * |   0  |   1  | Set data length |  0000 | Data Length |
+ * |------|------|-----------------|-------|-------------|
+ * |   1  |   0  | Transfer data   | Data address        |
+ * |------|------|-----------------|---------------------|
+ * |   1  |   1  | Link descriptor | Descriptor address  |
+ * |------|------|-----------------|---------------------|
+ */
+/*! @brief The bit shift for ADDRESS filed in ADMA1's descriptor */
+#define SDHC_ADMA1_DESCRIPTOR_ADDRESS_SHIFT (12U)
+/*! @brief The bit mask for ADDRESS field in ADMA1's descriptor */
+#define SDHC_ADMA1_DESCRIPTOR_ADDRESS_MASK (0xFFFFFU)
+/*! @brief The bit shift for LENGTH filed in ADMA1's descriptor */
+#define SDHC_ADMA1_DESCRIPTOR_LENGTH_SHIFT (12U)
+/*! @brief The mask for LENGTH field in ADMA1's descriptor */
+#define SDHC_ADMA1_DESCRIPTOR_LENGTH_MASK (0xFFFFU)
+/*! @brief The max value of LENGTH filed in ADMA1's descriptor */
+#define SDHC_ADMA1_DESCRIPTOR_MAX_LENGTH_PER_ENTRY (SDHC_ADMA1_DESCRIPTOR_LENGTH_MASK + 1U)
+
+/*! @brief The mask for the control/status field in ADMA1 descriptor */
+enum _sdhc_adma1_descriptor_flag
+{
+    kSDHC_Adma1DescriptorValidFlag = (1U << 0U),                     /*!< Valid flag */
+    kSDHC_Adma1DescriptorEndFlag = (1U << 1U),                       /*!< End flag */
+    kSDHC_Adma1DescriptorInterrupFlag = (1U << 2U),                  /*!< Interrupt flag */
+    kSDHC_Adma1DescriptorActivity1Flag = (1U << 4U),                 /*!< Activity 1 flag */
+    kSDHC_Adma1DescriptorActivity2Flag = (1U << 5U),                 /*!< Activity 2 flag */
+    kSDHC_Adma1DescriptorTypeNop = (kSDHC_Adma1DescriptorValidFlag), /*!< No operation */
+    kSDHC_Adma1DescriptorTypeTransfer =
+        (kSDHC_Adma1DescriptorActivity2Flag | kSDHC_Adma1DescriptorValidFlag), /*!< Transfer data */
+    kSDHC_Adma1DescriptorTypeLink = (kSDHC_Adma1DescriptorActivity1Flag | kSDHC_Adma1DescriptorActivity2Flag |
+                                     kSDHC_Adma1DescriptorValidFlag), /*!< Link descriptor */
+    kSDHC_Adma1DescriptorTypeSetLength =
+        (kSDHC_Adma1DescriptorActivity1Flag | kSDHC_Adma1DescriptorValidFlag), /*!< Set data length */
+};
+
+/* ADMA2 descriptor table
+ * |----------------|---------------|-------------|--------------------------|
+ * | Address field  |     Length    | Reserved    |         Attribute        |
+ * |----------------|---------------|-------------|--------------------------|
+ * |63            32|31           16|15         06|05  |04  |03|02 |01 |00   |
+ * |----------------|---------------|-------------|----|----|--|---|---|-----|
+ * | 32-bit address | 16-bit length | 0000000000  |Act2|Act1| 0|Int|End|Valid|
+ * |----------------|---------------|-------------|----|----|--|---|---|-----|
+ *
+ *
+ * | Act2 | Act1 |     Comment     | Operation                                                         |
+ * |------|------|-----------------|-------------------------------------------------------------------|
+ * |   0  |   0  | No op           | Don't care                                                        |
+ * |------|------|-----------------|-------------------------------------------------------------------|
+ * |   0  |   1  | Reserved        | Read this line and go to next one                                 |
+ * |------|------|-----------------|-------------------------------------------------------------------|
+ * |   1  |   0  | Transfer data   | Transfer data with address and length set in this descriptor line |
+ * |------|------|-----------------|-------------------------------------------------------------------|
+ * |   1  |   1  | Link descriptor | Link to another descriptor                                        |
+ * |------|------|-----------------|-------------------------------------------------------------------|
+ */
+/*! @brief The bit shift for LENGTH field in ADMA2's descriptor */
+#define SDHC_ADMA2_DESCRIPTOR_LENGTH_SHIFT (16U)
+/*! @brief The bit mask for LENGTH field in ADMA2's descriptor */
+#define SDHC_ADMA2_DESCRIPTOR_LENGTH_MASK (0xFFFFU)
+/*! @brief The max value of LENGTH field in ADMA2's descriptor */
+#define SDHC_ADMA2_DESCRIPTOR_MAX_LENGTH_PER_ENTRY (SDHC_ADMA2_DESCRIPTOR_LENGTH_MASK)
+
+/*! @brief ADMA1 descriptor control and status mask */
+enum _sdhc_adma2_descriptor_flag
+{
+    kSDHC_Adma2DescriptorValidFlag = (1U << 0U),     /*!< Valid flag */
+    kSDHC_Adma2DescriptorEndFlag = (1U << 1U),       /*!< End flag */
+    kSDHC_Adma2DescriptorInterruptFlag = (1U << 2U), /*!< Interrupt flag */
+    kSDHC_Adma2DescriptorActivity1Flag = (1U << 4U), /*!< Activity 1 mask */
+    kSDHC_Adma2DescriptorActivity2Flag = (1U << 5U), /*!< Activity 2 mask */
+
+    kSDHC_Adma2DescriptorTypeNop = (kSDHC_Adma2DescriptorValidFlag), /*!< No operation */
+    kSDHC_Adma2DescriptorTypeReserved =
+        (kSDHC_Adma2DescriptorActivity1Flag | kSDHC_Adma2DescriptorValidFlag), /*!< Reserved */
+    kSDHC_Adma2DescriptorTypeTransfer =
+        (kSDHC_Adma2DescriptorActivity2Flag | kSDHC_Adma2DescriptorValidFlag), /*!< Transfer type */
+    kSDHC_Adma2DescriptorTypeLink = (kSDHC_Adma2DescriptorActivity1Flag | kSDHC_Adma2DescriptorActivity2Flag |
+                                     kSDHC_Adma2DescriptorValidFlag), /*!< Link type */
+};
+
+/*! @brief Define the adma1 descriptor structure. */
+typedef uint32_t sdhc_adma1_descriptor_t;
+
+/*! @brief Define the ADMA2 descriptor structure. */
+typedef struct _sdhc_adma2_descriptor
+{
+    uint32_t attribute;      /*!< The control and status field */
+    const uint32_t *address; /*!< The address field */
+} sdhc_adma2_descriptor_t;
+
+/*!
+ * @brief SDHC capability information.
+ *
+ * Define structure to save the capability information of SDHC.
+ */
+typedef struct _sdhc_capability
+{
+    uint32_t specVersion;    /*!< Specification version */
+    uint32_t vendorVersion;  /*!< Vendor version */
+    uint32_t maxBlockLength; /*!< Maximum block length united as byte */
+    uint32_t maxBlockCount;  /*!< Maximum block count can be set one time */
+    uint32_t flags;          /*!< Capability flags to indicate the support information(_sdhc_capability_flag) */
+} sdhc_capability_t;
+
+/*! @brief Card transfer configuration.
+ *
+ * Define structure to configure the transfer-related command index/argument/flags and data block
+ * size/data block numbers. This structure needs to be filled each time a command is sent to the card.
+ */
+typedef struct _sdhc_transfer_config
+{
+    size_t dataBlockSize;     /*!< Data block size */
+    uint32_t dataBlockCount;  /*!< Data block count */
+    uint32_t commandArgument; /*!< Command argument */
+    uint32_t commandIndex;    /*!< Command index */
+    uint32_t flags;           /*!< Transfer flags(_sdhc_transfer_flag) */
+} sdhc_transfer_config_t;
+
+/*! @brief Data structure to configure the MMC boot feature */
+typedef struct _sdhc_boot_config
+{
+    uint32_t ackTimeoutCount;      /*!< Timeout value for the boot ACK */
+    sdhc_boot_mode_t bootMode;     /*!< Boot mode selection. */
+    uint32_t blockCount;           /*!< Stop at block gap value of automatic mode */
+    bool enableBootAck;            /*!< Enable or disable boot ACK */
+    bool enableBoot;               /*!< Enable or disable fast boot */
+    bool enableAutoStopAtBlockGap; /*!< Enable or disable auto stop at block gap function in boot period */
+} sdhc_boot_config_t;
+
+/*! @brief Data structure to initialize the SDHC */
+typedef struct _sdhc_config
+{
+    bool cardDetectDat3;           /*!< Enable DAT3 as card detection pin */
+    sdhc_endian_mode_t endianMode; /*!< Endian mode */
+    sdhc_dma_mode_t dmaMode;       /*!< DMA mode */
+    uint32_t readWatermarkLevel;   /*!< Watermark level for DMA read operation */
+    uint32_t writeWatermarkLevel;  /*!< Watermark level for DMA write operation */
+} sdhc_config_t;
+
+/*!
+ * @brief Card data descriptor
+ *
+ * Define structure to contain data-related attribute. 'enableIgnoreError' is used for the case that upper card driver
+ * want to ignore the error event to read/write all the data not to stop read/write immediately when error event
+ * happen for example bus testing procedure for MMC card.
+ */
+typedef struct _sdhc_data
+{
+    bool enableAutoCommand12; /*!< Enable auto CMD12 */
+    bool enableIgnoreError;   /*!< Enable to ignore error event to read/write all the data */
+    size_t blockSize;         /*!< Block size */
+    uint32_t blockCount;      /*!< Block count */
+    uint32_t *rxData;         /*!< Buffer to save data read */
+    const uint32_t *txData;   /*!< Data buffer to write */
+} sdhc_data_t;
+
+/*!
+ * @brief Card command descriptor
+ *
+ * Define card command-related attribute.
+ */
+typedef struct _sdhc_command
+{
+    uint32_t index;                    /*!< Command index */
+    uint32_t argument;                 /*!< Command argument */
+    sdhc_command_type_t type;          /*!< Command type */
+    sdhc_response_type_t responseType; /*!< Command response type */
+    uint32_t response[4U];             /*!< Response for this command */
+} sdhc_command_t;
+
+/*! @brief Transfer state */
+typedef struct _sdhc_transfer
+{
+    sdhc_data_t *data;       /*!< Data to transfer */
+    sdhc_command_t *command; /*!< Command to send */
+} sdhc_transfer_t;
+
+/*! @brief SDHC handle typedef */
+typedef struct _sdhc_handle sdhc_handle_t;
+
+/*! @brief SDHC callback functions. */
+typedef struct _sdhc_transfer_callback
+{
+    void (*CardInserted)(void);  /*!< Card inserted occurs when DAT3/CD pin is for card detect */
+    void (*CardRemoved)(void);   /*!< Card removed occurs */
+    void (*SdioInterrupt)(void); /*!< SDIO card interrupt occurs */
+    void (*SdioBlockGap)(void);  /*!< SDIO card stopped at block gap occurs */
+    void (*TransferComplete)(SDHC_Type *base,
+                             sdhc_handle_t *handle,
+                             status_t status,
+                             void *userData); /*!< Transfer complete callback */
+} sdhc_transfer_callback_t;
+
+/*!
+ * @brief Host descriptor
+ *
+ * Define the structure to save the SDHC state information and callback function. The detail interrupt status when
+ * send command or transfer data can be obtained from interruptFlags field by using mask defined in sdhc_interrupt_flag_t;
+ *
+ * @note All the fields except interruptFlags and transferredWords must be allocated by the user.
+ */
+struct _sdhc_handle
+{
+    /* Transfer parameter */
+    sdhc_data_t *volatile data;       /*!< Data to transfer */
+    sdhc_command_t *volatile command; /*!< Command to send */
+
+    /* Transfer status */
+    volatile uint32_t interruptFlags;   /*!< Interrupt flags of last transaction */
+    volatile uint32_t transferredWords; /*!< Words transferred by DATAPORT way */
+
+    /* Callback functions */
+    sdhc_transfer_callback_t callback; /*!< Callback function */
+    void *userData;                    /*!< Parameter for transfer complete callback */
+};
+
+/*! @brief SDHC transfer function. */
+typedef status_t (*sdhc_transfer_function_t)(SDHC_Type *base, sdhc_transfer_t *content);
+
+/*! @brief SDHC host descriptor */
+typedef struct _sdhc_host
+{
+    SDHC_Type *base;                   /*!< SDHC peripheral base address */
+    uint32_t sourceClock_Hz;           /*!< SDHC source clock frequency united in Hz */
+    sdhc_config_t config;              /*!< SDHC configuration */
+    sdhc_capability_t capability;      /*!< SDHC capability information */
+    sdhc_transfer_function_t transfer; /*!< SDHC transfer function */
+} sdhc_host_t;
+
+/*************************************************************************************************
+ * API
+ ************************************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief SDHC module initialization function.
+ *
+ * Configure the SDHC according to the user configuration.
+ *
+ * Example:
+   @code
+   sdhc_config_t config;
+   config.enableDat3AsCDPin = false;
+   config.endianMode = kSDHC_EndianModeLittle;
+   config.dmaMode = kSDHC_DmaModeAdma2;
+   config.readWatermarkLevel = 512U;
+   config.writeWatermarkLevel = 512U;
+   SDHC_Init(SDHC, &config);
+   @endcode
+ *
+ * @param base SDHC peripheral base address.
+ * @param config SDHC configuration information.
+ * @retval kStatus_Success Operate successfully.
+ */
+void SDHC_Init(SDHC_Type *base, const sdhc_config_t *config);
+
+/*!
+ * @brief Deinitialize the SDHC.
+ *
+ * @param base SDHC peripheral base address.
+ */
+void SDHC_Deinit(SDHC_Type *base);
+
+/*!
+ * @brief Reset the SDHC.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask The reset type mask(_sdhc_reset).
+ * @param timeout Timeout for reset.
+ * @retval true Reset successfully.
+ * @retval false Reset failed.
+ */
+bool SDHC_Reset(SDHC_Type *base, uint32_t mask, uint32_t timeout);
+
+/* @} */
+
+/*!
+ * @name DMA Control
+ * @{
+ */
+
+/*!
+ * @brief Set ADMA descriptor table configuration.
+ *
+ * @param base SDHC peripheral base address.
+ * @param dmaMode DMA mode.
+ * @param table ADMA table address.
+ * @param tableWords ADMA table buffer length united as Words.
+ * @param data Data buffer address.
+ * @param dataBytes Data length united as bytes.
+ * @retval kStatus_OutOfRange ADMA descriptor table length isn't enough to describe data.
+ * @retval kStatus_Success Operate successfully.
+ */
+status_t SDHC_SetAdmaTableConfig(SDHC_Type *base,
+                                 sdhc_dma_mode_t dmaMode,
+                                 uint32_t *table,
+                                 uint32_t tableWords,
+                                 const uint32_t *data,
+                                 uint32_t dataBytes);
+
+/* @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enable interrupt status
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask Interrupt status flags mask(_sdhc_interrupt_status_flag).
+ */
+static inline void SDHC_EnableInterruptStatus(SDHC_Type *base, uint32_t mask)
+{
+    base->IRQSTATEN |= mask;
+}
+
+/*!
+ * @brief Disable interrupt status.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask The interrupt status flags mask(_sdhc_interrupt_status_flag).
+ */
+static inline void SDHC_DisableInterruptStatus(SDHC_Type *base, uint32_t mask)
+{
+    base->IRQSTATEN &= ~mask;
+}
+
+/*!
+ * @brief Enable interrupts signal corresponding to the interrupt status flag.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask The interrupt status flags mask(_sdhc_interrupt_status_flag).
+ */
+static inline void SDHC_EnableInterruptSignal(SDHC_Type *base, uint32_t mask)
+{
+    base->IRQSIGEN |= mask;
+}
+
+/*!
+ * @brief Disable interrupts signal corresponding to the interrupt status flag.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask The interrupt status flags mask(_sdhc_interrupt_status_flag).
+ */
+static inline void SDHC_DisableInterruptSignal(SDHC_Type *base, uint32_t mask)
+{
+    base->IRQSIGEN &= ~mask;
+}
+
+/* @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Get current interrupt status.
+ *
+ * @param base SDHC peripheral base address.
+ * @return Current interrupt status flags mask(_sdhc_interrupt_status_flag).
+ */
+static inline uint32_t SDHC_GetInterruptStatusFlags(SDHC_Type *base)
+{
+    return base->IRQSTAT;
+}
+
+/*!
+ * @brief Clear specified interrupt status.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask The interrupt status flags mask(_sdhc_interrupt_status_flag).
+ */
+static inline void SDHC_ClearInterruptStatusFlags(SDHC_Type *base, uint32_t mask)
+{
+    base->IRQSTAT = mask;
+}
+
+/*!
+ * @brief Get the status of auto command 12 error.
+ *
+ * @param base SDHC peripheral base address.
+ * @return Auto command 12 error status flags mask(_sdhc_auto_command12_error_status_flag).
+ */
+static inline uint32_t SDHC_GetAutoCommand12ErrorStatusFlags(SDHC_Type *base)
+{
+    return base->AC12ERR;
+}
+
+/*!
+ * @brief Get the status of ADMA error.
+ *
+ * @param base SDHC peripheral base address.
+ * @return ADMA error status flags mask(_sdhc_adma_error_status_flag).
+ */
+static inline uint32_t SDHC_GetAdmaErrorStatusFlags(SDHC_Type *base)
+{
+    return base->ADMAES;
+}
+
+/*!
+ * @brief Get present status.
+ *
+ * This function gets the present SDHC's status except for interrupt status and error status.
+ *
+ * @param base SDHC peripheral base address.
+ * @return Present SDHC's status flags mask(_sdhc_present_status_flag).
+ */
+static inline uint32_t SDHC_GetPresentStatusFlags(SDHC_Type *base)
+{
+    return base->PRSSTAT;
+}
+
+/* @} */
+
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Get the capability information
+ *
+ * @param base SDHC peripheral base address.
+ * @param capability Structure to save capability information.
+ */
+void SDHC_GetCapability(SDHC_Type *base, sdhc_capability_t *capability);
+
+/*!
+ * @brief Enable or disable SD bus clock.
+ *
+ * @param base SDHC peripheral base address.
+ * @param enable True to enable, false to disable.
+ */
+static inline void SDHC_EnableSdClock(SDHC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->SYSCTL |= SDHC_SYSCTL_SDCLKEN_MASK;
+    }
+    else
+    {
+        base->SYSCTL &= ~SDHC_SYSCTL_SDCLKEN_MASK;
+    }
+}
+
+/*!
+ * @brief Set SD bus clock frequency.
+ *
+ * @param base SDHC peripheral base address.
+ * @param srcClock_Hz SDHC source clock frequency united in Hz.
+ * @param busClock_Hz SD bus clock frequency united in Hz.
+ *
+ * @return The nearest frequency of busClock_Hz configured to SD bus.
+ */
+uint32_t SDHC_SetSdClock(SDHC_Type *base, uint32_t srcClock_Hz, uint32_t busClock_Hz);
+
+/*!
+ * @brief Send 80 clocks to the card to set it to be active state.
+ *
+ * This function must be called after each time the card is inserted to make card can receive command correctly.
+ *
+ * @param base SDHC peripheral base address.
+ * @param timeout Timeout to initialize card.
+ * @retval true Set card active successfully.
+ * @retval false Set card active failed.
+ */
+bool SDHC_SetCardActive(SDHC_Type *base, uint32_t timeout);
+
+/*!
+ * @brief Set the data transfer width.
+ *
+ * @param base SDHC peripheral base address.
+ * @param width Data transfer width.
+ */
+static inline void SDHC_SetDataBusWidth(SDHC_Type *base, sdhc_data_bus_width_t width)
+{
+    base->PROCTL = ((base->PROCTL & ~SDHC_PROCTL_DTW_MASK) | SDHC_PROCTL_DTW(width));
+}
+
+/*!
+ * @brief Set card transfer-related configuration.
+ *
+ * This function fills card transfer-related command argument/transfer flag/data size. Command and data will be sent by
+ * SDHC after calling this function.
+ *
+ * Example:
+   @code
+   sdhc_transfer_config_t transferConfig;
+   transferConfig.dataBlockSize = 512U;
+   transferConfig.dataBlockCount = 2U;
+   transferConfig.commandArgument = 0x01AAU;
+   transferConfig.commandIndex = 8U;
+   transferConfig.flags |= (kSDHC_EnableDmaFlag | kSDHC_EnableAutoCommand12Flag | kSDHC_MultipleBlockFlag);
+   SDHC_SetTransferConfig(SDHC, &transferConfig);
+   @endcode
+ *
+ * @param base SDHC peripheral base address.
+ * @param config Command configuration structure.
+ */
+void SDHC_SetTransferConfig(SDHC_Type *base, const sdhc_transfer_config_t *config);
+
+/*!
+ * @brief Get the command response.
+ *
+ * @param base SDHC peripheral base address.
+ * @param index The index of response register, range from 0 to 3.
+ * @return Response register transfer.
+ */
+static inline uint32_t SDHC_GetCommandResponse(SDHC_Type *base, uint32_t index)
+{
+    assert(index < 4U);
+
+    return base->CMDRSP[index];
+}
+
+/*!
+ * @brief Fill the the data port.
+ *
+ * This function is mainly used to implement the data transfer by Data Port instead of DMA.
+ *
+ * @param base SDHC peripheral base address.
+ * @param data The data about to be sent.
+ */
+static inline void SDHC_WriteData(SDHC_Type *base, uint32_t data)
+{
+    base->DATPORT = data;
+}
+
+/*!
+ * @brief Retrieve the data from the data port.
+ *
+ * This function is mainly used to implement the data transfer by Data Port instead of DMA.
+ *
+ * @param base SDHC peripheral base address.
+ * @return The data has been read.
+ */
+static inline uint32_t SDHC_ReadData(SDHC_Type *base)
+{
+    return base->DATPORT;
+}
+
+/*!
+ * @brief Enable or disable wakeup event in low power mode
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask Wakeup events mask(_sdhc_wakeup_event).
+ * @param enable True to enable, false to disable.
+ */
+static inline void SDHC_EnableWakeupEvent(SDHC_Type *base, uint32_t mask, bool enable)
+{
+    if (enable)
+    {
+        base->PROCTL |= mask;
+    }
+    else
+    {
+        base->PROCTL &= ~mask;
+    }
+}
+
+/*!
+ * @brief Enable or disable card detection level for test.
+ *
+ * @param base SDHC peripheral base address.
+ * @param enable True to enable, false to disable.
+ */
+static inline void SDHC_EnableCardDetectTest(SDHC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->PROCTL |= SDHC_PROCTL_CDSS_MASK;
+    }
+    else
+    {
+        base->PROCTL &= ~SDHC_PROCTL_CDSS_MASK;
+    }
+}
+
+/*!
+ * @brief Set card detection test level.
+ *
+ * This function set the card detection test level to indicate whether the card is inserted into SDHC when DAT[3]/
+ * CD pin is selected as card detection pin. This function can also assert the pin logic when DAT[3]/CD pin is select
+ * as the card detection pin.
+ *
+ * @param base SDHC peripheral base address.
+ * @param high True to set the card detect level to high.
+ */
+static inline void SDHC_SetCardDetectTestLevel(SDHC_Type *base, bool high)
+{
+    if (high)
+    {
+        base->PROCTL |= SDHC_PROCTL_CDTL_MASK;
+    }
+    else
+    {
+        base->PROCTL &= ~SDHC_PROCTL_CDTL_MASK;
+    }
+}
+
+/*!
+ * @brief Enable or disable SDIO card control.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask SDIO card control flags mask(_sdhc_sdio_control_flag).
+ * @param enable True to enable, false to disable.
+ */
+void SDHC_EnableSdioControl(SDHC_Type *base, uint32_t mask, bool enable);
+
+/*!
+ * @brief Restart a transaction which has stopped at the block gap for SDIO card.
+ *
+ * @param base SDHC peripheral base address.
+ */
+static inline void SDHC_SetContinueRequest(SDHC_Type *base)
+{
+    base->PROCTL |= SDHC_PROCTL_CREQ_MASK;
+}
+
+/*!
+ * @brief Configure the MMC boot feature.
+ *
+ * Example:
+   @code
+   sdhc_boot_config_t bootConfig;
+   bootConfig.ackTimeoutCount = 4;
+   bootConfig.bootMode = kSDHC_BootModeNormal;
+   bootConfig.blockCount = 5;
+   bootConfig.enableBootAck = true;
+   bootConfig.enableBoot = true;
+   enableBoot.enableAutoStopAtBlockGap = true;
+   SDHC_SetMmcBootConfig(SDHC, &bootConfig);
+   @endcode
+ *
+ * @param base SDHC peripheral base address.
+ * @param config The MMC boot configuration information.
+ */
+void SDHC_SetMmcBootConfig(SDHC_Type *base, const sdhc_boot_config_t *config);
+
+/*!
+ * @brief Force to generate events according to the given mask.
+ *
+ * @param base SDHC peripheral base address.
+ * @param mask The force events mask(_sdhc_force_event).
+ */
+static inline void SDHC_SetForceEvent(SDHC_Type *base, uint32_t mask)
+{
+    base->FEVT = mask;
+}
+
+/* @} */
+
+/*!
+ * @name Transactional
+ * @{
+ */
+
+/*!
+ * @brief Transfer command/data using blocking way.
+ *
+ * This function waits until the command response/data is got or SDHC encounters error by polling the status flag.
+ * Application must not call this API in multiple threads at the same time because of that this API doesn't support
+ * reentry mechanism.
+ *
+ * @note Needn't to call the API 'SDHC_TransferCreateHandle' when calling this API.
+ *
+ * @param base SDHC peripheral base address.
+ * @param admaTable ADMA table address, can't be null if transfer way is ADMA1/ADMA2.
+ * @param admaTableWords ADMA table length united as words, can't be 0 if transfer way is ADMA1/ADMA2.
+ * @param transfer Transfer content.
+ * @retval kStatus_InvalidArgument Argument is invalid.
+ * @retval kStatus_SDHC_PrepareAdmaDescriptorFailed Prepare ADMA descriptor failed.
+ * @retval kStatus_SDHC_SendCommandFailed Send command failed.
+ * @retval kStatus_SDHC_TransferDataFailed Transfer data failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+status_t SDHC_TransferBlocking(SDHC_Type *base,
+                               uint32_t *admaTable,
+                               uint32_t admaTableWords,
+                               sdhc_transfer_t *transfer);
+
+/*!
+ * @brief Create the SDHC handle.
+ *
+ * @param base SDHC peripheral base address.
+ * @param handle SDHC handle pointer.
+ * @param callback Structure pointer to contain all callback functions.
+ * @param userData Callback function parameter.
+ */
+void SDHC_TransferCreateHandle(SDHC_Type *base,
+                               sdhc_handle_t *handle,
+                               const sdhc_transfer_callback_t *callback,
+                               void *userData);
+
+/*!
+ * @brief Transfer command/data using interrupt and asynchronous way.
+ *
+ * This function send command and data and return immediately. It doesn't wait the transfer complete or encounter error.
+ * Application must not call this API in multiple threads at the same time because of that this API doesn't support
+ * reentry mechanism.
+ *
+ * @note Must call the API 'SDHC_TransferCreateHandle' when calling this API.
+ *
+ * @param base SDHC peripheral base address.
+ * @param handle SDHC handle.
+ * @param admaTable ADMA table address, can't be null if transfer way is ADMA1/ADMA2.
+ * @param admaTableWords ADMA table length united as words, can't be 0 if transfer way is ADMA1/ADMA2.
+ * @param transfer Transfer content.
+ * @retval kStatus_InvalidArgument Argument is invalid.
+ * @retval kStatus_SDHC_BusyTransferring Busy transferring.
+ * @retval kStatus_SDHC_PrepareAdmaDescriptorFailed Prepare ADMA descriptor failed.
+ * @retval kStatus_Success Operate successfully.
+ */
+status_t SDHC_TransferNonBlocking(
+    SDHC_Type *base, sdhc_handle_t *handle, uint32_t *admaTable, uint32_t admaTableWords, sdhc_transfer_t *transfer);
+
+/*!
+ * @brief IRQ handler for SDHC
+ *
+ * This function deals with IRQs on the given host controller.
+ *
+ * @param base SDHC peripheral base address.
+ * @param handle SDHC handle.
+ */
+void SDHC_TransferHandleIRQ(SDHC_Type *base, sdhc_handle_t *handle);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+/*! @} */
+
+#endif /* _FSL_SDHC_H_*/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sim.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sim.c
@@ -1,0 +1,53 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fsl_sim.h"
+
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+#if (defined(FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR) && FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR)
+void SIM_SetUsbVoltRegulatorEnableMode(uint32_t mask)
+{
+    SIM->SOPT1CFG |= (SIM_SOPT1CFG_URWE_MASK | SIM_SOPT1CFG_UVSWE_MASK | SIM_SOPT1CFG_USSWE_MASK);
+
+    SIM->SOPT1 = (SIM->SOPT1 & ~kSIM_UsbVoltRegEnableInAllModes) | mask;
+}
+#endif /* FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR */
+
+void SIM_GetUniqueId(sim_uid_t *uid)
+{
+#if defined(SIM_UIDH)
+    uid->H = SIM->UIDH;
+#endif
+    uid->MH = SIM->UIDMH;
+    uid->ML = SIM->UIDML;
+    uid->L = SIM->UIDL;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sim.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_sim.h
@@ -1,0 +1,128 @@
+/*
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _FSL_SIM_H_
+#define _FSL_SIM_H_
+
+#include "fsl_common.h"
+
+/*! @addtogroup sim */
+/*! @{*/
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_SIM_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Driver version 2.0.0 */
+/*@}*/
+
+#if (defined(FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR) && FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR)
+/*!@brief USB voltage regulator enable setting. */
+enum _sim_usb_volt_reg_enable_mode
+{
+    kSIM_UsbVoltRegEnable = SIM_SOPT1_USBREGEN_MASK,           /*!< Enable voltage regulator. */
+    kSIM_UsbVoltRegEnableInLowPower = SIM_SOPT1_USBVSTBY_MASK, /*!< Enable voltage regulator in VLPR/VLPW modes. */
+    kSIM_UsbVoltRegEnableInStop = SIM_SOPT1_USBSSTBY_MASK, /*!< Enable voltage regulator in STOP/VLPS/LLS/VLLS modes. */
+    kSIM_UsbVoltRegEnableInAllModes = SIM_SOPT1_USBREGEN_MASK | SIM_SOPT1_USBSSTBY_MASK |
+                                      SIM_SOPT1_USBVSTBY_MASK /*!< Enable voltage regulator in all power modes. */
+};
+#endif /* (defined(FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR) && FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR) */
+
+/*!@brief Unique ID. */
+typedef struct _sim_uid
+{
+#if defined(SIM_UIDH)
+    uint32_t H; /*!< UIDH.  */
+#endif
+    uint32_t MH; /*!< UIDMH. */
+    uint32_t ML; /*!< UIDML. */
+    uint32_t L;  /*!< UIDL.  */
+} sim_uid_t;
+
+/*!@brief Flash enable mode. */
+enum _sim_flash_mode
+{
+    kSIM_FlashDisableInWait = SIM_FCFG1_FLASHDOZE_MASK, /*!< Disable flash in wait mode.   */
+    kSIM_FlashDisable = SIM_FCFG1_FLASHDIS_MASK         /*!< Disable flash in normal mode. */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+#if (defined(FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR) && FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR)
+/*!
+ * @brief Sets the USB voltage regulator setting.
+ *
+ * This function configures whether the USB voltage regulator is enabled in
+ * normal RUN mode, STOP/VLPS/LLS/VLLS modes and VLPR/VLPW modes. The configurations
+ * are passed in as mask value of \ref _sim_usb_volt_reg_enable_mode. For example, enable
+ * USB voltage regulator in RUN/VLPR/VLPW modes and disable in STOP/VLPS/LLS/VLLS mode,
+ * please use:
+ *
+ * SIM_SetUsbVoltRegulatorEnableMode(kSIM_UsbVoltRegEnable | kSIM_UsbVoltRegEnableInLowPower);
+ *
+ * @param mask  USB voltage regulator enable setting.
+ */
+void SIM_SetUsbVoltRegulatorEnableMode(uint32_t mask);
+#endif /* FSL_FEATURE_SIM_OPT_HAS_USB_VOLTAGE_REGULATOR */
+
+/*!
+ * @brief Get the unique identification register value.
+ *
+ * @param uid Pointer to the structure to save the UID value.
+ */
+void SIM_GetUniqueId(sim_uid_t *uid);
+
+/*!
+ * @brief Set the flash enable mode.
+ *
+ * @param mode The mode to set, see \ref _sim_flash_mode for mode details.
+ */
+static inline void SIM_SetFlashMode(uint8_t mode)
+{
+    SIM->FCFG1 = mode;
+}
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*! @}*/
+
+#endif /* _FSL_SIM_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_smc.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_smc.c
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_smc.h"
+
+#if (defined(FSL_FEATURE_SMC_HAS_PARAM) && FSL_FEATURE_SMC_HAS_PARAM)
+void SMC_GetParam(SMC_Type *base, smc_param_t *param)
+{
+    uint32_t reg = base->PARAM;
+    param->hsrunEnable = (bool)(reg & SMC_PARAM_EHSRUN_MASK);
+    param->llsEnable = (bool)(reg & SMC_PARAM_ELLS_MASK);
+    param->lls2Enable = (bool)(reg & SMC_PARAM_ELLS2_MASK);
+    param->vlls0Enable = (bool)(reg & SMC_PARAM_EVLLS0_MASK);
+}
+#endif /* FSL_FEATURE_SMC_HAS_PARAM */
+
+status_t SMC_SetPowerModeRun(SMC_Type *base)
+{
+    uint8_t reg;
+
+    reg = base->PMCTRL;
+    /* configure Normal RUN mode */
+    reg &= ~SMC_PMCTRL_RUNM_MASK;
+    reg |= (kSMC_RunNormal << SMC_PMCTRL_RUNM_SHIFT);
+    base->PMCTRL = reg;
+
+    return kStatus_Success;
+}
+
+#if (defined(FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE) && FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE)
+status_t SMC_SetPowerModeHsrun(SMC_Type *base)
+{
+    uint8_t reg;
+
+    reg = base->PMCTRL;
+    /* configure High Speed RUN mode */
+    reg &= ~SMC_PMCTRL_RUNM_MASK;
+    reg |= (kSMC_Hsrun << SMC_PMCTRL_RUNM_SHIFT);
+    base->PMCTRL = reg;
+
+    return kStatus_Success;
+}
+#endif /* FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE */
+
+status_t SMC_SetPowerModeWait(SMC_Type *base)
+{
+    /* configure Normal Wait mode */
+    SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+    __WFI();
+
+    return kStatus_Success;
+}
+
+status_t SMC_SetPowerModeStop(SMC_Type *base, smc_partial_stop_option_t option)
+{
+    uint8_t reg;
+
+#if (defined(FSL_FEATURE_SMC_HAS_PSTOPO) && FSL_FEATURE_SMC_HAS_PSTOPO)
+    /* configure the Partial Stop mode in Noraml Stop mode */
+    reg = base->STOPCTRL;
+    reg &= ~SMC_STOPCTRL_PSTOPO_MASK;
+    reg |= ((uint32_t)option << SMC_STOPCTRL_PSTOPO_SHIFT);
+    base->STOPCTRL = reg;
+#endif
+
+    /* configure Normal Stop mode */
+    reg = base->PMCTRL;
+    reg &= ~SMC_PMCTRL_STOPM_MASK;
+    reg |= (kSMC_StopNormal << SMC_PMCTRL_STOPM_SHIFT);
+    base->PMCTRL = reg;
+
+    /* Set the SLEEPDEEP bit to enable deep sleep mode (stop mode) */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    /* read back to make sure the configuration valid before enter stop mode */
+    (void)base->PMCTRL;
+    __WFI();
+
+    /* check whether the power mode enter Stop mode succeed */
+    if (base->PMCTRL & SMC_PMCTRL_STOPA_MASK)
+    {
+        return kStatus_SMC_StopAbort;
+    }
+    else
+    {
+        return kStatus_Success;
+    }
+}
+
+status_t SMC_SetPowerModeVlpr(SMC_Type *base
+#if (defined(FSL_FEATURE_SMC_HAS_LPWUI) && FSL_FEATURE_SMC_HAS_LPWUI)
+                              ,
+                              bool wakeupMode
+#endif
+                              )
+{
+    uint8_t reg;
+
+    reg = base->PMCTRL;
+#if (defined(FSL_FEATURE_SMC_HAS_LPWUI) && FSL_FEATURE_SMC_HAS_LPWUI)
+    /* configure whether the system remains in VLP mode on an interrupt */
+    if (wakeupMode)
+    {
+        /* exits to RUN mode on an interrupt */
+        reg |= SMC_PMCTRL_LPWUI_MASK;
+    }
+    else
+    {
+        /* remains in VLP mode on an interrupt */
+        reg &= ~SMC_PMCTRL_LPWUI_MASK;
+    }
+#endif /* FSL_FEATURE_SMC_HAS_LPWUI */
+
+    /* configure VLPR mode */
+    reg &= ~SMC_PMCTRL_RUNM_MASK;
+    reg |= (kSMC_RunVlpr << SMC_PMCTRL_RUNM_SHIFT);
+    base->PMCTRL = reg;
+
+    return kStatus_Success;
+}
+
+status_t SMC_SetPowerModeVlpw(SMC_Type *base)
+{
+    /* Power mode transaction to VLPW can only happen in VLPR mode */
+    if (kSMC_PowerStateVlpr != SMC_GetPowerModeState(base))
+    {
+        return kStatus_Fail;
+    }
+
+    /* configure VLPW mode */
+    /* Set the SLEEPDEEP bit to enable deep sleep mode */
+    SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+    __WFI();
+
+    return kStatus_Success;
+}
+
+status_t SMC_SetPowerModeVlps(SMC_Type *base)
+{
+    uint8_t reg;
+
+    /* configure VLPS mode */
+    reg = base->PMCTRL;
+    reg &= ~SMC_PMCTRL_STOPM_MASK;
+    reg |= (kSMC_StopVlps << SMC_PMCTRL_STOPM_SHIFT);
+    base->PMCTRL = reg;
+
+    /* Set the SLEEPDEEP bit to enable deep sleep mode */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    /* read back to make sure the configuration valid before enter stop mode */
+    (void)base->PMCTRL;
+    __WFI();
+
+    /* check whether the power mode enter VLPS mode succeed */
+    if (base->PMCTRL & SMC_PMCTRL_STOPA_MASK)
+    {
+        return kStatus_SMC_StopAbort;
+    }
+    else
+    {
+        return kStatus_Success;
+    }
+}
+
+#if (defined(FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE)
+status_t SMC_SetPowerModeLls(SMC_Type *base
+#if ((defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE) || \
+     (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO))
+                             ,
+                             const smc_power_mode_lls_config_t *config
+#endif
+                             )
+{
+    uint8_t reg;
+
+    /* configure to LLS mode */
+    reg = base->PMCTRL;
+    reg &= ~SMC_PMCTRL_STOPM_MASK;
+    reg |= (kSMC_StopLls << SMC_PMCTRL_STOPM_SHIFT);
+    base->PMCTRL = reg;
+
+/* configure LLS sub-mode*/
+#if (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE)
+    reg = base->STOPCTRL;
+    reg &= ~SMC_STOPCTRL_LLSM_MASK;
+    reg |= ((uint32_t)config->subMode << SMC_STOPCTRL_LLSM_SHIFT);
+    base->STOPCTRL = reg;
+#endif /* FSL_FEATURE_SMC_HAS_LLS_SUBMODE */
+
+#if (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO)
+    if (config->enableLpoClock)
+    {
+        base->STOPCTRL &= ~SMC_STOPCTRL_LPOPO_MASK;
+    }
+    else
+    {
+        base->STOPCTRL |= SMC_STOPCTRL_LPOPO_MASK;
+    }
+#endif /* FSL_FEATURE_SMC_HAS_LPOPO */
+
+    /* Set the SLEEPDEEP bit to enable deep sleep mode */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    /* read back to make sure the configuration valid before enter stop mode */
+    (void)base->PMCTRL;
+    __WFI();
+
+    /* check whether the power mode enter LLS mode succeed */
+    if (base->PMCTRL & SMC_PMCTRL_STOPA_MASK)
+    {
+        return kStatus_SMC_StopAbort;
+    }
+    else
+    {
+        return kStatus_Success;
+    }
+}
+#endif /* FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE */
+
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+status_t SMC_SetPowerModeVlls(SMC_Type *base, const smc_power_mode_vlls_config_t *config)
+{
+    uint8_t reg;
+
+#if (defined(FSL_FEATURE_SMC_HAS_PORPO) && FSL_FEATURE_SMC_HAS_PORPO)
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG) ||     \
+    (defined(FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM) && FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM) || \
+    (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE)
+    if (config->subMode == kSMC_StopSub0)
+#endif
+    {
+        /* configure whether the Por Detect work in Vlls0 mode */
+        if (config->enablePorDetectInVlls0)
+        {
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG)
+            base->VLLSCTRL &= ~SMC_VLLSCTRL_PORPO_MASK;
+#else
+            base->STOPCTRL &= ~SMC_STOPCTRL_PORPO_MASK;
+#endif
+        }
+        else
+        {
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG)
+            base->VLLSCTRL |= SMC_VLLSCTRL_PORPO_MASK;
+#else
+            base->STOPCTRL |= SMC_STOPCTRL_PORPO_MASK;
+#endif
+        }
+    }
+#endif /* FSL_FEATURE_SMC_HAS_PORPO */
+
+#if (defined(FSL_FEATURE_SMC_HAS_RAM2_POWER_OPTION) && FSL_FEATURE_SMC_HAS_RAM2_POWER_OPTION)
+    else if (config->subMode == kSMC_StopSub2)
+    {
+        /* configure whether the Por Detect work in Vlls0 mode */
+        if (config->enableRam2InVlls2)
+        {
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG)
+            base->VLLSCTRL |= SMC_VLLSCTRL_RAM2PO_MASK;
+#else
+            base->STOPCTRL |= SMC_STOPCTRL_RAM2PO_MASK;
+#endif
+        }
+        else
+        {
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG)
+            base->VLLSCTRL &= ~SMC_VLLSCTRL_RAM2PO_MASK;
+#else
+            base->STOPCTRL &= ~SMC_STOPCTRL_RAM2PO_MASK;
+#endif
+        }
+    }
+    else
+    {
+    }
+#endif /* FSL_FEATURE_SMC_HAS_RAM2_POWER_OPTION */
+
+    /* configure to VLLS mode */
+    reg = base->PMCTRL;
+    reg &= ~SMC_PMCTRL_STOPM_MASK;
+    reg |= (kSMC_StopVlls << SMC_PMCTRL_STOPM_SHIFT);
+    base->PMCTRL = reg;
+
+/* configure the VLLS sub-mode */
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG)
+    reg = base->VLLSCTRL;
+    reg &= ~SMC_VLLSCTRL_VLLSM_MASK;
+    reg |= ((uint32_t)config->subMode << SMC_VLLSCTRL_VLLSM_SHIFT);
+    base->VLLSCTRL = reg;
+#else
+#if (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE)
+    reg = base->STOPCTRL;
+    reg &= ~SMC_STOPCTRL_LLSM_MASK;
+    reg |= ((uint32_t)config->subMode << SMC_STOPCTRL_LLSM_SHIFT);
+    base->STOPCTRL = reg;
+#else
+    reg = base->STOPCTRL;
+    reg &= ~SMC_STOPCTRL_VLLSM_MASK;
+    reg |= ((uint32_t)config->subMode << SMC_STOPCTRL_VLLSM_SHIFT);
+    base->STOPCTRL = reg;
+#endif /* FSL_FEATURE_SMC_HAS_LLS_SUBMODE */
+#endif
+
+#if (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO)
+    if (config->enableLpoClock)
+    {
+        base->STOPCTRL &= ~SMC_STOPCTRL_LPOPO_MASK;
+    }
+    else
+    {
+        base->STOPCTRL |= SMC_STOPCTRL_LPOPO_MASK;
+    }
+#endif /* FSL_FEATURE_SMC_HAS_LPOPO */
+
+    /* Set the SLEEPDEEP bit to enable deep sleep mode */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    /* read back to make sure the configuration valid before enter stop mode */
+    (void)base->PMCTRL;
+    __WFI();
+
+    /* check whether the power mode enter LLS mode succeed */
+    if (base->PMCTRL & SMC_PMCTRL_STOPA_MASK)
+    {
+        return kStatus_SMC_StopAbort;
+    }
+    else
+    {
+        return kStatus_Success;
+    }
+}
+#endif /* FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_smc.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_smc.h
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_SMC_H_
+#define _FSL_SMC_H_
+
+#include "fsl_common.h"
+
+/*! @addtogroup smc */
+/*! @{ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief SMC driver version 2.0.1. */
+#define FSL_SMC_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*!
+ * @brief Power Modes Protection
+ */
+typedef enum _smc_power_mode_protection
+{
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+    kSMC_AllowPowerModeVlls = SMC_PMPROT_AVLLS_MASK, /*!< Allow Very-Low-Leakage Stop Mode. */
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE)
+    kSMC_AllowPowerModeLls = SMC_PMPROT_ALLS_MASK, /*!< Allow Low-Leakage Stop Mode.      */
+#endif                                             /* FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE */
+    kSMC_AllowPowerModeVlp = SMC_PMPROT_AVLP_MASK, /*!< Allow Very-Low-Power Mode.        */
+#if (defined(FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE) && FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE)
+    kSMC_AllowPowerModeHsrun = SMC_PMPROT_AHSRUN_MASK, /*!< Allow High Speed Run mode.        */
+#endif                                                 /* FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE */
+    kSMC_AllowPowerModeAll = (0U
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+                              |
+                              SMC_PMPROT_AVLLS_MASK
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE)
+                              |
+                              SMC_PMPROT_ALLS_MASK
+#endif /* FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE */
+                              |
+                              SMC_PMPROT_AVLP_MASK
+#if (defined(FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE) && FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE)
+                              |
+                              kSMC_AllowPowerModeHsrun
+#endif                          /* FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE */
+                              ) /*!< Allow all power mode.              */
+} smc_power_mode_protection_t;
+
+/*!
+ * @brief Power Modes in PMSTAT
+ */
+typedef enum _smc_power_state
+{
+    kSMC_PowerStateRun = 0x01U << 0U,  /*!< 0000_0001 - Current power mode is RUN   */
+    kSMC_PowerStateStop = 0x01U << 1U, /*!< 0000_0010 - Current power mode is STOP  */
+    kSMC_PowerStateVlpr = 0x01U << 2U, /*!< 0000_0100 - Current power mode is VLPR  */
+    kSMC_PowerStateVlpw = 0x01U << 3U, /*!< 0000_1000 - Current power mode is VLPW  */
+    kSMC_PowerStateVlps = 0x01U << 4U, /*!< 0001_0000 - Current power mode is VLPS  */
+#if (defined(FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE)
+    kSMC_PowerStateLls = 0x01U << 5U, /*!< 0010_0000 - Current power mode is LLS   */
+#endif                                /* FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE */
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+    kSMC_PowerStateVlls = 0x01U << 6U, /*!< 0100_0000 - Current power mode is VLLS  */
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE) && FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE)
+    kSMC_PowerStateHsrun = 0x01U << 7U /*!< 1000_0000 - Current power mode is HSRUN */
+#endif                                 /* FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE */
+} smc_power_state_t;
+
+/*!
+ * @brief Run mode definition
+ */
+typedef enum _smc_run_mode
+{
+    kSMC_RunNormal = 0U, /*!< normal RUN mode.             */
+    kSMC_RunVlpr = 2U,   /*!< Very-Low-Power RUN mode.     */
+#if (defined(FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE) && FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE)
+    kSMC_Hsrun = 3U /*!< High Speed Run mode (HSRUN). */
+#endif              /* FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE */
+} smc_run_mode_t;
+
+/*!
+ * @brief Stop mode definition
+ */
+typedef enum _smc_stop_mode
+{
+    kSMC_StopNormal = 0U, /*!< Normal STOP mode.           */
+    kSMC_StopVlps = 2U,   /*!< Very-Low-Power STOP mode.   */
+#if (defined(FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE)
+    kSMC_StopLls = 3U, /*!< Low-Leakage Stop mode.      */
+#endif                 /* FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE */
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+    kSMC_StopVlls = 4U /*!< Very-Low-Leakage Stop mode. */
+#endif
+} smc_stop_mode_t;
+
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG) ||     \
+    (defined(FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM) && FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM) || \
+    (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE)
+/*!
+ * @brief VLLS/LLS stop sub mode definition
+ */
+typedef enum _smc_stop_submode
+{
+    kSMC_StopSub0 = 0U, /*!< Stop submode 0, for VLLS0/LLS0. */
+    kSMC_StopSub1 = 1U, /*!< Stop submode 1, for VLLS1/LLS1. */
+    kSMC_StopSub2 = 2U, /*!< Stop submode 2, for VLLS2/LLS2. */
+    kSMC_StopSub3 = 3U  /*!< Stop submode 3, for VLLS3/LLS3. */
+} smc_stop_submode_t;
+#endif
+
+/*!
+ * @brief Partial STOP option
+ */
+typedef enum _smc_partial_stop_mode
+{
+    kSMC_PartialStop = 0U,  /*!< STOP - Normal Stop mode*/
+    kSMC_PartialStop1 = 1U, /*!< Partial Stop with both system and bus clocks disabled*/
+    kSMC_PartialStop2 = 2U, /*!< Partial Stop with system clock disabled and bus clock enabled*/
+} smc_partial_stop_option_t;
+
+/*!
+ * @brief SMC configuration status
+ */
+enum _smc_status
+{
+    kStatus_SMC_StopAbort = MAKE_STATUS(kStatusGroup_POWER, 0) /*!< Entering Stop mode is abort*/
+};
+
+#if (defined(FSL_FEATURE_SMC_HAS_VERID) && FSL_FEATURE_SMC_HAS_VERID)
+/*!
+ * @brief IP version ID definition.
+ */
+typedef struct _smc_version_id
+{
+    uint16_t feature; /*!< Feature Specification Number. */
+    uint8_t minor;    /*!< Minor version number.         */
+    uint8_t major;    /*!< Major version number.         */
+} smc_version_id_t;
+#endif /* FSL_FEATURE_SMC_HAS_VERID */
+
+#if (defined(FSL_FEATURE_SMC_HAS_PARAM) && FSL_FEATURE_SMC_HAS_PARAM)
+/*!
+ * @brief IP parameter definition.
+ */
+typedef struct _smc_param
+{
+    bool hsrunEnable; /*!< HSRUN mode enable. */
+    bool llsEnable;   /*!< LLS mode enable.   */
+    bool lls2Enable;  /*!< LLS2 mode enable.  */
+    bool vlls0Enable; /*!< VLLS0 mode enable. */
+} smc_param_t;
+#endif /* FSL_FEATURE_SMC_HAS_PARAM */
+
+#if (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE) || \
+    (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO)
+/*!
+ * @brief SMC Low-Leakage Stop power mode config
+ */
+typedef struct _smc_power_mode_lls_config
+{
+#if (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE)
+    smc_stop_submode_t subMode; /*!< Low-leakage Stop sub-mode */
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO)
+    bool enableLpoClock; /*!< Enable LPO clock in LLS mode */
+#endif
+} smc_power_mode_lls_config_t;
+#endif /* (FSL_FEATURE_SMC_HAS_LLS_SUBMODE || FSL_FEATURE_SMC_HAS_LPOPO) */
+
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+/*!
+ * @brief SMC Very Low-Leakage Stop power mode config
+ */
+typedef struct _smc_power_mode_vlls_config
+{
+#if (defined(FSL_FEATURE_SMC_USE_VLLSCTRL_REG) && FSL_FEATURE_SMC_USE_VLLSCTRL_REG) ||     \
+    (defined(FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM) && FSL_FEATURE_SMC_USE_STOPCTRL_VLLSM) || \
+    (defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE)
+    smc_stop_submode_t subMode; /*!< Very Low-leakage Stop sub-mode */
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_PORPO) && FSL_FEATURE_SMC_HAS_PORPO)
+    bool enablePorDetectInVlls0; /*!< Enable Power on reset detect in VLLS mode */
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_RAM2_POWER_OPTION) && FSL_FEATURE_SMC_HAS_RAM2_POWER_OPTION)
+    bool enableRam2InVlls2; /*!< Enable RAM2 power in VLLS2 */
+#endif
+#if (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO)
+    bool enableLpoClock; /*!< Enable LPO clock in VLLS mode */
+#endif
+} smc_power_mode_vlls_config_t;
+#endif
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*! @name System mode controller APIs*/
+/*@{*/
+
+#if (defined(FSL_FEATURE_SMC_HAS_VERID) && FSL_FEATURE_SMC_HAS_VERID)
+/*!
+ * @brief Gets the SMC version ID.
+ *
+ * This function gets the SMC version ID, including major version number,
+ * minor version number and feature specification number.
+ *
+ * @param base SMC peripheral base address.
+ * @param versionId     Pointer to version ID structure.
+ */
+static inline void SMC_GetVersionId(SMC_Type *base, smc_version_id_t *versionId)
+{
+    *((uint32_t *)versionId) = base->VERID;
+}
+#endif /* FSL_FEATURE_SMC_HAS_VERID */
+
+#if (defined(FSL_FEATURE_SMC_HAS_PARAM) && FSL_FEATURE_SMC_HAS_PARAM)
+/*!
+ * @brief Gets the SMC parameter.
+ *
+ * This function gets the SMC parameter, including the enabled power mdoes.
+ *
+ * @param base SMC peripheral base address.
+ * @param param         Pointer to SMC param structure.
+ */
+void SMC_GetParam(SMC_Type *base, smc_param_t *param);
+#endif
+
+/*!
+ * @brief Configures all power mode protection settings.
+ *
+ * This function  configures the power mode protection settings for
+ * supported power modes in the specified chip family. The available power modes
+ * are defined in the smc_power_mode_protection_t. This should be done at an early
+ * system level initialization stage. See the reference manual for details.
+ * This register can only write once after the power reset.
+ *
+ * The allowed modes are passed as bit map, for example, to allow LLS and VLLS,
+ * use SMC_SetPowerModeProtection(kSMC_AllowPowerModeVlls | kSMC_AllowPowerModeVlps).
+ * To allow all modes, use SMC_SetPowerModeProtection(kSMC_AllowPowerModeAll).
+ *
+ * @param base SMC peripheral base address.
+ * @param allowedModes Bitmap of the allowed power modes.
+ */
+static inline void SMC_SetPowerModeProtection(SMC_Type *base, uint8_t allowedModes)
+{
+    base->PMPROT = allowedModes;
+}
+
+/*!
+ * @brief Gets the current power mode status.
+ *
+ * This function  returns the current power mode stat. Once application
+ * switches the power mode, it should always check the stat to check whether it
+ * runs into the specified mode or not. An application  should  check
+ * this mode before switching to a different mode. The system  requires that
+ * only certain modes can switch to other specific modes. See the
+ * reference manual for details and the smc_power_state_t for information about
+ * the power stat.
+ *
+ * @param base SMC peripheral base address.
+ * @return Current power mode status.
+ */
+static inline smc_power_state_t SMC_GetPowerModeState(SMC_Type *base)
+{
+    return (smc_power_state_t)base->PMSTAT;
+}
+
+/*!
+ * @brief Configure the system to RUN power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeRun(SMC_Type *base);
+
+#if (defined(FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE) && FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE)
+/*!
+ * @brief Configure the system to HSRUN power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeHsrun(SMC_Type *base);
+#endif /* FSL_FEATURE_SMC_HAS_HIGH_SPEED_RUN_MODE */
+
+/*!
+ * @brief Configure the system to WAIT power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeWait(SMC_Type *base);
+
+/*!
+ * @brief Configure the system to Stop power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @param  option Partial Stop mode option.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeStop(SMC_Type *base, smc_partial_stop_option_t option);
+
+#if (defined(FSL_FEATURE_SMC_HAS_LPWUI) && FSL_FEATURE_SMC_HAS_LPWUI)
+/*!
+ * @brief Configure the system to VLPR power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @param  wakeupMode Enter Normal Run mode if true, else stay in VLPR mode.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeVlpr(SMC_Type *base, bool wakeupMode);
+#else
+/*!
+ * @brief Configure the system to VLPR power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeVlpr(SMC_Type *base);
+#endif /* FSL_FEATURE_SMC_HAS_LPWUI */
+
+/*!
+ * @brief Configure the system to VLPW power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeVlpw(SMC_Type *base);
+
+/*!
+ * @brief Configure the system to VLPS power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeVlps(SMC_Type *base);
+
+#if (defined(FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE)
+#if ((defined(FSL_FEATURE_SMC_HAS_LLS_SUBMODE) && FSL_FEATURE_SMC_HAS_LLS_SUBMODE) || \
+     (defined(FSL_FEATURE_SMC_HAS_LPOPO) && FSL_FEATURE_SMC_HAS_LPOPO))
+/*!
+ * @brief Configure the system to LLS power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @param  config The LLS power mode configuration structure
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeLls(SMC_Type *base, const smc_power_mode_lls_config_t *config);
+#else
+/*!
+ * @brief Configure the system to LLS power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeLls(SMC_Type *base);
+#endif
+#endif /* FSL_FEATURE_SMC_HAS_LOW_LEAKAGE_STOP_MODE */
+
+#if (defined(FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE) && FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE)
+/*!
+ * @brief Configure the system to VLLS power mode.
+ *
+ * @param base SMC peripheral base address.
+ * @param  config The VLLS power mode configuration structure.
+ * @return SMC configuration error code.
+ */
+status_t SMC_SetPowerModeVlls(SMC_Type *base, const smc_power_mode_vlls_config_t *config);
+#endif /* FSL_FEATURE_SMC_HAS_VERY_LOW_LEAKAGE_STOP_MODE */
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_SMC_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart.c
@@ -1,0 +1,1032 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_uart.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* UART transfer state. */
+enum _uart_tansfer_states
+{
+    kUART_TxIdle, /* TX idle. */
+    kUART_TxBusy, /* TX busy. */
+    kUART_RxIdle, /* RX idle. */
+    kUART_RxBusy  /* RX busy. */
+};
+
+/* Typedef for interrupt handler. */
+typedef void (*uart_isr_t)(UART_Type *base, uart_handle_t *handle);
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Get the UART instance from peripheral base address.
+ *
+ * @param base UART peripheral base address.
+ * @return UART instance.
+ */
+uint32_t UART_GetInstance(UART_Type *base);
+
+/*!
+ * @brief Get the length of received data in RX ring buffer.
+ *
+ * @param handle UART handle pointer.
+ * @return Length of received data in RX ring buffer.
+ */
+static size_t UART_TransferGetRxRingBufferLength(uart_handle_t *handle);
+
+/*!
+ * @brief Check whether the RX ring buffer is full.
+ *
+ * @param handle UART handle pointer.
+ * @retval true  RX ring buffer is full.
+ * @retval false RX ring buffer is not full.
+ */
+static bool UART_TransferIsRxRingBufferFull(uart_handle_t *handle);
+
+/*!
+ * @brief Read RX register using non-blocking method.
+ *
+ * This function reads data from the TX register directly, upper layer must make
+ * sure the RX register is full or TX FIFO has data before calling this function.
+ *
+ * @param base UART peripheral base address.
+ * @param data Start addresss of the buffer to store the received data.
+ * @param length Size of the buffer.
+ */
+static void UART_ReadNonBlocking(UART_Type *base, uint8_t *data, size_t length);
+
+/*!
+ * @brief Write to TX register using non-blocking method.
+ *
+ * This function writes data to the TX register directly, upper layer must make
+ * sure the TX register is empty or TX FIFO has empty room before calling this function.
+ *
+ * @note This function does not check whether all the data has been sent out to bus,
+ * so before disable TX, check kUART_TransmissionCompleteFlag to ensure the TX is
+ * finished.
+ *
+ * @param base UART peripheral base address.
+ * @param data Start addresss of the data to write.
+ * @param length Size of the buffer to be sent.
+ */
+static void UART_WriteNonBlocking(UART_Type *base, const uint8_t *data, size_t length);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* Array of UART handle. */
+#if (defined(UART5))
+#define UART_HANDLE_ARRAY_SIZE 6
+#else /* UART5 */
+#if (defined(UART4))
+#define UART_HANDLE_ARRAY_SIZE 5
+#else /* UART4 */
+#if (defined(UART3))
+#define UART_HANDLE_ARRAY_SIZE 4
+#else /* UART3 */
+#if (defined(UART2))
+#define UART_HANDLE_ARRAY_SIZE 3
+#else /* UART2 */
+#if (defined(UART1))
+#define UART_HANDLE_ARRAY_SIZE 2
+#else /* UART1 */
+#if (defined(UART0))
+#define UART_HANDLE_ARRAY_SIZE 1
+#else /* UART0 */
+#error No UART instance.
+#endif /* UART 0 */
+#endif /* UART 1 */
+#endif /* UART 2 */
+#endif /* UART 3 */
+#endif /* UART 4 */
+#endif /* UART 5 */
+static uart_handle_t *s_uartHandle[UART_HANDLE_ARRAY_SIZE];
+/* Array of UART peripheral base address. */
+static UART_Type *const s_uartBases[] = UART_BASE_PTRS;
+
+/* Array of UART IRQ number. */
+static const IRQn_Type s_uartIRQ[] = UART_RX_TX_IRQS;
+/* Array of UART clock name. */
+static const clock_ip_name_t s_uartClock[] = UART_CLOCKS;
+
+/* UART ISR for transactional APIs. */
+static uart_isr_t s_uartIsr;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+uint32_t UART_GetInstance(UART_Type *base)
+{
+    uint32_t instance;
+    uint32_t uartArrayCount = (sizeof(s_uartBases) / sizeof(s_uartBases[0]));
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < uartArrayCount; instance++)
+    {
+        if (s_uartBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < uartArrayCount);
+
+    return instance;
+}
+
+static size_t UART_TransferGetRxRingBufferLength(uart_handle_t *handle)
+{
+    size_t size;
+
+    if (handle->rxRingBufferTail > handle->rxRingBufferHead)
+    {
+        size = (size_t)(handle->rxRingBufferHead + handle->rxRingBufferSize - handle->rxRingBufferTail);
+    }
+    else
+    {
+        size = (size_t)(handle->rxRingBufferHead - handle->rxRingBufferTail);
+    }
+
+    return size;
+}
+
+static bool UART_TransferIsRxRingBufferFull(uart_handle_t *handle)
+{
+    bool full;
+
+    if (UART_TransferGetRxRingBufferLength(handle) == (handle->rxRingBufferSize - 1U))
+    {
+        full = true;
+    }
+    else
+    {
+        full = false;
+    }
+
+    return full;
+}
+
+void UART_Init(UART_Type *base, const uart_config_t *config, uint32_t srcClock_Hz)
+{
+    assert(config);
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    assert(FSL_FEATURE_UART_FIFO_SIZEn(base) >= config->txFifoWatermark);
+    assert(FSL_FEATURE_UART_FIFO_SIZEn(base) >= config->rxFifoWatermark);
+#endif
+
+    uint16_t sbr;
+    uint8_t temp;
+
+    /* Enable uart clock */
+    CLOCK_EnableClock(s_uartClock[UART_GetInstance(base)]);
+
+    /* Disable UART TX RX before setting. */
+    base->C2 &= ~(UART_C2_TE_MASK | UART_C2_RE_MASK);
+
+    /* Calculate the baud rate modulo divisor, sbr*/
+    sbr = srcClock_Hz / (config->baudRate_Bps * 16);
+
+    /* Write the sbr value to the BDH and BDL registers*/
+    base->BDH = (base->BDH & ~UART_BDH_SBR_MASK) | (uint8_t)(sbr >> 8);
+    base->BDL = (uint8_t)sbr;
+
+#if defined(FSL_FEATURE_UART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT) && FSL_FEATURE_UART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT
+    /* Determine if a fractional divider is needed to fine tune closer to the
+     * desired baud, each value of brfa is in 1/32 increments,
+     * hence the multiply-by-32. */
+    uint16_t brfa = (32 * srcClock_Hz / (config->baudRate_Bps * 16)) - 32 * sbr;
+
+    /* Write the brfa value to the register*/
+    base->C4 = (base->C4 & ~UART_C4_BRFA_MASK) | (brfa & UART_C4_BRFA_MASK);
+#endif
+
+    /* Set bit count and parity mode. */
+    temp = base->C1 & ~(UART_C1_PE_MASK | UART_C1_PT_MASK | UART_C1_M_MASK);
+
+    if (kUART_ParityDisabled != config->parityMode)
+    {
+        temp |= (UART_C1_M_MASK | (uint8_t)config->parityMode);
+    }
+
+    base->C1 = temp;
+
+#if defined(FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT
+    /* Set stop bit per char */
+    base->BDH = (base->BDH & ~UART_BDH_SBNS_MASK) | UART_BDH_SBNS((uint8_t)config->stopBitCount);
+#endif
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    /* Set tx/rx FIFO watermark */
+    base->TWFIFO = config->txFifoWatermark;
+    base->RWFIFO = config->rxFifoWatermark;
+
+    /* Enable tx/rx FIFO */
+    base->PFIFO |= (UART_PFIFO_TXFE_MASK | UART_PFIFO_RXFE_MASK);
+
+    /* Flush FIFO */
+    base->CFIFO |= (UART_CFIFO_TXFLUSH_MASK | UART_CFIFO_RXFLUSH_MASK);
+#endif
+
+    /* Enable TX/RX base on configure structure. */
+    temp = base->C2;
+
+    if (config->enableTx)
+    {
+        temp |= UART_C2_TE_MASK;
+    }
+
+    if (config->enableRx)
+    {
+        temp |= UART_C2_RE_MASK;
+    }
+
+    base->C2 = temp;
+}
+
+void UART_Deinit(UART_Type *base)
+{
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    /* Wait tx FIFO send out*/
+    while (0 != base->TCFIFO)
+    {
+    }
+#endif
+    /* Wait last char shoft out */
+    while (0 == (base->S1 & UART_S1_TC_MASK))
+    {
+    }
+
+    /* Disable the module. */
+    base->C2 = 0;
+
+    /* Disable uart clock */
+    CLOCK_DisableClock(s_uartClock[UART_GetInstance(base)]);
+}
+
+void UART_GetDefaultConfig(uart_config_t *config)
+{
+    assert(config);
+
+    config->baudRate_Bps = 115200U;
+    config->parityMode = kUART_ParityDisabled;
+#if defined(FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT
+    config->stopBitCount = kUART_OneStopBit;
+#endif
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    config->txFifoWatermark = 0;
+    config->rxFifoWatermark = 1;
+#endif
+    config->enableTx = false;
+    config->enableRx = false;
+}
+
+void UART_SetBaudRate(UART_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
+{
+    uint16_t sbr;
+    uint8_t oldCtrl;
+
+    /* Store C2 before disable Tx and Rx */
+    oldCtrl = base->C2;
+
+    /* Disable UART TX RX before setting. */
+    base->C2 &= ~(UART_C2_TE_MASK | UART_C2_RE_MASK);
+
+    /* Calculate the baud rate modulo divisor, sbr*/
+    sbr = srcClock_Hz / (baudRate_Bps * 16);
+
+    /* Write the sbr value to the BDH and BDL registers*/
+    base->BDH = (base->BDH & ~UART_BDH_SBR_MASK) | (uint8_t)(sbr >> 8);
+    base->BDL = (uint8_t)sbr;
+
+#if defined(FSL_FEATURE_UART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT) && FSL_FEATURE_UART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT
+    /* Determine if a fractional divider is needed to fine tune closer to the
+     * desired baud, each value of brfa is in 1/32 increments,
+     * hence the multiply-by-32. */
+    uint16_t brfa = (32 * srcClock_Hz / (baudRate_Bps * 16)) - 32 * sbr;
+
+    /* Write the brfa value to the register*/
+    base->C4 = (base->C4 & ~UART_C4_BRFA_MASK) | (brfa & UART_C4_BRFA_MASK);
+#endif
+
+    /* Restore C2. */
+    base->C2 = oldCtrl;
+}
+
+void UART_EnableInterrupts(UART_Type *base, uint32_t mask)
+{
+    /* The interrupt mask is combined by control bits from several register: ((CFIFO<<24) | (C3<<16) | (C2<<8) |(BDH))
+     */
+    base->BDH |= (mask & 0xFF);
+    base->C2 |= ((mask >> 8) & 0xFF);
+    base->C3 |= ((mask >> 16) & 0xFF);
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    base->CFIFO |= ((mask >> 24) & 0xFF);
+#endif
+}
+
+void UART_DisableInterrupts(UART_Type *base, uint32_t mask)
+{
+    /* The interrupt mask is combined by control bits from several register: ((CFIFO<<24) | (C3<<16) | (C2<<8) |(BDH))
+     */
+    base->BDH &= ~(mask & 0xFF);
+    base->C2 &= ~((mask >> 8) & 0xFF);
+    base->C3 &= ~((mask >> 16) & 0xFF);
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    base->CFIFO &= ~((mask >> 24) & 0xFF);
+#endif
+}
+
+uint32_t UART_GetEnabledInterrupts(UART_Type *base)
+{
+    uint32_t temp;
+
+    temp = base->BDH | ((uint32_t)(base->C2) << 8) | ((uint32_t)(base->C3) << 16);
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    temp |= ((uint32_t)(base->CFIFO) << 24);
+#endif
+
+    return temp;
+}
+
+uint32_t UART_GetStatusFlags(UART_Type *base)
+{
+    uint32_t status_flag;
+
+    status_flag = base->S1 | ((uint32_t)(base->S2) << 8);
+
+#if defined(FSL_FEATURE_UART_HAS_EXTENDED_DATA_REGISTER_FLAGS) && FSL_FEATURE_UART_HAS_EXTENDED_DATA_REGISTER_FLAGS
+    status_flag |= ((uint32_t)(base->ED) << 16);
+#endif
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    status_flag |= ((uint32_t)(base->SFIFO) << 24);
+#endif
+
+    return status_flag;
+}
+
+status_t UART_ClearStatusFlags(UART_Type *base, uint32_t mask)
+{
+    uint8_t reg = base->S2;
+    status_t status;
+
+#if defined(FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT) && FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT
+    reg &= ~(UART_S2_RXEDGIF_MASK | UART_S2_LBKDIF_MASK);
+#else
+    reg &= ~UART_S2_RXEDGIF_MASK;
+#endif
+
+    base->S2 = reg | (uint8_t)(mask >> 8);
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    base->SFIFO = (uint8_t)(mask >> 24);
+#endif
+
+    if (mask & (kUART_IdleLineFlag | kUART_RxOverrunFlag | kUART_NoiseErrorFlag | kUART_FramingErrorFlag |
+                kUART_ParityErrorFlag))
+    {
+        /* Read base->D to clear the flags. */
+        (void)base->S1;
+        (void)base->D;
+    }
+
+    /* If some flags still pending. */
+    if (mask & UART_GetStatusFlags(base))
+    {
+        /* Some flags can only clear or set by the hardware itself, these flags are: kUART_TxDataRegEmptyFlag,
+        kUART_TransmissionCompleteFlag, kUART_RxDataRegFullFlag, kUART_RxActiveFlag, kUART_NoiseErrorInRxDataRegFlag,
+        kUART_ParityErrorInRxDataRegFlag, kUART_TxFifoEmptyFlag, kUART_RxFifoEmptyFlag. */
+        status = kStatus_UART_FlagCannotClearManually;
+    }
+    else
+    {
+        status = kStatus_Success;
+    }
+
+    return status;
+}
+
+void UART_WriteBlocking(UART_Type *base, const uint8_t *data, size_t length)
+{
+    /* This API can only ensure that the data is written into the data buffer but can't
+    ensure all data in the data buffer are sent into the transmit shift buffer. */
+    while (length--)
+    {
+        while (!(base->S1 & UART_S1_TDRE_MASK))
+        {
+        }
+        base->D = *(data++);
+    }
+}
+
+static void UART_WriteNonBlocking(UART_Type *base, const uint8_t *data, size_t length)
+{
+    size_t i;
+
+    /* The Non Blocking write data API assume user have ensured there is enough space in
+    peripheral to write. */
+    for (i = 0; i < length; i++)
+    {
+        base->D = data[i];
+    }
+}
+
+status_t UART_ReadBlocking(UART_Type *base, uint8_t *data, size_t length)
+{
+    uint32_t statusFlag;
+
+    while (length--)
+    {
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+        while (!base->RCFIFO)
+#else
+        while (!(base->S1 & UART_S1_RDRF_MASK))
+#endif
+        {
+            statusFlag = UART_GetStatusFlags(base);
+
+            if (statusFlag & kUART_RxOverrunFlag)
+            {
+                return kStatus_UART_RxHardwareOverrun;
+            }
+
+            if (statusFlag & kUART_NoiseErrorFlag)
+            {
+                return kStatus_UART_NoiseError;
+            }
+
+            if (statusFlag & kUART_FramingErrorFlag)
+            {
+                return kStatus_UART_FramingError;
+            }
+
+            if (statusFlag & kUART_ParityErrorFlag)
+            {
+                return kStatus_UART_ParityError;
+            }
+        }
+        *(data++) = base->D;
+    }
+
+    return kStatus_Success;
+}
+
+static void UART_ReadNonBlocking(UART_Type *base, uint8_t *data, size_t length)
+{
+    size_t i;
+
+    /* The Non Blocking read data API assume user have ensured there is enough space in
+    peripheral to write. */
+    for (i = 0; i < length; i++)
+    {
+        data[i] = base->D;
+    }
+}
+
+void UART_TransferCreateHandle(UART_Type *base,
+                               uart_handle_t *handle,
+                               uart_transfer_callback_t callback,
+                               void *userData)
+{
+    assert(handle);
+
+    uint32_t instance;
+
+    /* Zero the handle. */
+    memset(handle, 0, sizeof(*handle));
+
+    /* Set the TX/RX state. */
+    handle->rxState = kUART_RxIdle;
+    handle->txState = kUART_TxIdle;
+
+    /* Set the callback and user data. */
+    handle->callback = callback;
+    handle->userData = userData;
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    /* Note:
+       Take care of the RX FIFO, RX interrupt request only assert when received bytes
+       equal or more than RX water mark, there is potential issue if RX water
+       mark larger than 1.
+       For example, if RX FIFO water mark is 2, upper layer needs 5 bytes and
+       5 bytes are received. the last byte will be saved in FIFO but not trigger
+       RX interrupt because the water mark is 2.
+     */
+    base->RWFIFO = 1U;
+#endif
+
+    /* Get instance from peripheral base address. */
+    instance = UART_GetInstance(base);
+
+    /* Save the handle in global variables to support the double weak mechanism. */
+    s_uartHandle[instance] = handle;
+
+    s_uartIsr = UART_TransferHandleIRQ;
+
+    /* Enable interrupt in NVIC. */
+    EnableIRQ(s_uartIRQ[instance]);
+}
+
+void UART_TransferStartRingBuffer(UART_Type *base, uart_handle_t *handle, uint8_t *ringBuffer, size_t ringBufferSize)
+{
+    assert(handle);
+
+    /* Setup the ringbuffer address */
+    if (ringBuffer)
+    {
+        handle->rxRingBuffer = ringBuffer;
+        handle->rxRingBufferSize = ringBufferSize;
+        handle->rxRingBufferHead = 0U;
+        handle->rxRingBufferTail = 0U;
+
+        /* Enable the interrupt to accept the data when user need the ring buffer. */
+        UART_EnableInterrupts(base, kUART_RxDataRegFullInterruptEnable | kUART_RxOverrunInterruptEnable);
+    }
+}
+
+void UART_TransferStopRingBuffer(UART_Type *base, uart_handle_t *handle)
+{
+    assert(handle);
+
+    if (handle->rxState == kUART_RxIdle)
+    {
+        UART_DisableInterrupts(base, kUART_RxDataRegFullInterruptEnable | kUART_RxOverrunInterruptEnable);
+    }
+
+    handle->rxRingBuffer = NULL;
+    handle->rxRingBufferSize = 0U;
+    handle->rxRingBufferHead = 0U;
+    handle->rxRingBufferTail = 0U;
+}
+
+status_t UART_TransferSendNonBlocking(UART_Type *base, uart_handle_t *handle, uart_transfer_t *xfer)
+{
+    status_t status;
+
+    /* Return error if xfer invalid. */
+    if ((0U == xfer->dataSize) || (NULL == xfer->data))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Return error if current TX busy. */
+    if (kUART_TxBusy == handle->txState)
+    {
+        status = kStatus_UART_TxBusy;
+    }
+    else
+    {
+        handle->txData = xfer->data;
+        handle->txDataSize = xfer->dataSize;
+        handle->txDataSizeAll = xfer->dataSize;
+        handle->txState = kUART_TxBusy;
+
+        /* Enable transmiter interrupt. */
+        UART_EnableInterrupts(base, kUART_TxDataRegEmptyInterruptEnable);
+
+        status = kStatus_Success;
+    }
+
+    return status;
+}
+
+void UART_TransferAbortSend(UART_Type *base, uart_handle_t *handle)
+{
+    UART_DisableInterrupts(base, kUART_TxDataRegEmptyInterruptEnable | kUART_TransmissionCompleteInterruptEnable);
+
+    handle->txDataSize = 0;
+    handle->txState = kUART_TxIdle;
+}
+
+status_t UART_TransferGetSendCount(UART_Type *base, uart_handle_t *handle, uint32_t *count)
+{
+    if (kUART_TxIdle == handle->txState)
+    {
+        return kStatus_NoTransferInProgress;
+    }
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    *count = handle->txDataSizeAll - handle->txDataSize;
+
+    return kStatus_Success;
+}
+
+status_t UART_TransferReceiveNonBlocking(UART_Type *base,
+                                         uart_handle_t *handle,
+                                         uart_transfer_t *xfer,
+                                         size_t *receivedBytes)
+{
+    uint32_t i;
+    status_t status;
+    /* How many bytes to copy from ring buffer to user memory. */
+    size_t bytesToCopy = 0U;
+    /* How many bytes to receive. */
+    size_t bytesToReceive;
+    /* How many bytes currently have received. */
+    size_t bytesCurrentReceived;
+    uint32_t regPrimask = 0U;
+
+    /* Return error if xfer invalid. */
+    if ((0U == xfer->dataSize) || (NULL == xfer->data))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* How to get data:
+       1. If RX ring buffer is not enabled, then save xfer->data and xfer->dataSize
+          to uart handle, enable interrupt to store received data to xfer->data. When
+          all data received, trigger callback.
+       2. If RX ring buffer is enabled and not empty, get data from ring buffer first.
+          If there are enough data in ring buffer, copy them to xfer->data and return.
+          If there are not enough data in ring buffer, copy all of them to xfer->data,
+          save the xfer->data remained empty space to uart handle, receive data
+          to this empty space and trigger callback when finished. */
+
+    if (kUART_RxBusy == handle->rxState)
+    {
+        status = kStatus_UART_RxBusy;
+    }
+    else
+    {
+        bytesToReceive = xfer->dataSize;
+        bytesCurrentReceived = 0U;
+
+        /* If RX ring buffer is used. */
+        if (handle->rxRingBuffer)
+        {
+            /* Disable IRQ, protect ring buffer. */
+            regPrimask = DisableGlobalIRQ();
+
+            /* How many bytes in RX ring buffer currently. */
+            bytesToCopy = UART_TransferGetRxRingBufferLength(handle);
+
+            if (bytesToCopy)
+            {
+                bytesToCopy = MIN(bytesToReceive, bytesToCopy);
+
+                bytesToReceive -= bytesToCopy;
+
+                /* Copy data from ring buffer to user memory. */
+                for (i = 0U; i < bytesToCopy; i++)
+                {
+                    xfer->data[bytesCurrentReceived++] = handle->rxRingBuffer[handle->rxRingBufferTail];
+
+                    /* Wrap to 0. Not use modulo (%) because it might be large and slow. */
+                    if (handle->rxRingBufferTail + 1U == handle->rxRingBufferSize)
+                    {
+                        handle->rxRingBufferTail = 0U;
+                    }
+                    else
+                    {
+                        handle->rxRingBufferTail++;
+                    }
+                }
+            }
+
+            /* If ring buffer does not have enough data, still need to read more data. */
+            if (bytesToReceive)
+            {
+                /* No data in ring buffer, save the request to UART handle. */
+                handle->rxData = xfer->data + bytesCurrentReceived;
+                handle->rxDataSize = bytesToReceive;
+                handle->rxDataSizeAll = bytesToReceive;
+                handle->rxState = kUART_RxBusy;
+            }
+
+            /* Enable IRQ if previously enabled. */
+            EnableGlobalIRQ(regPrimask);
+
+            /* Call user callback since all data are received. */
+            if (0 == bytesToReceive)
+            {
+                if (handle->callback)
+                {
+                    handle->callback(base, handle, kStatus_UART_RxIdle, handle->userData);
+                }
+            }
+        }
+        /* Ring buffer not used. */
+        else
+        {
+            handle->rxData = xfer->data + bytesCurrentReceived;
+            handle->rxDataSize = bytesToReceive;
+            handle->rxDataSizeAll = bytesToReceive;
+            handle->rxState = kUART_RxBusy;
+
+            /* Enable RX interrupt. */
+            UART_EnableInterrupts(base, kUART_RxDataRegFullInterruptEnable | kUART_RxOverrunInterruptEnable);
+        }
+
+        /* Return the how many bytes have read. */
+        if (receivedBytes)
+        {
+            *receivedBytes = bytesCurrentReceived;
+        }
+
+        status = kStatus_Success;
+    }
+
+    return status;
+}
+
+void UART_TransferAbortReceive(UART_Type *base, uart_handle_t *handle)
+{
+    /* Only abort the receive to handle->rxData, the RX ring buffer is still working. */
+    if (!handle->rxRingBuffer)
+    {
+        /* Disable RX interrupt. */
+        UART_DisableInterrupts(base, kUART_RxDataRegFullInterruptEnable | kUART_RxOverrunInterruptEnable);
+    }
+
+    handle->rxDataSize = 0U;
+    handle->rxState = kUART_RxIdle;
+}
+
+status_t UART_TransferGetReceiveCount(UART_Type *base, uart_handle_t *handle, uint32_t *count)
+{
+    if (kUART_RxIdle == handle->rxState)
+    {
+        return kStatus_NoTransferInProgress;
+    }
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    *count = handle->rxDataSizeAll - handle->rxDataSize;
+
+    return kStatus_Success;
+}
+
+void UART_TransferHandleIRQ(UART_Type *base, uart_handle_t *handle)
+{
+    uint8_t count;
+    uint8_t tempCount;
+
+    assert(handle);
+
+    /* If RX overrun. */
+    if (UART_S1_OR_MASK & base->S1)
+    {
+        /* Read base->D, otherwise the RX does not work. */
+        (void)base->D;
+
+        /* Trigger callback. */
+        if (handle->callback)
+        {
+            handle->callback(base, handle, kStatus_UART_RxHardwareOverrun, handle->userData);
+        }
+    }
+
+    /* Receive data register full */
+    if ((UART_S1_RDRF_MASK & base->S1) && (UART_C2_RIE_MASK & base->C2))
+    {
+/* Get the size that can be stored into buffer for this interrupt. */
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+        count = base->RCFIFO;
+#else
+        count = 1;
+#endif
+
+        /* If handle->rxDataSize is not 0, first save data to handle->rxData. */
+        while ((count) && (handle->rxDataSize))
+        {
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+            tempCount = MIN(handle->rxDataSize, count);
+#else
+            tempCount = 1;
+#endif
+
+            /* Using non block API to read the data from the registers. */
+            UART_ReadNonBlocking(base, handle->rxData, tempCount);
+            handle->rxData += tempCount;
+            handle->rxDataSize -= tempCount;
+            count -= tempCount;
+
+            /* If all the data required for upper layer is ready, trigger callback. */
+            if (!handle->rxDataSize)
+            {
+                handle->rxState = kUART_RxIdle;
+
+                if (handle->callback)
+                {
+                    handle->callback(base, handle, kStatus_UART_RxIdle, handle->userData);
+                }
+            }
+        }
+
+        /* If use RX ring buffer, receive data to ring buffer. */
+        if (handle->rxRingBuffer)
+        {
+            while (count--)
+            {
+                /* If RX ring buffer is full, trigger callback to notify over run. */
+                if (UART_TransferIsRxRingBufferFull(handle))
+                {
+                    if (handle->callback)
+                    {
+                        handle->callback(base, handle, kStatus_UART_RxRingBufferOverrun, handle->userData);
+                    }
+                }
+
+                /* If ring buffer is still full after callback function, the oldest data is overrided. */
+                if (UART_TransferIsRxRingBufferFull(handle))
+                {
+                    /* Increase handle->rxRingBufferTail to make room for new data. */
+                    if (handle->rxRingBufferTail + 1U == handle->rxRingBufferSize)
+                    {
+                        handle->rxRingBufferTail = 0U;
+                    }
+                    else
+                    {
+                        handle->rxRingBufferTail++;
+                    }
+                }
+
+                /* Read data. */
+                handle->rxRingBuffer[handle->rxRingBufferHead] = base->D;
+
+                /* Increase handle->rxRingBufferHead. */
+                if (handle->rxRingBufferHead + 1U == handle->rxRingBufferSize)
+                {
+                    handle->rxRingBufferHead = 0U;
+                }
+                else
+                {
+                    handle->rxRingBufferHead++;
+                }
+            }
+        }
+        /* If no receive requst pending, stop RX interrupt. */
+        else if (!handle->rxDataSize)
+        {
+            UART_DisableInterrupts(base, kUART_RxDataRegFullInterruptEnable | kUART_RxOverrunInterruptEnable);
+        }
+        else
+        {
+        }
+    }
+
+    /* Send data register empty and the interrupt is enabled. */
+    if ((base->S1 & UART_S1_TDRE_MASK) && (base->C2 & UART_C2_TIE_MASK))
+    {
+/* Get the bytes that available at this moment. */
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+        count = FSL_FEATURE_UART_FIFO_SIZEn(base) - base->TCFIFO;
+#else
+        count = 1;
+#endif
+
+        while ((count) && (handle->txDataSize))
+        {
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+            tempCount = MIN(handle->txDataSize, count);
+#else
+            tempCount = 1;
+#endif
+
+            /* Using non block API to write the data to the registers. */
+            UART_WriteNonBlocking(base, handle->txData, tempCount);
+            handle->txData += tempCount;
+            handle->txDataSize -= tempCount;
+            count -= tempCount;
+
+            /* If all the data are written to data register, TX finished. */
+            if (!handle->txDataSize)
+            {
+                handle->txState = kUART_TxIdle;
+
+                /* Disable TX register empty interrupt. */
+                base->C2 = (base->C2 & ~UART_C2_TIE_MASK);
+
+                /* Trigger callback. */
+                if (handle->callback)
+                {
+                    handle->callback(base, handle, kStatus_UART_TxIdle, handle->userData);
+                }
+            }
+        }
+    }
+}
+
+void UART_TransferHandleErrorIRQ(UART_Type *base, uart_handle_t *handle)
+{
+    /* TODO: To be implemented. */
+}
+
+#if defined(UART0)
+#if ((!(defined(FSL_FEATURE_SOC_LPSCI_COUNT))) || \
+     ((defined(FSL_FEATURE_SOC_LPSCI_COUNT)) && (FSL_FEATURE_SOC_LPSCI_COUNT == 0)))
+void UART0_DriverIRQHandler(void)
+{
+    s_uartIsr(UART0, s_uartHandle[0]);
+}
+
+void UART0_RX_TX_DriverIRQHandler(void)
+{
+    UART0_DriverIRQHandler();
+}
+#endif
+#endif
+
+#if defined(UART1)
+void UART1_DriverIRQHandler(void)
+{
+    s_uartIsr(UART1, s_uartHandle[1]);
+}
+
+void UART1_RX_TX_DriverIRQHandler(void)
+{
+    UART1_DriverIRQHandler();
+}
+#endif
+
+#if defined(UART2)
+void UART2_DriverIRQHandler(void)
+{
+    s_uartIsr(UART2, s_uartHandle[2]);
+}
+
+void UART2_RX_TX_DriverIRQHandler(void)
+{
+    UART2_DriverIRQHandler();
+}
+
+#endif
+
+#if defined(UART3)
+void UART3_DriverIRQHandler(void)
+{
+    s_uartIsr(UART3, s_uartHandle[3]);
+}
+
+void UART3_RX_TX_DriverIRQHandler(void)
+{
+    UART3_DriverIRQHandler();
+}
+#endif
+
+#if defined(UART4)
+void UART4_DriverIRQHandler(void)
+{
+    s_uartIsr(UART4, s_uartHandle[4]);
+}
+
+void UART4_RX_TX_DriverIRQHandler(void)
+{
+    UART4_DriverIRQHandler();
+}
+#endif
+
+#if defined(UART5)
+void UART5_DriverIRQHandler(void)
+{
+    s_uartIsr(UART5, s_uartHandle[5]);
+}
+
+void UART5_RX_TX_DriverIRQHandler(void)
+{
+    UART5_DriverIRQHandler();
+}
+#endif

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart.h
@@ -1,0 +1,757 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_UART_H_
+#define _FSL_UART_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup uart_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief UART driver version 2.1.0. */
+#define FSL_UART_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*@}*/
+
+/*! @brief Error codes for the UART driver. */
+enum _uart_status
+{
+    kStatus_UART_TxBusy = MAKE_STATUS(kStatusGroup_UART, 0),              /*!< Transmitter is busy. */
+    kStatus_UART_RxBusy = MAKE_STATUS(kStatusGroup_UART, 1),              /*!< Receiver is busy. */
+    kStatus_UART_TxIdle = MAKE_STATUS(kStatusGroup_UART, 2),              /*!< UART transmitter is idle. */
+    kStatus_UART_RxIdle = MAKE_STATUS(kStatusGroup_UART, 3),              /*!< UART receiver is idle. */
+    kStatus_UART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_UART, 4), /*!< TX FIFO watermark too large  */
+    kStatus_UART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_UART, 5), /*!< RX FIFO watermark too large  */
+    kStatus_UART_FlagCannotClearManually =
+        MAKE_STATUS(kStatusGroup_UART, 6),                                /*!< UART flag can't be manually cleared. */
+    kStatus_UART_Error = MAKE_STATUS(kStatusGroup_UART, 7),               /*!< Error happens on UART. */
+    kStatus_UART_RxRingBufferOverrun = MAKE_STATUS(kStatusGroup_UART, 8), /*!< UART RX software ring buffer overrun. */
+    kStatus_UART_RxHardwareOverrun = MAKE_STATUS(kStatusGroup_UART, 9),   /*!< UART RX receiver overrun. */
+    kStatus_UART_NoiseError = MAKE_STATUS(kStatusGroup_UART, 10),         /*!< UART noise error. */
+    kStatus_UART_FramingError = MAKE_STATUS(kStatusGroup_UART, 11),       /*!< UART framing error. */
+    kStatus_UART_ParityError = MAKE_STATUS(kStatusGroup_UART, 12),        /*!< UART parity error. */
+};
+
+/*! @brief UART parity mode. */
+typedef enum _uart_parity_mode
+{
+    kUART_ParityDisabled = 0x0U, /*!< Parity disabled */
+    kUART_ParityEven = 0x2U,     /*!< Parity enabled, type even, bit setting: PE|PT = 10 */
+    kUART_ParityOdd = 0x3U,      /*!< Parity enabled, type odd,  bit setting: PE|PT = 11 */
+} uart_parity_mode_t;
+
+/*! @brief UART stop bit count. */
+typedef enum _uart_stop_bit_count
+{
+    kUART_OneStopBit = 0U, /*!< One stop bit */
+    kUART_TwoStopBit = 1U, /*!< Two stop bits */
+} uart_stop_bit_count_t;
+
+/*!
+ * @brief UART interrupt configuration structure, default settings all disabled.
+ *
+ * This structure contains the settings for all of the UART interrupt configurations.
+ */
+enum _uart_interrupt_enable
+{
+#if defined(FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT) && FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT
+    kUART_LinBreakInterruptEnable = (UART_BDH_LBKDIE_MASK), /*!< LIN break detect interrupt. */
+#endif
+    kUART_RxActiveEdgeInterruptEnable = (UART_BDH_RXEDGIE_MASK),   /*!< RX active edge interrupt. */
+    kUART_TxDataRegEmptyInterruptEnable = (UART_C2_TIE_MASK << 8), /*!< Transmit data register empty interrupt. */
+    kUART_TransmissionCompleteInterruptEnable = (UART_C2_TCIE_MASK << 8), /*!< Transmission complete interrupt. */
+    kUART_RxDataRegFullInterruptEnable = (UART_C2_RIE_MASK << 8),         /*!< Receiver data register full interrupt. */
+    kUART_IdleLineInterruptEnable = (UART_C2_ILIE_MASK << 8),             /*!< Idle line interrupt. */
+    kUART_RxOverrunInterruptEnable = (UART_C3_ORIE_MASK << 16),           /*!< Receiver overrun interrupt. */
+    kUART_NoiseErrorInterruptEnable = (UART_C3_NEIE_MASK << 16),          /*!< Noise error flag interrupt. */
+    kUART_FramingErrorInterruptEnable = (UART_C3_FEIE_MASK << 16),        /*!< Framing error flag interrupt. */
+    kUART_ParityErrorInterruptEnable = (UART_C3_PEIE_MASK << 16),         /*!< Parity error flag interrupt. */
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    kUART_RxFifoOverflowInterruptEnable = (UART_CFIFO_TXOFE_MASK << 24),  /*!< TX FIFO overflow interrupt. */
+    kUART_TxFifoOverflowInterruptEnable = (UART_CFIFO_RXUFE_MASK << 24),  /*!< RX FIFO underflow interrupt. */
+    kUART_RxFifoUnderflowInterruptEnable = (UART_CFIFO_RXUFE_MASK << 24), /*!< RX FIFO underflow interrupt. */
+#endif
+};
+
+/*!
+ * @brief UART status flags.
+ *
+ * This provides constants for the UART status flags for use in the UART functions.
+ */
+enum _uart_flags
+{
+    kUART_TxDataRegEmptyFlag = (UART_S1_TDRE_MASK),     /*!< TX data register empty flag. */
+    kUART_TransmissionCompleteFlag = (UART_S1_TC_MASK), /*!< Transmission complete flag. */
+    kUART_RxDataRegFullFlag = (UART_S1_RDRF_MASK),      /*!< RX data register full flag. */
+    kUART_IdleLineFlag = (UART_S1_IDLE_MASK),           /*!< Idle line detect flag. */
+    kUART_RxOverrunFlag = (UART_S1_OR_MASK),            /*!< RX overrun flag. */
+    kUART_NoiseErrorFlag = (UART_S1_NF_MASK),           /*!< RX takes 3 samples of each received bit.
+                                                             If any of these samples differ, noise flag sets */
+    kUART_FramingErrorFlag = (UART_S1_FE_MASK),         /*!< Frame error flag, sets if logic 0 was detected
+                                                             where stop bit expected */
+    kUART_ParityErrorFlag = (UART_S1_PF_MASK),          /*!< If parity enabled, sets upon parity error detection */
+#if defined(FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT) && FSL_FEATURE_UART_HAS_LIN_BREAK_DETECT
+    kUART_LinBreakFlag =
+        (UART_S2_LBKDIF_MASK << 8), /*!< LIN break detect interrupt flag, sets when
+                                                           LIN break char detected and LIN circuit enabled */
+#endif
+    kUART_RxActiveEdgeFlag = (UART_S2_RXEDGIF_MASK << 8), /*!< RX pin active edge interrupt flag,
+                                                                                 sets when active edge detected */
+    kUART_RxActiveFlag = (UART_S2_RAF_MASK << 8),         /*!< Receiver Active Flag (RAF),
+                                                                                 sets at beginning of valid start bit */
+#if defined(FSL_FEATURE_UART_HAS_EXTENDED_DATA_REGISTER_FLAGS) && FSL_FEATURE_UART_HAS_EXTENDED_DATA_REGISTER_FLAGS
+    kUART_NoiseErrorInRxDataRegFlag = (UART_ED_NOISY_MASK << 16),    /*!< Noisy bit, sets if noise detected. */
+    kUART_ParityErrorInRxDataRegFlag = (UART_ED_PARITYE_MASK << 16), /*!< Paritye bit, sets if parity error detected. */
+#endif
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    kUART_TxFifoEmptyFlag = (UART_SFIFO_TXEMPT_MASK << 24),   /*!< TXEMPT bit, sets if TX buffer is empty */
+    kUART_RxFifoEmptyFlag = (UART_SFIFO_RXEMPT_MASK << 24),   /*!< RXEMPT bit, sets if RX buffer is empty */
+    kUART_TxFifoOverflowFlag = (UART_SFIFO_TXOF_MASK << 24),  /*!< TXOF bit, sets if TX buffer overflow occurred */
+    kUART_RxFifoOverflowFlag = (UART_SFIFO_RXOF_MASK << 24),  /*!< RXOF bit, sets if receive buffer overflow */
+    kUART_RxFifoUnderflowFlag = (UART_SFIFO_RXUF_MASK << 24), /*!< RXUF bit, sets if receive buffer underflow */
+#endif
+};
+
+/*! @brief UART configuration structure. */
+typedef struct _uart_config
+{
+    uint32_t baudRate_Bps;         /*!< UART baud rate  */
+    uart_parity_mode_t parityMode; /*!< Parity mode, disabled (default), even, odd */
+#if defined(FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_UART_HAS_STOP_BIT_CONFIG_SUPPORT
+    uart_stop_bit_count_t stopBitCount; /*!< Number of stop bits, 1 stop bit (default) or 2 stop bits  */
+#endif
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    uint8_t txFifoWatermark; /*!< TX FIFO watermark */
+    uint8_t rxFifoWatermark; /*!< RX FIFO watermark */
+#endif
+    bool enableTx; /*!< Enable TX */
+    bool enableRx; /*!< Enable RX */
+} uart_config_t;
+
+/*! @brief UART transfer structure. */
+typedef struct _uart_transfer
+{
+    uint8_t *data;   /*!< The buffer of data to be transfer.*/
+    size_t dataSize; /*!< The byte count to be transfer. */
+} uart_transfer_t;
+
+/* Forward declaration of the handle typedef. */
+typedef struct _uart_handle uart_handle_t;
+
+/*! @brief UART transfer callback function. */
+typedef void (*uart_transfer_callback_t)(UART_Type *base, uart_handle_t *handle, status_t status, void *userData);
+
+/*! @brief UART handle structure. */
+struct _uart_handle
+{
+    uint8_t *volatile txData;   /*!< Address of remaining data to send. */
+    volatile size_t txDataSize; /*!< Size of the remaining data to send. */
+    size_t txDataSizeAll;       /*!< Size of the data to send out. */
+    uint8_t *volatile rxData;   /*!< Address of remaining data to receive. */
+    volatile size_t rxDataSize; /*!< Size of the remaining data to receive. */
+    size_t rxDataSizeAll;       /*!< Size of the data to receive. */
+
+    uint8_t *rxRingBuffer;              /*!< Start address of the receiver ring buffer. */
+    size_t rxRingBufferSize;            /*!< Size of the ring buffer. */
+    volatile uint16_t rxRingBufferHead; /*!< Index for the driver to store received data into ring buffer. */
+    volatile uint16_t rxRingBufferTail; /*!< Index for the user to get data from the ring buffer. */
+
+    uart_transfer_callback_t callback; /*!< Callback function. */
+    void *userData;                    /*!< UART callback function parameter.*/
+
+    volatile uint8_t txState; /*!< TX transfer state. */
+    volatile uint8_t rxState; /*!< RX transfer state */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* _cplusplus */
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes a UART instance with user configuration structure and peripheral clock.
+ *
+ * This function configures the UART module with the user-defined settings. The user can configure the configuration
+ * structure and also get the default configuration by using the UART_GetDefaultConfig() function.
+ * Example below shows how to use this API to configure UART.
+ * @code
+ *  uart_config_t uartConfig;
+ *  uartConfig.baudRate_Bps = 115200U;
+ *  uartConfig.parityMode = kUART_ParityDisabled;
+ *  uartConfig.stopBitCount = kUART_OneStopBit;
+ *  uartConfig.txFifoWatermark = 0;
+ *  uartConfig.rxFifoWatermark = 1;
+ *  UART_Init(UART1, &uartConfig, 20000000U);
+ * @endcode
+ *
+ * @param base UART peripheral base address.
+ * @param config Pointer to user-defined configuration structure.
+ * @param srcClock_Hz UART clock source frequency in HZ.
+ */
+void UART_Init(UART_Type *base, const uart_config_t *config, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Deinitializes a UART instance.
+ *
+ * This function waits for TX complete, disables TX and RX, and disables the UART clock.
+ *
+ * @param base UART peripheral base address.
+ */
+void UART_Deinit(UART_Type *base);
+
+/*!
+ * @brief Gets the default configuration structure.
+ *
+ * This function initializes the UART configuration structure to a default value. The default
+ * values are:
+ *   uartConfig->baudRate_Bps = 115200U;
+ *   uartConfig->bitCountPerChar = kUART_8BitsPerChar;
+ *   uartConfig->parityMode = kUART_ParityDisabled;
+ *   uartConfig->stopBitCount = kUART_OneStopBit;
+ *   uartConfig->txFifoWatermark = 0;
+ *   uartConfig->rxFifoWatermark = 1;
+ *   uartConfig->enableTx = false;
+ *   uartConfig->enableRx = false;
+ *
+ * @param config Pointer to configuration structure.
+ */
+void UART_GetDefaultConfig(uart_config_t *config);
+
+/*!
+ * @brief Sets the UART instance baud rate.
+ *
+ * This function configures the UART module baud rate. This function is used to update
+ * the UART module baud rate after the UART module is initialized by the UART_Init.
+ * @code
+ *  UART_SetBaudRate(UART1, 115200U, 20000000U);
+ * @endcode
+ *
+ * @param base UART peripheral base address.
+ * @param baudRate_Bps UART baudrate to be set.
+ * @param srcClock_Hz UART clock source freqency in HZ.
+ */
+void UART_SetBaudRate(UART_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz);
+
+/* @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Get UART status flags.
+ *
+ * This function get all UART status flags, the flags are returned as the logical
+ * OR value of the enumerators @ref _uart_flags. To check specific status,
+ * compare the return value with enumerators in @ref _uart_flags.
+ * For example, to check whether the TX is empty:
+ * @code
+ *     if (kUART_TxDataRegEmptyFlag & UART_GetStatusFlags(UART1))
+ *     {
+ *         ...
+ *     }
+ * @endcode
+ *
+ * @param base UART peripheral base address.
+ * @return UART status flags which are ORed by the enumerators in the _uart_flags.
+ */
+uint32_t UART_GetStatusFlags(UART_Type *base);
+
+/*!
+ * @brief Clears status flags with the provided mask.
+ *
+ * This function clears UART status flags with a provided mask. Automatically cleared flag
+ * can't be cleared by this function.
+ * Some flags can only be cleared or set by hardware itself. These flags are:
+ *    kUART_TxDataRegEmptyFlag, kUART_TransmissionCompleteFlag, kUART_RxDataRegFullFlag,
+ *    kUART_RxActiveFlag, kUART_NoiseErrorInRxDataRegFlag, kUART_ParityErrorInRxDataRegFlag,
+ *    kUART_TxFifoEmptyFlag,kUART_RxFifoEmptyFlag
+ * Note: This API should be called when the Tx/Rx is idle, otherwise it takes no effects.
+ *
+ * @param base UART peripheral base address.
+ * @param mask The status flags to be cleared, it is logical OR value of @ref _uart_flags.
+ * @retval kStatus_UART_FlagCannotClearManually The flag can't be cleared by this function but
+ *         it is cleared automatically by hardware.
+ * @retval kStatus_Success Status in the mask are cleared.
+ */
+status_t UART_ClearStatusFlags(UART_Type *base, uint32_t mask);
+
+/* @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enables UART interrupts according to the provided mask.
+ *
+ * This function enables the UART interrupts according to the provided mask. The mask
+ * is a logical OR of enumeration members. See @ref _uart_interrupt_enable.
+ * For example, to enable TX empty interrupt and RX full interrupt:
+ * @code
+ *     UART_EnableInterrupts(UART1,kUART_TxDataRegEmptyInterruptEnable | kUART_RxDataRegFullInterruptEnable);
+ * @endcode
+ *
+ * @param base UART peripheral base address.
+ * @param mask The interrupts to enable. Logical OR of @ref _uart_interrupt_enable.
+ */
+void UART_EnableInterrupts(UART_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables the UART interrupts according to the provided mask.
+ *
+ * This function disables the UART interrupts according to the provided mask. The mask
+ * is a logical OR of enumeration members. See @ref _uart_interrupt_enable.
+ * For example, to disable TX empty interrupt and RX full interrupt:
+ * @code
+ *     UART_DisableInterrupts(UART1,kUART_TxDataRegEmptyInterruptEnable | kUART_RxDataRegFullInterruptEnable);
+ * @endcode
+ *
+ * @param base UART peripheral base address.
+ * @param mask The interrupts to disable. Logical OR of @ref _uart_interrupt_enable.
+ */
+void UART_DisableInterrupts(UART_Type *base, uint32_t mask);
+
+/*!
+ * @brief Gets the enabled UART interrupts.
+ *
+ * This function gets the enabled UART interrupts. The enabled interrupts are returned
+ * as the logical OR value of the enumerators @ref _uart_interrupt_enable. To check
+ * specific interrupts enable status, compare the return value with enumerators
+ * in @ref _uart_interrupt_enable.
+ * For example, to check whether TX empty interrupt is enabled:
+ * @code
+ *     uint32_t enabledInterrupts = UART_GetEnabledInterrupts(UART1);
+ *
+ *     if (kUART_TxDataRegEmptyInterruptEnable & enabledInterrupts)
+ *     {
+ *         ...
+ *     }
+ * @endcode
+ *
+ * @param base UART peripheral base address.
+ * @return UART interrupt flags which are logical OR of the enumerators in @ref _uart_interrupt_enable.
+ */
+uint32_t UART_GetEnabledInterrupts(UART_Type *base);
+
+/* @} */
+
+#if defined(FSL_FEATURE_UART_HAS_DMA_SELECT) && FSL_FEATURE_UART_HAS_DMA_SELECT
+/*!
+ * @name DMA Control
+ * @{
+ */
+
+/*!
+ * @brief Gets the UART data register address.
+ *
+ * This function returns the UART data register address, which is mainly used by DMA/eDMA.
+ *
+ * @param base UART peripheral base address.
+ * @return UART data register address which are used both by transmitter and receiver.
+ */
+static inline uint32_t UART_GetDataRegisterAddress(UART_Type *base)
+{
+    return (uint32_t) & (base->D);
+}
+
+/*!
+ * @brief Enables or disables the UART transmitter DMA request.
+ *
+ * This function enables or disables the transmit data register empty flag, S1[TDRE], to generate the DMA requests.
+ *
+ * @param base UART peripheral base address.
+ * @param enable True to enable, false to disable.
+ */
+static inline void UART_EnableTxDMA(UART_Type *base, bool enable)
+{
+    if (enable)
+    {
+#if (defined(FSL_FEATURE_UART_IS_SCI) && FSL_FEATURE_UART_IS_SCI)
+        base->C4 |= UART_C4_TDMAS_MASK;
+#else
+        base->C5 |= UART_C5_TDMAS_MASK;
+#endif
+        base->C2 |= UART_C2_TIE_MASK;
+    }
+    else
+    {
+#if (defined(FSL_FEATURE_UART_IS_SCI) && FSL_FEATURE_UART_IS_SCI)
+        base->C4 &= ~UART_C4_TDMAS_MASK;
+#else
+        base->C5 &= ~UART_C5_TDMAS_MASK;
+#endif
+        base->C2 &= ~UART_C2_TIE_MASK;
+    }
+}
+
+/*!
+ * @brief Enables or disables the UART receiver DMA.
+ *
+ * This function enables or disables the receiver data register full flag, S1[RDRF], to generate DMA requests.
+ *
+ * @param base UART peripheral base address.
+ * @param enable True to enable, false to disable.
+ */
+static inline void UART_EnableRxDMA(UART_Type *base, bool enable)
+{
+    if (enable)
+    {
+#if (defined(FSL_FEATURE_UART_IS_SCI) && FSL_FEATURE_UART_IS_SCI)
+        base->C4 |= UART_C4_RDMAS_MASK;
+#else
+        base->C5 |= UART_C5_RDMAS_MASK;
+#endif
+        base->C2 |= UART_C2_RIE_MASK;
+    }
+    else
+    {
+#if (defined(FSL_FEATURE_UART_IS_SCI) && FSL_FEATURE_UART_IS_SCI)
+        base->C4 &= ~UART_C4_RDMAS_MASK;
+#else
+        base->C5 &= ~UART_C5_RDMAS_MASK;
+#endif
+        base->C2 &= ~UART_C2_RIE_MASK;
+    }
+}
+
+/* @} */
+#endif /* FSL_FEATURE_UART_HAS_DMA_SELECT */
+
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Enables or disables the UART transmitter.
+ *
+ * This function enables or disables the UART transmitter.
+ *
+ * @param base UART peripheral base address.
+ * @param enable True to enable, false to disable.
+ */
+static inline void UART_EnableTx(UART_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C2 |= UART_C2_TE_MASK;
+    }
+    else
+    {
+        base->C2 &= ~UART_C2_TE_MASK;
+    }
+}
+
+/*!
+ * @brief Enables or disables the UART receiver.
+ *
+ * This function enables or disables the UART receiver.
+ *
+ * @param base UART peripheral base address.
+ * @param enable True to enable, false to disable.
+ */
+static inline void UART_EnableRx(UART_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C2 |= UART_C2_RE_MASK;
+    }
+    else
+    {
+        base->C2 &= ~UART_C2_RE_MASK;
+    }
+}
+
+/*!
+ * @brief Writes to the TX register.
+ *
+ * This function writes data to the TX register directly. The upper layer must ensure
+ * that the TX register is empty or TX FIFO has empty room before calling this function.
+ *
+ * @param base UART peripheral base address.
+ * @param data The byte to write.
+ */
+static inline void UART_WriteByte(UART_Type *base, uint8_t data)
+{
+    base->D = data;
+}
+
+/*!
+ * @brief Reads the RX register directly.
+ *
+ * This function reads data from the TX register directly. The upper layer must
+ * ensure that the RX register is full or that the TX FIFO has data before calling this function.
+ *
+ * @param base UART peripheral base address.
+ * @return The byte read from UART data register.
+ */
+static inline uint8_t UART_ReadByte(UART_Type *base)
+{
+    return base->D;
+}
+
+/*!
+ * @brief Writes to the TX register using a blocking method.
+ *
+ * This function polls the TX register, waits for the TX register to be empty or for the TX FIFO
+ * to have room and writes data to the TX buffer.
+ *
+ * @note This function does not check whether all the data has been sent out to the bus.
+ * Before disabling the TX, check kUART_TransmissionCompleteFlag to ensure that the TX is
+ * finished.
+ *
+ * @param base UART peripheral base address.
+ * @param data Start address of the data to write.
+ * @param length Size of the data to write.
+ */
+void UART_WriteBlocking(UART_Type *base, const uint8_t *data, size_t length);
+
+/*!
+ * @brief Read RX data register using a blocking method.
+ *
+ * This function polls the RX register, waits for the RX register to be full or for RX FIFO to
+ * have data and read data from the TX register.
+ *
+ * @param base UART peripheral base address.
+ * @param data Start address of the buffer to store the received data.
+ * @param length Size of the buffer.
+ * @retval kStatus_UART_RxHardwareOverrun Receiver overrun happened while receiving data.
+ * @retval kStatus_UART_NoiseError Noise error happened while receiving data.
+ * @retval kStatus_UART_FramingError Framing error happened while receiving data.
+ * @retval kStatus_UART_ParityError Parity error happened while receiving data.
+ * @retval kStatus_Success Successfully received all data.
+ */
+status_t UART_ReadBlocking(UART_Type *base, uint8_t *data, size_t length);
+
+/* @} */
+
+/*!
+ * @name Transactional
+ * @{
+ */
+
+/*!
+ * @brief Initializes the UART handle.
+ *
+ * This function initializes the UART handle which can be used for other UART
+ * transactional APIs. Usually, for a specified UART instance,
+ * call this API once to get the initialized handle.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param callback The callback function.
+ * @param userData The parameter of the callback function.
+ */
+void UART_TransferCreateHandle(UART_Type *base,
+                               uart_handle_t *handle,
+                               uart_transfer_callback_t callback,
+                               void *userData);
+
+/*!
+ * @brief Sets up the RX ring buffer.
+ *
+ * This function sets up the RX ring buffer to a specific UART handle.
+ *
+ * When the RX ring buffer is used, data received are stored into the ring buffer even when the
+ * user doesn't call the UART_TransferReceiveNonBlocking() API. If there is already data received
+ * in the ring buffer, the user can get the received data from the ring buffer directly.
+ *
+ * @note When using the RX ring buffer, one byte is reserved for internal use. In other
+ * words, if @p ringBufferSize is 32, then only 31 bytes are used for saving data.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param ringBuffer Start address of the ring buffer for background receiving. Pass NULL to disable the ring buffer.
+ * @param ringBufferSize size of the ring buffer.
+ */
+void UART_TransferStartRingBuffer(UART_Type *base, uart_handle_t *handle, uint8_t *ringBuffer, size_t ringBufferSize);
+
+/*!
+ * @brief Aborts the background transfer and uninstalls the ring buffer.
+ *
+ * This function aborts the background transfer and uninstalls the ring buffer.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ */
+void UART_TransferStopRingBuffer(UART_Type *base, uart_handle_t *handle);
+
+/*!
+ * @brief Transmits a buffer of data using the interrupt method.
+ *
+ * This function sends data using an interrupt method. This is a non-blocking function, which
+ * returns directly without waiting for all data to be written to the TX register. When
+ * all data is written to the TX register in the ISR, the UART driver calls the callback
+ * function and passes the @ref kStatus_UART_TxIdle as status parameter.
+ *
+ * @note The kStatus_UART_TxIdle is passed to the upper layer when all data is written
+ * to the TX register. However it does not ensure that all data are sent out. Before disabling the TX,
+ * check the kUART_TransmissionCompleteFlag to ensure that the TX is finished.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param xfer UART transfer structure. See  #uart_transfer_t.
+ * @retval kStatus_Success Successfully start the data transmission.
+ * @retval kStatus_UART_TxBusy Previous transmission still not finished, data not all written to TX register yet.
+ * @retval kStatus_InvalidArgument Invalid argument.
+ */
+status_t UART_TransferSendNonBlocking(UART_Type *base, uart_handle_t *handle, uart_transfer_t *xfer);
+
+/*!
+ * @brief Aborts the interrupt driven data transmit.
+ *
+ * This function aborts the interrupt driven data sending. The user can get the remainBytes to find out
+ * how many bytes are still not sent out.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ */
+void UART_TransferAbortSend(UART_Type *base, uart_handle_t *handle);
+
+/*!
+ * @brief Get the number of bytes that have been written to UART TX register.
+ *
+ * This function gets the number of bytes that have been written to UART TX
+ * register by interrupt method.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param count Send bytes count.
+ * @retval kStatus_NoTransferInProgress No send in progress.
+ * @retval kStatus_InvalidArgument Parameter is invalid.
+ * @retval kStatus_Success Get successfully through the parameter \p count;
+ */
+status_t UART_TransferGetSendCount(UART_Type *base, uart_handle_t *handle, uint32_t *count);
+
+/*!
+ * @brief Receives a buffer of data using an interrupt method.
+ *
+ * This function receives data using an interrupt method. This is a non-blocking function, which
+ *  returns without waiting for all data to be received.
+ * If the RX ring buffer is used and not empty, the data in the ring buffer is copied and
+ * the parameter @p receivedBytes shows how many bytes are copied from the ring buffer.
+ * After copying, if the data in the ring buffer is not enough to read, the receive
+ * request is saved by the UART driver. When the new data arrives, the receive request
+ * is serviced first. When all data is received, the UART driver notifies the upper layer
+ * through a callback function and passes the status parameter @ref kStatus_UART_RxIdle.
+ * For example, the upper layer needs 10 bytes but there are only 5 bytes in the ring buffer.
+ * The 5 bytes are copied to the xfer->data and this function returns with the
+ * parameter @p receivedBytes set to 5. For the left 5 bytes, newly arrived data is
+ * saved from the xfer->data[5]. When 5 bytes are received, the UART driver notifies the upper layer.
+ * If the RX ring buffer is not enabled, this function enables the RX and RX interrupt
+ * to receive data to the xfer->data. When all data is received, the upper layer is notified.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param xfer UART transfer structure, refer to #uart_transfer_t.
+ * @param receivedBytes Bytes received from the ring buffer directly.
+ * @retval kStatus_Success Successfully queue the transfer into transmit queue.
+ * @retval kStatus_UART_RxBusy Previous receive request is not finished.
+ * @retval kStatus_InvalidArgument Invalid argument.
+ */
+status_t UART_TransferReceiveNonBlocking(UART_Type *base,
+                                         uart_handle_t *handle,
+                                         uart_transfer_t *xfer,
+                                         size_t *receivedBytes);
+
+/*!
+ * @brief Aborts the interrupt-driven data receiving.
+ *
+ * This function aborts the interrupt-driven data receiving. The user can get the remainBytes to know
+ * how many bytes not received yet.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ */
+void UART_TransferAbortReceive(UART_Type *base, uart_handle_t *handle);
+
+/*!
+ * @brief Get the number of bytes that have been received.
+ *
+ * This function gets the number of bytes that have been received.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param count Receive bytes count.
+ * @retval kStatus_NoTransferInProgress No receive in progress.
+ * @retval kStatus_InvalidArgument Parameter is invalid.
+ * @retval kStatus_Success Get successfully through the parameter \p count;
+ */
+status_t UART_TransferGetReceiveCount(UART_Type *base, uart_handle_t *handle, uint32_t *count);
+
+/*!
+ * @brief UART IRQ handle function.
+ *
+ * This function handles the UART transmit and receive IRQ request.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ */
+void UART_TransferHandleIRQ(UART_Type *base, uart_handle_t *handle);
+
+/*!
+ * @brief UART Error IRQ handle function.
+ *
+ * This function handle the UART error IRQ request.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ */
+void UART_TransferHandleErrorIRQ(UART_Type *base, uart_handle_t *handle);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_UART_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart_edma.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart_edma.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_uart_edma.h"
+#include "fsl_dmamux.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Array of UART handle. */
+#if (defined(UART5))
+#define UART_HANDLE_ARRAY_SIZE 6
+#else /* UART5 */
+#if (defined(UART4))
+#define UART_HANDLE_ARRAY_SIZE 5
+#else /* UART4 */
+#if (defined(UART3))
+#define UART_HANDLE_ARRAY_SIZE 4
+#else /* UART3 */
+#if (defined(UART2))
+#define UART_HANDLE_ARRAY_SIZE 3
+#else /* UART2 */
+#if (defined(UART1))
+#define UART_HANDLE_ARRAY_SIZE 2
+#else /* UART1 */
+#if (defined(UART0))
+#define UART_HANDLE_ARRAY_SIZE 1
+#else /* UART0 */
+#error No UART instance.
+#endif /* UART 0 */
+#endif /* UART 1 */
+#endif /* UART 2 */
+#endif /* UART 3 */
+#endif /* UART 4 */
+#endif /* UART 5 */
+
+/*<! Structure definition for uart_edma_private_handle_t. The structure is private. */
+typedef struct _uart_edma_private_handle
+{
+    UART_Type *base;
+    uart_edma_handle_t *handle;
+} uart_edma_private_handle_t;
+
+/* UART EDMA transfer handle. */
+enum _uart_edma_tansfer_states
+{
+    kUART_TxIdle, /* TX idle. */
+    kUART_TxBusy, /* TX busy. */
+    kUART_RxIdle, /* RX idle. */
+    kUART_RxBusy  /* RX busy. */
+};
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*<! Private handle only used for internally. */
+static uart_edma_private_handle_t s_edmaPrivateHandle[UART_HANDLE_ARRAY_SIZE];
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief UART EDMA send finished callback function.
+ *
+ * This function is called when UART EDMA send finished. It disables the UART
+ * TX EDMA request and sends @ref kStatus_UART_TxIdle to UART callback.
+ *
+ * @param handle The EDMA handle.
+ * @param param Callback function parameter.
+ */
+static void UART_SendEDMACallback(edma_handle_t *handle, void *param, bool transferDone, uint32_t tcds);
+
+/*!
+ * @brief UART EDMA receive finished callback function.
+ *
+ * This function is called when UART EDMA receive finished. It disables the UART
+ * RX EDMA request and sends @ref kStatus_UART_RxIdle to UART callback.
+ *
+ * @param handle The EDMA handle.
+ * @param param Callback function parameter.
+ */
+static void UART_ReceiveEDMACallback(edma_handle_t *handle, void *param, bool transferDone, uint32_t tcds);
+
+/*!
+ * @brief Get the UART instance from peripheral base address.
+ *
+ * @param base UART peripheral base address.
+ * @return UART instance.
+ */
+extern uint32_t UART_GetInstance(UART_Type *base);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static void UART_SendEDMACallback(edma_handle_t *handle, void *param, bool transferDone, uint32_t tcds)
+{
+    uart_edma_private_handle_t *uartPrivateHandle = (uart_edma_private_handle_t *)param;
+
+    /* Avoid the warning for unused variables. */
+    handle = handle;
+    tcds = tcds;
+
+    if (transferDone)
+    {
+        UART_TransferAbortSendEDMA(uartPrivateHandle->base, uartPrivateHandle->handle);
+
+        if (uartPrivateHandle->handle->callback)
+        {
+            uartPrivateHandle->handle->callback(uartPrivateHandle->base, uartPrivateHandle->handle, kStatus_UART_TxIdle,
+                                                uartPrivateHandle->handle->userData);
+        }
+    }
+}
+
+static void UART_ReceiveEDMACallback(edma_handle_t *handle, void *param, bool transferDone, uint32_t tcds)
+{
+    uart_edma_private_handle_t *uartPrivateHandle = (uart_edma_private_handle_t *)param;
+
+    /* Avoid warning for unused parameters. */
+    handle = handle;
+    tcds = tcds;
+
+    if (transferDone)
+    {
+        /* Disable transfer. */
+        UART_TransferAbortReceiveEDMA(uartPrivateHandle->base, uartPrivateHandle->handle);
+
+        if (uartPrivateHandle->handle->callback)
+        {
+            uartPrivateHandle->handle->callback(uartPrivateHandle->base, uartPrivateHandle->handle, kStatus_UART_RxIdle,
+                                                uartPrivateHandle->handle->userData);
+        }
+    }
+}
+
+void UART_TransferCreateHandleEDMA(UART_Type *base,
+                           uart_edma_handle_t *handle,
+                           uart_edma_transfer_callback_t callback,
+                           void *userData,
+                           edma_handle_t *txEdmaHandle,
+                           edma_handle_t *rxEdmaHandle)
+{
+    assert(handle);
+
+    uint32_t instance = UART_GetInstance(base);
+
+    s_edmaPrivateHandle[instance].base = base;
+    s_edmaPrivateHandle[instance].handle = handle;
+
+    memset(handle, 0, sizeof(*handle));
+
+    handle->rxState = kUART_RxIdle;
+    handle->txState = kUART_TxIdle;
+
+    handle->rxEdmaHandle = rxEdmaHandle;
+    handle->txEdmaHandle = txEdmaHandle;
+
+    handle->callback = callback;
+    handle->userData = userData;
+
+#if defined(FSL_FEATURE_UART_HAS_FIFO) && FSL_FEATURE_UART_HAS_FIFO
+    /* Note:
+       Take care of the RX FIFO, EDMA request only assert when received bytes
+       equal or more than RX water mark, there is potential issue if RX water
+       mark larger than 1.
+       For example, if RX FIFO water mark is 2, upper layer needs 5 bytes and
+       5 bytes are received. the last byte will be saved in FIFO but not trigger
+       EDMA transfer because the water mark is 2.
+     */
+    if (rxEdmaHandle)
+    {
+        base->RWFIFO = 1U;
+    }
+#endif
+
+    /* Configure TX. */
+    if (txEdmaHandle)
+    {
+        EDMA_SetCallback(handle->txEdmaHandle, UART_SendEDMACallback, &s_edmaPrivateHandle[instance]);
+    }
+
+    /* Configure RX. */
+    if (rxEdmaHandle)
+    {
+        EDMA_SetCallback(handle->rxEdmaHandle, UART_ReceiveEDMACallback, &s_edmaPrivateHandle[instance]);
+    }
+}
+
+status_t UART_SendEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer)
+{
+    assert(handle->txEdmaHandle);
+
+    edma_transfer_config_t xferConfig;
+    status_t status;
+
+    /* Return error if xfer invalid. */
+    if ((0U == xfer->dataSize) || (NULL == xfer->data))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* If previous TX not finished. */
+    if (kUART_TxBusy == handle->txState)
+    {
+        status = kStatus_UART_TxBusy;
+    }
+    else
+    {
+        handle->txState = kUART_TxBusy;
+        handle->txDataSizeAll = xfer->dataSize;
+
+        /* Prepare transfer. */
+        EDMA_PrepareTransfer(&xferConfig, xfer->data, sizeof(uint8_t), (void *)UART_GetDataRegisterAddress(base),
+                             sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_MemoryToPeripheral);
+
+        /* Submit transfer. */
+        EDMA_SubmitTransfer(handle->txEdmaHandle, &xferConfig);
+        EDMA_StartTransfer(handle->txEdmaHandle);
+
+        /* Enable UART TX EDMA. */
+        UART_EnableTxDMA(base, true);
+
+        status = kStatus_Success;
+    }
+
+    return status;
+}
+
+status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer)
+{
+    assert(handle->rxEdmaHandle);
+
+    edma_transfer_config_t xferConfig;
+    status_t status;
+
+    /* Return error if xfer invalid. */
+    if ((0U == xfer->dataSize) || (NULL == xfer->data))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* If previous RX not finished. */
+    if (kUART_RxBusy == handle->rxState)
+    {
+        status = kStatus_UART_RxBusy;
+    }
+    else
+    {
+        handle->rxState = kUART_RxBusy;
+        handle->rxDataSizeAll = xfer->dataSize;
+
+        /* Prepare transfer. */
+        EDMA_PrepareTransfer(&xferConfig, (void *)UART_GetDataRegisterAddress(base), sizeof(uint8_t), xfer->data,
+                             sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_PeripheralToMemory);
+
+        /* Submit transfer. */
+        EDMA_SubmitTransfer(handle->rxEdmaHandle, &xferConfig);
+        EDMA_StartTransfer(handle->rxEdmaHandle);
+
+        /* Enable UART RX EDMA. */
+        UART_EnableRxDMA(base, true);
+
+        status = kStatus_Success;
+    }
+
+    return status;
+}
+
+void UART_TransferAbortSendEDMA(UART_Type *base, uart_edma_handle_t *handle)
+{
+    assert(handle->txEdmaHandle);
+
+    /* Disable UART TX EDMA. */
+    UART_EnableTxDMA(base, false);
+
+    /* Stop transfer. */
+    EDMA_AbortTransfer(handle->txEdmaHandle);
+
+    handle->txState = kUART_TxIdle;
+}
+
+void UART_TransferAbortReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle)
+{
+    assert(handle->rxEdmaHandle);
+
+    /* Disable UART RX EDMA. */
+    UART_EnableRxDMA(base, false);
+
+    /* Stop transfer. */
+    EDMA_AbortTransfer(handle->rxEdmaHandle);
+
+    handle->rxState = kUART_RxIdle;
+}
+
+status_t UART_TransferGetReceiveCountEDMA(UART_Type *base, uart_edma_handle_t *handle, uint32_t *count)
+{
+    assert(handle->rxEdmaHandle);
+
+    if (kUART_RxIdle == handle->rxState)
+    {
+        return kStatus_NoTransferInProgress;
+    }
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    *count = handle->rxDataSizeAll - EDMA_GetRemainingBytes(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
+
+    return kStatus_Success;
+}
+
+status_t UART_TransferGetSendCountEDMA(UART_Type *base, uart_edma_handle_t *handle, uint32_t *count)
+{
+    assert(handle->txEdmaHandle);
+
+    if (kUART_TxIdle == handle->txState)
+    {
+        return kStatus_NoTransferInProgress;
+    }
+
+    if (!count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    *count = handle->txDataSizeAll - EDMA_GetRemainingBytes(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
+
+    return kStatus_Success;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart_edma.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_uart_edma.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_UART_EDMA_H_
+#define _FSL_UART_EDMA_H_
+
+#include "fsl_uart.h"
+#include "fsl_dmamux.h"
+#include "fsl_edma.h"
+
+/*!
+ * @addtogroup uart_edma_driver
+ * @{
+ */
+
+/*! @file*/
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Forward declaration of the handle typedef. */
+typedef struct _uart_edma_handle uart_edma_handle_t;
+
+/*! @brief UART transfer callback function. */
+typedef void (*uart_edma_transfer_callback_t)(UART_Type *base,
+                                              uart_edma_handle_t *handle,
+                                              status_t status,
+                                              void *userData);
+
+/*!
+* @brief UART eDMA handle
+*/
+struct _uart_edma_handle
+{
+    uart_edma_transfer_callback_t callback; /*!< Callback function. */
+    void *userData;                         /*!< UART callback function parameter.*/
+    size_t rxDataSizeAll;                   /*!< Size of the data to receive. */
+    size_t txDataSizeAll;                   /*!< Size of the data to send out. */
+
+    edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
+    edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
+
+    volatile uint8_t txState; /*!< TX transfer state. */
+    volatile uint8_t rxState; /*!< RX transfer state */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name eDMA transactional
+ * @{
+ */
+
+/*!
+ * @brief Initializes the UART handle which is used in transactional functions.
+ * @param base UART peripheral base address.
+ * @param handle Pointer to uart_edma_handle_t structure.
+ * @param callback UART callback, NULL means no callback.
+ * @param userData User callback function data.
+ * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
+ * @param txEdmaHandle User requested DMA handle for TX DMA transfer.
+ */
+void UART_TransferCreateHandleEDMA(UART_Type *base,
+                           uart_edma_handle_t *handle,
+                           uart_edma_transfer_callback_t callback,
+                           void *userData,
+                           edma_handle_t *txEdmaHandle,
+                           edma_handle_t *rxEdmaHandle);
+
+/*!
+ * @brief Sends data using eDMA.
+ *
+ * This function sends data using eDMA. This is a non-blocking function, which returns
+ * right away. When all data is sent, the send callback function is called.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param xfer UART eDMA transfer structure. See #uart_transfer_t.
+ * @retval kStatus_Success if succeed, others failed.
+ * @retval kStatus_UART_TxBusy Previous transfer on going.
+ * @retval kStatus_InvalidArgument Invalid argument.
+ */
+status_t UART_SendEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer);
+
+/*!
+ * @brief Receive data using eDMA.
+ *
+ * This function receives data using eDMA. This is a non-blocking function, which returns
+ * right away. When all data is received, the receive callback function is called.
+ *
+ * @param base UART peripheral base address.
+ * @param handle Pointer to uart_edma_handle_t structure.
+ * @param xfer UART eDMA transfer structure. See #uart_transfer_t.
+ * @retval kStatus_Success if succeed, others failed.
+ * @retval kStatus_UART_RxBusy Previous transfer on going.
+ * @retval kStatus_InvalidArgument Invalid argument.
+ */
+status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer);
+
+/*!
+ * @brief Aborts the sent data using eDMA.
+ *
+ * This function aborts sent data using eDMA.
+ *
+ * @param base UART peripheral base address.
+ * @param handle Pointer to uart_edma_handle_t structure.
+ */
+void UART_TransferAbortSendEDMA(UART_Type *base, uart_edma_handle_t *handle);
+
+/*!
+ * @brief Aborts the receive data using eDMA.
+ *
+ * This function aborts receive data using eDMA.
+ *
+ * @param base UART peripheral base address.
+ * @param handle Pointer to uart_edma_handle_t structure.
+ */
+void UART_TransferAbortReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle);
+
+/*!
+ * @brief Get the number of bytes that have been written to UART TX register.
+ *
+ * This function gets the number of bytes that have been written to UART TX
+ * register by DMA.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param count Send bytes count.
+ * @retval kStatus_NoTransferInProgress No send in progress.
+ * @retval kStatus_InvalidArgument Parameter is invalid.
+ * @retval kStatus_Success Get successfully through the parameter \p count;
+ */
+status_t UART_TransferGetSendCountEDMA(UART_Type *base, uart_edma_handle_t *handle, uint32_t *count);
+
+/*!
+ * @brief Get the number of bytes that have been received.
+ *
+ * This function gets the number of bytes that have been received.
+ *
+ * @param base UART peripheral base address.
+ * @param handle UART handle pointer.
+ * @param count Receive bytes count.
+ * @retval kStatus_NoTransferInProgress No receive in progress.
+ * @retval kStatus_InvalidArgument Parameter is invalid.
+ * @retval kStatus_Success Get successfully through the parameter \p count;
+ */
+status_t UART_TransferGetReceiveCountEDMA(UART_Type *base, uart_edma_handle_t *handle, uint32_t *count);
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_UART_EDMA_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_vref.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_vref.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_vref.h"
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Gets the instance from the base address
+ *
+ * @param base VREF peripheral base address
+ *
+ * @return The VREF instance
+ */
+static uint32_t VREF_GetInstance(VREF_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to VREF bases for each instance. */
+static VREF_Type *const s_vrefBases[] = VREF_BASE_PTRS;
+
+/*! @brief Pointers to VREF clocks for each instance. */
+static const clock_ip_name_t s_vrefClocks[] = VREF_CLOCKS;
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t VREF_GetInstance(VREF_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < FSL_FEATURE_SOC_VREF_COUNT; instance++)
+    {
+        if (s_vrefBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < FSL_FEATURE_SOC_VREF_COUNT);
+
+    return instance;
+}
+
+void VREF_Init(VREF_Type *base, const vref_config_t *config)
+{
+    assert(config != NULL);
+
+    uint8_t reg = 0U;
+
+    /* Ungate clock for VREF */
+    CLOCK_EnableClock(s_vrefClocks[VREF_GetInstance(base)]);
+
+/* Configure VREF to a known state */
+#if defined(FSL_FEATURE_VREF_HAS_CHOP_OSC) && FSL_FEATURE_VREF_HAS_CHOP_OSC
+    /* Set chop oscillator bit */
+    base->TRM |= VREF_TRM_CHOPEN_MASK;
+#endif /* FSL_FEATURE_VREF_HAS_CHOP_OSC */
+    reg = base->SC;
+    /* Set buffer Mode selection and Regulator enable bit */
+    reg |= VREF_SC_MODE_LV(config->bufferMode) | VREF_SC_REGEN(1U);
+#if defined(FSL_FEATURE_VREF_HAS_COMPENSATION) && FSL_FEATURE_VREF_HAS_COMPENSATION
+    /* Set second order curvature compensation enable bit */
+    reg |= VREF_SC_ICOMPEN(1U);
+#endif /* FSL_FEATURE_VREF_HAS_COMPENSATION */
+    /* Enable VREF module */
+    reg |= VREF_SC_VREFEN(1U);
+    /* Update bit-field from value to Status and Control register */
+    base->SC = reg;
+#if defined(FSL_FEATURE_VREF_HAS_LOW_REFERENCE) && FSL_FEATURE_VREF_HAS_LOW_REFERENCE
+    reg = base->VREFL_TRM;
+    /* Clear old select external voltage reference and VREFL (0.4 V) reference buffer enable bits*/
+    reg &= ~(VREF_VREFL_TRM_VREFL_EN_MASK | VREF_VREFL_TRM_VREFL_SEL_MASK);
+    /* Select external voltage reference and set VREFL (0.4 V) reference buffer enable */
+    reg |= VREF_VREFL_TRM_VREFL_SEL(config->enableExternalVoltRef) | VREF_VREFL_TRM_VREFL_EN(config->enableLowRef);
+    base->VREFL_TRM = reg;
+#endif /* FSL_FEATURE_VREF_HAS_LOW_REFERENCE */
+
+    /* Wait until internal voltage stable */
+    while ((base->SC & VREF_SC_VREFST_MASK) == 0)
+    {
+    }
+}
+
+void VREF_Deinit(VREF_Type *base)
+{
+    /* Gate clock for VREF */
+    CLOCK_DisableClock(s_vrefClocks[VREF_GetInstance(base)]);
+}
+
+void VREF_GetDefaultConfig(vref_config_t *config)
+{
+/* Set High power buffer mode in */
+#if defined(FSL_FEATURE_VREF_MODE_LV_TYPE) && FSL_FEATURE_VREF_MODE_LV_TYPE
+    config->bufferMode = kVREF_ModeHighPowerBuffer;
+#else
+    config->bufferMode = kVREF_ModeTightRegulationBuffer;
+#endif /* FSL_FEATURE_VREF_MODE_LV_TYPE */
+
+#if defined(FSL_FEATURE_VREF_HAS_LOW_REFERENCE) && FSL_FEATURE_VREF_HAS_LOW_REFERENCE
+    /* Select internal voltage reference */
+    config->enableExternalVoltRef = false;
+    /* Set VREFL (0.4 V) reference buffer disable */
+    config->enableLowRef = false;
+#endif /* FSL_FEATURE_VREF_HAS_LOW_REFERENCE */
+}
+
+void VREF_SetTrimVal(VREF_Type *base, uint8_t trimValue)
+{
+    uint8_t reg = 0U;
+
+    /* Set TRIM bits value in voltage reference */
+    reg = base->TRM;
+    reg = ((reg & ~VREF_TRM_TRIM_MASK) | VREF_TRM_TRIM(trimValue));
+    base->TRM = reg;
+    /* Wait until internal voltage stable */
+    while ((base->SC & VREF_SC_VREFST_MASK) == 0)
+    {
+    }
+}
+
+#if defined(FSL_FEATURE_VREF_HAS_LOW_REFERENCE) && FSL_FEATURE_VREF_HAS_LOW_REFERENCE
+void VREF_SetLowReferenceTrimVal(VREF_Type *base, uint8_t trimValue)
+{
+    /* The values 111b and 110b are NOT valid/allowed */
+    assert((trimValue != 0x7U) && (trimValue != 0x6U));
+
+    uint8_t reg = 0U;
+
+    /* Set TRIM bits value in low voltage reference */
+    reg = base->VREFL_TRM;
+    reg = ((reg & ~VREF_VREFL_TRM_VREFL_TRIM_MASK) | VREF_VREFL_TRM_VREFL_TRIM(trimValue));
+    base->VREFL_TRM = reg;
+    /* Wait until internal voltage stable */
+    while ((base->SC & VREF_SC_VREFST_MASK) == 0)
+    {
+    }
+}
+#endif /* FSL_FEATURE_VREF_HAS_LOW_REFERENCE */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_vref.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_vref.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_VREF_H_
+#define _FSL_VREF_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup vref
+ * @{
+ */
+
+/*! @file */
+
+/******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_VREF_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0. */
+/*@}*/
+
+/* Those macros below defined to support SoC family which have VREFL (0.4V) reference */
+#if defined(FSL_FEATURE_VREF_HAS_LOW_REFERENCE) && FSL_FEATURE_VREF_HAS_LOW_REFERENCE
+#define SC VREFH_SC
+#define VREF_SC_MODE_LV VREF_VREFH_SC_MODE_LV
+#define VREF_SC_REGEN VREF_VREFH_SC_REGEN
+#define VREF_SC_VREFEN VREF_VREFH_SC_VREFEN
+#define VREF_SC_ICOMPEN VREF_VREFH_SC_ICOMPEN
+#define VREF_SC_REGEN_MASK VREF_VREFH_SC_REGEN_MASK
+#define VREF_SC_VREFST_MASK VREF_VREFH_SC_VREFST_MASK
+#define VREF_SC_VREFEN_MASK VREF_VREFH_SC_VREFEN_MASK
+#define VREF_SC_MODE_LV_MASK VREF_VREFH_SC_MODE_LV_MASK
+#define VREF_SC_ICOMPEN_MASK VREF_VREFH_SC_ICOMPEN_MASK
+#define TRM VREFH_TRM
+#define VREF_TRM_TRIM VREF_VREFH_TRM_TRIM
+#define VREF_TRM_CHOPEN_MASK VREF_VREFH_TRM_CHOPEN_MASK
+#define VREF_TRM_TRIM_MASK VREF_VREFH_TRM_TRIM_MASK
+#define VREF_TRM_CHOPEN_SHIFT VREF_VREFH_TRM_CHOPEN_SHIFT
+#define VREF_TRM_TRIM_SHIFT VREF_VREFH_TRM_TRIM_SHIFT
+#define VREF_SC_MODE_LV_SHIFT VREF_VREFH_SC_MODE_LV_SHIFT
+#define VREF_SC_REGEN_SHIFT VREF_VREFH_SC_REGEN_SHIFT
+#define VREF_SC_VREFST_SHIFT VREF_VREFH_SC_VREFST_SHIFT
+#define VREF_SC_ICOMPEN_SHIFT VREF_VREFH_SC_ICOMPEN_SHIFT
+#endif /* FSL_FEATURE_VREF_HAS_LOW_REFERENCE */
+
+/*!
+ * @brief VREF modes.
+ */
+typedef enum _vref_buffer_mode
+{
+    kVREF_ModeBandgapOnly = 0U, /*!< Bandgap on only, for stabilization and startup */
+#if defined(FSL_FEATURE_VREF_MODE_LV_TYPE) && FSL_FEATURE_VREF_MODE_LV_TYPE
+    kVREF_ModeHighPowerBuffer = 1U, /*!< High power buffer mode enabled */
+    kVREF_ModeLowPowerBuffer = 2U   /*!< Low power buffer mode enabled */
+#else
+    kVREF_ModeTightRegulationBuffer = 2U /*!< Tight regulation buffer enabled */
+#endif /* FSL_FEATURE_VREF_MODE_LV_TYPE */
+} vref_buffer_mode_t;
+
+/*!
+ * @brief The description structure for the VREF module.
+ */
+typedef struct _vref_config
+{
+    vref_buffer_mode_t bufferMode; /*!< Buffer mode selection */
+#if defined(FSL_FEATURE_VREF_HAS_LOW_REFERENCE) && FSL_FEATURE_VREF_HAS_LOW_REFERENCE
+    bool enableLowRef;          /*!< Set VREFL (0.4 V) reference buffer enable or disable */
+    bool enableExternalVoltRef; /*!< Select external voltage reference or not (internal) */
+#endif                          /* FSL_FEATURE_VREF_HAS_LOW_REFERENCE */
+} vref_config_t;
+
+/******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name VREF functional operation
+ * @{
+ */
+
+/*!
+ * @brief Enables the clock gate and configures the VREF module according to the configuration structure.
+ *
+ * This function must be called before calling all the other VREF driver functions,
+ * read/write registers, and configurations with user-defined settings.
+ * The example below shows how to set up  vref_config_t parameters and
+ * how to call the VREF_Init function by passing in these parameters:
+ * Example:
+ * @code
+ *   vref_config_t vrefConfig;
+ *   vrefConfig.bufferMode = kVREF_ModeHighPowerBuffer;
+ *   vrefConfig.enableExternalVoltRef = false;
+ *   vrefConfig.enableLowRef = false;
+ *   VREF_Init(VREF, &vrefConfig);
+ * @endcode
+ *
+ * @param base VREF peripheral address.
+ * @param config Pointer to the configuration structure.
+ */
+void VREF_Init(VREF_Type *base, const vref_config_t *config);
+
+/*!
+ * @brief Stops and disables the clock for the VREF module.
+ *
+ * This function should be called to shut down the module.
+ * Example:
+ * @code
+ *   vref_config_t vrefUserConfig;
+ *   VREF_Init(VREF);
+ *   VREF_GetDefaultConfig(&vrefUserConfig);
+ *   ...
+ *   VREF_Deinit(VREF);
+ * @endcode
+ *
+ * @param base VREF peripheral address.
+ */
+void VREF_Deinit(VREF_Type *base);
+
+/*!
+ * @brief Initializes the VREF configuration structure.
+ *
+ * This function initializes the VREF configuration structure to a default value.
+ * Example:
+ * @code
+ *   vrefConfig->bufferMode = kVREF_ModeHighPowerBuffer;
+ *   vrefConfig->enableExternalVoltRef = false;
+ *   vrefConfig->enableLowRef = false;
+ * @endcode
+ *
+ * @param config Pointer to the initialization structure.
+ */
+void VREF_GetDefaultConfig(vref_config_t *config);
+
+/*!
+ * @brief Sets a TRIM value for reference voltage.
+ *
+ * This function sets a TRIM value for reference voltage.
+ * Note that the TRIM value maximum is 0x3F.
+ *
+ * @param base VREF peripheral address.
+ * @param trimValue Value of the trim register to set the output reference voltage (maximum 0x3F (6-bit)).
+ */
+void VREF_SetTrimVal(VREF_Type *base, uint8_t trimValue);
+
+/*!
+ * @brief Reads the value of the TRIM meaning output voltage.
+ *
+ * This function gets the TRIM value from the TRM register.
+ *
+ * @param base VREF peripheral address.
+ * @return Six-bit value of trim setting.
+ */
+static inline uint8_t VREF_GetTrimVal(VREF_Type *base)
+{
+    return (base->TRM & VREF_TRM_TRIM_MASK);
+}
+#if defined(FSL_FEATURE_VREF_HAS_LOW_REFERENCE) && FSL_FEATURE_VREF_HAS_LOW_REFERENCE
+
+/*!
+ * @brief Sets the TRIM value for low voltage reference.
+ *
+ * This function sets the TRIM value for low reference voltage.
+ * NOTE:
+ *      - The TRIM value maximum is 0x05U
+ *      - The values 111b and 110b are not valid/allowed.
+ *
+ * @param base VREF peripheral address.
+ * @param trimValue Value of the trim register to set output low reference voltage (maximum 0x05U (3-bit)).
+ */
+void VREF_SetLowReferenceTrimVal(VREF_Type *base, uint8_t trimValue);
+
+/*!
+ * @brief Reads the value of the TRIM meaning output voltage.
+ *
+ * This function gets the TRIM value from the VREFL_TRM register.
+ *
+ * @param base VREF peripheral address.
+ * @return Three-bit value of the trim setting.
+ */
+static inline uint8_t VREF_GetLowReferenceTrimVal(VREF_Type *base)
+{
+    return (base->VREFL_TRM & VREF_VREFL_TRM_VREFL_TRIM_MASK);
+}
+#endif /* FSL_FEATURE_VREF_HAS_LOW_REFERENCE */
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_VREF_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_wdog.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_wdog.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_wdog.h"
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+void WDOG_GetDefaultConfig(wdog_config_t *config)
+{
+    assert(config);
+
+    config->enableWdog = true;
+    config->clockSource = kWDOG_LpoClockSource;
+    config->prescaler = kWDOG_ClockPrescalerDivide1;
+#if defined(FSL_FEATURE_WDOG_HAS_WAITEN) && FSL_FEATURE_WDOG_HAS_WAITEN
+    config->workMode.enableWait = true;
+#endif /* FSL_FEATURE_WDOG_HAS_WAITEN */
+    config->workMode.enableStop = false;
+    config->workMode.enableDebug = false;
+    config->enableUpdate = true;
+    config->enableInterrupt = false;
+    config->enableWindowMode = false;
+    config->windowValue = 0U;
+    config->timeoutValue = 0xFFFFU;
+}
+
+void WDOG_Init(WDOG_Type *base, const wdog_config_t *config)
+{
+    assert(config);
+
+    uint32_t value = 0U;
+    uint32_t primaskValue = 0U;
+
+    value = WDOG_STCTRLH_WDOGEN(config->enableWdog) | WDOG_STCTRLH_CLKSRC(config->clockSource) |
+            WDOG_STCTRLH_IRQRSTEN(config->enableInterrupt) | WDOG_STCTRLH_WINEN(config->enableWindowMode) |
+            WDOG_STCTRLH_ALLOWUPDATE(config->enableUpdate) | WDOG_STCTRLH_DBGEN(config->workMode.enableDebug) |
+            WDOG_STCTRLH_STOPEN(config->workMode.enableStop) |
+#if defined(FSL_FEATURE_WDOG_HAS_WAITEN) && FSL_FEATURE_WDOG_HAS_WAITEN
+            WDOG_STCTRLH_WAITEN(config->workMode.enableWait) |
+#endif /* FSL_FEATURE_WDOG_HAS_WAITEN */
+            WDOG_STCTRLH_DISTESTWDOG(1U);
+
+    /* Disable the global interrupts. Otherwise, an interrupt could effectively invalidate the unlock sequence
+     * and the WCT may expire. After the configuration finishes, re-enable the global interrupts. */
+    primaskValue = DisableGlobalIRQ();
+    WDOG_Unlock(base);
+    /* Wait one bus clock cycle */
+    base->RSTCNT = 0U;
+    /* Set configruation */
+    base->PRESC = WDOG_PRESC_PRESCVAL(config->prescaler);
+    base->WINH = (uint16_t)((config->windowValue >> 16U) & 0xFFFFU);
+    base->WINL = (uint16_t)((config->windowValue) & 0xFFFFU);
+    base->TOVALH = (uint16_t)((config->timeoutValue >> 16U) & 0xFFFFU);
+    base->TOVALL = (uint16_t)((config->timeoutValue) & 0xFFFFU);
+    base->STCTRLH = value;
+    EnableGlobalIRQ(primaskValue);
+}
+
+void WDOG_Deinit(WDOG_Type *base)
+{
+    uint32_t primaskValue = 0U;
+
+    /* Disable the global interrupts */
+    primaskValue = DisableGlobalIRQ();
+    WDOG_Unlock(base);
+    /* Wait one bus clock cycle */
+    base->RSTCNT = 0U;
+    WDOG_Disable(base);
+    EnableGlobalIRQ(primaskValue);
+    WDOG_ClearResetCount(base);
+}
+
+void WDOG_SetTestModeConfig(WDOG_Type *base, wdog_test_config_t *config)
+{
+    assert(config);
+
+    uint32_t value = 0U;
+    uint32_t primaskValue = 0U;
+
+    value = WDOG_STCTRLH_DISTESTWDOG(0U) | WDOG_STCTRLH_TESTWDOG(1U) | WDOG_STCTRLH_TESTSEL(config->testMode) |
+            WDOG_STCTRLH_BYTESEL(config->testedByte) | WDOG_STCTRLH_IRQRSTEN(0U) | WDOG_STCTRLH_WDOGEN(1U) |
+            WDOG_STCTRLH_ALLOWUPDATE(1U);
+
+    /* Disable the global interrupts. Otherwise, an interrupt could effectively invalidate the unlock sequence
+     * and the WCT may expire. After the configuration finishes, re-enable the global interrupts. */
+    primaskValue = DisableGlobalIRQ();
+    WDOG_Unlock(base);
+    /* Wait one bus clock cycle */
+    base->RSTCNT = 0U;
+    /* Set configruation */
+    base->TOVALH = (uint16_t)((config->timeoutValue >> 16U) & 0xFFFFU);
+    base->TOVALL = (uint16_t)((config->timeoutValue) & 0xFFFFU);
+    base->STCTRLH = value;
+    EnableGlobalIRQ(primaskValue);
+}
+
+uint32_t WDOG_GetStatusFlags(WDOG_Type *base)
+{
+    uint32_t status_flag = 0U;
+
+    status_flag |= (base->STCTRLH & WDOG_STCTRLH_WDOGEN_MASK);
+    status_flag |= (base->STCTRLL & WDOG_STCTRLL_INTFLG_MASK);
+
+    return status_flag;
+}
+
+void WDOG_ClearStatusFlags(WDOG_Type *base, uint32_t mask)
+{
+    if (mask & kWDOG_TimeoutFlag)
+    {
+        base->STCTRLL |= WDOG_STCTRLL_INTFLG_MASK;
+    }
+}
+
+void WDOG_Refresh(WDOG_Type *base)
+{
+    uint32_t primaskValue = 0U;
+
+    /* Disable the global interrupt to protect refresh sequence */
+    primaskValue = DisableGlobalIRQ();
+    base->REFRESH = WDOG_FIRST_WORD_OF_REFRESH;
+    base->REFRESH = WDOG_SECOND_WORD_OF_REFRESH;
+    EnableGlobalIRQ(primaskValue);
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_wdog.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_wdog.h
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _FSL_WDOG_H_
+#define _FSL_WDOG_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup wdog_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief Defines WDOG driver version 2.0.0. */
+#define FSL_WDOG_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*! @name Unlock sequence */
+/*@{*/
+#define WDOG_FIRST_WORD_OF_UNLOCK (0xC520U)  /*!< First word of unlock sequence */
+#define WDOG_SECOND_WORD_OF_UNLOCK (0xD928U) /*!< Second word of unlock sequence */
+/*@}*/
+
+/*! @name Refresh sequence */
+/*@{*/
+#define WDOG_FIRST_WORD_OF_REFRESH (0xA602U)  /*!< First word of refresh sequence */
+#define WDOG_SECOND_WORD_OF_REFRESH (0xB480U) /*!< Second word of refresh sequence */
+/*@}*/
+
+/*! @brief Describes WDOG clock source. */
+typedef enum _wdog_clock_source
+{
+    kWDOG_LpoClockSource = 0U,       /*!< WDOG clock sourced from LPO*/
+    kWDOG_AlternateClockSource = 1U, /*!< WDOG clock sourced from alternate clock source*/
+} wdog_clock_source_t;
+
+/*! @brief Defines WDOG work mode. */
+typedef struct _wdog_work_mode
+{
+#if defined(FSL_FEATURE_WDOG_HAS_WAITEN) && FSL_FEATURE_WDOG_HAS_WAITEN
+    bool enableWait;  /*!< Enables or disables WDOG in wait mode  */
+#endif                /* FSL_FEATURE_WDOG_HAS_WAITEN */
+    bool enableStop;  /*!< Enables or disables WDOG in stop mode  */
+    bool enableDebug; /*!< Enables or disables WDOG in debug mode */
+} wdog_work_mode_t;
+
+/*! @brief Describes the selection of the clock prescaler. */
+typedef enum _wdog_clock_prescaler
+{
+    kWDOG_ClockPrescalerDivide1 = 0x0U, /*!< Divided by 1 */
+    kWDOG_ClockPrescalerDivide2 = 0x1U, /*!< Divided by 2 */
+    kWDOG_ClockPrescalerDivide3 = 0x2U, /*!< Divided by 3 */
+    kWDOG_ClockPrescalerDivide4 = 0x3U, /*!< Divided by 4 */
+    kWDOG_ClockPrescalerDivide5 = 0x4U, /*!< Divided by 5 */
+    kWDOG_ClockPrescalerDivide6 = 0x5U, /*!< Divided by 6 */
+    kWDOG_ClockPrescalerDivide7 = 0x6U, /*!< Divided by 7 */
+    kWDOG_ClockPrescalerDivide8 = 0x7U, /*!< Divided by 8 */
+} wdog_clock_prescaler_t;
+
+/*! @brief Describes WDOG configuration structure. */
+typedef struct _wdog_config
+{
+    bool enableWdog;                  /*!< Enables or disables WDOG */
+    wdog_clock_source_t clockSource;  /*!< Clock source select */
+    wdog_clock_prescaler_t prescaler; /*!< Clock prescaler value */
+    wdog_work_mode_t workMode;        /*!< Configures WDOG work mode in debug stop and wait mode */
+    bool enableUpdate;                /*!< Update write-once register enable */
+    bool enableInterrupt;             /*!< Enables or disables WDOG interrupt */
+    bool enableWindowMode;            /*!< Enables or disables WDOG window mode */
+    uint32_t windowValue;             /*!< Window value */
+    uint32_t timeoutValue;            /*!< Timeout value */
+} wdog_config_t;
+
+/*! @brief Describes WDOG test mode. */
+typedef enum _wdog_test_mode
+{
+    kWDOG_QuickTest = 0U, /*!< Selects quick test */
+    kWDOG_ByteTest = 1U,  /*!< Selects byte test */
+} wdog_test_mode_t;
+
+/*! @brief Describes WDOG tested byte selection in byte test mode. */
+typedef enum _wdog_tested_byte
+{
+    kWDOG_TestByte0 = 0U, /*!< Byte 0 selected in byte test mode */
+    kWDOG_TestByte1 = 1U, /*!< Byte 1 selected in byte test mode */
+    kWDOG_TestByte2 = 2U, /*!< Byte 2 selected in byte test mode */
+    kWDOG_TestByte3 = 3U, /*!< Byte 3 selected in byte test mode */
+} wdog_tested_byte_t;
+
+/*! @brief Describes WDOG test mode configuration structure. */
+typedef struct _wdog_test_config
+{
+    wdog_test_mode_t testMode;     /*!< Selects test mode */
+    wdog_tested_byte_t testedByte; /*!< Selects tested byte in byte test mode */
+    uint32_t timeoutValue;         /*!< Timeout value */
+} wdog_test_config_t;
+
+/*!
+ * @brief WDOG interrupt configuration structure, default settings all disabled.
+ *
+ * This structure contains the settings for all of the WDOG interrupt configurations.
+ */
+enum _wdog_interrupt_enable_t
+{
+    kWDOG_InterruptEnable = WDOG_STCTRLH_IRQRSTEN_MASK, /*!< WDOG timeout will generate interrupt before reset*/
+};
+
+/*!
+ * @brief WDOG status flags.
+ *
+ * This structure contains the WDOG status flags for use in the WDOG functions.
+ */
+enum _wdog_status_flags_t
+{
+    kWDOG_RunningFlag = WDOG_STCTRLH_WDOGEN_MASK, /*!< Running flag, set when WDOG is enabled*/
+    kWDOG_TimeoutFlag = WDOG_STCTRLL_INTFLG_MASK, /*!< Interrupt flag, set when an exception occurs*/
+};
+
+/*******************************************************************************
+ * API
+ *******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name WDOG Initialization and De-initialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes WDOG configure sturcture.
+ *
+ * This function initializes the WDOG configure structure to default value. The default
+ * value are:
+ * @code
+ *   wdogConfig->enableWdog = true;
+ *   wdogConfig->clockSource = kWDOG_LpoClockSource;
+ *   wdogConfig->prescaler = kWDOG_ClockPrescalerDivide1;
+ *   wdogConfig->workMode.enableWait = true;
+ *   wdogConfig->workMode.enableStop = false;
+ *   wdogConfig->workMode.enableDebug = false;
+ *   wdogConfig->enableUpdate = true;
+ *   wdogConfig->enableInterrupt = false;
+ *   wdogConfig->enableWindowMode = false;
+ *   wdogConfig->windowValue = 0;
+ *   wdogConfig->timeoutValue = 0xFFFFU;
+ * @endcode
+ *
+ * @param config Pointer to WDOG config structure.
+ * @see wdog_config_t
+ */
+void WDOG_GetDefaultConfig(wdog_config_t *config);
+
+/*!
+ * @brief Initializes the WDOG.
+ *
+ * This function initializes the WDOG. When called, the WDOG runs according to the configuration.
+ * If user wants to reconfigure WDOG without forcing a reset first, enableUpdate must be set to true
+ * in configuration.
+ *
+ * Example:
+ * @code
+ *   wdog_config_t config;
+ *   WDOG_GetDefaultConfig(&config);
+ *   config.timeoutValue = 0x7ffU;
+ *   config.enableUpdate = true;
+ *   WDOG_Init(wdog_base,&config);
+ * @endcode
+ *
+ * @param base   WDOG peripheral base address
+ * @param config The configuration of WDOG
+ */
+void WDOG_Init(WDOG_Type *base, const wdog_config_t *config);
+
+/*!
+ * @brief Shuts down the WDOG.
+ *
+ * This function shuts down the WDOG.
+ * Make sure that the WDOG_STCTRLH.ALLOWUPDATE is 1 which means that the register update is enabled.
+ */
+void WDOG_Deinit(WDOG_Type *base);
+
+/*!
+ * @brief Configures WDOG functional test.
+ *
+ * This function is used to configure the WDOG functional test. When called, the WDOG goes into test mode
+ * and runs according to the configuration.
+ * Make sure that the WDOG_STCTRLH.ALLOWUPDATE is 1 which means that the register update is enabled.
+ *
+ * Example:
+ * @code
+ *   wdog_test_config_t test_config;
+ *   test_config.testMode = kWDOG_QuickTest;
+ *   test_config.timeoutValue = 0xfffffu;
+ *   WDOG_SetTestModeConfig(wdog_base, &test_config);
+ * @endcode
+ * @param base   WDOG peripheral base address
+ * @param config The functional test configuration of WDOG
+ */
+void WDOG_SetTestModeConfig(WDOG_Type *base, wdog_test_config_t *config);
+
+/* @} */
+
+/*!
+ * @name WDOG Functional Operation
+ * @{
+ */
+
+/*!
+ * @brief Enables the WDOG module.
+ *
+ * This function write value into WDOG_STCTRLH register to enable the WDOG, it is a write-once register,
+ * make sure that the WCT window is still open and this register has not been written in this WCT
+ * while this function is called.
+ *
+ * @param base WDOG peripheral base address
+ */
+static inline void WDOG_Enable(WDOG_Type *base)
+{
+    base->STCTRLH |= WDOG_STCTRLH_WDOGEN_MASK;
+}
+
+/*!
+ * @brief Disables the WDOG module.
+ *
+ * This function write value into WDOG_STCTRLH register to disable the WDOG, it is a write-once register,
+ * make sure that the WCT window is still open and this register has not been written in this WCT
+ * while this function is called.
+ *
+ * @param base WDOG peripheral base address
+ */
+static inline void WDOG_Disable(WDOG_Type *base)
+{
+    base->STCTRLH &= ~WDOG_STCTRLH_WDOGEN_MASK;
+}
+
+/*!
+ * @brief Enable WDOG interrupt.
+ *
+ * This function write value into WDOG_STCTRLH register to enable WDOG interrupt, it is a write-once register,
+ * make sure that the WCT window is still open and this register has not been written in this WCT
+ * while this function is called.
+ *
+ * @param base WDOG peripheral base address
+ * @param mask The interrupts to enable
+ *        The parameter can be combination of the following source if defined:
+ *        @arg kWDOG_InterruptEnable
+ */
+static inline void WDOG_EnableInterrupts(WDOG_Type *base, uint32_t mask)
+{
+    base->STCTRLH |= mask;
+}
+
+/*!
+ * @brief Disable WDOG interrupt.
+ *
+ * This function write value into WDOG_STCTRLH register to disable WDOG interrupt, it is a write-once register,
+ * make sure that the WCT window is still open and this register has not been written in this WCT
+ * while this function is called.
+ *
+ * @param base WDOG peripheral base address
+ * @param mask The interrupts to disable
+ *        The parameter can be combination of the following source if defined:
+ *        @arg kWDOG_InterruptEnable
+ */
+static inline void WDOG_DisableInterrupts(WDOG_Type *base, uint32_t mask)
+{
+    base->STCTRLH &= ~mask;
+}
+
+/*!
+ * @brief Gets WDOG all status flags.
+ *
+ * This function gets all status flags.
+ *
+ * Example for getting Running Flag:
+ * @code
+ *   uint32_t status;
+ *   status = WDOG_GetStatusFlags(wdog_base) & kWDOG_RunningFlag;
+ * @endcode
+ * @param base        WDOG peripheral base address
+ * @return            State of the status flag: asserted (true) or not-asserted (false).@see _wdog_status_flags_t
+ *                    - true: related status flag has been set.
+ *                    - false: related status flag is not set.
+ */
+uint32_t WDOG_GetStatusFlags(WDOG_Type *base);
+
+/*!
+ * @brief Clear WDOG flag.
+ *
+ * This function clears WDOG status flag.
+ *
+ * Example for clearing timeout(interrupt) flag:
+ * @code
+ *   WDOG_ClearStatusFlags(wdog_base,kWDOG_TimeoutFlag);
+ * @endcode
+ * @param base        WDOG peripheral base address
+ * @param mask        The status flags to clear.
+ *                    The parameter could be any combination of the following values:
+ *                    kWDOG_TimeoutFlag
+ */
+void WDOG_ClearStatusFlags(WDOG_Type *base, uint32_t mask);
+
+/*!
+ * @brief Set the WDOG timeout value.
+ *
+ * This function sets the timeout value.
+ * It should be ensured that the time-out value for the WDOG is always greater than
+ * 2xWCT time + 20 bus clock cycles.
+ * This function write value into WDOG_TOVALH and WDOG_TOVALL registers which are wirte-once.
+ * Make sure the WCT window is still open and these two registers have not been written in this WCT
+ * while this function is called.
+ *
+ * @param base WDOG peripheral base address
+ * @param timeoutCount WDOG timeout value, count of WDOG clock tick.
+ */
+static inline void WDOG_SetTimeoutValue(WDOG_Type *base, uint32_t timeoutCount)
+{
+    base->TOVALH = (uint16_t)((timeoutCount >> 16U) & 0xFFFFU);
+    base->TOVALL = (uint16_t)((timeoutCount)&0xFFFFU);
+}
+
+/*!
+ * @brief Sets the WDOG window value.
+ *
+ * This function sets the WDOG window value.
+ * This function write value into WDOG_WINH and WDOG_WINL registers which are wirte-once.
+ * Make sure the WCT window is still open and these two registers have not been written in this WCT
+ * while this function is called.
+ *
+ * @param base WDOG peripheral base address
+ * @param windowValue WDOG window value.
+ */
+static inline void WDOG_SetWindowValue(WDOG_Type *base, uint32_t windowValue)
+{
+    base->WINH = (uint16_t)((windowValue >> 16U) & 0xFFFFU);
+    base->WINL = (uint16_t)((windowValue)&0xFFFFU);
+}
+
+/*!
+ * @brief Unlocks the WDOG register written.
+ *
+ * This function unlocks the WDOG register written.
+ * Before starting the unlock sequence and following congfiguration, disable the global interrupts.
+ * Otherwise, an interrupt could effectively invalidate the unlock sequence and the WCT may expire,
+ * After the configuration finishes, re-enable the global interrupts.
+ *
+ * @param base WDOG peripheral base address
+ */
+static inline void WDOG_Unlock(WDOG_Type *base)
+{
+    base->UNLOCK = WDOG_FIRST_WORD_OF_UNLOCK;
+    base->UNLOCK = WDOG_SECOND_WORD_OF_UNLOCK;
+}
+
+/*!
+ * @brief Refreshes the WDOG timer.
+ *
+ * This function feeds the WDOG.
+ * This function should be called before WDOG timer is in timeout. Otherwise, a reset is asserted.
+ *
+ * @param base WDOG peripheral base address
+ */
+void WDOG_Refresh(WDOG_Type *base);
+
+/*!
+ * @brief Gets the WDOG reset count.
+ *
+ * This function gets the WDOG reset count value.
+ *
+ * @param base WDOG peripheral base address
+ * @return     WDOG reset count value
+ */
+static inline uint16_t WDOG_GetResetCount(WDOG_Type *base)
+{
+    return base->RSTCNT;
+}
+/*!
+ * @brief Clears the WDOG reset count.
+ *
+ * This function clears the WDOG reset count value.
+ *
+ * @param base WDOG peripheral base address
+ */
+static inline void WDOG_ClearResetCount(WDOG_Type *base)
+{
+    base->RSTCNT |= UINT16_MAX;
+}
+
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_WDOG_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/fsl_device_registers.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/fsl_device_registers.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2014 - 2016, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __FSL_DEVICE_REGISTERS_H__
+#define __FSL_DEVICE_REGISTERS_H__
+
+/*
+ * Include the cpu specific register header files.
+ *
+ * The CPU macro should be declared in the project or makefile.
+ */
+#if (defined(CPU_MK64FN1M0CAJ12) || defined(CPU_MK64FN1M0VDC12) || defined(CPU_MK64FN1M0VLL12) || \
+    defined(CPU_MK64FN1M0VLQ12) || defined(CPU_MK64FN1M0VMD12) || defined(CPU_MK64FX512VDC12) || \
+    defined(CPU_MK64FX512VLL12) || defined(CPU_MK64FX512VLQ12) || defined(CPU_MK64FX512VMD12))
+
+#define K64F12_SERIES
+
+/* CMSIS-style register definitions */
+#include "MK64F12.h"
+/* CPU specific feature definitions */
+#include "MK64F12_features.h"
+
+#else
+    #error "No valid CPU defined!"
+#endif
+
+#endif /* __FSL_DEVICE_REGISTERS_H__ */
+
+/*******************************************************************************
+ * EOF
+ ******************************************************************************/

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FN1M0xxx12_flash.ld
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FN1M0xxx12_flash.ld
@@ -1,0 +1,262 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
+  m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
+  m_text                (RX)  : ORIGIN = 0x00000410, LENGTH = 0x000FFBF0
+  m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
+  m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal flash */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  .flash_config :
+  {
+    . = ALIGN(4);
+    KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
+    . = ALIGN(4);
+  } > m_flash_config
+
+  /* The program code and other data goes into internal flash */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .interrupts_ram :
+  {
+    . = ALIGN(4);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(4);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_data
+
+  __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
+  __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    . = ALIGN(512);
+    USB_RAM_START = .;
+    . += USB_RAM_GAP;
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data_2
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data_2
+
+  m_usb_bdt USB_RAM_START (NOLOAD) :
+  {
+    *(m_usb_bdt)
+    USB_RAM_BDT_END = .;
+  }
+
+  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  {
+    *(m_usb_global)
+  }
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data_2) + LENGTH(m_data_2);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
+}
+

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FN1M0xxx12_ram.ld
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FN1M0xxx12_ram.ld
@@ -1,0 +1,241 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00000400
+  m_text                (RX)  : ORIGIN = 0x1FFF0400, LENGTH = 0x0000FC00
+  m_data                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal RAM */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  __VECTOR_RAM = __VECTOR_TABLE;
+  __RAM_VECTOR_TABLE_SIZE_BYTES = 0x0;
+
+  /* The program code and other data goes into internal RAM */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    . = ALIGN(512);
+    USB_RAM_START = .;
+    . += USB_RAM_GAP;
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data
+
+  m_usb_bdt USB_RAM_START (NOLOAD) :
+  {
+    *(m_usb_bdt)
+    USB_RAM_BDT_END = .;
+  }
+
+  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  {
+    *(m_usb_global)
+  }
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data) + LENGTH(m_data);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
+}
+

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FX512xxx12_flash.ld
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FX512xxx12_flash.ld
@@ -1,0 +1,261 @@
+/*
+** ###################################################################
+**     Processors:          MK64FX512VDC12
+**                          MK64FX512VLL12
+**                          MK64FX512VLQ12
+**                          MK64FX512VMD12
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
+  m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
+  m_text                (RX)  : ORIGIN = 0x00000410, LENGTH = 0x0007FBF0
+  m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
+  m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00020000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal flash */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  .flash_config :
+  {
+    . = ALIGN(4);
+    KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
+    . = ALIGN(4);
+  } > m_flash_config
+
+  /* The program code and other data goes into internal flash */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .interrupts_ram :
+  {
+    . = ALIGN(4);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(4);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_data
+
+  __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
+  __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    . = ALIGN(512);
+    USB_RAM_START = .;
+    . += USB_RAM_GAP;
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data_2
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data_2
+
+  m_usb_bdt USB_RAM_START (NOLOAD) :
+  {
+    *(m_usb_bdt)
+    USB_RAM_BDT_END = .;
+  }
+
+  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  {
+    *(m_usb_global)
+  }
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data_2) + LENGTH(m_data_2);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
+}
+

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FX512xxx12_ram.ld
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/MK64FX512xxx12_ram.ld
@@ -1,0 +1,240 @@
+/*
+** ###################################################################
+**     Processors:          MK64FX512VDC12
+**                          MK64FX512VLL12
+**                          MK64FX512VLQ12
+**                          MK64FX512VMD12
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00000400
+  m_text                (RX)  : ORIGIN = 0x1FFF0400, LENGTH = 0x0000FC00
+  m_data                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00020000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal RAM */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  __VECTOR_RAM = __VECTOR_TABLE;
+  __RAM_VECTOR_TABLE_SIZE_BYTES = 0x0;
+
+  /* The program code and other data goes into internal RAM */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    . = ALIGN(512);
+    USB_RAM_START = .;
+    . += USB_RAM_GAP;
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data
+
+  m_usb_bdt USB_RAM_START (NOLOAD) :
+  {
+    *(m_usb_bdt)
+    USB_RAM_BDT_END = .;
+  }
+
+  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  {
+    *(m_usb_global)
+  }
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data) + LENGTH(m_data);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
+}
+

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/startup_MK64F12.S
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/gcc/startup_MK64F12.S
@@ -1,0 +1,993 @@
+/* ---------------------------------------------------------------------------------------*/
+/*  @file:    startup_MK64F12.s                                                           */
+/*  @purpose: CMSIS Cortex-M4 Core Device Startup File                                    */
+/*            MK64F12                                                                     */
+/*  @version: 2.9                                                                         */
+/*  @date:    2016-3-21                                                                   */
+/*  @build:   b160321                                                                     */
+/* ---------------------------------------------------------------------------------------*/
+/*                                                                                        */
+/* Copyright (c) 1997 - 2016 , Freescale Semiconductor, Inc.                              */
+/* All rights reserved.                                                                   */
+/*                                                                                        */
+/* Redistribution and use in source and binary forms, with or without modification,       */
+/* are permitted provided that the following conditions are met:                          */
+/*                                                                                        */
+/* o Redistributions of source code must retain the above copyright notice, this list     */
+/*   of conditions and the following disclaimer.                                          */
+/*                                                                                        */
+/* o Redistributions in binary form must reproduce the above copyright notice, this       */
+/*   list of conditions and the following disclaimer in the documentation and/or          */
+/*   other materials provided with the distribution.                                      */
+/*                                                                                        */
+/* o Neither the name of Freescale Semiconductor, Inc. nor the names of its               */
+/*   contributors may be used to endorse or promote products derived from this            */
+/*   software without specific prior written permission.                                  */
+/*                                                                                        */
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND        */
+/* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED          */
+/* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                 */
+/* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR       */
+/* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         */
+/* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;           */
+/* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON         */
+/* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                */
+/* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS          */
+/* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/*****************************************************************************/
+/* Version: GCC for ARM Embedded Processors                                  */
+/*****************************************************************************/
+    .syntax unified
+    .arch armv7-m
+
+    .section .isr_vector, "a"
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long   __StackTop                                      /* Top of Stack */
+    .long   Reset_Handler                                   /* Reset Handler */
+    .long   NMI_Handler                                     /* NMI Handler*/
+    .long   HardFault_Handler                               /* Hard Fault Handler*/
+    .long   MemManage_Handler                               /* MPU Fault Handler*/
+    .long   BusFault_Handler                                /* Bus Fault Handler*/
+    .long   UsageFault_Handler                              /* Usage Fault Handler*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   SVC_Handler                                     /* SVCall Handler*/
+    .long   DebugMon_Handler                                /* Debug Monitor Handler*/
+    .long   0                                               /* Reserved*/
+    .long   PendSV_Handler                                  /* PendSV Handler*/
+    .long   SysTick_Handler                                 /* SysTick Handler*/
+
+                                                            /* External Interrupts*/
+    .long   DMA0_IRQHandler                                 /* DMA Channel 0 Transfer Complete*/
+    .long   DMA1_IRQHandler                                 /* DMA Channel 1 Transfer Complete*/
+    .long   DMA2_IRQHandler                                 /* DMA Channel 2 Transfer Complete*/
+    .long   DMA3_IRQHandler                                 /* DMA Channel 3 Transfer Complete*/
+    .long   DMA4_IRQHandler                                 /* DMA Channel 4 Transfer Complete*/
+    .long   DMA5_IRQHandler                                 /* DMA Channel 5 Transfer Complete*/
+    .long   DMA6_IRQHandler                                 /* DMA Channel 6 Transfer Complete*/
+    .long   DMA7_IRQHandler                                 /* DMA Channel 7 Transfer Complete*/
+    .long   DMA8_IRQHandler                                 /* DMA Channel 8 Transfer Complete*/
+    .long   DMA9_IRQHandler                                 /* DMA Channel 9 Transfer Complete*/
+    .long   DMA10_IRQHandler                                /* DMA Channel 10 Transfer Complete*/
+    .long   DMA11_IRQHandler                                /* DMA Channel 11 Transfer Complete*/
+    .long   DMA12_IRQHandler                                /* DMA Channel 12 Transfer Complete*/
+    .long   DMA13_IRQHandler                                /* DMA Channel 13 Transfer Complete*/
+    .long   DMA14_IRQHandler                                /* DMA Channel 14 Transfer Complete*/
+    .long   DMA15_IRQHandler                                /* DMA Channel 15 Transfer Complete*/
+    .long   DMA_Error_IRQHandler                            /* DMA Error Interrupt*/
+    .long   MCM_IRQHandler                                  /* Normal Interrupt*/
+    .long   FTFE_IRQHandler                                 /* FTFE Command complete interrupt*/
+    .long   Read_Collision_IRQHandler                       /* Read Collision Interrupt*/
+    .long   LVD_LVW_IRQHandler                              /* Low Voltage Detect, Low Voltage Warning*/
+    .long   LLWU_IRQHandler                                 /* Low Leakage Wakeup Unit*/
+    .long   WDOG_EWM_IRQHandler                             /* WDOG Interrupt*/
+    .long   RNG_IRQHandler                                  /* RNG Interrupt*/
+    .long   I2C0_IRQHandler                                 /* I2C0 interrupt*/
+    .long   I2C1_IRQHandler                                 /* I2C1 interrupt*/
+    .long   SPI0_IRQHandler                                 /* SPI0 Interrupt*/
+    .long   SPI1_IRQHandler                                 /* SPI1 Interrupt*/
+    .long   I2S0_Tx_IRQHandler                              /* I2S0 transmit interrupt*/
+    .long   I2S0_Rx_IRQHandler                              /* I2S0 receive interrupt*/
+    .long   UART0_LON_IRQHandler                            /* UART0 LON interrupt*/
+    .long   UART0_RX_TX_IRQHandler                          /* UART0 Receive/Transmit interrupt*/
+    .long   UART0_ERR_IRQHandler                            /* UART0 Error interrupt*/
+    .long   UART1_RX_TX_IRQHandler                          /* UART1 Receive/Transmit interrupt*/
+    .long   UART1_ERR_IRQHandler                            /* UART1 Error interrupt*/
+    .long   UART2_RX_TX_IRQHandler                          /* UART2 Receive/Transmit interrupt*/
+    .long   UART2_ERR_IRQHandler                            /* UART2 Error interrupt*/
+    .long   UART3_RX_TX_IRQHandler                          /* UART3 Receive/Transmit interrupt*/
+    .long   UART3_ERR_IRQHandler                            /* UART3 Error interrupt*/
+    .long   ADC0_IRQHandler                                 /* ADC0 interrupt*/
+    .long   CMP0_IRQHandler                                 /* CMP0 interrupt*/
+    .long   CMP1_IRQHandler                                 /* CMP1 interrupt*/
+    .long   FTM0_IRQHandler                                 /* FTM0 fault, overflow and channels interrupt*/
+    .long   FTM1_IRQHandler                                 /* FTM1 fault, overflow and channels interrupt*/
+    .long   FTM2_IRQHandler                                 /* FTM2 fault, overflow and channels interrupt*/
+    .long   CMT_IRQHandler                                  /* CMT interrupt*/
+    .long   RTC_IRQHandler                                  /* RTC interrupt*/
+    .long   RTC_Seconds_IRQHandler                          /* RTC seconds interrupt*/
+    .long   PIT0_IRQHandler                                 /* PIT timer channel 0 interrupt*/
+    .long   PIT1_IRQHandler                                 /* PIT timer channel 1 interrupt*/
+    .long   PIT2_IRQHandler                                 /* PIT timer channel 2 interrupt*/
+    .long   PIT3_IRQHandler                                 /* PIT timer channel 3 interrupt*/
+    .long   PDB0_IRQHandler                                 /* PDB0 Interrupt*/
+    .long   USB0_IRQHandler                                 /* USB0 interrupt*/
+    .long   USBDCD_IRQHandler                               /* USBDCD Interrupt*/
+    .long   Reserved71_IRQHandler                           /* Reserved interrupt 71*/
+    .long   DAC0_IRQHandler                                 /* DAC0 interrupt*/
+    .long   MCG_IRQHandler                                  /* MCG Interrupt*/
+    .long   LPTMR0_IRQHandler                               /* LPTimer interrupt*/
+    .long   PORTA_IRQHandler                                /* Port A interrupt*/
+    .long   PORTB_IRQHandler                                /* Port B interrupt*/
+    .long   PORTC_IRQHandler                                /* Port C interrupt*/
+    .long   PORTD_IRQHandler                                /* Port D interrupt*/
+    .long   PORTE_IRQHandler                                /* Port E interrupt*/
+    .long   SWI_IRQHandler                                  /* Software interrupt*/
+    .long   SPI2_IRQHandler                                 /* SPI2 Interrupt*/
+    .long   UART4_RX_TX_IRQHandler                          /* UART4 Receive/Transmit interrupt*/
+    .long   UART4_ERR_IRQHandler                            /* UART4 Error interrupt*/
+    .long   UART5_RX_TX_IRQHandler                          /* UART5 Receive/Transmit interrupt*/
+    .long   UART5_ERR_IRQHandler                            /* UART5 Error interrupt*/
+    .long   CMP2_IRQHandler                                 /* CMP2 interrupt*/
+    .long   FTM3_IRQHandler                                 /* FTM3 fault, overflow and channels interrupt*/
+    .long   DAC1_IRQHandler                                 /* DAC1 interrupt*/
+    .long   ADC1_IRQHandler                                 /* ADC1 interrupt*/
+    .long   I2C2_IRQHandler                                 /* I2C2 interrupt*/
+    .long   CAN0_ORed_Message_buffer_IRQHandler             /* CAN0 OR'd message buffers interrupt*/
+    .long   CAN0_Bus_Off_IRQHandler                         /* CAN0 bus off interrupt*/
+    .long   CAN0_Error_IRQHandler                           /* CAN0 error interrupt*/
+    .long   CAN0_Tx_Warning_IRQHandler                      /* CAN0 Tx warning interrupt*/
+    .long   CAN0_Rx_Warning_IRQHandler                      /* CAN0 Rx warning interrupt*/
+    .long   CAN0_Wake_Up_IRQHandler                         /* CAN0 wake up interrupt*/
+    .long   SDHC_IRQHandler                                 /* SDHC interrupt*/
+    .long   ENET_1588_Timer_IRQHandler                      /* Ethernet MAC IEEE 1588 Timer Interrupt*/
+    .long   ENET_Transmit_IRQHandler                        /* Ethernet MAC Transmit Interrupt*/
+    .long   ENET_Receive_IRQHandler                         /* Ethernet MAC Receive Interrupt*/
+    .long   ENET_Error_IRQHandler                           /* Ethernet MAC Error and miscelaneous Interrupt*/
+    .long   DefaultISR                                      /* 102*/
+    .long   DefaultISR                                      /* 103*/
+    .long   DefaultISR                                      /* 104*/
+    .long   DefaultISR                                      /* 105*/
+    .long   DefaultISR                                      /* 106*/
+    .long   DefaultISR                                      /* 107*/
+    .long   DefaultISR                                      /* 108*/
+    .long   DefaultISR                                      /* 109*/
+    .long   DefaultISR                                      /* 110*/
+    .long   DefaultISR                                      /* 111*/
+    .long   DefaultISR                                      /* 112*/
+    .long   DefaultISR                                      /* 113*/
+    .long   DefaultISR                                      /* 114*/
+    .long   DefaultISR                                      /* 115*/
+    .long   DefaultISR                                      /* 116*/
+    .long   DefaultISR                                      /* 117*/
+    .long   DefaultISR                                      /* 118*/
+    .long   DefaultISR                                      /* 119*/
+    .long   DefaultISR                                      /* 120*/
+    .long   DefaultISR                                      /* 121*/
+    .long   DefaultISR                                      /* 122*/
+    .long   DefaultISR                                      /* 123*/
+    .long   DefaultISR                                      /* 124*/
+    .long   DefaultISR                                      /* 125*/
+    .long   DefaultISR                                      /* 126*/
+    .long   DefaultISR                                      /* 127*/
+    .long   DefaultISR                                      /* 128*/
+    .long   DefaultISR                                      /* 129*/
+    .long   DefaultISR                                      /* 130*/
+    .long   DefaultISR                                      /* 131*/
+    .long   DefaultISR                                      /* 132*/
+    .long   DefaultISR                                      /* 133*/
+    .long   DefaultISR                                      /* 134*/
+    .long   DefaultISR                                      /* 135*/
+    .long   DefaultISR                                      /* 136*/
+    .long   DefaultISR                                      /* 137*/
+    .long   DefaultISR                                      /* 138*/
+    .long   DefaultISR                                      /* 139*/
+    .long   DefaultISR                                      /* 140*/
+    .long   DefaultISR                                      /* 141*/
+    .long   DefaultISR                                      /* 142*/
+    .long   DefaultISR                                      /* 143*/
+    .long   DefaultISR                                      /* 144*/
+    .long   DefaultISR                                      /* 145*/
+    .long   DefaultISR                                      /* 146*/
+    .long   DefaultISR                                      /* 147*/
+    .long   DefaultISR                                      /* 148*/
+    .long   DefaultISR                                      /* 149*/
+    .long   DefaultISR                                      /* 150*/
+    .long   DefaultISR                                      /* 151*/
+    .long   DefaultISR                                      /* 152*/
+    .long   DefaultISR                                      /* 153*/
+    .long   DefaultISR                                      /* 154*/
+    .long   DefaultISR                                      /* 155*/
+    .long   DefaultISR                                      /* 156*/
+    .long   DefaultISR                                      /* 157*/
+    .long   DefaultISR                                      /* 158*/
+    .long   DefaultISR                                      /* 159*/
+    .long   DefaultISR                                      /* 160*/
+    .long   DefaultISR                                      /* 161*/
+    .long   DefaultISR                                      /* 162*/
+    .long   DefaultISR                                      /* 163*/
+    .long   DefaultISR                                      /* 164*/
+    .long   DefaultISR                                      /* 165*/
+    .long   DefaultISR                                      /* 166*/
+    .long   DefaultISR                                      /* 167*/
+    .long   DefaultISR                                      /* 168*/
+    .long   DefaultISR                                      /* 169*/
+    .long   DefaultISR                                      /* 170*/
+    .long   DefaultISR                                      /* 171*/
+    .long   DefaultISR                                      /* 172*/
+    .long   DefaultISR                                      /* 173*/
+    .long   DefaultISR                                      /* 174*/
+    .long   DefaultISR                                      /* 175*/
+    .long   DefaultISR                                      /* 176*/
+    .long   DefaultISR                                      /* 177*/
+    .long   DefaultISR                                      /* 178*/
+    .long   DefaultISR                                      /* 179*/
+    .long   DefaultISR                                      /* 180*/
+    .long   DefaultISR                                      /* 181*/
+    .long   DefaultISR                                      /* 182*/
+    .long   DefaultISR                                      /* 183*/
+    .long   DefaultISR                                      /* 184*/
+    .long   DefaultISR                                      /* 185*/
+    .long   DefaultISR                                      /* 186*/
+    .long   DefaultISR                                      /* 187*/
+    .long   DefaultISR                                      /* 188*/
+    .long   DefaultISR                                      /* 189*/
+    .long   DefaultISR                                      /* 190*/
+    .long   DefaultISR                                      /* 191*/
+    .long   DefaultISR                                      /* 192*/
+    .long   DefaultISR                                      /* 193*/
+    .long   DefaultISR                                      /* 194*/
+    .long   DefaultISR                                      /* 195*/
+    .long   DefaultISR                                      /* 196*/
+    .long   DefaultISR                                      /* 197*/
+    .long   DefaultISR                                      /* 198*/
+    .long   DefaultISR                                      /* 199*/
+    .long   DefaultISR                                      /* 200*/
+    .long   DefaultISR                                      /* 201*/
+    .long   DefaultISR                                      /* 202*/
+    .long   DefaultISR                                      /* 203*/
+    .long   DefaultISR                                      /* 204*/
+    .long   DefaultISR                                      /* 205*/
+    .long   DefaultISR                                      /* 206*/
+    .long   DefaultISR                                      /* 207*/
+    .long   DefaultISR                                      /* 208*/
+    .long   DefaultISR                                      /* 209*/
+    .long   DefaultISR                                      /* 210*/
+    .long   DefaultISR                                      /* 211*/
+    .long   DefaultISR                                      /* 212*/
+    .long   DefaultISR                                      /* 213*/
+    .long   DefaultISR                                      /* 214*/
+    .long   DefaultISR                                      /* 215*/
+    .long   DefaultISR                                      /* 216*/
+    .long   DefaultISR                                      /* 217*/
+    .long   DefaultISR                                      /* 218*/
+    .long   DefaultISR                                      /* 219*/
+    .long   DefaultISR                                      /* 220*/
+    .long   DefaultISR                                      /* 221*/
+    .long   DefaultISR                                      /* 222*/
+    .long   DefaultISR                                      /* 223*/
+    .long   DefaultISR                                      /* 224*/
+    .long   DefaultISR                                      /* 225*/
+    .long   DefaultISR                                      /* 226*/
+    .long   DefaultISR                                      /* 227*/
+    .long   DefaultISR                                      /* 228*/
+    .long   DefaultISR                                      /* 229*/
+    .long   DefaultISR                                      /* 230*/
+    .long   DefaultISR                                      /* 231*/
+    .long   DefaultISR                                      /* 232*/
+    .long   DefaultISR                                      /* 233*/
+    .long   DefaultISR                                      /* 234*/
+    .long   DefaultISR                                      /* 235*/
+    .long   DefaultISR                                      /* 236*/
+    .long   DefaultISR                                      /* 237*/
+    .long   DefaultISR                                      /* 238*/
+    .long   DefaultISR                                      /* 239*/
+    .long   DefaultISR                                      /* 240*/
+    .long   DefaultISR                                      /* 241*/
+    .long   DefaultISR                                      /* 242*/
+    .long   DefaultISR                                      /* 243*/
+    .long   DefaultISR                                      /* 244*/
+    .long   DefaultISR                                      /* 245*/
+    .long   DefaultISR                                      /* 246*/
+    .long   DefaultISR                                      /* 247*/
+    .long   DefaultISR                                      /* 248*/
+    .long   DefaultISR                                      /* 249*/
+    .long   DefaultISR                                      /* 250*/
+    .long   DefaultISR                                      /* 251*/
+    .long   DefaultISR                                      /* 252*/
+    .long   DefaultISR                                      /* 253*/
+    .long   DefaultISR                                      /* 254*/
+    .long   0xFFFFFFFF                                      /*  Reserved for user TRIM value*/
+
+    .size    __isr_vector, . - __isr_vector
+
+/* Flash Configuration */
+    .section .FlashConfig, "a"
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFE
+
+    .text
+    .thumb
+
+/* Reset Handler */
+
+    .thumb_func
+    .align 2
+    .globl   Reset_Handler
+    .weak    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    cpsid   i               /* Mask interrupts */
+    .equ    VTOR, 0xE000ED08
+    ldr     r0, =VTOR
+    ldr     r1, =__isr_vector
+    str     r1, [r0]
+#ifndef __NO_SYSTEM_INIT
+    ldr   r0,=SystemInit
+    blx   r0
+#endif
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+#if 1
+/* Here are two copies of loop implemenations. First one favors code size
+ * and the second one favors performance. Default uses the first one.
+ * Change to "#if 0" to use the second one */
+.LC0:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC0
+#else
+    subs    r3, r2
+    ble    .LC1
+.LC0:
+    subs    r3, #4
+    ldr    r0, [r1, r3]
+    str    r0, [r2, r3]
+    bgt    .LC0
+.LC1:
+#endif
+
+#ifdef __STARTUP_CLEAR_BSS
+/*     This part of work usually is done in C library startup code. Otherwise,
+ *     define this macro to enable it in this startup.
+ *
+ *     Loop to zero out BSS section, which uses following symbols
+ *     in linker script:
+ *      __bss_start__: start of BSS section. Must align to 4
+ *      __bss_end__: end of BSS section. Must align to 4
+ */
+    ldr r1, =__bss_start__
+    ldr r2, =__bss_end__
+
+    movs    r0, 0
+.LC2:
+    cmp     r1, r2
+    itt    lt
+    strlt   r0, [r1], #4
+    blt    .LC2
+#endif /* __STARTUP_CLEAR_BSS */
+
+    cpsie   i               /* Unmask interrupts */
+#ifndef __START
+#define __START _start
+#endif
+#ifndef __ATOLLIC__
+    ldr   r0,=__START
+    blx   r0
+#else
+    ldr   r0,=__libc_init_array
+    blx   r0
+    ldr   r0,=main
+    bx    r0
+#endif
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .align  1
+    .thumb_func
+    .weak DefaultISR
+    .type DefaultISR, %function
+DefaultISR:
+    b DefaultISR
+    .size DefaultISR, . - DefaultISR
+
+    .align 1
+    .thumb_func
+    .weak NMI_Handler
+    .type NMI_Handler, %function
+NMI_Handler:
+    ldr   r0,=NMI_Handler
+    bx    r0
+    .size NMI_Handler, . - NMI_Handler
+
+    .align 1
+    .thumb_func
+    .weak HardFault_Handler
+    .type HardFault_Handler, %function
+HardFault_Handler:
+    ldr   r0,=HardFault_Handler
+    bx    r0
+    .size HardFault_Handler, . - HardFault_Handler
+
+    .align 1
+    .thumb_func
+    .weak SVC_Handler
+    .type SVC_Handler, %function
+SVC_Handler:
+    ldr   r0,=SVC_Handler
+    bx    r0
+    .size SVC_Handler, . - SVC_Handler
+
+    .align 1
+    .thumb_func
+    .weak PendSV_Handler
+    .type PendSV_Handler, %function
+PendSV_Handler:
+    ldr   r0,=PendSV_Handler
+    bx    r0
+    .size PendSV_Handler, . - PendSV_Handler
+
+    .align 1
+    .thumb_func
+    .weak SysTick_Handler
+    .type SysTick_Handler, %function
+SysTick_Handler:
+    ldr   r0,=SysTick_Handler
+    bx    r0
+    .size SysTick_Handler, . - SysTick_Handler
+
+    .align 1
+    .thumb_func
+    .weak DMA0_IRQHandler
+    .type DMA0_IRQHandler, %function
+DMA0_IRQHandler:
+    ldr   r0,=DMA0_DriverIRQHandler
+    bx    r0
+    .size DMA0_IRQHandler, . - DMA0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA1_IRQHandler
+    .type DMA1_IRQHandler, %function
+DMA1_IRQHandler:
+    ldr   r0,=DMA1_DriverIRQHandler
+    bx    r0
+    .size DMA1_IRQHandler, . - DMA1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA2_IRQHandler
+    .type DMA2_IRQHandler, %function
+DMA2_IRQHandler:
+    ldr   r0,=DMA2_DriverIRQHandler
+    bx    r0
+    .size DMA2_IRQHandler, . - DMA2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_IRQHandler
+    .type DMA3_IRQHandler, %function
+DMA3_IRQHandler:
+    ldr   r0,=DMA3_DriverIRQHandler
+    bx    r0
+    .size DMA3_IRQHandler, . - DMA3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_IRQHandler
+    .type DMA4_IRQHandler, %function
+DMA4_IRQHandler:
+    ldr   r0,=DMA4_DriverIRQHandler
+    bx    r0
+    .size DMA4_IRQHandler, . - DMA4_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA5_IRQHandler
+    .type DMA5_IRQHandler, %function
+DMA5_IRQHandler:
+    ldr   r0,=DMA5_DriverIRQHandler
+    bx    r0
+    .size DMA5_IRQHandler, . - DMA5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA6_IRQHandler
+    .type DMA6_IRQHandler, %function
+DMA6_IRQHandler:
+    ldr   r0,=DMA6_DriverIRQHandler
+    bx    r0
+    .size DMA6_IRQHandler, . - DMA6_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA7_IRQHandler
+    .type DMA7_IRQHandler, %function
+DMA7_IRQHandler:
+    ldr   r0,=DMA7_DriverIRQHandler
+    bx    r0
+    .size DMA7_IRQHandler, . - DMA7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA8_IRQHandler
+    .type DMA8_IRQHandler, %function
+DMA8_IRQHandler:
+    ldr   r0,=DMA8_DriverIRQHandler
+    bx    r0
+    .size DMA8_IRQHandler, . - DMA8_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA9_IRQHandler
+    .type DMA9_IRQHandler, %function
+DMA9_IRQHandler:
+    ldr   r0,=DMA9_DriverIRQHandler
+    bx    r0
+    .size DMA9_IRQHandler, . - DMA9_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA10_IRQHandler
+    .type DMA10_IRQHandler, %function
+DMA10_IRQHandler:
+    ldr   r0,=DMA10_DriverIRQHandler
+    bx    r0
+    .size DMA10_IRQHandler, . - DMA10_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA11_IRQHandler
+    .type DMA11_IRQHandler, %function
+DMA11_IRQHandler:
+    ldr   r0,=DMA11_DriverIRQHandler
+    bx    r0
+    .size DMA11_IRQHandler, . - DMA11_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA12_IRQHandler
+    .type DMA12_IRQHandler, %function
+DMA12_IRQHandler:
+    ldr   r0,=DMA12_DriverIRQHandler
+    bx    r0
+    .size DMA12_IRQHandler, . - DMA12_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA13_IRQHandler
+    .type DMA13_IRQHandler, %function
+DMA13_IRQHandler:
+    ldr   r0,=DMA13_DriverIRQHandler
+    bx    r0
+    .size DMA13_IRQHandler, . - DMA13_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA14_IRQHandler
+    .type DMA14_IRQHandler, %function
+DMA14_IRQHandler:
+    ldr   r0,=DMA14_DriverIRQHandler
+    bx    r0
+    .size DMA14_IRQHandler, . - DMA14_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA15_IRQHandler
+    .type DMA15_IRQHandler, %function
+DMA15_IRQHandler:
+    ldr   r0,=DMA15_DriverIRQHandler
+    bx    r0
+    .size DMA15_IRQHandler, . - DMA15_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA_Error_IRQHandler
+    .type DMA_Error_IRQHandler, %function
+DMA_Error_IRQHandler:
+    ldr   r0,=DMA_Error_DriverIRQHandler
+    bx    r0
+    .size DMA_Error_IRQHandler, . - DMA_Error_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2C0_IRQHandler
+    .type I2C0_IRQHandler, %function
+I2C0_IRQHandler:
+    ldr   r0,=I2C0_DriverIRQHandler
+    bx    r0
+    .size I2C0_IRQHandler, . - I2C0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2C1_IRQHandler
+    .type I2C1_IRQHandler, %function
+I2C1_IRQHandler:
+    ldr   r0,=I2C1_DriverIRQHandler
+    bx    r0
+    .size I2C1_IRQHandler, . - I2C1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SPI0_IRQHandler
+    .type SPI0_IRQHandler, %function
+SPI0_IRQHandler:
+    ldr   r0,=SPI0_DriverIRQHandler
+    bx    r0
+    .size SPI0_IRQHandler, . - SPI0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SPI1_IRQHandler
+    .type SPI1_IRQHandler, %function
+SPI1_IRQHandler:
+    ldr   r0,=SPI1_DriverIRQHandler
+    bx    r0
+    .size SPI1_IRQHandler, . - SPI1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2S0_Tx_IRQHandler
+    .type I2S0_Tx_IRQHandler, %function
+I2S0_Tx_IRQHandler:
+    ldr   r0,=I2S0_Tx_DriverIRQHandler
+    bx    r0
+    .size I2S0_Tx_IRQHandler, . - I2S0_Tx_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2S0_Rx_IRQHandler
+    .type I2S0_Rx_IRQHandler, %function
+I2S0_Rx_IRQHandler:
+    ldr   r0,=I2S0_Rx_DriverIRQHandler
+    bx    r0
+    .size I2S0_Rx_IRQHandler, . - I2S0_Rx_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART0_LON_IRQHandler
+    .type UART0_LON_IRQHandler, %function
+UART0_LON_IRQHandler:
+    ldr   r0,=UART0_LON_DriverIRQHandler
+    bx    r0
+    .size UART0_LON_IRQHandler, . - UART0_LON_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART0_RX_TX_IRQHandler
+    .type UART0_RX_TX_IRQHandler, %function
+UART0_RX_TX_IRQHandler:
+    ldr   r0,=UART0_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART0_RX_TX_IRQHandler, . - UART0_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART0_ERR_IRQHandler
+    .type UART0_ERR_IRQHandler, %function
+UART0_ERR_IRQHandler:
+    ldr   r0,=UART0_ERR_DriverIRQHandler
+    bx    r0
+    .size UART0_ERR_IRQHandler, . - UART0_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART1_RX_TX_IRQHandler
+    .type UART1_RX_TX_IRQHandler, %function
+UART1_RX_TX_IRQHandler:
+    ldr   r0,=UART1_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART1_RX_TX_IRQHandler, . - UART1_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART1_ERR_IRQHandler
+    .type UART1_ERR_IRQHandler, %function
+UART1_ERR_IRQHandler:
+    ldr   r0,=UART1_ERR_DriverIRQHandler
+    bx    r0
+    .size UART1_ERR_IRQHandler, . - UART1_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART2_RX_TX_IRQHandler
+    .type UART2_RX_TX_IRQHandler, %function
+UART2_RX_TX_IRQHandler:
+    ldr   r0,=UART2_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART2_RX_TX_IRQHandler, . - UART2_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART2_ERR_IRQHandler
+    .type UART2_ERR_IRQHandler, %function
+UART2_ERR_IRQHandler:
+    ldr   r0,=UART2_ERR_DriverIRQHandler
+    bx    r0
+    .size UART2_ERR_IRQHandler, . - UART2_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART3_RX_TX_IRQHandler
+    .type UART3_RX_TX_IRQHandler, %function
+UART3_RX_TX_IRQHandler:
+    ldr   r0,=UART3_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART3_RX_TX_IRQHandler, . - UART3_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART3_ERR_IRQHandler
+    .type UART3_ERR_IRQHandler, %function
+UART3_ERR_IRQHandler:
+    ldr   r0,=UART3_ERR_DriverIRQHandler
+    bx    r0
+    .size UART3_ERR_IRQHandler, . - UART3_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SPI2_IRQHandler
+    .type SPI2_IRQHandler, %function
+SPI2_IRQHandler:
+    ldr   r0,=SPI2_DriverIRQHandler
+    bx    r0
+    .size SPI2_IRQHandler, . - SPI2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART4_RX_TX_IRQHandler
+    .type UART4_RX_TX_IRQHandler, %function
+UART4_RX_TX_IRQHandler:
+    ldr   r0,=UART4_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART4_RX_TX_IRQHandler, . - UART4_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART4_ERR_IRQHandler
+    .type UART4_ERR_IRQHandler, %function
+UART4_ERR_IRQHandler:
+    ldr   r0,=UART4_ERR_DriverIRQHandler
+    bx    r0
+    .size UART4_ERR_IRQHandler, . - UART4_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART5_RX_TX_IRQHandler
+    .type UART5_RX_TX_IRQHandler, %function
+UART5_RX_TX_IRQHandler:
+    ldr   r0,=UART5_RX_TX_DriverIRQHandler
+    bx    r0
+    .size UART5_RX_TX_IRQHandler, . - UART5_RX_TX_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak UART5_ERR_IRQHandler
+    .type UART5_ERR_IRQHandler, %function
+UART5_ERR_IRQHandler:
+    ldr   r0,=UART5_ERR_DriverIRQHandler
+    bx    r0
+    .size UART5_ERR_IRQHandler, . - UART5_ERR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I2C2_IRQHandler
+    .type I2C2_IRQHandler, %function
+I2C2_IRQHandler:
+    ldr   r0,=I2C2_DriverIRQHandler
+    bx    r0
+    .size I2C2_IRQHandler, . - I2C2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_ORed_Message_buffer_IRQHandler
+    .type CAN0_ORed_Message_buffer_IRQHandler, %function
+CAN0_ORed_Message_buffer_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_ORed_Message_buffer_IRQHandler, . - CAN0_ORed_Message_buffer_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Bus_Off_IRQHandler
+    .type CAN0_Bus_Off_IRQHandler, %function
+CAN0_Bus_Off_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Bus_Off_IRQHandler, . - CAN0_Bus_Off_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Error_IRQHandler
+    .type CAN0_Error_IRQHandler, %function
+CAN0_Error_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Error_IRQHandler, . - CAN0_Error_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Tx_Warning_IRQHandler
+    .type CAN0_Tx_Warning_IRQHandler, %function
+CAN0_Tx_Warning_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Tx_Warning_IRQHandler, . - CAN0_Tx_Warning_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Rx_Warning_IRQHandler
+    .type CAN0_Rx_Warning_IRQHandler, %function
+CAN0_Rx_Warning_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Rx_Warning_IRQHandler, . - CAN0_Rx_Warning_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN0_Wake_Up_IRQHandler
+    .type CAN0_Wake_Up_IRQHandler, %function
+CAN0_Wake_Up_IRQHandler:
+    ldr   r0,=CAN0_DriverIRQHandler
+    bx    r0
+    .size CAN0_Wake_Up_IRQHandler, . - CAN0_Wake_Up_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SDHC_IRQHandler
+    .type SDHC_IRQHandler, %function
+SDHC_IRQHandler:
+    ldr   r0,=SDHC_DriverIRQHandler
+    bx    r0
+    .size SDHC_IRQHandler, . - SDHC_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_1588_Timer_IRQHandler
+    .type ENET_1588_Timer_IRQHandler, %function
+ENET_1588_Timer_IRQHandler:
+    ldr   r0,=ENET_1588_Timer_DriverIRQHandler
+    bx    r0
+    .size ENET_1588_Timer_IRQHandler, . - ENET_1588_Timer_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_Transmit_IRQHandler
+    .type ENET_Transmit_IRQHandler, %function
+ENET_Transmit_IRQHandler:
+    ldr   r0,=ENET_Transmit_DriverIRQHandler
+    bx    r0
+    .size ENET_Transmit_IRQHandler, . - ENET_Transmit_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_Receive_IRQHandler
+    .type ENET_Receive_IRQHandler, %function
+ENET_Receive_IRQHandler:
+    ldr   r0,=ENET_Receive_DriverIRQHandler
+    bx    r0
+    .size ENET_Receive_IRQHandler, . - ENET_Receive_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_Error_IRQHandler
+    .type ENET_Error_IRQHandler, %function
+ENET_Error_IRQHandler:
+    ldr   r0,=ENET_Error_DriverIRQHandler
+    bx    r0
+    .size ENET_Error_IRQHandler, . - ENET_Error_IRQHandler
+
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro def_irq_handler  handler_name
+    .weak \handler_name
+    .set  \handler_name, DefaultISR
+    .endm
+
+/* Exception Handlers */
+    def_irq_handler    MemManage_Handler
+    def_irq_handler    BusFault_Handler
+    def_irq_handler    UsageFault_Handler
+    def_irq_handler    DebugMon_Handler
+    def_irq_handler    DMA0_DriverIRQHandler
+    def_irq_handler    DMA1_DriverIRQHandler
+    def_irq_handler    DMA2_DriverIRQHandler
+    def_irq_handler    DMA3_DriverIRQHandler
+    def_irq_handler    DMA4_DriverIRQHandler
+    def_irq_handler    DMA5_DriverIRQHandler
+    def_irq_handler    DMA6_DriverIRQHandler
+    def_irq_handler    DMA7_DriverIRQHandler
+    def_irq_handler    DMA8_DriverIRQHandler
+    def_irq_handler    DMA9_DriverIRQHandler
+    def_irq_handler    DMA10_DriverIRQHandler
+    def_irq_handler    DMA11_DriverIRQHandler
+    def_irq_handler    DMA12_DriverIRQHandler
+    def_irq_handler    DMA13_DriverIRQHandler
+    def_irq_handler    DMA14_DriverIRQHandler
+    def_irq_handler    DMA15_DriverIRQHandler
+    def_irq_handler    DMA_Error_DriverIRQHandler
+    def_irq_handler    MCM_IRQHandler
+    def_irq_handler    FTFE_IRQHandler
+    def_irq_handler    Read_Collision_IRQHandler
+    def_irq_handler    LVD_LVW_IRQHandler
+    def_irq_handler    LLWU_IRQHandler
+    def_irq_handler    WDOG_EWM_IRQHandler
+    def_irq_handler    RNG_IRQHandler
+    def_irq_handler    I2C0_DriverIRQHandler
+    def_irq_handler    I2C1_DriverIRQHandler
+    def_irq_handler    SPI0_DriverIRQHandler
+    def_irq_handler    SPI1_DriverIRQHandler
+    def_irq_handler    I2S0_Tx_DriverIRQHandler
+    def_irq_handler    I2S0_Rx_DriverIRQHandler
+    def_irq_handler    UART0_LON_DriverIRQHandler
+    def_irq_handler    UART0_RX_TX_DriverIRQHandler
+    def_irq_handler    UART0_ERR_DriverIRQHandler
+    def_irq_handler    UART1_RX_TX_DriverIRQHandler
+    def_irq_handler    UART1_ERR_DriverIRQHandler
+    def_irq_handler    UART2_RX_TX_DriverIRQHandler
+    def_irq_handler    UART2_ERR_DriverIRQHandler
+    def_irq_handler    UART3_RX_TX_DriverIRQHandler
+    def_irq_handler    UART3_ERR_DriverIRQHandler
+    def_irq_handler    ADC0_IRQHandler
+    def_irq_handler    CMP0_IRQHandler
+    def_irq_handler    CMP1_IRQHandler
+    def_irq_handler    FTM0_IRQHandler
+    def_irq_handler    FTM1_IRQHandler
+    def_irq_handler    FTM2_IRQHandler
+    def_irq_handler    CMT_IRQHandler
+    def_irq_handler    RTC_IRQHandler
+    def_irq_handler    RTC_Seconds_IRQHandler
+    def_irq_handler    PIT0_IRQHandler
+    def_irq_handler    PIT1_IRQHandler
+    def_irq_handler    PIT2_IRQHandler
+    def_irq_handler    PIT3_IRQHandler
+    def_irq_handler    PDB0_IRQHandler
+    def_irq_handler    USB0_IRQHandler
+    def_irq_handler    USBDCD_IRQHandler
+    def_irq_handler    Reserved71_IRQHandler
+    def_irq_handler    DAC0_IRQHandler
+    def_irq_handler    MCG_IRQHandler
+    def_irq_handler    LPTMR0_IRQHandler
+    def_irq_handler    PORTA_IRQHandler
+    def_irq_handler    PORTB_IRQHandler
+    def_irq_handler    PORTC_IRQHandler
+    def_irq_handler    PORTD_IRQHandler
+    def_irq_handler    PORTE_IRQHandler
+    def_irq_handler    SWI_IRQHandler
+    def_irq_handler    SPI2_DriverIRQHandler
+    def_irq_handler    UART4_RX_TX_DriverIRQHandler
+    def_irq_handler    UART4_ERR_DriverIRQHandler
+    def_irq_handler    UART5_RX_TX_DriverIRQHandler
+    def_irq_handler    UART5_ERR_DriverIRQHandler
+    def_irq_handler    CMP2_IRQHandler
+    def_irq_handler    FTM3_IRQHandler
+    def_irq_handler    DAC1_IRQHandler
+    def_irq_handler    ADC1_IRQHandler
+    def_irq_handler    I2C2_DriverIRQHandler
+    def_irq_handler    CAN0_DriverIRQHandler
+    def_irq_handler    SDHC_DriverIRQHandler
+    def_irq_handler    ENET_1588_Timer_DriverIRQHandler
+    def_irq_handler    ENET_Transmit_DriverIRQHandler
+    def_irq_handler    ENET_Receive_DriverIRQHandler
+    def_irq_handler    ENET_Error_DriverIRQHandler
+
+    .end

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/system_MK64F12.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/system_MK64F12.c
@@ -1,0 +1,251 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**                          MK64FX512VDC12
+**                          MK64FX512VLL12
+**                          MK64FX512VLQ12
+**                          MK64FX512VMD12
+**
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2013-08-12)
+**         Initial version.
+**     - rev. 2.0 (2013-10-29)
+**         Register accessor macros added to the memory map.
+**         Symbols for Processor Expert memory map compatibility added to the memory map.
+**         Startup file for gcc has been updated according to CMSIS 3.2.
+**         System initialization updated.
+**         MCG - registers updated.
+**         PORTA, PORTB, PORTC, PORTE - registers for digital filter removed.
+**     - rev. 2.1 (2013-10-30)
+**         Definition of BITBAND macros updated to support peripherals with 32-bit acces disabled.
+**     - rev. 2.2 (2013-12-09)
+**         DMA - EARS register removed.
+**         AIPS0, AIPS1 - MPRA register updated.
+**     - rev. 2.3 (2014-01-24)
+**         Update according to reference manual rev. 2
+**         ENET, MCG, MCM, SIM, USB - registers updated
+**     - rev. 2.4 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**     - rev. 2.5 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**         Module access macro module_BASES replaced by module_BASE_PTRS.
+**     - rev. 2.6 (2014-08-28)
+**         Update of system files - default clock configuration changed.
+**         Update of startup files - possibility to override DefaultISR added.
+**     - rev. 2.7 (2014-10-14)
+**         Interrupt INT_LPTimer renamed to INT_LPTMR0, interrupt INT_Watchdog renamed to INT_WDOG_EWM.
+**     - rev. 2.8 (2015-02-19)
+**         Renamed interrupt vector LLW to LLWU.
+**     - rev. 2.9 (2016-03-21)
+**         Added MK64FN1M0CAJ12 part.
+**         GPIO - renamed port instances: PTx -> GPIOx.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MK64F12
+ * @version 2.9
+ * @date 2016-03-21
+ * @brief Device specific configuration file for MK64F12 (implementation file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#include <stdint.h>
+#include "fsl_device_registers.h"
+
+
+
+/* ----------------------------------------------------------------------------
+   -- Core clock
+   ---------------------------------------------------------------------------- */
+
+uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
+
+/* ----------------------------------------------------------------------------
+   -- SystemInit()
+   ---------------------------------------------------------------------------- */
+
+void SystemInit (void) {
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  SCB->CPACR |= ((3UL << 10*2) | (3UL << 11*2));    /* set CP10, CP11 Full Access */
+#endif /* ((__FPU_PRESENT == 1) && (__FPU_USED == 1)) */
+#if (DISABLE_WDOG)
+  /* WDOG->UNLOCK: WDOGUNLOCK=0xC520 */
+  WDOG->UNLOCK = WDOG_UNLOCK_WDOGUNLOCK(0xC520); /* Key 1 */
+  /* WDOG->UNLOCK: WDOGUNLOCK=0xD928 */
+  WDOG->UNLOCK = WDOG_UNLOCK_WDOGUNLOCK(0xD928); /* Key 2 */
+  /* WDOG->STCTRLH: ?=0,DISTESTWDOG=0,BYTESEL=0,TESTSEL=0,TESTWDOG=0,?=0,?=1,WAITEN=1,STOPEN=1,DBGEN=0,ALLOWUPDATE=1,WINEN=0,IRQRSTEN=0,CLKSRC=1,WDOGEN=0 */
+  WDOG->STCTRLH = WDOG_STCTRLH_BYTESEL(0x00) |
+                 WDOG_STCTRLH_WAITEN_MASK |
+                 WDOG_STCTRLH_STOPEN_MASK |
+                 WDOG_STCTRLH_ALLOWUPDATE_MASK |
+                 WDOG_STCTRLH_CLKSRC_MASK |
+                 0x0100U;
+#endif /* (DISABLE_WDOG) */
+
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemCoreClockUpdate()
+   ---------------------------------------------------------------------------- */
+
+void SystemCoreClockUpdate (void) {
+  uint32_t MCGOUTClock;                /* Variable to store output clock frequency of the MCG module */
+  uint16_t Divider;
+
+  if ((MCG->C1 & MCG_C1_CLKS_MASK) == 0x00U) {
+    /* Output of FLL or PLL is selected */
+    if ((MCG->C6 & MCG_C6_PLLS_MASK) == 0x00U) {
+      /* FLL is selected */
+      if ((MCG->C1 & MCG_C1_IREFS_MASK) == 0x00U) {
+        /* External reference clock is selected */
+        switch (MCG->C7 & MCG_C7_OSCSEL_MASK) {
+        case 0x00U:
+          MCGOUTClock = CPU_XTAL_CLK_HZ; /* System oscillator drives MCG clock */
+          break;
+        case 0x01U:
+          MCGOUTClock = CPU_XTAL32k_CLK_HZ; /* RTC 32 kHz oscillator drives MCG clock */
+          break;
+        case 0x02U:
+        default:
+          MCGOUTClock = CPU_INT_IRC_CLK_HZ; /* IRC 48MHz oscillator drives MCG clock */
+          break;
+        }
+        if (((MCG->C2 & MCG_C2_RANGE_MASK) != 0x00U) && ((MCG->C7 & MCG_C7_OSCSEL_MASK) != 0x01U)) {
+          switch (MCG->C1 & MCG_C1_FRDIV_MASK) {
+          case 0x38U:
+            Divider = 1536U;
+            break;
+          case 0x30U:
+            Divider = 1280U;
+            break;
+          default:
+            Divider = (uint16_t)(32LU << ((MCG->C1 & MCG_C1_FRDIV_MASK) >> MCG_C1_FRDIV_SHIFT));
+            break;
+          }
+        } else {/* ((MCG->C2 & MCG_C2_RANGE_MASK) != 0x00U) */
+          Divider = (uint16_t)(1LU << ((MCG->C1 & MCG_C1_FRDIV_MASK) >> MCG_C1_FRDIV_SHIFT));
+        }
+        MCGOUTClock = (MCGOUTClock / Divider); /* Calculate the divided FLL reference clock */
+      } else { /* (!((MCG->C1 & MCG_C1_IREFS_MASK) == 0x00U)) */
+        MCGOUTClock = CPU_INT_SLOW_CLK_HZ; /* The slow internal reference clock is selected */
+      } /* (!((MCG->C1 & MCG_C1_IREFS_MASK) == 0x00U)) */
+      /* Select correct multiplier to calculate the MCG output clock  */
+      switch (MCG->C4 & (MCG_C4_DMX32_MASK | MCG_C4_DRST_DRS_MASK)) {
+        case 0x00U:
+          MCGOUTClock *= 640U;
+          break;
+        case 0x20U:
+          MCGOUTClock *= 1280U;
+          break;
+        case 0x40U:
+          MCGOUTClock *= 1920U;
+          break;
+        case 0x60U:
+          MCGOUTClock *= 2560U;
+          break;
+        case 0x80U:
+          MCGOUTClock *= 732U;
+          break;
+        case 0xA0U:
+          MCGOUTClock *= 1464U;
+          break;
+        case 0xC0U:
+          MCGOUTClock *= 2197U;
+          break;
+        case 0xE0U:
+          MCGOUTClock *= 2929U;
+          break;
+        default:
+          break;
+      }
+    } else { /* (!((MCG->C6 & MCG_C6_PLLS_MASK) == 0x00U)) */
+      /* PLL is selected */
+      Divider = (((uint16_t)MCG->C5 & MCG_C5_PRDIV0_MASK) + 0x01U);
+      MCGOUTClock = (uint32_t)(CPU_XTAL_CLK_HZ / Divider); /* Calculate the PLL reference clock */
+      Divider = (((uint16_t)MCG->C6 & MCG_C6_VDIV0_MASK) + 24U);
+      MCGOUTClock *= Divider;          /* Calculate the MCG output clock */
+    } /* (!((MCG->C6 & MCG_C6_PLLS_MASK) == 0x00U)) */
+  } else if ((MCG->C1 & MCG_C1_CLKS_MASK) == 0x40U) {
+    /* Internal reference clock is selected */
+    if ((MCG->C2 & MCG_C2_IRCS_MASK) == 0x00U) {
+      MCGOUTClock = CPU_INT_SLOW_CLK_HZ; /* Slow internal reference clock selected */
+    } else { /* (!((MCG->C2 & MCG_C2_IRCS_MASK) == 0x00U)) */
+      Divider = (uint16_t)(0x01LU << ((MCG->SC & MCG_SC_FCRDIV_MASK) >> MCG_SC_FCRDIV_SHIFT));
+      MCGOUTClock = (uint32_t) (CPU_INT_FAST_CLK_HZ / Divider); /* Fast internal reference clock selected */
+    } /* (!((MCG->C2 & MCG_C2_IRCS_MASK) == 0x00U)) */
+  } else if ((MCG->C1 & MCG_C1_CLKS_MASK) == 0x80U) {
+    /* External reference clock is selected */
+    switch (MCG->C7 & MCG_C7_OSCSEL_MASK) {
+    case 0x00U:
+      MCGOUTClock = CPU_XTAL_CLK_HZ;   /* System oscillator drives MCG clock */
+      break;
+    case 0x01U:
+      MCGOUTClock = CPU_XTAL32k_CLK_HZ; /* RTC 32 kHz oscillator drives MCG clock */
+      break;
+    case 0x02U:
+    default:
+      MCGOUTClock = CPU_INT_IRC_CLK_HZ; /* IRC 48MHz oscillator drives MCG clock */
+      break;
+    }
+  } else { /* (!((MCG->C1 & MCG_C1_CLKS_MASK) == 0x80U)) */
+    /* Reserved value */
+    return;
+  } /* (!((MCG->C1 & MCG_C1_CLKS_MASK) == 0x80U)) */
+  SystemCoreClock = (MCGOUTClock / (0x01U + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV1_MASK) >> SIM_CLKDIV1_OUTDIV1_SHIFT)));
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/system_MK64F12.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/system_MK64F12.h
@@ -1,0 +1,174 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**                          MK64FX512VDC12
+**                          MK64FX512VLL12
+**                          MK64FX512VLQ12
+**                          MK64FX512VMD12
+**
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160321
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2013-08-12)
+**         Initial version.
+**     - rev. 2.0 (2013-10-29)
+**         Register accessor macros added to the memory map.
+**         Symbols for Processor Expert memory map compatibility added to the memory map.
+**         Startup file for gcc has been updated according to CMSIS 3.2.
+**         System initialization updated.
+**         MCG - registers updated.
+**         PORTA, PORTB, PORTC, PORTE - registers for digital filter removed.
+**     - rev. 2.1 (2013-10-30)
+**         Definition of BITBAND macros updated to support peripherals with 32-bit acces disabled.
+**     - rev. 2.2 (2013-12-09)
+**         DMA - EARS register removed.
+**         AIPS0, AIPS1 - MPRA register updated.
+**     - rev. 2.3 (2014-01-24)
+**         Update according to reference manual rev. 2
+**         ENET, MCG, MCM, SIM, USB - registers updated
+**     - rev. 2.4 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**     - rev. 2.5 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**         Module access macro module_BASES replaced by module_BASE_PTRS.
+**     - rev. 2.6 (2014-08-28)
+**         Update of system files - default clock configuration changed.
+**         Update of startup files - possibility to override DefaultISR added.
+**     - rev. 2.7 (2014-10-14)
+**         Interrupt INT_LPTimer renamed to INT_LPTMR0, interrupt INT_Watchdog renamed to INT_WDOG_EWM.
+**     - rev. 2.8 (2015-02-19)
+**         Renamed interrupt vector LLW to LLWU.
+**     - rev. 2.9 (2016-03-21)
+**         Added MK64FN1M0CAJ12 part.
+**         GPIO - renamed port instances: PTx -> GPIOx.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MK64F12
+ * @version 2.9
+ * @date 2016-03-21
+ * @brief Device specific configuration file for MK64F12 (header file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#ifndef _SYSTEM_MK64F12_H_
+#define _SYSTEM_MK64F12_H_                       /**< Symbol preventing repeated inclusion */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+
+#ifndef DISABLE_WDOG
+  #define DISABLE_WDOG                 1
+#endif
+
+/* Define clock source values */
+
+#define CPU_XTAL_CLK_HZ                50000000u           /* Value of the external crystal or oscillator clock frequency in Hz */
+#define CPU_XTAL32k_CLK_HZ             32768u              /* Value of the external 32k crystal or oscillator clock frequency in Hz */
+#define CPU_INT_SLOW_CLK_HZ            32768u              /* Value of the slow internal oscillator clock frequency in Hz  */
+#define CPU_INT_FAST_CLK_HZ            4000000u            /* Value of the fast internal oscillator clock frequency in Hz  */
+#define CPU_INT_IRC_CLK_HZ             48000000u           /* Value of the 48M internal oscillator clock frequency in Hz  */
+
+/* RTC oscillator setting */
+/* RTC_CR: SC2P=0,SC4P=0,SC8P=0,SC16P=0,CLKO=1,OSCE=1,WPS=0,UM=0,SUP=0,WPE=0,SWR=0 */
+#define SYSTEM_RTC_CR_VALUE            0x0300U             /* RTC_CR */
+
+/* Low power mode enable */
+/* SMC_PMPROT: AVLP=1,ALLS=1,AVLLS=1 */
+#define SYSTEM_SMC_PMPROT_VALUE        0x2AU               /* SMC_PMPROT */
+
+#define DEFAULT_SYSTEM_CLOCK           20971520u           /* Default System clock value */
+
+
+/**
+ * @brief System clock frequency (core clock)
+ *
+ * The system clock frequency supplied to the SysTick timer and the processor
+ * core clock. This variable can be used by the user application to setup the
+ * SysTick timer or configure other parameters. It may also be used by debugger to
+ * query the frequency of the debug timer or configure the trace clock speed
+ * SystemCoreClock is initialized with a correct predefined value.
+ */
+extern uint32_t SystemCoreClock;
+
+/**
+ * @brief Setup the microcontroller system.
+ *
+ * Typically this function configures the oscillator (PLL) that is part of the
+ * microcontroller device. For systems with variable clock speed it also updates
+ * the variable SystemCoreClock. SystemInit is called from startup_device file.
+ */
+void SystemInit (void);
+
+/**
+ * @brief Updates the SystemCoreClock variable.
+ *
+ * It must be called whenever the core clock is changed during program
+ * execution. SystemCoreClockUpdate() evaluates the clock register settings and calculates
+ * the current core clock.
+ */
+void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _SYSTEM_MK64F12_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_debug_console.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_debug_console.c
@@ -1,0 +1,1763 @@
+/*
+ * This is a modified version of the file printf.c, which was distributed
+ * by Motorola as part of the M5407C3BOOT.zip package used to initialize
+ * the M5407C3 evaluation board.
+ *
+ * Copyright:
+ *      1999-2000 MOTOROLA, INC. All Rights Reserved.
+ *  You are hereby granted a copyright license to use, modify, and
+ *  distribute the SOFTWARE so long as this entire notice is
+ *  retained without alteration in any modified and/or redistributed
+ *  versions, and that such modified versions are clearly identified
+ *  as such. No licenses are granted by implication, estoppel or
+ *  otherwise under any patents or trademarks of Motorola, Inc. This
+ *  software is provided on an "AS IS" basis and without warranty.
+ *
+ *  To the maximum extent permitted by applicable law, MOTOROLA
+ *  DISCLAIMS ALL WARRANTIES WHETHER EXPRESS OR IMPLIED, INCLUDING
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+ *  PURPOSE AND ANY WARRANTY AGAINST INFRINGEMENT WITH REGARD TO THE
+ *  SOFTWARE (INCLUDING ANY MODIFIED VERSIONS THEREOF) AND ANY
+ *  ACCOMPANYING WRITTEN MATERIALS.
+ *
+ *  To the maximum extent permitted by applicable law, IN NO EVENT
+ *  SHALL MOTOROLA BE LIABLE FOR ANY DAMAGES WHATSOEVER (INCLUDING
+ *  WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS
+ *  INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR OTHER PECUNIARY
+ *  LOSS) ARISING OF THE USE OR INABILITY TO USE THE SOFTWARE.
+ *
+ *  Motorola assumes no responsibility for the maintenance and support
+ *  of this software
+
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#if defined(__CC_ARM)
+#include <stdio.h>
+#endif
+#include <math.h>
+#include "fsl_debug_console.h"
+
+#if defined(FSL_FEATURE_SOC_UART_COUNT) && (FSL_FEATURE_SOC_UART_COUNT > 0)
+#include "fsl_uart.h"
+#endif /* FSL_FEATURE_SOC_UART_COUNT */
+
+#if defined(FSL_FEATURE_SOC_LPSCI_COUNT) && (FSL_FEATURE_SOC_LPSCI_COUNT > 0)
+#include "fsl_lpsci.h"
+#endif /* FSL_FEATURE_SOC_LPSCI_COUNT */
+
+#if defined(FSL_FEATURE_SOC_LPUART_COUNT) && (FSL_FEATURE_SOC_LPUART_COUNT > 0)
+#include "fsl_lpuart.h"
+#endif /* FSL_FEATURE_SOC_LPUART_COUNT */
+
+/*! @brief Keil: suppress ellipsis warning in va_arg usage below. */
+#if defined(__CC_ARM)
+#pragma diag_suppress 1256
+#endif /* __CC_ARM */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief This definition is maximum line that debugconsole can scanf each time.*/
+#define IO_MAXLINE 20U
+
+/*! @brief The overflow value.*/
+#ifndef HUGE_VAL
+#define HUGE_VAL (99.e99)
+#endif /* HUGE_VAL */
+
+#if SCANF_FLOAT_ENABLE
+static double fnum = 0.0;
+#endif /* SCANF_FLOAT_ENABLE */
+
+/*! @brief Operation functions definitions for debug console. */
+typedef struct DebugConsoleOperationFunctions
+{
+    union
+    {
+        void (*PutChar)(void *base, const uint8_t *buffer, size_t length);
+#if defined(FSL_FEATURE_SOC_UART_COUNT) && (FSL_FEATURE_SOC_UART_COUNT > 0)
+        void (*UART_PutChar)(UART_Type *base, const uint8_t *buffer, size_t length);
+#endif /* FSL_FEATURE_SOC_UART_COUNT */
+#if defined(FSL_FEATURE_SOC_LPSCI_COUNT) && (FSL_FEATURE_SOC_LPSCI_COUNT > 0)
+        void (*LPSCI_PutChar)(UART0_Type *base, const uint8_t *buffer, size_t length);
+#endif /* FSL_FEATURE_SOC_LPSCI_COUNT */
+#if defined(FSL_FEATURE_SOC_LPUART_COUNT) && (FSL_FEATURE_SOC_LPUART_COUNT > 0)
+        void (*LPUART_PutChar)(LPUART_Type *base, const uint8_t *buffer, size_t length);
+#endif /* FSL_FEATURE_SOC_LPUART_COUNT */
+    } tx_union;
+    union
+    {
+        void (*GetChar)(void *base, const uint8_t *buffer, size_t length);
+#if defined(FSL_FEATURE_SOC_UART_COUNT) && (FSL_FEATURE_SOC_UART_COUNT > 0)
+        status_t (*UART_GetChar)(UART_Type *base, uint8_t *buffer, size_t length);
+#endif /* FSL_FEATURE_SOC_UART_COUNT */
+#if defined(FSL_FEATURE_SOC_LPSCI_COUNT) && (FSL_FEATURE_SOC_LPSCI_COUNT > 0)
+        status_t (*LPSCI_GetChar)(UART0_Type *base, uint8_t *buffer, size_t length);
+#endif /* FSL_FEATURE_SOC_LPSCI_COUNT */
+#if defined(FSL_FEATURE_SOC_LPUART_COUNT) && (FSL_FEATURE_SOC_LPUART_COUNT > 0)
+        status_t (*LPUART_GetChar)(LPUART_Type *base, uint8_t *buffer, size_t length);
+#endif /* FSL_FEATURE_SOC_LPUART_COUNT */
+    } rx_union;
+} debug_console_ops_t;
+
+/*! @brief State structure storing debug console. */
+typedef struct DebugConsoleState
+{
+    uint8_t type;            /*!< Indicator telling whether the debug console is initialized. */
+    void *base;              /*!< Base of the IP register. */
+    debug_console_ops_t ops; /*!< Operation function pointers for debug UART operations. */
+} debug_console_state_t;
+
+/*! @brief Type of KSDK printf function pointer. */
+typedef int (*PUTCHAR_FUNC)(int a);
+
+#if PRINTF_ADVANCED_ENABLE
+/*! @brief Specification modifier flags for printf. */
+enum _debugconsole_printf_flag
+{
+    kPRINTF_Minus = 0x01U,              /*!< Minus FLag. */
+    kPRINTF_Plus = 0x02U,               /*!< Plus Flag. */
+    kPRINTF_Space = 0x04U,              /*!< Space Flag. */
+    kPRINTF_Zero = 0x08U,               /*!< Zero Flag. */
+    kPRINTF_Pound = 0x10U,              /*!< Pound Flag. */
+    kPRINTF_LengthChar = 0x20U,         /*!< Length: Char Flag. */
+    kPRINTF_LengthShortInt = 0x40U,     /*!< Length: Short Int Flag. */
+    kPRINTF_LengthLongInt = 0x80U,      /*!< Length: Long Int Flag. */
+    kPRINTF_LengthLongLongInt = 0x100U, /*!< Length: Long Long Int Flag. */
+};
+#endif /* PRINTF_ADVANCED_ENABLE */
+
+/*! @brief Specification modifier flags for scanf. */
+enum _debugconsole_scanf_flag
+{
+    kSCANF_Suppress = 0x2U,      /*!< Suppress Flag. */
+    kSCANF_DestMask = 0x7cU,     /*!< Destination Mask. */
+    kSCANF_DestChar = 0x4U,      /*!< Destination Char Flag. */
+    kSCANF_DestString = 0x8U,    /*!< Destination String FLag. */
+    kSCANF_DestSet = 0x10U,      /*!< Destination Set Flag. */
+    kSCANF_DestInt = 0x20U,      /*!< Destination Int Flag. */
+    kSCANF_DestFloat = 0x30U,    /*!< Destination Float Flag. */
+    kSCANF_LengthMask = 0x1f00U, /*!< Length Mask Flag. */
+#if SCANF_ADVANCED_ENABLE
+    kSCANF_LengthChar = 0x100U,        /*!< Length Char Flag. */
+    kSCANF_LengthShortInt = 0x200U,    /*!< Length ShortInt Flag. */
+    kSCANF_LengthLongInt = 0x400U,     /*!< Length LongInt Flag. */
+    kSCANF_LengthLongLongInt = 0x800U, /*!< Length LongLongInt Flag. */
+#endif                                 /* SCANF_ADVANCED_ENABLE */
+#if PRINTF_FLOAT_ENABLE
+    kSCANF_LengthLongLongDouble = 0x1000U, /*!< Length LongLongDuoble Flag. */
+#endif                                     /*PRINTF_FLOAT_ENABLE */
+    kSCANF_TypeSinged = 0x2000U,           /*!< TypeSinged Flag. */
+};
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Debug UART state information. */
+static debug_console_state_t s_debugConsole = {.type = DEBUG_CONSOLE_DEVICE_TYPE_NONE, .base = NULL, .ops = {{0}, {0}}};
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+#if SDK_DEBUGCONSOLE
+static int DbgConsole_PrintfFormattedData(PUTCHAR_FUNC func_ptr, char *fmt, va_list ap);
+static int DbgConsole_ScanfFormattedData(const char *line_ptr, char *format, va_list args_ptr);
+double modf(double input_dbl, double *intpart_ptr);
+#endif /* SDK_DEBUGCONSOLE */
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+/*************Code for DbgConsole Init, Deinit, Printf, Scanf *******************************/
+
+/* See fsl_debug_console.h for documentation of this function. */
+status_t DbgConsole_Init(uint32_t baseAddr, uint32_t baudRate, uint8_t device, uint32_t clkSrcFreq)
+{
+    if (s_debugConsole.type != DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return kStatus_Fail;
+    }
+
+    /* Set debug console to initialized to avoid duplicated initialized operation. */
+    s_debugConsole.type = device;
+
+    /* Switch between different device. */
+    switch (device)
+    {
+#if defined(FSL_FEATURE_SOC_UART_COUNT) && (FSL_FEATURE_SOC_UART_COUNT > 0)
+        case DEBUG_CONSOLE_DEVICE_TYPE_UART:
+        {
+            uart_config_t uart_config;
+            s_debugConsole.base = (UART_Type *)baseAddr;
+            UART_GetDefaultConfig(&uart_config);
+            uart_config.baudRate_Bps = baudRate;
+            /* Enable clock and initial UART module follow user configure structure. */
+            UART_Init(s_debugConsole.base, &uart_config, clkSrcFreq);
+            UART_EnableTx(s_debugConsole.base, true);
+            UART_EnableRx(s_debugConsole.base, true);
+            /* Set the function pointer for send and receive for this kind of device. */
+            s_debugConsole.ops.tx_union.UART_PutChar = UART_WriteBlocking;
+            s_debugConsole.ops.rx_union.UART_GetChar = UART_ReadBlocking;
+        }
+        break;
+#endif /* FSL_FEATURE_SOC_UART_COUNT */
+#if defined(FSL_FEATURE_SOC_LPSCI_COUNT) && (FSL_FEATURE_SOC_LPSCI_COUNT > 0)
+        case DEBUG_CONSOLE_DEVICE_TYPE_LPSCI:
+        {
+            lpsci_config_t lpsci_config;
+            s_debugConsole.base = (UART0_Type *)baseAddr;
+            LPSCI_GetDefaultConfig(&lpsci_config);
+            lpsci_config.baudRate_Bps = baudRate;
+            /* Enable clock and initial UART module follow user configure structure. */
+            LPSCI_Init(s_debugConsole.base, &lpsci_config, clkSrcFreq);
+            LPSCI_EnableTx(s_debugConsole.base, true);
+            LPSCI_EnableRx(s_debugConsole.base, true);
+            /* Set the function pointer for send and receive for this kind of device. */
+            s_debugConsole.ops.tx_union.LPSCI_PutChar = LPSCI_WriteBlocking;
+            s_debugConsole.ops.rx_union.LPSCI_GetChar = LPSCI_ReadBlocking;
+        }
+        break;
+#endif /* FSL_FEATURE_SOC_LPSCI_COUNT */
+#if defined(FSL_FEATURE_SOC_LPUART_COUNT) && (FSL_FEATURE_SOC_LPUART_COUNT > 0)
+        case DEBUG_CONSOLE_DEVICE_TYPE_LPUART:
+        {
+            lpuart_config_t lpuart_config;
+            s_debugConsole.base = (LPUART_Type *)baseAddr;
+            LPUART_GetDefaultConfig(&lpuart_config);
+            lpuart_config.baudRate_Bps = baudRate;
+            /* Enable clock and initial UART module follow user configure structure. */
+            LPUART_Init(s_debugConsole.base, &lpuart_config, clkSrcFreq);
+            LPUART_EnableTx(s_debugConsole.base, true);
+            LPUART_EnableRx(s_debugConsole.base, true);
+            /* Set the function pointer for send and receive for this kind of device. */
+            s_debugConsole.ops.tx_union.LPUART_PutChar = LPUART_WriteBlocking;
+            s_debugConsole.ops.rx_union.LPUART_GetChar = LPUART_ReadBlocking;
+        }
+        break;
+#endif  /* FSL_FEATURE_SOC_LPUART_COUNT */
+        /* If new device is required as the low level device for debug console,
+         * Add the case branch and add the preprocessor macro to judge whether
+         * this kind of device exist in this SOC. */
+        default:
+            /* Device identified is invalid, return invalid device error code. */
+            return kStatus_InvalidArgument;
+    }
+
+    return kStatus_Success;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+status_t DbgConsole_Deinit(void)
+{
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return kStatus_Success;
+    }
+
+    switch (s_debugConsole.type)
+    {
+#if defined(FSL_FEATURE_SOC_UART_COUNT) && (FSL_FEATURE_SOC_UART_COUNT > 0)
+        case DEBUG_CONSOLE_DEVICE_TYPE_UART:
+            /* Disable UART module. */
+            UART_Deinit(s_debugConsole.base);
+            break;
+#endif /* FSL_FEATURE_SOC_UART_COUNT */
+#if defined(FSL_FEATURE_SOC_LPSCI_COUNT) && (FSL_FEATURE_SOC_LPSCI_COUNT > 0)
+        case DEBUG_CONSOLE_DEVICE_TYPE_LPSCI:
+            /* Disable LPSCI module. */
+            LPSCI_Deinit(s_debugConsole.base);
+            break;
+#endif /* FSL_FEATURE_SOC_LPSCI_COUNT */
+#if defined(FSL_FEATURE_SOC_LPUART_COUNT) && (FSL_FEATURE_SOC_LPUART_COUNT > 0)
+        case DEBUG_CONSOLE_DEVICE_TYPE_LPUART:
+            /* Disable LPUART module. */
+            LPUART_Deinit(s_debugConsole.base);
+            break;
+#endif /* FSL_FEATURE_SOC_LPUART_COUNT */
+        default:
+            /* Device identified is invalid, return invalid device error code. */
+            return kStatus_InvalidArgument;
+    }
+    s_debugConsole.type = DEBUG_CONSOLE_DEVICE_TYPE_NONE;
+    return kStatus_Success;
+}
+
+#if SDK_DEBUGCONSOLE
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_Printf(char *fmt_s, ...)
+{
+    va_list ap;
+    int result;
+
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+    va_start(ap, fmt_s);
+    result = DbgConsole_PrintfFormattedData(DbgConsole_Putchar, fmt_s, ap);
+    va_end(ap);
+
+    return result;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_Putchar(int ch)
+{
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+    s_debugConsole.ops.tx_union.PutChar(s_debugConsole.base, (uint8_t *)(&ch), 1);
+
+    return 1;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_Scanf(char *fmt_ptr, ...)
+{
+    char temp_buf[IO_MAXLINE];
+    va_list ap;
+    uint32_t i;
+    char result;
+
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+    va_start(ap, fmt_ptr);
+    temp_buf[0] = '\0';
+
+    for (i = 0; i < IO_MAXLINE; i++)
+    {
+        temp_buf[i] = result = DbgConsole_Getchar();
+
+        if ((result == '\r') || (result == '\n'))
+        {
+            /* End of Line. */
+            if (i == 0)
+            {
+                i = (uint32_t)-1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        temp_buf[i + 1] = '\0';
+    }
+
+    result = DbgConsole_ScanfFormattedData(temp_buf, fmt_ptr, ap);
+    va_end(ap);
+
+    return result;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_Getchar(void)
+{
+    char ch;
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+    s_debugConsole.ops.rx_union.GetChar(s_debugConsole.base, (uint8_t *)(&ch), 1);
+
+    return ch;
+}
+
+/*************Code for process formatted data*******************************/
+/*!
+ * @brief Scanline function which ignores white spaces.
+ *
+ * @param[in]   s The address of the string pointer to update.
+ * @return      String without white spaces.
+ */
+static uint32_t DbgConsole_ScanIgnoreWhiteSpace(const char **s)
+{
+    uint8_t count = 0;
+    uint8_t c;
+
+    c = **s;
+    while ((c == ' ') || (c == '\t') || (c == '\n') || (c == '\r') || (c == '\v') || (c == '\f'))
+    {
+        count++;
+        (*s)++;
+        c = **s;
+    }
+    return count;
+}
+
+/*!
+ * @brief This function puts padding character.
+ *
+ * @param[in] c         Padding character.
+ * @param[in] curlen    Length of current formatted string .
+ * @param[in] width     Width of expected formatted string.
+ * @param[in] count     Number of characters.
+ * @param[in] func_ptr  Function to put character out.
+ */
+static void DbgConsole_PrintfPaddingCharacter(
+    char c, int32_t curlen, int32_t width, int32_t *count, PUTCHAR_FUNC func_ptr)
+{
+    int32_t i;
+
+    for (i = curlen; i < width; i++)
+    {
+        func_ptr(c);
+        (*count)++;
+    }
+}
+
+/*!
+ * @brief Converts a radix number to a string and return its length.
+ *
+ * @param[in] numstr    Converted string of the number.
+ * @param[in] nump      Pointer to the number.
+ * @param[in] neg       Polarity of the number.
+ * @param[in] radix     The radix to be converted to.
+ * @param[in] use_caps  Used to identify %x/X output format.
+
+ * @return Length of the converted string.
+ */
+static int32_t DbgConsole_ConvertRadixNumToString(char *numstr, void *nump, int32_t neg, int32_t radix, bool use_caps)
+{
+#if PRINTF_ADVANCED_ENABLE
+    int64_t a;
+    int64_t b;
+    int64_t c;
+
+    uint64_t ua;
+    uint64_t ub;
+    uint64_t uc;
+#else
+    int32_t a;
+    int32_t b;
+    int32_t c;
+
+    uint32_t ua;
+    uint32_t ub;
+    uint32_t uc;
+#endif /* PRINTF_ADVANCED_ENABLE */
+
+    int32_t nlen;
+    char *nstrp;
+
+    nlen = 0;
+    nstrp = numstr;
+    *nstrp++ = '\0';
+
+    if (neg)
+    {
+#if PRINTF_ADVANCED_ENABLE
+        a = *(int64_t *)nump;
+#else
+        a = *(int32_t *)nump;
+#endif /* PRINTF_ADVANCED_ENABLE */
+        if (a == 0)
+        {
+            *nstrp = '0';
+            ++nlen;
+            return nlen;
+        }
+        while (a != 0)
+        {
+#if PRINTF_ADVANCED_ENABLE
+            b = (int64_t)a / (int64_t)radix;
+            c = (int64_t)a - ((int64_t)b * (int64_t)radix);
+            if (c < 0)
+            {
+                uc = (uint64_t)c;
+                c = (int64_t)(~uc) + 1 + '0';
+            }
+#else
+            b = a / radix;
+            c = a - (b * radix);
+            if (c < 0)
+            {
+                uc = (uint32_t)c;
+                c = (uint32_t)(~uc) + 1 + '0';
+            }
+#endif /* PRINTF_ADVANCED_ENABLE */
+            else
+            {
+                c = c + '0';
+            }
+            a = b;
+            *nstrp++ = (char)c;
+            ++nlen;
+        }
+    }
+    else
+    {
+#if PRINTF_ADVANCED_ENABLE
+        ua = *(uint64_t *)nump;
+#else
+        ua = *(uint32_t *)nump;
+#endif /* PRINTF_ADVANCED_ENABLE */
+        if (ua == 0)
+        {
+            *nstrp = '0';
+            ++nlen;
+            return nlen;
+        }
+        while (ua != 0)
+        {
+#if PRINTF_ADVANCED_ENABLE
+            ub = (uint64_t)ua / (uint64_t)radix;
+            uc = (uint64_t)ua - ((uint64_t)ub * (uint64_t)radix);
+#else
+            ub = ua / (uint32_t)radix;
+            uc = ua - (ub * (uint32_t)radix);
+#endif /* PRINTF_ADVANCED_ENABLE */
+
+            if (uc < 10)
+            {
+                uc = uc + '0';
+            }
+            else
+            {
+                uc = uc - 10 + (use_caps ? 'A' : 'a');
+            }
+            ua = ub;
+            *nstrp++ = (char)uc;
+            ++nlen;
+        }
+    }
+    return nlen;
+}
+
+#if PRINTF_FLOAT_ENABLE
+/*!
+ * @brief Converts a floating radix number to a string and return its length.
+ *
+ * @param[in] numstr            Converted string of the number.
+ * @param[in] nump              Pointer to the number.
+ * @param[in] radix             The radix to be converted to.
+ * @param[in] precision_width   Specify the precision width.
+
+ * @return Length of the converted string.
+ */
+static int32_t DbgConsole_ConvertFloatRadixNumToString(char *numstr,
+                                                       void *nump,
+                                                       int32_t radix,
+                                                       uint32_t precision_width)
+{
+    int32_t a;
+    int32_t b;
+    int32_t c;
+    int32_t i;
+    uint32_t uc;
+    double fa;
+    double dc;
+    double fb;
+    double r;
+    double fractpart;
+    double intpart;
+
+    int32_t nlen;
+    char *nstrp;
+    nlen = 0;
+    nstrp = numstr;
+    *nstrp++ = '\0';
+    r = *(double *)nump;
+    if (!r)
+    {
+        *nstrp = '0';
+        ++nlen;
+        return nlen;
+    }
+    fractpart = modf((double)r, (double *)&intpart);
+    /* Process fractional part. */
+    for (i = 0; i < precision_width; i++)
+    {
+        fractpart *= radix;
+    }
+    if (r >= 0)
+    {
+        fa = fractpart + (double)0.5;
+        if (fa >= pow(10, precision_width))
+        {
+            intpart++;
+        }
+    }
+    else
+    {
+        fa = fractpart - (double)0.5;
+        if (fa <= pow(-10, precision_width))
+        {
+            intpart--;
+        }
+    }
+    for (i = 0; i < precision_width; i++)
+    {
+        fb = fa / (int32_t)radix;
+        dc = (fa - (int64_t)fb * (int32_t)radix);
+        c = (int32_t)dc;
+        if (c < 0)
+        {
+            uc = (uint32_t)c;
+            c = (int32_t)(~uc) + 1 + '0';
+        }
+        else
+        {
+            c = c + '0';
+        }
+        fa = fb;
+        *nstrp++ = (char)c;
+        ++nlen;
+    }
+    *nstrp++ = (char)'.';
+    ++nlen;
+    a = (int32_t)intpart;
+    if (a == 0)
+    {
+        *nstrp++ = '0';
+        ++nlen;
+    }
+    else
+    {
+        while (a != 0)
+        {
+            b = (int32_t)a / (int32_t)radix;
+            c = (int32_t)a - ((int32_t)b * (int32_t)radix);
+            if (c < 0)
+            {
+                uc = (uint32_t)c;
+                c = (int32_t)(~uc) + 1 + '0';
+            }
+            else
+            {
+                c = c + '0';
+            }
+            a = b;
+            *nstrp++ = (char)c;
+            ++nlen;
+        }
+    }
+    return nlen;
+}
+#endif /* PRINTF_FLOAT_ENABLE */
+
+/*!
+ * @brief This function outputs its parameters according to a formatted string.
+ *
+ * @note I/O is performed by calling given function pointer using following
+ * (*func_ptr)(c);
+ *
+ * @param[in] func_ptr  Function to put character out.
+ * @param[in] fmt_ptr   Format string for printf.
+ * @param[in] args_ptr  Arguments to printf.
+ *
+ * @return Number of characters
+ */
+static int DbgConsole_PrintfFormattedData(PUTCHAR_FUNC func_ptr, char *fmt, va_list ap)
+{
+    /* va_list ap; */
+    char *p;
+    int32_t c;
+
+    char vstr[33];
+    char *vstrp = NULL;
+    int32_t vlen = 0;
+
+    int32_t done;
+    int32_t count = 0;
+
+    uint32_t field_width;
+    uint32_t precision_width;
+    char *sval;
+    int32_t cval;
+    bool use_caps;
+    uint8_t radix = 0;
+
+#if PRINTF_ADVANCED_ENABLE
+    uint32_t flags_used;
+    int32_t schar, dschar;
+    int64_t ival;
+    uint64_t uval = 0;
+#else
+    int32_t ival;
+    uint32_t uval = 0;
+#endif /* PRINTF_ADVANCED_ENABLE */
+
+#if PRINTF_FLOAT_ENABLE
+    double fval;
+#endif /* PRINTF_FLOAT_ENABLE */
+
+    /* Start parsing apart the format string and display appropriate formats and data. */
+    for (p = (char *)fmt; (c = *p) != 0; p++)
+    {
+        /*
+         * All formats begin with a '%' marker.  Special chars like
+         * '\n' or '\t' are normally converted to the appropriate
+         * character by the __compiler__.  Thus, no need for this
+         * routine to account for the '\' character.
+         */
+        if (c != '%')
+        {
+            func_ptr(c);
+            count++;
+            /* By using 'continue', the next iteration of the loop is used, skipping the code that follows. */
+            continue;
+        }
+
+        use_caps = true;
+
+#if PRINTF_ADVANCED_ENABLE
+        /* First check for specification modifier flags. */
+        flags_used = 0;
+        done = false;
+        while (!done)
+        {
+            switch (*++p)
+            {
+                case '-':
+                    flags_used |= kPRINTF_Minus;
+                    break;
+                case '+':
+                    flags_used |= kPRINTF_Plus;
+                    break;
+                case ' ':
+                    flags_used |= kPRINTF_Space;
+                    break;
+                case '0':
+                    flags_used |= kPRINTF_Zero;
+                    break;
+                case '#':
+                    flags_used |= kPRINTF_Pound;
+                    break;
+                default:
+                    /* We've gone one char too far. */
+                    --p;
+                    done = true;
+                    break;
+            }
+        }
+#endif /* PRINTF_ADVANCED_ENABLE */
+
+        /* Next check for minimum field width. */
+        field_width = 0;
+        done = false;
+        while (!done)
+        {
+            c = *++p;
+            if ((c >= '0') && (c <= '9'))
+            {
+                field_width = (field_width * 10) + (c - '0');
+            }
+            else
+            {
+                /* We've gone one char too far. */
+                --p;
+                done = true;
+            }
+        }
+        /* Next check for the width and precision field separator. */
+        precision_width = 6;
+        if (*++p == '.')
+        {
+            /* Must get precision field width, if present. */
+            precision_width = 0;
+            done = false;
+            while (!done)
+            {
+                c = *++p;
+                if ((c >= '0') && (c <= '9'))
+                {
+                    precision_width = (precision_width * 10) + (c - '0');
+                }
+                else
+                {
+                    /* We've gone one char too far. */
+                    --p;
+                    done = true;
+                }
+            }
+        }
+        else
+        {
+            /* We've gone one char too far. */
+            --p;
+        }
+#if PRINTF_ADVANCED_ENABLE
+        /*
+         * Check for the length modifier.
+         */
+        switch (/* c = */ *++p)
+        {
+            case 'h':
+                if (*++p != 'h')
+                {
+                    flags_used |= kPRINTF_LengthShortInt;
+                    --p;
+                }
+                else
+                {
+                    flags_used |= kPRINTF_LengthChar;
+                }
+                break;
+            case 'l':
+                if (*++p != 'l')
+                {
+                    flags_used |= kPRINTF_LengthLongInt;
+                    --p;
+                }
+                else
+                {
+                    flags_used |= kPRINTF_LengthLongLongInt;
+                }
+                break;
+            default:
+                /* we've gone one char too far */
+                --p;
+                break;
+        }
+#endif /* PRINTF_ADVANCED_ENABLE */
+        /* Now we're ready to examine the format. */
+        c = *++p;
+        {
+            if ((c == 'd') || (c == 'i') || (c == 'f') || (c == 'F') || (c == 'x') || (c == 'X') || (c == 'o') ||
+                (c == 'b') || (c == 'p') || (c == 'u'))
+            {
+                if ((c == 'd') || (c == 'i'))
+                {
+#if PRINTF_ADVANCED_ENABLE
+                    if (flags_used & kPRINTF_LengthLongLongInt)
+                    {
+                        ival = (int64_t)va_arg(ap, int64_t);
+                    }
+                    else
+#endif /* PRINTF_ADVANCED_ENABLE */
+                    {
+                        ival = (int32_t)va_arg(ap, int32_t);
+                    }
+                    vlen = DbgConsole_ConvertRadixNumToString(vstr, &ival, true, 10, use_caps);
+                    vstrp = &vstr[vlen];
+#if PRINTF_ADVANCED_ENABLE
+                    if (ival < 0)
+                    {
+                        schar = '-';
+                        ++vlen;
+                    }
+                    else
+                    {
+                        if (flags_used & kPRINTF_Plus)
+                        {
+                            schar = '+';
+                            ++vlen;
+                        }
+                        else
+                        {
+                            if (flags_used & kPRINTF_Space)
+                            {
+                                schar = ' ';
+                                ++vlen;
+                            }
+                            else
+                            {
+                                schar = 0;
+                            }
+                        }
+                    }
+                    dschar = false;
+                    /* Do the ZERO pad. */
+                    if (flags_used & kPRINTF_Zero)
+                    {
+                        if (schar)
+                        {
+                            func_ptr(schar);
+                            count++;
+                        }
+                        dschar = true;
+
+                        DbgConsole_PrintfPaddingCharacter('0', vlen, field_width, &count, func_ptr);
+                        vlen = field_width;
+                    }
+                    else
+                    {
+                        if (!(flags_used & kPRINTF_Minus))
+                        {
+                            DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                            if (schar)
+                            {
+                                func_ptr(schar);
+                                count++;
+                            }
+                            dschar = true;
+                        }
+                    }
+                    /* The string was built in reverse order, now display in correct order. */
+                    if ((!dschar) && schar)
+                    {
+                        func_ptr(schar);
+                        count++;
+                    }
+#endif /* PRINTF_ADVANCED_ENABLE */
+                }
+
+#if PRINTF_FLOAT_ENABLE
+                if ((c == 'f') || (c == 'F'))
+                {
+                    fval = (double)va_arg(ap, double);
+                    vlen = DbgConsole_ConvertFloatRadixNumToString(vstr, &fval, 10, precision_width);
+                    vstrp = &vstr[vlen];
+
+#if PRINTF_ADVANCED_ENABLE
+                    if (fval < 0)
+                    {
+                        schar = '-';
+                        ++vlen;
+                    }
+                    else
+                    {
+                        if (flags_used & kPRINTF_Plus)
+                        {
+                            schar = '+';
+                            ++vlen;
+                        }
+                        else
+                        {
+                            if (flags_used & kPRINTF_Space)
+                            {
+                                schar = ' ';
+                                ++vlen;
+                            }
+                            else
+                            {
+                                schar = 0;
+                            }
+                        }
+                    }
+                    dschar = false;
+                    if (flags_used & kPRINTF_Zero)
+                    {
+                        if (schar)
+                        {
+                            func_ptr(schar);
+                            count++;
+                        }
+                        dschar = true;
+                        DbgConsole_PrintfPaddingCharacter('0', vlen, field_width, &count, func_ptr);
+                        vlen = field_width;
+                    }
+                    else
+                    {
+                        if (!(flags_used & kPRINTF_Minus))
+                        {
+                            DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                            if (schar)
+                            {
+                                func_ptr(schar);
+                                count++;
+                            }
+                            dschar = true;
+                        }
+                    }
+                    if ((!dschar) && schar)
+                    {
+                        func_ptr(schar);
+                        count++;
+                    }
+#endif /* PRINTF_ADVANCED_ENABLE */
+                }
+#endif /* PRINTF_FLOAT_ENABLE */
+                if ((c == 'X') || (c == 'x'))
+                {
+                    if (c == 'x')
+                    {
+                        use_caps = false;
+                    }
+#if PRINTF_ADVANCED_ENABLE
+                    if (flags_used & kPRINTF_LengthLongLongInt)
+                    {
+                        uval = (uint64_t)va_arg(ap, uint64_t);
+                    }
+                    else
+#endif /* PRINTF_ADVANCED_ENABLE */
+                    {
+                        uval = (uint32_t)va_arg(ap, uint32_t);
+                    }
+                    vlen = DbgConsole_ConvertRadixNumToString(vstr, &uval, false, 16, use_caps);
+                    vstrp = &vstr[vlen];
+
+#if PRINTF_ADVANCED_ENABLE
+                    dschar = false;
+                    if (flags_used & kPRINTF_Zero)
+                    {
+                        if (flags_used & kPRINTF_Pound)
+                        {
+                            func_ptr('0');
+                            func_ptr((use_caps ? 'X' : 'x'));
+                            count += 2;
+                            /*vlen += 2;*/
+                            dschar = true;
+                        }
+                        DbgConsole_PrintfPaddingCharacter('0', vlen, field_width, &count, func_ptr);
+                        vlen = field_width;
+                    }
+                    else
+                    {
+                        if (!(flags_used & kPRINTF_Minus))
+                        {
+                            if (flags_used & kPRINTF_Pound)
+                            {
+                                vlen += 2;
+                            }
+                            DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                            if (flags_used & kPRINTF_Pound)
+                            {
+                                func_ptr('0');
+                                func_ptr(use_caps ? 'X' : 'x');
+                                count += 2;
+
+                                dschar = true;
+                            }
+                        }
+                    }
+
+                    if ((flags_used & kPRINTF_Pound) && (!dschar))
+                    {
+                        func_ptr('0');
+                        func_ptr(use_caps ? 'X' : 'x');
+                        count += 2;
+                        vlen += 2;
+                    }
+#endif /* PRINTF_ADVANCED_ENABLE */
+                }
+                if (c == 'o')
+                {
+                    uval = (uint32_t)va_arg(ap, uint32_t);
+                    radix = 8;
+                }
+                if (c == 'b')
+                {
+                    uval = (uint32_t)va_arg(ap, uint32_t);
+                    radix = 2;
+                    vstrp = &vstr[vlen];
+                }
+                if (c == 'p')
+                {
+                    uval = (uint32_t)va_arg(ap, void *);
+                    radix = 16;
+                    vstrp = &vstr[vlen];
+                }
+                if (c == 'u')
+                {
+                    uval = (uint32_t)va_arg(ap, uint32_t);
+                    radix = 10;
+                    vstrp = &vstr[vlen];
+                }
+                if ((c == 'o') || (c == 'b') || (c == 'p') || (c == 'u'))
+                {
+                    vlen = DbgConsole_ConvertRadixNumToString(vstr, &uval, false, radix, use_caps);
+                    vstrp = &vstr[vlen];
+#if PRINTF_ADVANCED_ENABLE
+                    if (flags_used & kPRINTF_Zero)
+                    {
+                        DbgConsole_PrintfPaddingCharacter('0', vlen, field_width, &count, func_ptr);
+                        vlen = field_width;
+                    }
+                    else
+                    {
+                        if (!(flags_used & kPRINTF_Minus))
+                        {
+                            DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                        }
+                    }
+#endif /* PRINTF_ADVANCED_ENABLE */
+                }
+#if !PRINTF_ADVANCED_ENABLE
+                DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+#endif /* !PRINTF_ADVANCED_ENABLE */
+                while (*vstrp)
+                {
+                    func_ptr(*vstrp--);
+                    count++;
+                }
+#if PRINTF_ADVANCED_ENABLE
+                if (flags_used & kPRINTF_Minus)
+                {
+                    DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                }
+#endif /* PRINTF_ADVANCED_ENABLE */
+            }
+            else if (c == 'c')
+            {
+                cval = (char)va_arg(ap, uint32_t);
+                func_ptr(cval);
+                count++;
+            }
+            else if (c == 's')
+            {
+                sval = (char *)va_arg(ap, char *);
+                if (sval)
+                {
+                    vlen = strlen(sval);
+#if PRINTF_ADVANCED_ENABLE
+                    if (!(flags_used & kPRINTF_Minus))
+#endif /* PRINTF_ADVANCED_ENABLE */
+                    {
+                        DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                    }
+                    while (*sval)
+                    {
+                        func_ptr(*sval++);
+                        count++;
+                    }
+#if PRINTF_ADVANCED_ENABLE
+                    if (flags_used & kPRINTF_Minus)
+                    {
+                        DbgConsole_PrintfPaddingCharacter(' ', vlen, field_width, &count, func_ptr);
+                    }
+#endif /* PRINTF_ADVANCED_ENABLE */
+                }
+            }
+            else
+            {
+                func_ptr(c);
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+/*!
+ * @brief Converts an input line of ASCII characters based upon a provided
+ * string format.
+ *
+ * @param[in] line_ptr The input line of ASCII data.
+ * @param[in] format   Format first points to the format string.
+ * @param[in] args_ptr The list of parameters.
+ *
+ * @return Number of input items converted and assigned.
+ * @retval IO_EOF When line_ptr is empty string "".
+ */
+static int DbgConsole_ScanfFormattedData(const char *line_ptr, char *format, va_list args_ptr)
+{
+    uint8_t base;
+    int8_t neg;
+    /* Identifier for the format string. */
+    char *c = format;
+    char temp;
+    char *buf;
+    /* Flag telling the conversion specification. */
+    uint32_t flag = 0;
+    /* Filed width for the matching input streams. */
+    uint32_t field_width;
+    /* How many arguments are assigned except the suppress. */
+    uint32_t nassigned = 0;
+    /* How many characters are read from the input streams. */
+    uint32_t n_decode = 0;
+
+    int32_t val;
+
+    const char *s;
+    /* Identifier for the input string. */
+    const char *p = line_ptr;
+
+    /* Return EOF error before any conversion. */
+    if (*p == '\0')
+    {
+        return -1;
+    }
+
+    /* Decode directives. */
+    while ((*c) && (*p))
+    {
+        /* Ignore all white-spaces in the format strings. */
+        if (DbgConsole_ScanIgnoreWhiteSpace((const char **)&c))
+        {
+            n_decode += DbgConsole_ScanIgnoreWhiteSpace(&p);
+        }
+        else if ((*c != '%') || ((*c == '%') && (*(c + 1) == '%')))
+        {
+            /* Ordinary characters. */
+            c++;
+            if (*p == *c)
+            {
+                n_decode++;
+                p++;
+                c++;
+            }
+            else
+            {
+                /* Match failure. Misalignment with C99, the unmatched characters need to be pushed back to stream.
+                 * However, it is deserted now. */
+                break;
+            }
+        }
+        else
+        {
+            /* convernsion specification */
+            c++;
+            /* Reset. */
+            flag = 0;
+            field_width = 0;
+            base = 0;
+
+            /* Loop to get full conversion specification. */
+            while ((*c) && (!(flag & kSCANF_DestMask)))
+            {
+                switch (*c)
+                {
+#if SCANF_ADVANCED_ENABLE
+                    case '*':
+                        if (flag & kSCANF_Suppress)
+                        {
+                            /* Match failure. */
+                            return nassigned;
+                        }
+                        flag |= kSCANF_Suppress;
+                        c++;
+                        break;
+                    case 'h':
+                        if (flag & kSCANF_LengthMask)
+                        {
+                            /* Match failure. */
+                            return nassigned;
+                        }
+
+                        if (c[1] == 'h')
+                        {
+                            flag |= kSCANF_LengthChar;
+                            c++;
+                        }
+                        else
+                        {
+                            flag |= kSCANF_LengthShortInt;
+                        }
+                        c++;
+                        break;
+                    case 'l':
+                        if (flag & kSCANF_LengthMask)
+                        {
+                            /* Match failure. */
+                            return nassigned;
+                        }
+
+                        if (c[1] == 'l')
+                        {
+                            flag |= kSCANF_LengthLongLongInt;
+                            c++;
+                        }
+                        else
+                        {
+                            flag |= kSCANF_LengthLongInt;
+                        }
+                        c++;
+                        break;
+#endif /* SCANF_ADVANCED_ENABLE */
+#if SCANF_FLOAT_ENABLE
+                    case 'L':
+                        if (flag & kSCANF_LengthMask)
+                        {
+                            /* Match failure. */
+                            return nassigned;
+                        }
+                        flag |= kSCANF_LengthLongLongDouble;
+                        c++;
+                        break;
+#endif /* SCANF_FLOAT_ENABLE */
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        if (field_width)
+                        {
+                            /* Match failure. */
+                            return nassigned;
+                        }
+                        do
+                        {
+                            field_width = field_width * 10 + *c - '0';
+                            c++;
+                        } while ((*c >= '0') && (*c <= '9'));
+                        break;
+                    case 'd':
+                        base = 10;
+                        flag |= kSCANF_TypeSinged;
+                        flag |= kSCANF_DestInt;
+                        c++;
+                        break;
+                    case 'u':
+                        base = 10;
+                        flag |= kSCANF_DestInt;
+                        c++;
+                        break;
+                    case 'o':
+                        base = 8;
+                        flag |= kSCANF_DestInt;
+                        c++;
+                        break;
+                    case 'x':
+                    case 'X':
+                        base = 16;
+                        flag |= kSCANF_DestInt;
+                        c++;
+                        break;
+                    case 'i':
+                        base = 0;
+                        flag |= kSCANF_DestInt;
+                        c++;
+                        break;
+#if SCANF_FLOAT_ENABLE
+                    case 'a':
+                    case 'A':
+                    case 'e':
+                    case 'E':
+                    case 'f':
+                    case 'F':
+                    case 'g':
+                    case 'G':
+                        flag |= kSCANF_DestFloat;
+                        c++;
+                        break;
+#endif /* SCANF_FLOAT_ENABLE */
+                    case 'c':
+                        flag |= kSCANF_DestChar;
+                        if (!field_width)
+                        {
+                            field_width = 1;
+                        }
+                        c++;
+                        break;
+                    case 's':
+                        flag |= kSCANF_DestString;
+                        c++;
+                        break;
+                    default:
+                        return nassigned;
+                }
+            }
+
+            if (!(flag & kSCANF_DestMask))
+            {
+                /* Format strings are exhausted. */
+                return nassigned;
+            }
+
+            if (!field_width)
+            {
+                /* Large than length of a line. */
+                field_width = 99;
+            }
+
+            /* Matching strings in input streams and assign to argument. */
+            switch (flag & kSCANF_DestMask)
+            {
+                case kSCANF_DestChar:
+                    s = (const char *)p;
+                    buf = va_arg(args_ptr, char *);
+                    while ((field_width--) && (*p))
+                    {
+                        if (!(flag & kSCANF_Suppress))
+                        {
+                            *buf++ = *p++;
+                        }
+                        else
+                        {
+                            p++;
+                        }
+                        n_decode++;
+                    }
+
+                    if (((!(flag)) & kSCANF_Suppress) && (s != p))
+                    {
+                        nassigned++;
+                    }
+                    break;
+                case kSCANF_DestString:
+                    n_decode += DbgConsole_ScanIgnoreWhiteSpace(&p);
+                    s = p;
+                    buf = va_arg(args_ptr, char *);
+                    while ((field_width--) && (*p != '\0') && (*p != ' ') && (*p != '\t') && (*p != '\n') &&
+                           (*p != '\r') && (*p != '\v') && (*p != '\f'))
+                    {
+                        if (flag & kSCANF_Suppress)
+                        {
+                            p++;
+                        }
+                        else
+                        {
+                            *buf++ = *p++;
+                        }
+                        n_decode++;
+                    }
+
+                    if ((!(flag & kSCANF_Suppress)) && (s != p))
+                    {
+                        /* Add NULL to end of string. */
+                        *buf = '\0';
+                        nassigned++;
+                    }
+                    break;
+                case kSCANF_DestInt:
+                    n_decode += DbgConsole_ScanIgnoreWhiteSpace(&p);
+                    s = p;
+                    val = 0;
+                    if ((base == 0) || (base == 16))
+                    {
+                        if ((s[0] == '0') && ((s[1] == 'x') || (s[1] == 'X')))
+                        {
+                            base = 16;
+                            if (field_width >= 1)
+                            {
+                                p += 2;
+                                n_decode += 2;
+                                field_width -= 2;
+                            }
+                        }
+                    }
+
+                    if (base == 0)
+                    {
+                        if (s[0] == '0')
+                        {
+                            base = 8;
+                        }
+                        else
+                        {
+                            base = 10;
+                        }
+                    }
+
+                    neg = 1;
+                    switch (*p)
+                    {
+                        case '-':
+                            neg = -1;
+                            n_decode++;
+                            p++;
+                            field_width--;
+                            break;
+                        case '+':
+                            neg = 1;
+                            n_decode++;
+                            p++;
+                            field_width--;
+                            break;
+                        default:
+                            break;
+                    }
+
+                    while ((*p) && (field_width--))
+                    {
+                        if ((*p <= '9') && (*p >= '0'))
+                        {
+                            temp = *p - '0';
+                        }
+                        else if ((*p <= 'f') && (*p >= 'a'))
+                        {
+                            temp = *p - 'a' + 10;
+                        }
+                        else if ((*p <= 'F') && (*p >= 'A'))
+                        {
+                            temp = *p - 'A' + 10;
+                        }
+                        else
+                        {
+                            temp = base;
+                        }
+
+                        if (temp >= base)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            val = base * val + temp;
+                        }
+                        p++;
+                        n_decode++;
+                    }
+                    val *= neg;
+                    if (!(flag & kSCANF_Suppress))
+                    {
+#if SCANF_ADVANCED_ENABLE
+                        switch (flag & kSCANF_LengthMask)
+                        {
+                            case kSCANF_LengthChar:
+                                if (flag & kSCANF_TypeSinged)
+                                {
+                                    *va_arg(args_ptr, signed char *) = (signed char)val;
+                                }
+                                else
+                                {
+                                    *va_arg(args_ptr, unsigned char *) = (unsigned char)val;
+                                }
+                                break;
+                            case kSCANF_LengthShortInt:
+                                if (flag & kSCANF_TypeSinged)
+                                {
+                                    *va_arg(args_ptr, signed short *) = (signed short)val;
+                                }
+                                else
+                                {
+                                    *va_arg(args_ptr, unsigned short *) = (unsigned short)val;
+                                }
+                                break;
+                            case kSCANF_LengthLongInt:
+                                if (flag & kSCANF_TypeSinged)
+                                {
+                                    *va_arg(args_ptr, signed long int *) = (signed long int)val;
+                                }
+                                else
+                                {
+                                    *va_arg(args_ptr, unsigned long int *) = (unsigned long int)val;
+                                }
+                                break;
+                            case kSCANF_LengthLongLongInt:
+                                if (flag & kSCANF_TypeSinged)
+                                {
+                                    *va_arg(args_ptr, signed long long int *) = (signed long long int)val;
+                                }
+                                else
+                                {
+                                    *va_arg(args_ptr, unsigned long long int *) = (unsigned long long int)val;
+                                }
+                                break;
+                            default:
+                                /* The default type is the type int. */
+                                if (flag & kSCANF_TypeSinged)
+                                {
+                                    *va_arg(args_ptr, signed int *) = (signed int)val;
+                                }
+                                else
+                                {
+                                    *va_arg(args_ptr, unsigned int *) = (unsigned int)val;
+                                }
+                                break;
+                        }
+#else
+                        /* The default type is the type int. */
+                        if (flag & kSCANF_TypeSinged)
+                        {
+                            *va_arg(args_ptr, signed int *) = (signed int)val;
+                        }
+                        else
+                        {
+                            *va_arg(args_ptr, unsigned int *) = (unsigned int)val;
+                        }
+#endif /* SCANF_ADVANCED_ENABLE */
+                        nassigned++;
+                    }
+                    break;
+#if SCANF_FLOAT_ENABLE
+                case kSCANF_DestFloat:
+                    n_decode += DbgConsole_ScanIgnoreWhiteSpace(&p);
+                    fnum = strtod(p, (char **)&s);
+
+                    if ((fnum >= HUGE_VAL) || (fnum <= -HUGE_VAL))
+                    {
+                        break;
+                    }
+
+                    n_decode += (int)(s) - (int)(p);
+                    p = s;
+                    if (!(flag & kSCANF_Suppress))
+                    {
+                        if (flag & kSCANF_LengthLongLongDouble)
+                        {
+                            *va_arg(args_ptr, double *) = fnum;
+                        }
+                        else
+                        {
+                            *va_arg(args_ptr, float *) = (float)fnum;
+                        }
+                        nassigned++;
+                    }
+                    break;
+#endif /* SCANF_FLOAT_ENABLE */
+                default:
+                    return nassigned;
+            }
+        }
+    }
+    return nassigned;
+}
+#endif /* SDK_DEBUGCONSOLE */
+/*************Code to support toolchain's printf, scanf *******************************/
+/* These function __write and __read is used to support IAR toolchain to printf and scanf*/
+#if (defined(__ICCARM__))
+#pragma weak __write
+size_t __write(int handle, const unsigned char *buffer, size_t size)
+{
+    if (buffer == 0)
+    {
+        /*
+         * This means that we should flush internal buffers.  Since we don't we just return.
+         * (Remember, "handle" == -1 means that all handles should be flushed.)
+         */
+        return 0;
+    }
+
+    /* This function only writes to "standard out" and "standard err" for all other file handles it returns failure. */
+    if ((handle != 1) && (handle != 2))
+    {
+        return ((size_t)-1);
+    }
+
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return ((size_t)-1);
+    }
+
+    /* Send data. */
+    s_debugConsole.ops.tx_union.PutChar(s_debugConsole.base, buffer, 1);
+    return size;
+}
+
+#pragma weak __read
+size_t __read(int handle, unsigned char *buffer, size_t size)
+{
+    /* This function only reads from "standard in", for all other file  handles it returns failure. */
+    if (handle != 0)
+    {
+        return ((size_t)-1);
+    }
+
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return ((size_t)-1);
+    }
+
+    /* Receive data. */
+    s_debugConsole.ops.rx_union.GetChar(s_debugConsole.base, buffer, size);
+
+    return size;
+}
+/* These function __write and __read is used to support ARM_GCC, KDS, Atollic toolchains to printf and scanf*/
+#elif(defined(__GNUC__))
+int _write(int handle, char *buffer, int size)
+{
+    if (buffer == 0)
+    {
+        /* return -1 if error. */
+        return -1;
+    }
+
+    /* This function only writes to "standard out" and "standard err" for all other file handles it returns failure. */
+    if ((handle != 1) && (handle != 2))
+    {
+        return -1;
+    }
+
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+
+    /* Send data. */
+    s_debugConsole.ops.tx_union.PutChar(s_debugConsole.base, (uint8_t *)buffer, size);
+    return size;
+}
+
+int _read(int handle, char *buffer, int size)
+{
+    /* This function only reads from "standard in", for all other file handles it returns failure. */
+    if (handle != 0)
+    {
+        return -1;
+    }
+
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+
+    /* Receive data. */
+    s_debugConsole.ops.rx_union.GetChar(s_debugConsole.base, (uint8_t *)buffer, size);
+    return size;
+}
+/* These function fputc and fgetc is used to support KEIL toolchain to printf and scanf*/
+#elif defined(__CC_ARM)
+struct __FILE
+{
+    int handle;
+    /*
+     * Whatever you require here. If the only file you are using is standard output using printf() for debugging,
+     * no file handling is required.
+     */
+};
+
+/* FILE is typedef in stdio.h. */
+#pragma weak __stdout
+FILE __stdout;
+FILE __stdin;
+
+#pragma weak fputc
+int fputc(int ch, FILE *f)
+{
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+
+    /* Send data. */
+    s_debugConsole.ops.tx_union.PutChar(s_debugConsole.base, (uint8_t *)(&ch), 1);
+    return 1;
+}
+
+#pragma weak fgetc
+int fgetc(FILE *f)
+{
+    char ch;
+    /* Do nothing if the debug UART is not initialized. */
+    if (s_debugConsole.type == DEBUG_CONSOLE_DEVICE_TYPE_NONE)
+    {
+        return -1;
+    }
+
+    /* Receive data. */
+    s_debugConsole.ops.rx_union.GetChar(s_debugConsole.base, (uint8_t *)(&ch), 1);
+    return ch;
+}
+#endif /* __ICCARM__ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_debug_console.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_debug_console.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Debug console shall provide input and output functions to scan and print formatted data.
+ * o Support a format specifier for PRINTF follows this prototype "%[flags][width][.precision][length]specifier"
+ *   - [flags] :'-', '+', '#', ' ', '0'
+ *   - [width]:  number (0,1...)
+ *   - [.precision]: number (0,1...)
+ *   - [length]: do not support
+ *   - [specifier]: 'd', 'i', 'f', 'F', 'x', 'X', 'o', 'p', 'u', 'c', 's', 'n'
+ * o Support a format specifier for SCANF follows this prototype " %[*][width][length]specifier"
+ *   - [*]: is supported.
+ *   - [width]: number (0,1...)
+ *   - [length]: 'h', 'hh', 'l','ll','L'. ignore ('j','z','t')
+ *   - [specifier]: 'd', 'i', 'u', 'f', 'F', 'e', 'E', 'g', 'G', 'a', 'A', 'o', 'c', 's'
+ */
+
+#ifndef _FSL_DEBUGCONSOLE_H_
+#define _FSL_DEBUGCONSOLE_H_
+
+#include "fsl_common.h"
+
+/*
+ * @addtogroup debug_console
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief Definition to select sdk or toolchain printf, scanf. */
+#ifndef SDK_DEBUGCONSOLE
+#define SDK_DEBUGCONSOLE 1U
+#endif
+
+/*! @brief Definition to printf float number. */
+#ifndef PRINTF_FLOAT_ENABLE
+#define PRINTF_FLOAT_ENABLE 1U
+#endif /* PRINTF_FLOAT_ENABLE */
+
+/*! @brief Definition to scanf float number. */
+#ifndef SCANF_FLOAT_ENABLE
+#define SCANF_FLOAT_ENABLE 1U
+#endif /* SCANF_FLOAT_ENABLE */
+
+/*! @brief Definition to support advanced format specifier for printf. */
+#ifndef PRINTF_ADVANCED_ENABLE
+#define PRINTF_ADVANCED_ENABLE 1U
+#endif /* PRINTF_ADVANCED_ENABLE */
+
+/*! @brief Definition to support advanced format specifier for scanf. */
+#ifndef SCANF_ADVANCED_ENABLE
+#define SCANF_ADVANCED_ENABLE 1U
+#endif /* SCANF_ADVANCED_ENABLE */
+
+#if SDK_DEBUGCONSOLE /* Select printf, scanf, putchar, getchar of SDK version. */
+#define PRINTF DbgConsole_Printf
+#define SCANF DbgConsole_Scanf
+#define PUTCHAR DbgConsole_Putchar
+#define GETCHAR DbgConsole_Getchar
+#else /* Select printf, scanf, putchar, getchar of toolchain. */
+#define PRINTF printf
+#define SCANF scanf
+#define PUTCHAR putchar
+#define GETCHAR getchar
+#endif /* SDK_DEBUGCONSOLE */
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*! @name Initialization*/
+/* @{ */
+
+/*!
+ * @brief Initialize the the peripheral used for debug messages.
+ *
+ * Call this function to enable debug log messages to be output via the specified peripheral,
+ * frequency of peripheral source clock, base address at the specified baud rate.
+ * After this function has returned, stdout and stdin will be connected to the selected peripheral.
+ *
+ * @param baseAddr      Which address of peripheral is used to send debug messages.
+ * @param baudRate      The desired baud rate in bits per second.
+ * @param device        Low level device type for the debug console, could be one of:
+ *                      @arg DEBUG_CONSOLE_DEVICE_TYPE_UART,
+ *                      @arg DEBUG_CONSOLE_DEVICE_TYPE_LPUART,
+ *                      @arg DEBUG_CONSOLE_DEVICE_TYPE_LPSCI,
+ *                      @arg DEBUG_CONSOLE_DEVICE_TYPE_USBCDC.
+ * @param clkSrcFreq    Frequency of peripheral source clock.
+ *
+ * @return              Whether initialization was successful or not.
+ * @retval kStatus_Success          Execution successfully
+ * @retval kStatus_Fail             Execution failure
+ * @retval kStatus_InvalidArgument  Invalid argument existed
+ */
+status_t DbgConsole_Init(uint32_t baseAddr, uint32_t baudRate, uint8_t device, uint32_t clkSrcFreq);
+
+/*!
+ * @brief De-initialize the peripheral used for debug messages.
+ *
+ * Call this function to disable debug log messages to be output via the specified peripheral
+ * base address and at the specified baud rate.
+ *
+ * @return Whether de-initialization was successful or not.
+ */
+status_t DbgConsole_Deinit(void);
+
+#if SDK_DEBUGCONSOLE
+/*!
+ * @brief Writes formatted output to the standard output stream.
+ *
+ * Call this function to Writes formatted output to the standard output stream.
+ *
+ * @param   fmt_s Format control string.
+ * @return  Returns the number of characters printed, or a negative value if an error occurs.
+ */
+int DbgConsole_Printf(char *fmt_s, ...);
+
+/*!
+ * @brief Writes a character to stdout.
+ *
+ * Call this function to write a character to stdout.
+ *
+ * @param   ch Character to be written.
+ * @return  Returns the character written.
+ */
+int DbgConsole_Putchar(int ch);
+
+/*!
+ * @brief Reads formatted data from the standard input stream.
+ *
+ * Call this function to read formatted data from the standard input stream.
+ *
+ * @param   fmt_ptr Format control string.
+ * @return  Returns the number of fields successfully converted and assigned.
+ */
+int DbgConsole_Scanf(char *fmt_ptr, ...);
+
+/*!
+ * @brief Reads a character from standard input.
+ *
+ * Call this function to read a character from standard input.
+ *
+ * @return Returns the character read.
+ */
+int DbgConsole_Getchar(void);
+
+#endif /* SDK_DEBUGCONSOLE */
+
+/*! @} */
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @} */
+
+#endif /* _FSL_DEBUGCONSOLE_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_notifier.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_notifier.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_notifier.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+status_t NOTIFIER_CreateHandle(notifier_handle_t *notifierHandle,
+                               notifier_user_config_t **configs,
+                               uint8_t configsNumber,
+                               notifier_callback_config_t *callbacks,
+                               uint8_t callbacksNumber,
+                               notifier_user_function_t userFunction,
+                               void *userData)
+{
+    /* Check input parameter - at least one configuration is required and userFunction must exist */
+    if ((configs == NULL) || (configsNumber == 0U) || (userFunction == NULL))
+    {
+        return kStatus_Fail;
+    }
+    /* Initialize handle structure */
+    memset(notifierHandle, 0, sizeof(notifier_handle_t));
+    /* Store references to user-defined configurations */
+    notifierHandle->configsTable = configs;
+    notifierHandle->configsNumber = configsNumber;
+    /* Store references to user-defined callback configurations */
+    if (callbacks != NULL)
+    {
+        notifierHandle->callbacksTable = callbacks;
+        notifierHandle->callbacksNumber = callbacksNumber;
+        /* If all callbacks return success, then the errorCallbackIndex is callbacksNumber */
+        notifierHandle->errorCallbackIndex = callbacksNumber;
+    }
+    notifierHandle->userFunction = userFunction;
+    notifierHandle->userData = userData;
+
+    return kStatus_Success;
+}
+
+status_t NOTIFIER_SwitchConfig(notifier_handle_t *notifierHandle, uint8_t configIndex, notifier_policy_t policy)
+{
+    uint8_t currentStaticCallback = 0U;    /* Index to array of statically registered call-backs */
+    status_t returnCode = kStatus_Success; /* Function return */
+
+    notifier_notification_block_t notifyBlock;  /*  Callback notification block */
+    notifier_callback_config_t *callbackConfig; /* Pointer to callback configuration */
+
+    /* Set errorcallbackindex as callbacksNumber, which means no callback error now */
+    notifierHandle->errorCallbackIndex = notifierHandle->callbacksNumber;
+
+    /* Requested configuration availability check */
+    if (configIndex >= notifierHandle->configsNumber)
+    {
+        return kStatus_OutOfRange;
+    }
+
+    /* Initialization of local variables from the Notifier handle structure */
+
+    notifyBlock.policy = policy;
+    notifyBlock.targetConfig = notifierHandle->configsTable[configIndex];
+    notifyBlock.notifyType = kNOTIFIER_NotifyBefore;
+
+    /* From all statically registered call-backs... */
+    for (currentStaticCallback = 0U; currentStaticCallback < notifierHandle->callbacksNumber; currentStaticCallback++)
+    {
+        callbackConfig = &(notifierHandle->callbacksTable[currentStaticCallback]);
+        /* ...notify only those which asked to be called before the configuration switch */
+        if (((uint32_t)callbackConfig->callbackType) & kNOTIFIER_CallbackBefore)
+        {
+            /* In case that call-back returned error code mark it, store the call-back handle and eventually cancel
+            * the configuration switch */
+            if (callbackConfig->callback(&notifyBlock, callbackConfig->callbackData) != kStatus_Success)
+            {
+                returnCode = kStatus_NOTIFIER_ErrorNotificationBefore;
+                notifierHandle->errorCallbackIndex = currentStaticCallback;
+                /* If not forcing configuration switch, call all already notified call-backs to revert their state
+                * as the switch is canceled */
+                if (policy != kNOTIFIER_PolicyForcible)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set configuration */
+
+    /* In case that any call-back returned error code and  policy doesn't force the configuration set, go to after
+     * switch call-backs */
+    if ((policy == kNOTIFIER_PolicyForcible) || (returnCode == kStatus_Success))
+    {
+        returnCode = notifierHandle->userFunction(notifierHandle->configsTable[configIndex], notifierHandle->userData);
+        if (returnCode != kStatus_Success)
+        {
+            return returnCode;
+        }
+        /* Update current configuration index */
+        notifierHandle->currentConfigIndex = configIndex;
+        notifyBlock.notifyType = kNOTIFIER_NotifyAfter;
+        /* From all statically registered call-backs... */
+        for (currentStaticCallback = 0U; currentStaticCallback < notifierHandle->callbacksNumber;
+             currentStaticCallback++)
+        {
+            callbackConfig = &(notifierHandle->callbacksTable[currentStaticCallback]);
+            /* ...notify only those which asked to be called after the configruation switch */
+            if (((uint32_t)callbackConfig->callbackType) & kNOTIFIER_CallbackAfter)
+            {
+                /* In case that call-back returned error code mark it and store the call-back handle */
+                if (callbackConfig->callback(&notifyBlock, callbackConfig->callbackData) != kStatus_Success)
+                {
+                    returnCode = kStatus_NOTIFIER_ErrorNotificationAfter;
+                    notifierHandle->errorCallbackIndex = currentStaticCallback;
+                    if (policy != kNOTIFIER_PolicyForcible)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        /* End of unsuccessful switch */
+        notifyBlock.notifyType = kNOTIFIER_NotifyRecover;
+        while (currentStaticCallback--)
+        {
+            callbackConfig = &(notifierHandle->callbacksTable[currentStaticCallback]);
+            if (((uint32_t)callbackConfig->callbackType) & kNOTIFIER_CallbackBefore)
+            {
+                callbackConfig->callback(&notifyBlock, callbackConfig->callbackData);
+            }
+        }
+    }
+
+    return returnCode;
+}
+
+uint8_t NOTIFIER_GetErrorCallbackIndex(notifier_handle_t *notifierHandle)
+{
+    return notifierHandle->errorCallbackIndex;
+}

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_notifier.h
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_notifier.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _FSL_NOTIFIER_H_
+#define _FSL_NOTIFIER_H_
+
+#include "fsl_common.h"
+/*!
+ * @addtogroup notifier
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*!
+ * @brief Notifier error codes.
+ *
+ * Used as return value of Notifier functions.
+ */
+enum _notifier_status
+{
+    kStatus_NOTIFIER_ErrorNotificationBefore =
+        MAKE_STATUS(kStatusGroup_NOTIFIER, 0), /*!< Error occurs during send "BEFORE" notification. */
+    kStatus_NOTIFIER_ErrorNotificationAfter =
+        MAKE_STATUS(kStatusGroup_NOTIFIER, 1), /*!< Error occurs during send "AFTER" notification. */
+};
+
+/*!
+ * @brief Notifier policies.
+ *
+ * Defines whether user function execution is forced or not.
+ * For kNOTIFIER_PolicyForcible, the user function is executed regardless of the callback results,
+ * while kNOTIFIER_PolicyAgreement policy is used to exit NOTIFIER_SwitchConfig()
+ * when any of the callbacks returns error code.
+ * See also NOTIFIER_SwitchConfig() description.
+ */
+typedef enum _notifier_policy
+{
+    kNOTIFIER_PolicyAgreement, /*!< NOTIFIER_SwitchConfig() method is exited when any of the callbacks returns error
+                                      code. */
+    kNOTIFIER_PolicyForcible,  /*!< user function is executed regardless of the results. */
+} notifier_policy_t;
+
+/*! @brief Notification type. Used to notify registered callbacks */
+typedef enum _notifier_notification_type
+{
+    kNOTIFIER_NotifyRecover = 0x00U, /*!< Notify IP to recover to previous work state. */
+    kNOTIFIER_NotifyBefore = 0x01U,  /*!< Notify IP that configuration setting is going to change. */
+    kNOTIFIER_NotifyAfter = 0x02U,   /*!< Notify IP that configuration setting has been changed. */
+} notifier_notification_type_t;
+
+/*!
+ * @brief The callback type, indicates what kinds of notification the callback handles.
+ *
+ * Used in the callback configuration structure (notifier_callback_config_t)
+ * to specify when the registered callback is called during configuration switch initiated by
+ * NOTIFIER_SwitchConfig().
+ * Callback can be invoked in following situations:
+ *  - before the configuration switch (Callback return value can affect NOTIFIER_SwitchConfig()
+ *    execution. Refer to the NOTIFIER_SwitchConfig() and notifier_policy_t documentation).
+ *  - after unsuccessful attempt to switch configuration
+ *  - after sucecessful configuration switch
+ */
+typedef enum _notifier_callback_type
+{
+    kNOTIFIER_CallbackBefore = 0x01U,      /*!< Callback handles BEFORE notification. */
+    kNOTIFIER_CallbackAfter = 0x02U,       /*!< Callback handles AFTER notification. */
+    kNOTIFIER_CallbackBeforeAfter = 0x03U, /*!< Callback handles BEFORE and AFTER notification. */
+} notifier_callback_type_t;
+
+/*! @brief notifier user configuration type.
+ *
+ * Reference of user defined configuration is stored in an array, notifer switch between these configurations
+ * based on this array.
+ */
+typedef void notifier_user_config_t;
+
+/*! @brief notifier user function prototype
+ * User can use this function to execute specific operations in configuration switch.
+ * Before and after this function execution, different notification will be sent to registered callbacks.
+ * If this function returns any error code, NOTIFIER_SwitchConfig() will exit.
+ *
+ * @param targetConfig target Configuration.
+ * @param userData Refers to other specific data passed to user function.
+ * @return An error code or kStatus_Success.
+ */
+typedef status_t (*notifier_user_function_t)(notifier_user_config_t *targetConfig, void *userData);
+
+/*! @brief notification block passed to the registered callback function. */
+typedef struct _notifier_notification_block
+{
+    notifier_user_config_t *targetConfig;    /*!< Pointer to target configuration. */
+    notifier_policy_t policy;                /*!< Configure transition policy. */
+    notifier_notification_type_t notifyType; /*!< Configure notification type. */
+} notifier_notification_block_t;
+
+/*!
+ * @brief Callback prototype.
+ *
+ * Declaration of callback. It is common for registered callbacks.
+ * Reference to function of this type is part of notifier_callback_config_t callback configuration structure.
+ * Depending on callback type, function of this prototype is called (see NOTIFIER_SwitchConfig())
+ * before configuration switch, after it or in both cases to notify about
+ * the switch progress (see notifier_callback_type_t). When called, type of the notification
+ * is passed as parameter along with reference to the target configuration structure (see notifier_notification_block_t)
+ * and any data passed during the callback registration.
+ * When notified before configuration switch, depending on the configuration switch policy (see
+ * notifier_policy_t) the callback may deny the execution of user function by returning any error code different
+ * from kStatus_Success (see NOTIFIER_SwitchConfig()).
+ *
+ * @param notify Notification block.
+ * @param data Callback data. Refers to the data passed during callback registration. Intended to
+ *  pass any driver or application data such as internal state information.
+ * @return An error code or kStatus_Success.
+ */
+typedef status_t (*notifier_callback_t)(notifier_notification_block_t *notify, void *data);
+
+/*!
+ * @brief callback configuration structure
+ *
+ * This structure holds configuration of callbacks.
+ * Callbacks of this type are expected to be statically allocated.
+ * This structure contains following application-defined data:
+ *  callback - pointer to the callback function
+ *  callbackType - specifies when the callback is called
+ *  callbackData - pointer to the data passed to the callback.
+ */
+typedef struct _notifier_callback_config
+{
+    notifier_callback_t callback;          /*!< Pointer to the callback function. */
+    notifier_callback_type_t callbackType; /*!< Callback type. */
+    void *callbackData;                    /*!< Pointer to the data passed to the callback. */
+} notifier_callback_config_t;
+
+/*!
+ * @brief Notifier handle structure.
+ *
+ * Notifier handle structure. Contains data necessary for Notifier proper function.
+ * Stores references to registered configurations, callbacks, information about their numbers,
+ * user function, user data and other internal data.
+ * NOTIFIER_CreateHandle() must be called to intialize this handle.
+ */
+typedef struct _notifier_handle
+{
+    notifier_user_config_t **configsTable;      /*!< Pointer to configure table. */
+    uint8_t configsNumber;                      /*!< Number of configurations. */
+    notifier_callback_config_t *callbacksTable; /*!< Pointer to callback table. */
+    uint8_t callbacksNumber;                    /*!< Maximum number of callback configurations. */
+    uint8_t errorCallbackIndex;                 /*!< Index of callback returns error. */
+    uint8_t currentConfigIndex;                 /*!< Index of current configuration.  */
+    notifier_user_function_t userFunction;      /*!< user function. */
+    void *userData;                             /*!< user data passed to user function. */
+} notifier_handle_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @brief Create Notifier handle.
+ *
+ * @param notifierHandle A pointer to notifier handle
+ * @param configs A pointer to an array with references to all configurations which is handled by the Notifier.
+ * @param configsNumber Number of configurations. Size of configs array.
+ * @param callbacks A pointer to an array of callback configurations.
+ *  If there are no callbacks to register during Notifier initialization, use NULL value.
+ * @param callbacksNumber Number of registered callbacks. Size of callbacks array.
+ * @param userFunction user function.
+ * @param userData user data passed to user function.
+ * @return An error code or kStatus_Success.
+ */
+status_t NOTIFIER_CreateHandle(notifier_handle_t *notifierHandle,
+                               notifier_user_config_t **configs,
+                               uint8_t configsNumber,
+                               notifier_callback_config_t *callbacks,
+                               uint8_t callbacksNumber,
+                               notifier_user_function_t userFunction,
+                               void *userData);
+
+/*!
+ * @brief Switch configuration according to a pre-defined structure.
+ *
+ * This function sets the system to the target configuration. Before transition,
+ * the Notifier sends notifications to all callbacks registered to the callback table.
+ * Callbacks are invoked in the following order: All registered callbacks are notified
+ * ordered by index in the callbacks array. The same order is used for before and after switch notifications.
+ * The notifications before the configuration switch can be used to obtain confirmation about
+ * the change from registered callbacks. If any registered callback denies the
+ * configuration change, further execution of this function depends on the notifier policy: the
+ * configuration change is either forced (kNOTIFIER_PolicyForcible) or exited (kNOTIFIER_PolicyAgreement).
+ * When configuration change is forced, the result of the before switch notifications are ignored. If
+ * agreement is required, if any callback returns an error code then further notifications
+ * before switch notifications are cancelled and all already notified callbacks are re-invoked
+ * The index of the callback which returned error code during pre-switch notifications is stored
+ * (any error codes during callbacks re-invocation are ignored) and NOTIFIER_GetErrorCallback() can be used to get it.
+ * Regardless of the policies, if any callback returned an error code, an error code denoting in which phase
+ * the error occurred is returned when NOTIFIER_SwitchConfig() exits.
+ * @param notifierHandle pointer to notifier handle
+ * @param configIndex Index of the target configuration.
+ * @param policy            Transaction policy, kNOTIFIER_PolicyAgreement or kNOTIFIER_PolicyForcible.
+ *
+ * @return An error code or kStatus_Success.
+ *
+ */
+status_t NOTIFIER_SwitchConfig(notifier_handle_t *notifierHandle, uint8_t configIndex, notifier_policy_t policy);
+
+/*!
+ * @brief This function returns the last failed notification callback.
+ *
+ * This function returns index of the last callback that failed during the configuration switch while
+ * the last NOTIFIER_SwitchConfig() was called. If the last NOTIFIER_SwitchConfig() call ended successfully
+ * value equal to callbacks number is returned. Returned value represents index in the array of
+ * static call-backs.
+ *
+ * @param notifierHandle pointer to notifier handle
+ * @return Callback index of last failed callback or value equal to callbacks count.
+ */
+uint8_t NOTIFIER_GetErrorCallbackIndex(notifier_handle_t *notifierHandle);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_NOTIFIER_H_ */

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_sbrk.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/utilities/fsl_sbrk.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#if defined(__GNUC__)
+#include <stdio.h>
+#include <errno.h>
+#endif
+
+#if defined(__GNUC__)
+/*!
+ * @brief Function to override ARMGCC default function _sbrk
+ *
+ * _sbrk is called by malloc. ARMGCC default _sbrk compares "SP" register and
+ * heap end, if heap end is larger than "SP", then _sbrk returns error and
+ * memory allocation failed. This function changes to compare __HeapLimit with
+ * heap end.
+ */
+caddr_t _sbrk(int incr)
+{
+    extern char end __asm("end");
+    extern char heap_limit __asm("__HeapLimit");
+    static char *heap_end;
+    char *prev_heap_end;
+
+    if (heap_end == NULL)
+        heap_end = &end;
+
+    prev_heap_end = heap_end;
+
+    if (heap_end + incr > &heap_limit)
+    {
+        errno = ENOMEM;
+        return (caddr_t)-1;
+    }
+
+    heap_end += incr;
+
+    return (caddr_t)prev_heap_end;
+}
+#endif


### PR DESCRIPTION
This patch series adds the HAL layers (and KSDK files) to support the NXP FRDM-K64F board:
- Cortex M4
- 1MB NAND flash
- 384kB RAM

At Linaro Connect we were using this board as test hardware with the MyNewt bootloader and various other RTOS user apps which were signed and pushed via OTA.

NOTES:
- I tested the board using the boot and slinky apps.  Both were built normally and the boot app can be flashed with newt load <name>, however the slinky app should be signed via zep2newt prior to flashing as any non-bootloader application needs the 20 byte header.
- UART only supports TX currently.  RX needs debugging.
- UART0 is initialized earlier in the uart_hal_init function using the SDK's DebugConsole routines which allow for printf debugging.  The other UARTs are initialized normally.
- no I2C HAL
- no SPI HAL
- no timer HAL