### PR TITLE
bletiny: fix passing correct handle to gattc disc all dscs

### DIFF
--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -1166,12 +1166,12 @@ bletiny_disc_svc_by_uuid(uint16_t conn_handle, uint8_t *uuid128)
 }
 
 int
-bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t chr_def_handle,
-                      uint16_t chr_end_handle)
+bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+                      uint16_t end_handle)
 {
     int rc;
 
-    rc = ble_gattc_disc_all_dscs(conn_handle, chr_def_handle, chr_end_handle,
+    rc = ble_gattc_disc_all_dscs(conn_handle, start_handle - 1, end_handle,
                                  bletiny_on_disc_d, NULL);
     return rc;
 }


### PR DESCRIPTION
When passing start handle, the search starts from handle+1,
because ble_gattc_disc_all_dscs uses chr_val as first parameter.
So we assume that chr_val=handle-1.

With this patch it is possible to pass TC_GAD_CL_BV_06_C.