### PR TITLE
First pass at LSM303DLHC sensor driver

### DIFF
--- a/hw/drivers/sensors/lsm303dlhc/include/lsm303dlhc/lsm303dlhc.h
+++ b/hw/drivers/sensors/lsm303dlhc/include/lsm303dlhc/lsm303dlhc.h
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SENSOR_LSM303DLHC_H__
+#define __SENSOR_LSM303DLHC_H__
+
+#include "os/os.h"
+#include "os/os_dev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum lsm303dlhc_accel_range {
+    LSM303DLHC_ACCEL_RANGE_2            = 0x00 << 4, /* +/- 2g  */
+    LSM303DLHC_ACCEL_RANGE_4            = 0x01 << 4, /* +/- 4g  */
+    LSM303DLHC_ACCEL_RANGE_8            = 0x02 << 4, /* +/- 8g  */
+    LSM303DLHC_ACCEL_RANGE_16           = 0x03 << 4, /* +/- 16g */
+};
+
+enum lsm303dlhc_accel_rate {
+    LSM303DLHC_ACCEL_RATE_POWER_DOWN    = 0x00 << 4,
+    LSM303DLHC_ACCEL_RATE_1             = 0x01 << 4,
+    LSM303DLHC_ACCEL_RATE_10            = 0x02 << 4,
+    LSM303DLHC_ACCEL_RATE_25            = 0x03 << 4,
+    LSM303DLHC_ACCEL_RATE_50            = 0x04 << 4,
+    LSM303DLHC_ACCEL_RATE_100           = 0x05 << 4,
+    LSM303DLHC_ACCEL_RATE_200           = 0x06 << 4,
+    LSM303DLHC_ACCEL_RATE_400           = 0x07 << 4,
+    LSM303DLHC_ACCEL_RATE_1620          = 0x08 << 4
+};
+
+enum lsm303dlhc_mag_gain {
+    LSM303DLHC_MAG_GAIN_1_3             = 0x20 << 5, /* +/- 1.3 gauss */
+    LSM303DLHC_MAG_GAIN_1_9             = 0x40 << 5, /* +/- 1.9 gauss */
+    LSM303DLHC_MAG_GAIN_2_5             = 0x60 << 5, /* +/- 2.5 gauss */
+    LSM303DLHC_MAG_GAIN_4_0             = 0x80 << 5, /* +/- 4.0 gauss */
+    LSM303DLHC_MAG_GAIN_4_7             = 0xA0 << 5, /* +/- 4.7 gauss */
+    LSM303DLHC_MAG_GAIN_5_6             = 0xC0 << 5, /* +/- 5.6 gauss */
+    LSM303DLHC_MAG_GAIN_8_1             = 0xE0 << 5  /* +/- 8.1 gauss */
+};
+
+enum lsm303dlhc_mag_rate {
+    LSM303DLHC_MAG_RATE_0_7             = 0x00 << 2,  /* 0.75 Hz */
+    LSM303DLHC_MAG_RATE_1_5             = 0x01 << 2,  /* 1.5 Hz  */
+    LSM303DLHC_MAG_RATE_3_0             = 0x02 << 2,  /* 3.0 Hz  */
+    LSM303DLHC_MAG_RATE_7_5             = 0x03 << 2,  /* 7.5 Hz  */
+    LSM303DLHC_MAG_RATE_15              = 0x04 << 2,  /* 15 Hz   */
+    LSM303DLHC_MAG_RATE_30              = 0x05 << 2,  /* 30 Hz   */
+    LSM303DLHC_MAG_RATE_75              = 0x06 << 2,  /* 75 Hz   */
+    LSM303DLHC_MAG_RATE_220             = 0x07 << 2   /* 220 Hz  */
+};
+
+struct lsm303dlhc_cfg {
+    enum lsm303dlhc_accel_range accel_range;
+    enum lsm303dlhc_accel_rate accel_rate;
+    uint16_t sample_itvl;
+};
+
+struct lsm303dlhc {
+    struct os_dev dev;
+    struct sensor sensor;
+    struct lsm303dlhc_cfg cfg;
+    os_time_t last_read_time;
+};
+
+int lsm303dlhc_init(struct os_dev *, void *);
+int lsm303dlhc_config(struct lsm303dlhc *, struct lsm303dlhc_cfg *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SENSOR_LSM303DLHC_H__ */

--- a/hw/drivers/sensors/lsm303dlhc/pkg.yml
+++ b/hw/drivers/sensors/lsm303dlhc/pkg.yml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/sensors/lsm303dlhc
+pkg.description: Driver for the LSM303DLHC 3 axis accel/mag
+pkg.author: "Adafruit Industries"
+pkg.homepage: "http://www.adafruit.com"
+pkg.keywords:

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * resarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "defs/error.h"
+#include "os/os.h"
+#include "sysinit/sysinit.h"
+#include "hal/hal_i2c.h"
+#include "sensor/sensor.h"
+#include "sensor/accel.h"
+#include "lsm303dlhc/lsm303dlhc.h"
+#include "lsm303dlhc_priv.h"
+
+#if MYNEWT_VAL(LSM303DLHC_LOG)
+#include "log/log.h"
+#endif
+
+#if MYNEWT_VAL(LSM303DLHC_STATS)
+#include "stats/stats.h"
+#endif
+
+#if MYNEWT_VAL(LSM303DLHC_STATS)
+/* Define the stats section and records */
+STATS_SECT_START(lsm303dlhc_stat_section)
+    STATS_SECT_ENTRY(samples_acc_2g)
+    STATS_SECT_ENTRY(samples_acc_4g)
+    STATS_SECT_ENTRY(samples_acc_8g)
+    STATS_SECT_ENTRY(samples_acc_16g)
+    STATS_SECT_ENTRY(errors)
+STATS_SECT_END
+
+/* Define stat names for querying */
+STATS_NAME_START(lsm303dlhc_stat_section)
+    STATS_NAME(lsm303dlhc_stat_section, samples_acc_2g)
+    STATS_NAME(lsm303dlhc_stat_section, samples_acc_4g)
+    STATS_NAME(lsm303dlhc_stat_section, samples_acc_8g)
+    STATS_NAME(lsm303dlhc_stat_section, samples_acc_16g)
+    STATS_NAME(lsm303dlhc_stat_section, errors)
+STATS_NAME_END(lsm303dlhc_stat_section)
+
+/* Global variable used to hold stats data */
+STATS_SECT_DECL(lsm303dlhc_stat_section) g_lsm303dlhcstats;
+#endif
+
+#if MYNEWT_VAL(LSM303DLHC_LOG)
+#define LOG_MODULE_LSM303DLHC (303)
+#define LSM303DLHC_INFO(...)  LOG_INFO(&_log, LOG_MODULE_LSM303DLHC, __VA_ARGS__)
+#define LSM303DLHC_ERR(...)   LOG_ERROR(&_log, LOG_MODULE_LSM303DLHC, __VA_ARGS__)
+static struct log _log;
+#else
+#define LSM303DLHC_INFO(...)
+#define LSM303DLHC_ERR(...)
+#endif
+
+/* Exports for the sensor interface.
+ */
+static void *lsm303dlhc_sensor_get_interface(struct sensor *, sensor_type_t);
+static int lsm303dlhc_sensor_read(struct sensor *, sensor_type_t,
+        sensor_data_func_t, void *, uint32_t);
+static int lsm303dlhc_sensor_get_config(struct sensor *, sensor_type_t,
+        struct sensor_cfg *);
+
+static const struct sensor_driver g_lsm303dlhc_sensor_driver = {
+    lsm303dlhc_sensor_get_interface,
+    lsm303dlhc_sensor_read,
+    lsm303dlhc_sensor_get_config
+};
+
+/**
+ * Writes a single byte to the specified register
+ *
+ * @param The I2C address to use
+ * @param The register address to write to
+ * @param The value to write
+ *
+ * @return 0 on success, non-zero error on failure.
+ */
+int
+lsm303dlhc_write8(uint8_t addr, uint8_t reg, uint32_t value)
+{
+    int rc;
+    uint8_t payload[2] = { reg, value & 0xFF };
+
+    struct hal_i2c_master_data data_struct = {
+        .address = addr,
+        .len = 2,
+        .buffer = payload
+    };
+
+    rc = hal_i2c_master_write(MYNEWT_VAL(LSM303DLHC_I2CBUS), &data_struct,
+                              OS_TICKS_PER_SEC / 10, 1);
+    if (rc) {
+        LSM303DLHC_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
+                       addr, reg, value);
+        #if MYNEWT_VAL(LSM303DLHC_STATS)
+        STATS_INC(g_lsm303dlhcstats, errors);
+        #endif
+    }
+
+    return rc;
+}
+
+/**
+ * Reads a single byte from the specified register
+ *
+ * @param The I2C address to use
+ * @param The register address to read from
+ * @param Pointer to where the register value should be written
+ *
+ * @return 0 on success, non-zero error on failure.
+ */
+int
+lsm303dlhc_read8(uint8_t addr, uint8_t reg, uint8_t *value)
+{
+    int rc;
+    uint8_t payload;
+
+    struct hal_i2c_master_data data_struct = {
+        .address = addr,
+        .len = 1,
+        .buffer = &payload
+    };
+
+    /* Register write */
+    payload = reg;
+    rc = hal_i2c_master_write(MYNEWT_VAL(LSM303DLHC_I2CBUS), &data_struct,
+                              OS_TICKS_PER_SEC / 10, 1);
+    if (rc) {
+        LSM303DLHC_ERR("I2C access failed at address 0x%02X\n", addr);
+        #if MYNEWT_VAL(LSM303DLHC_STATS)
+        STATS_INC(g_lsm303dlhcstats, errors);
+        #endif
+        goto error;
+    }
+
+    /* Read one byte back */
+    payload = 0;
+    rc = hal_i2c_master_read(MYNEWT_VAL(LSM303DLHC_I2CBUS), &data_struct,
+                             OS_TICKS_PER_SEC / 10, 1);
+    *value = payload;
+    if (rc) {
+        LSM303DLHC_ERR("Failed to read from 0x%02X:0x%02X\n", addr, reg);
+        #if MYNEWT_VAL(LSM303DLHC_STATS)
+        STATS_INC(g_lsm303dlhcstats, errors);
+        #endif
+    }
+
+error:
+    return rc;
+}
+
+int
+lsm303dlhc_read48(uint8_t addr, uint8_t reg, int16_t *x, int16_t*y, int16_t *z)
+{
+    int rc;
+    uint8_t payload[7] = { reg | 0x80, 0, 0, 0, 0, 0, 0 };
+
+    struct hal_i2c_master_data data_struct = {
+        .address = addr,
+        .len = 1,
+        .buffer = payload
+    };
+
+    /* Register write */
+    rc = hal_i2c_master_write(MYNEWT_VAL(LSM303DLHC_I2CBUS), &data_struct,
+                              OS_TICKS_PER_SEC / 10, 1);
+    if (rc) {
+        LSM303DLHC_ERR("I2C access failed at address 0x%02X\n", addr);
+        #if MYNEWT_VAL(LSM303DLHC_STATS)
+        STATS_INC(g_lsm303dlhcstats, errors);
+        #endif
+        goto error;
+    }
+
+    /* Read six bytes back */
+    memset(payload, 0, sizeof(payload));
+    data_struct.len = 6;
+    rc = hal_i2c_master_read(MYNEWT_VAL(LSM303DLHC_I2CBUS), &data_struct,
+                             OS_TICKS_PER_SEC / 10, 1);
+
+    /* Shift 12-bit left-aligned accel values into 16-bit int */
+    *x = ((int16_t)(payload[0] | (payload[1] << 8))) >> 4;
+    *y = ((int16_t)(payload[2] | (payload[3] << 8))) >> 4;
+    *z = ((int16_t)(payload[4] | (payload[5] << 8))) >> 4;
+
+    if (rc) {
+        LSM303DLHC_ERR("Failed to read from 0x%02X:0x%02X\n", addr, reg);
+        #if MYNEWT_VAL(LSM303DLHC_STATS)
+        STATS_INC(g_lsm303dlhcstats, errors);
+        #endif
+        goto error;
+    }
+
+    /* ToDo: Log raw reads */
+    // console_printf("0x%04X\n", (uint16_t)payload[0] | ((uint16_t)payload[1] << 8));
+
+error:
+    return rc;
+}
+
+/**
+ * Expects to be called back through os_dev_create().
+ *
+ * @param The device object associated with this accellerometer
+ * @param Argument passed to OS device init, unused
+ *
+ * @return 0 on success, non-zero error on failure.
+ */
+int
+lsm303dlhc_init(struct os_dev *dev, void *arg)
+{
+    struct lsm303dlhc *lsm;
+    struct sensor *sensor;
+    int rc;
+
+    lsm = (struct lsm303dlhc *) dev;
+
+    #if MYNEWT_VAL(LSM303DLHC_LOG)
+    log_register("lsm303dlhc", &_log, &log_console_handler, NULL, LOG_SYSLEVEL);
+    #endif
+
+    sensor = &lsm->sensor;
+
+    #if MYNEWT_VAL(LSM303DLHC_STATS)
+    /* Initialise the stats entry */
+    rc = stats_init(
+        STATS_HDR(g_lsm303dlhcstats),
+        STATS_SIZE_INIT_PARMS(g_lsm303dlhcstats, STATS_SIZE_32),
+        STATS_NAME_INIT_PARMS(lsm303dlhc_stat_section));
+    SYSINIT_PANIC_ASSERT(rc == 0);
+    /* Register the entry with the stats registry */
+    rc = stats_register("lsm303dlhc", STATS_HDR(g_lsm303dlhcstats));
+    SYSINIT_PANIC_ASSERT(rc == 0);
+    #endif
+
+    rc = sensor_init(sensor, dev);
+    if (rc != 0) {
+        goto err;
+    }
+
+    rc = sensor_set_driver(sensor, SENSOR_TYPE_ACCELEROMETER,
+            (struct sensor_driver *) &g_lsm303dlhc_sensor_driver);
+    if (rc != 0) {
+        goto err;
+    }
+
+    rc = sensor_mgr_register(sensor);
+    if (rc != 0) {
+        goto err;
+    }
+
+    return (0);
+err:
+    return (rc);
+}
+
+int
+lsm303dlhc_config(struct lsm303dlhc *lsm, struct lsm303dlhc_cfg *cfg)
+{
+    int rc;
+
+    /* Overwrite the configuration associated with this generic accelleromter. */
+    memcpy(&lsm->cfg, cfg, sizeof(*cfg));
+
+    /* Set data rate (or power down) and enable XYZ output */
+    rc = lsm303dlhc_write8(LSM303DLHC_ADDR_ACCEL,
+        LSM303DLHC_REGISTER_ACCEL_CTRL_REG1_A,
+        lsm->cfg.accel_rate | 0x07);
+    if (rc != 0) {
+        goto err;
+    }
+
+    /* Set scale */
+    rc = lsm303dlhc_write8(LSM303DLHC_ADDR_ACCEL,
+        LSM303DLHC_REGISTER_ACCEL_CTRL_REG4_A,
+        lsm->cfg.accel_range);
+    if (rc != 0) {
+        goto err;
+    }
+
+err:
+    return (rc);
+}
+
+static void *
+lsm303dlhc_sensor_get_interface(struct sensor *sensor, sensor_type_t type)
+{
+    return (NULL);
+}
+
+static int
+lsm303dlhc_sensor_read(struct sensor *sensor, sensor_type_t type,
+        sensor_data_func_t data_func, void *data_arg, uint32_t timeout)
+{
+    struct lsm303dlhc *lsm;
+    struct sensor_accel_data sad;
+    int rc;
+    int16_t x, y, z;
+    float mg_lsb;
+
+    /* If the read isn't looking for accel data, then don't do anything. */
+    if (!(type & SENSOR_TYPE_ACCELEROMETER)) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    lsm = (struct lsm303dlhc *) SENSOR_GET_DEVICE(sensor);
+
+    x = y = z = 0;
+    lsm303dlhc_read48(LSM303DLHC_ADDR_ACCEL,
+                      LSM303DLHC_REGISTER_ACCEL_OUT_X_L_A,
+                      &x, &y, &z);
+
+    /* Determine mg per lsb based on range */
+    switch(lsm->cfg.accel_range) {
+        case LSM303DLHC_ACCEL_RANGE_2:
+            #if MYNEWT_VAL(LSM303DLHC_STATS)
+            STATS_INC(g_lsm303dlhcstats, samples_acc_2g);
+            #endif
+            mg_lsb = 0.001F;
+            break;
+        case LSM303DLHC_ACCEL_RANGE_4:
+            #if MYNEWT_VAL(LSM303DLHC_STATS)
+            STATS_INC(g_lsm303dlhcstats, samples_acc_4g);
+            #endif
+            mg_lsb = 0.002F;
+            break;
+        case LSM303DLHC_ACCEL_RANGE_8:
+            #if MYNEWT_VAL(LSM303DLHC_STATS)
+            STATS_INC(g_lsm303dlhcstats, samples_acc_8g);
+            #endif
+            mg_lsb = 0.004F;
+            break;
+        case LSM303DLHC_ACCEL_RANGE_16:
+            #if MYNEWT_VAL(LSM303DLHC_STATS)
+            STATS_INC(g_lsm303dlhcstats, samples_acc_16g);
+            #endif
+            mg_lsb = 0.012F;
+            break;
+        default:
+            LSM303DLHC_ERR("Unknown accel range: 0x%02X. Assuming +/-2G.\n",
+                lsm->cfg.accel_range);
+            mg_lsb = 0.001F;
+            break;
+    }
+
+    /* Convert from mg to Earth gravity in m/s^2 */
+    sad.sad_x = (float)x * mg_lsb * 9.80665F;
+    sad.sad_y = (float)y * mg_lsb * 9.80665F;
+    sad.sad_z = (float)z * mg_lsb * 9.80665F;
+
+    /* Call data function */
+    rc = data_func(sensor, data_arg, &sad);
+    if (rc != 0) {
+        goto err;
+    }
+
+    return (0);
+err:
+    return (rc);
+}
+
+static int
+lsm303dlhc_sensor_get_config(struct sensor *sensor, sensor_type_t type,
+        struct sensor_cfg *cfg)
+{
+    int rc;
+
+    if (type != SENSOR_TYPE_ACCELEROMETER) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    cfg->sc_valtype = SENSOR_VALUE_TYPE_FLOAT_TRIPLET;
+
+    return (0);
+err:
+    return (rc);
+}

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc_priv.h
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc_priv.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __LSM303DLHC_PRIV_H__
+#define __LSM303DLHC_PRIV_H__
+
+#define LSM303DLHC_ADDR_ACCEL                     (0x19) /* 0011001 */
+#define LSM303DLHC_ADDR_MAG                       (0x1E) /* 0011110 */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum lsm303dlhc_registers_accel {                         /* DEFAULT    TYPE */
+    LSM303DLHC_REGISTER_ACCEL_CTRL_REG1_A         = 0x20, /* 00000111   rw   */
+    LSM303DLHC_REGISTER_ACCEL_CTRL_REG2_A         = 0x21, /* 00000000   rw   */
+    LSM303DLHC_REGISTER_ACCEL_CTRL_REG3_A         = 0x22, /* 00000000   rw   */
+    LSM303DLHC_REGISTER_ACCEL_CTRL_REG4_A         = 0x23, /* 00000000   rw   */
+    LSM303DLHC_REGISTER_ACCEL_CTRL_REG5_A         = 0x24, /* 00000000   rw   */
+    LSM303DLHC_REGISTER_ACCEL_CTRL_REG6_A         = 0x25, /* 00000000   rw   */
+    LSM303DLHC_REGISTER_ACCEL_REFERENCE_A         = 0x26, /* 00000000   r    */
+    LSM303DLHC_REGISTER_ACCEL_STATUS_REG_A        = 0x27, /* 00000000   r    */
+    LSM303DLHC_REGISTER_ACCEL_OUT_X_L_A           = 0x28,
+    LSM303DLHC_REGISTER_ACCEL_OUT_X_H_A           = 0x29,
+    LSM303DLHC_REGISTER_ACCEL_OUT_Y_L_A           = 0x2A,
+    LSM303DLHC_REGISTER_ACCEL_OUT_Y_H_A           = 0x2B,
+    LSM303DLHC_REGISTER_ACCEL_OUT_Z_L_A           = 0x2C,
+    LSM303DLHC_REGISTER_ACCEL_OUT_Z_H_A           = 0x2D,
+    LSM303DLHC_REGISTER_ACCEL_FIFO_CTRL_REG_A     = 0x2E,
+    LSM303DLHC_REGISTER_ACCEL_FIFO_SRC_REG_A      = 0x2F,
+    LSM303DLHC_REGISTER_ACCEL_INT1_CFG_A          = 0x30,
+    LSM303DLHC_REGISTER_ACCEL_INT1_SOURCE_A       = 0x31,
+    LSM303DLHC_REGISTER_ACCEL_INT1_THS_A          = 0x32,
+    LSM303DLHC_REGISTER_ACCEL_INT1_DURATION_A     = 0x33,
+    LSM303DLHC_REGISTER_ACCEL_INT2_CFG_A          = 0x34,
+    LSM303DLHC_REGISTER_ACCEL_INT2_SOURCE_A       = 0x35,
+    LSM303DLHC_REGISTER_ACCEL_INT2_THS_A          = 0x36,
+    LSM303DLHC_REGISTER_ACCEL_INT2_DURATION_A     = 0x37,
+    LSM303DLHC_REGISTER_ACCEL_CLICK_CFG_A         = 0x38,
+    LSM303DLHC_REGISTER_ACCEL_CLICK_SRC_A         = 0x39,
+    LSM303DLHC_REGISTER_ACCEL_CLICK_THS_A         = 0x3A,
+    LSM303DLHC_REGISTER_ACCEL_TIME_LIMIT_A        = 0x3B,
+    LSM303DLHC_REGISTER_ACCEL_TIME_LATENCY_A      = 0x3C,
+    LSM303DLHC_REGISTER_ACCEL_TIME_WINDOW_A       = 0x3D
+};
+
+enum lsm303dlhc_registers_mag {
+    LSM303DLHC_REGISTER_MAG_CRA_REG_M             = 0x00,
+    LSM303DLHC_REGISTER_MAG_CRB_REG_M             = 0x01,
+    LSM303DLHC_REGISTER_MAG_MR_REG_M              = 0x02,
+    LSM303DLHC_REGISTER_MAG_OUT_X_H_M             = 0x03,
+    LSM303DLHC_REGISTER_MAG_OUT_X_L_M             = 0x04,
+    LSM303DLHC_REGISTER_MAG_OUT_Z_H_M             = 0x05,
+    LSM303DLHC_REGISTER_MAG_OUT_Z_L_M             = 0x06,
+    LSM303DLHC_REGISTER_MAG_OUT_Y_H_M             = 0x07,
+    LSM303DLHC_REGISTER_MAG_OUT_Y_L_M             = 0x08,
+    LSM303DLHC_REGISTER_MAG_SR_REG_Mg             = 0x09,
+    LSM303DLHC_REGISTER_MAG_IRA_REG_M             = 0x0A,
+    LSM303DLHC_REGISTER_MAG_IRB_REG_M             = 0x0B,
+    LSM303DLHC_REGISTER_MAG_IRC_REG_M             = 0x0C,
+    LSM303DLHC_REGISTER_MAG_TEMP_OUT_H_M          = 0x31,
+    LSM303DLHC_REGISTER_MAG_TEMP_OUT_L_M          = 0x32
+};
+
+int lsm303dlhc_write8(uint8_t addr, uint8_t reg, uint32_t value);
+int lsm303dlhc_read8(uint8_t addr, uint8_t reg, uint8_t *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LSM303DLHC_PRIV_H__ */

--- a/hw/drivers/sensors/lsm303dlhc/syscfg.yml
+++ b/hw/drivers/sensors/lsm303dlhc/syscfg.yml
@@ -1,0 +1,32 @@
+# The BSD License (BSD)
+#
+# Copyright (c) 2016 Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+syscfg.defs:
+    LSM303DLHC_I2CBUS:
+        description: 'I2C bus number for the LSM303DLHC'
+        value: -1
+    LSM303DLHC_LOG:
+        description: 'Enable LSM303DLHC logging'
+        value: 0
+    LSM303DLHC_STATS:
+        description: 'Enable LSM303DLHC statistics'
+        value: 0


### PR DESCRIPTION
This adds a first pass at an [LSM303DLHC](https://www.adafruit.com/product/1120) ([datasheet](http://www.st.com/content/ccc/resource/technical/document/datasheet/56/ec/ac/de/28/21/4d/48/DM00027543.pdf/files/DM00027543.pdf/jcr:content/translations/en.DM00027543.pdf)) driver using the new sensor API.

The current driver only includes support for reading from the accelerometer. The magnetometer and temperature sensor will be added in the future once the sensor API has stabilized a bit more.

## Initializing the Driver

You can initialize the driver with the following code in main (or elsewhere):

```
os_dev_create((struct os_dev *) &lsm303dlhc_sensor, "lsm303dlhc",
        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIMARY, lsm303dlhc_drvr_init, NULL);
```
...
```
static int
lsm303dlhc_drvr_init(struct os_dev *dev, void *arg)
{
    struct lsm303dlhc_cfg cfg;
    int rc;

    rc = lsm303dlhc_init(dev, arg);
    if (rc != 0) {
        goto err;
    }

    cfg.accel_range = LSM303DLHC_ACCEL_RANGE_2;
    cfg.accel_rate = LSM303DLHC_ACCEL_RATE_400;
    cfg.sample_itvl = OS_TICKS_PER_SEC / 200;

    rc = lsm303dlhc_config((struct lsm303dlhc *) dev, &cfg);
    if (rc != 0) {
        goto err;
    }

    return (0);
err:
    return (rc);

}
```

## Displaying Sensor Data in Shell

To display data in the shell enter the following commands:

```
sensor read lsm303dlhc 1 10
```

**Note**: This PR doesn't address the lack of %f/float support in tinylibc in the mynewt repo, so the current code in sensors_shell.c won't display the accelerometer data as-is. You can modify `sensor_shell.c` with the following hacky code to display a float value until a more permanent solution is found:

```
static int
sensor_shell_float_fraction(float f, int precision)
{
    if (f < 0.0F) {
        f *= -1.0F;
    };
    return (int)(f * precision) % precision;
}

static int
sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
{
    struct sensor_shell_read_ctx *ctx;
    struct sensor_accel_data *sad;
    float *temp;

    ctx = (struct sensor_shell_read_ctx *) arg;

    ++ctx->num_entries;

    if (ctx->type == SENSOR_TYPE_ACCELEROMETER) {
        sad = (struct sensor_accel_data *) data;
        if (sad->sad_x != SENSOR_ACCEL_DATA_UNUSED) {
            console_printf("x = %i.%05i, ", (int)sad->sad_x,
                sensor_shell_float_fraction(sad->sad_x, 100000));
        }
        if (sad->sad_y != SENSOR_ACCEL_DATA_UNUSED) {
            console_printf("y = %i.%05i, ", (int)sad->sad_y,
                sensor_shell_float_fraction(sad->sad_y, 100000));
        }
        if (sad->sad_z != SENSOR_ACCEL_DATA_UNUSED) {
            console_printf("z = %i.%05i", (int)sad->sad_z,
                sensor_shell_float_fraction(sad->sad_z, 100000));
        }
        console_printf("\n");
    }

    return (0);
}
```
