### PR TITLE
Updated lsm303dlhc_read48 to allow for differences with mag output

### DIFF
--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc_priv.h
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc_priv.h
@@ -80,6 +80,7 @@ enum lsm303dlhc_registers_mag {
 
 int lsm303dlhc_write8(uint8_t addr, uint8_t reg, uint32_t value);
 int lsm303dlhc_read8(uint8_t addr, uint8_t reg, uint8_t *value);
+int lsm303dlhc_read48(uint8_t addr, uint8_t reg, uint8_t *buffer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request solves an issue that will be encountered when magnetometer support is added. The magnetometer data is 16-bit and requires a different shifting strategy than the 12-bit accelerometer data. To keep the `lsm303dlhc_read48` function generic, a raw buffer is now returned and the 16-bit value formation happens in the calling function.

The return code is also checked when `lsm303dlhc_read48` is called in case the I2C transaction fails.