### PR TITLE
Fix orphaned openocd when gdb is detached while running

### DIFF
--- a/hw/bsp/arduino_primo_nrf52/primo_debug.sh
+++ b/hw/bsp/arduino_primo_nrf52/primo_debug.sh
@@ -42,7 +42,8 @@ if [ $USE_OPENOCD -eq 1 ]; then
     . $CORE_PATH/hw/scripts/openocd.sh
 
     CFG="-s $BSP_PATH -f arduino_primo.cfg"
-    EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {resume;shutdown}"
+    # Exit openocd when gdb detaches.
+    EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"
 
     openocd_debug
 else

--- a/hw/bsp/nrf51-blenano/nrf51dk_debug.sh
+++ b/hw/bsp/nrf51-blenano/nrf51dk_debug.sh
@@ -31,6 +31,7 @@
 
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f interface/cmsis-dap.cfg -f target/nrf51.cfg"
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf51.cpu configure -event gdb-detach {resume;shutdown}"
+# Exit openocd when gdb detaches.
+EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf51.cpu configure -event gdb-detach {if {[nrf51.cpu curstate] eq \"halted\"} resume;shutdown}"
 
 openocd_debug

--- a/hw/bsp/nucleo-f401re/nucleo-f401re_debug.sh
+++ b/hw/bsp/nucleo-f401re/nucleo-f401re_debug.sh
@@ -32,6 +32,6 @@
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f board/st_nucleo_f4.cfg"
 # Exit openocd when gdb detaches.
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {resume;shutdown}"
+EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {if {[stm32f4x.cpu curstate] eq \"halted\"} resume;shutdown}"
 
 openocd_debug

--- a/hw/bsp/olimex_stm32-e407_devboard/olimex_stm32-e407_devboard_debug.sh
+++ b/hw/bsp/olimex_stm32-e407_devboard/olimex_stm32-e407_devboard_debug.sh
@@ -32,6 +32,6 @@
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f interface/ftdi/olimex-arm-usb-tiny-h.cfg -s $BSP_PATH -f f407.cfg"
 # Exit openocd when gdb detaches.
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {resume;shutdown}"
+EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {if {[stm32f4x.cpu curstate] eq \"halted\"} resume;shutdown}"
 
 openocd_debug

--- a/hw/bsp/rb-nano2/rb-nano2_debug.sh
+++ b/hw/bsp/rb-nano2/rb-nano2_debug.sh
@@ -31,7 +31,8 @@
 
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f interface/cmsis-dap.cfg -f target/nrf52.cfg"
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {resume;shutdown}"
+# Exit openocd when gdb detaches.
+EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"
 
 openocd_debug
 

--- a/hw/bsp/stm32f4discovery/stm32f4discovery_debug.sh
+++ b/hw/bsp/stm32f4discovery/stm32f4discovery_debug.sh
@@ -31,6 +31,7 @@
 
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-s $BSP_PATH -f $BSP_PATH/f4discovery.cfg"
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {resume;shutdown}"
+# Exit openocd when gdb detaches.
+EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {if {[stm32f4x.cpu curstate] eq \"halted\"} resume;shutdown}"
 
 openocd_debug


### PR DESCRIPTION
If `gdb` is detached while cpu is running (e.g. by sending SIGINT to `gdb`), the openocd detach handler hits an error when trying to execute `resume` command since cpu is not in a resumable state. This aborts the handler and doesn't run the shutdown command, resulting in an orphaned `openocd` process hanging around (and dumping errors to console when device is unplugged, etc.)

This checks that cpu is halted before trying to `resume`. If cpu is already running, it just shuts down `openocd` without touching cpu state.