### PR TITLE
gattc: Fix unnecessary status overwrite in read by type err

### DIFF
--- a/net/nimble/host/src/ble_gattc.c
+++ b/net/nimble/host/src/ble_gattc.c
@@ -3108,10 +3108,6 @@ ble_gattc_read_uuid_err(struct ble_gattc_proc *proc, int status,
 {
     ble_gattc_dbg_assert_proc_not_inserted(proc);
 
-    if (status == BLE_HS_ATT_ERR(BLE_ATT_ERR_ATTR_NOT_FOUND)) {
-        /* Read is complete. */
-        status = 0;
-    }
     ble_gattc_read_uuid_cb(proc, status, att_handle, NULL);
 }
 


### PR DESCRIPTION
This status change is not needed. With this patch it is possible to pass TC_GAR_CL_BI_07_C.