### PR TITLE
Nimble: proper encryption state handling in ATT

### DIFF
--- a/apps/bletiny/src/gatt_svr.c
+++ b/apps/bletiny/src/gatt_svr.c
@@ -144,6 +144,7 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
                 .access_cb = gatt_svr_access_test,
                 .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC |
                 BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_ENC,
+                .min_key_size = 16,
             }, {
                 .uuid128 = PTS_UUID(PTS_CHR_READ_WRITE_AUTHEN),
                 .access_cb = gatt_svr_access_test,
@@ -167,6 +168,7 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
                         .access_cb = gatt_svr_access_test,
                         .att_flags = BLE_ATT_F_READ | BLE_ATT_F_READ_ENC |
                         BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_ENC,
+                        .min_key_size = 16,
                     }, {
                         .uuid128 = PTS_UUID(PTS_DSC_READ_WRITE_AUTHEN),
                         .access_cb = gatt_svr_access_test,
@@ -209,6 +211,7 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
                 .access_cb = gatt_svr_long_access_test,
                 .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC |
                 BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_ENC,
+                .min_key_size = 16,
             }, {
                 .uuid128 = PTS_UUID(PTS_LONG_CHR_READ_WRITE_AUTHEN),
                 .access_cb = gatt_svr_long_access_test,
@@ -232,6 +235,7 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
                         .access_cb = gatt_svr_long_access_test,
                         .att_flags = BLE_ATT_F_READ | BLE_ATT_F_READ_ENC |
                         BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_ENC,
+                        .min_key_size = 16,
                     }, {
                         .uuid128 = PTS_UUID(PTS_LONG_DSC_READ_WRITE_AUTHEN),
                         .access_cb = gatt_svr_long_access_test,

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -131,6 +131,7 @@ struct ble_gap_sec_state {
     unsigned encrypted:1;
     unsigned authenticated:1;
     unsigned bonded:1;
+    unsigned key_size:5;
 };
 
 /**

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -225,6 +225,9 @@ struct ble_gatt_chr_def {
     /** Specifies the set of permitted operations for this characteristic. */
     ble_gatt_chr_flags flags;
 
+    /** Specifies minimum required key size to access this characteristic. */
+    uint8_t min_key_size;
+
     /** 
      * At registration time, this is filled in with the characteristic's value
      * attribute handle.
@@ -270,6 +273,9 @@ struct ble_gatt_dsc_def {
 
     /** Specifies the set of permitted operations for this descriptor. */
     uint8_t att_flags;
+
+    /** Specifies minimum required key size to access this descriptor. */
+    uint8_t min_key_size;
 
     /** Callback that gets executed when the descriptor is read or written. */
     ble_gatt_access_fn *access_cb;

--- a/net/nimble/host/include/host/ble_store.h
+++ b/net/nimble/host/include/host/ble_store.h
@@ -72,6 +72,7 @@ struct ble_store_value_sec {
     uint8_t peer_addr[6];
     uint8_t peer_addr_type;
 
+    uint8_t key_size;
     uint16_t ediv;
     uint64_t rand_num;
     uint8_t ltk[16];

--- a/net/nimble/host/pts/pts-gap.txt
+++ b/net/nimble/host/pts/pts-gap.txt
@@ -329,7 +329,7 @@ TC_ADV_BV_16_C		PASS	b set adv_data le_role=1
 				b adv
 -------------------------------------------------------------------------------
 
-TC_GAT_BV_01_C		INC
+TC_GAT_BV_01_C		PASS
 TC_GAT_BV_02_C		N/A
 TC_GAT_BV_03_C		N/A
 TC_GAT_BV_04_C		N/A

--- a/net/nimble/host/pts/pts-gatt.txt
+++ b/net/nimble/host/pts/pts-gatt.txt
@@ -194,7 +194,7 @@ TC_GAR_SR_BI_02_C	PASS	b adv
 				<enter ffff>
 TC_GAR_SR_BI_03_C	N/A
 TC_GAR_SR_BI_04_C	PASS	b adv
-TC_GAR_SR_BI_05_C	INC
+TC_GAR_SR_BI_05_C	PASS	b adv
 TC_GAR_SR_BV_03_C	PASS	b adv
 TC_GAR_SR_BI_06_C	PASS	b adv
 				<enter uuid without READ flag>
@@ -205,7 +205,8 @@ TC_GAR_SR_BI_08_C	PASS	b adv
 TC_GAR_SR_BI_09_C	N/A
 TC_GAR_SR_BI_10_C	PASS	b adv
 				<enter characteristic with READ|READ_AUTH flags>
-TC_GAR_SR_BI_11_C	INC
+TC_GAR_SR_BI_11_C	PASS	b adv
+				<enter UUID=000000078c26476f89a7a108033a69c7 and appropriate handle>
 TC_GAR_SR_BV_04_C	PASS	b adv
 TC_GAR_SR_BI_12_C	PASS	b adv
 				<enter long value handle without READ flag>
@@ -214,7 +215,7 @@ TC_GAR_SR_BI_14_C	PASS	b adv
 				<enter ffff>
 TC_GAR_SR_BI_15_C	N/A
 TC_GAR_SR_BI_16_C	PASS	b adv
-TC_GAR_SR_BI_17_C	INC
+TC_GAR_SR_BI_17_C	PASS	b adv
 TC_GAR_SR_BV_05_C	PASS	b adv
 				NOTE: Probably correct, no confirmation in cmd
 TC_GAR_SR_BI_18_C	PASS	b adv
@@ -223,7 +224,7 @@ TC_GAR_SR_BI_19_C	PASS	b adv
 				<enter ffff>
 TC_GAR_SR_BI_20_C	N/A
 TC_GAR_SR_BI_21_C	PASS	b adv
-TC_GAR_SR_BI_22_C	INC
+TC_GAR_SR_BI_22_C	PASS	b adv
 TC_GAR_SR_BV_06_C	PASS	b adv
 TC_GAR_SR_BI_23_C	PASS	b adv
 				<enter value handle without READ flag>
@@ -231,7 +232,7 @@ TC_GAR_SR_BI_24_C	PASS	b adv
 				<enter ffff>
 TC_GAR_SR_BI_25_C	N/A
 TC_GAR_SR_BI_26_C	PASS	b adv
-TC_GAR_SR_BI_27_C	INC
+TC_GAR_SR_BI_27_C	PASS	b adv
 TC_GAR_SR_BV_07_C	PASS	b adv
 TC_GAR_SR_BV_08_C	PASS	b adv
 TC_GAR_SR_BI_28_C	PASS	b adv
@@ -241,7 +242,7 @@ TC_GAR_SR_BI_30_C	PASS	b adv
 				<enter ffff>
 TC_GAR_SR_BI_31_C	N/A
 TC_GAR_SR_BI_32_C	PASS	b adv
-TC_GAR_SR_BI_33_C	INC
+TC_GAR_SR_BI_33_C	PASS	b adv
 TC_GAR_SR_BI_34_C	N/A
 TC_GAR_SR_BI_35_C	N/A
 -------------------------------------------------------------------------------
@@ -371,7 +372,7 @@ TC_GAW_SR_BI_02_C	PASS	b adv
 TC_GAW_SR_BI_03_C	PASS	b adv
 TC_GAW_SR_BI_04_C	N/A
 TC_GAW_SR_BI_05_C	PASS	b adv
-TC_GAW_SR_BI_06_C	INC
+TC_GAW_SR_BI_06_C	PASS	b adv
 TC_GAW_SR_BV_05_C	PASS	b adv
 TC_GAW_SR_BI_07_C	PASS	b adv
 				<enter ffff>
@@ -380,7 +381,7 @@ TC_GAW_SR_BI_08_C	PASS	b adv
 TC_GAW_SR_BI_09_C	PASS	b adv
 TC_GAW_SR_BI_11_C	N/A
 TC_GAW_SR_BI_12_C	PASS	b adv	
-TC_GAW_SR_BI_13_C	INC
+TC_GAW_SR_BI_13_C	PASS	b adv
 TC_GAW_SR_BV_06_C	PASS	b adv
 TC_GAW_SR_BV_10_C	PASS	b adv
 TC_GAW_SR_BI_14_C	PASS	b adv
@@ -389,7 +390,7 @@ TC_GAW_SR_BI_15_C	PASS	b adv
 				<enter value handle without WRITE flag>
 TC_GAW_SR_BI_17_C	N/A
 TC_GAW_SR_BI_18_C	PASS	b adv
-TC_GAW_SR_BI_19_C	INC	
+TC_GAW_SR_BI_19_C	PASS	b adv
 TC_GAW_SR_BV_07_C	PASS	b adv
 TC_GAW_SR_BV_08_C	PASS	b adv
 TC_GAW_SR_BI_20_C	PASS	b adv
@@ -398,7 +399,7 @@ TC_GAW_SR_BI_21_C	PASS	b adv
 				<enter dsc value handle without WRITE flag>
 TC_GAW_SR_BI_22_C	N/A
 TC_GAW_SR_BI_23_C	PASS	b adv
-TC_GAW_SR_BI_24_C	INC
+TC_GAW_SR_BI_24_C	PASS	b adv
 TC_GAW_SR_BV_09_C	PASS	b adv
 TC_GAW_SR_BI_25_C	PASS	b adv
 				<enter ffff>
@@ -407,7 +408,7 @@ TC_GAW_SR_BI_26_C	PASS	b adv
 TC_GAW_SR_BI_27_C	PASS	b adv
 TC_GAW_SR_BI_29_C	N/A
 TC_GAW_SR_BI_30_C	PASS
-TC_GAW_SR_BI_31_C	INC	
+TC_GAW_SR_BI_31_C	PASS	b adv
 TC_GAW_SR_BI_32_C	PASS	b adv
 TC_GAW_SR_BI_33_C	PASS	b adv
 TC_GAW_SR_BI_34_C	PASS	b adv

--- a/net/nimble/host/src/ble_att_priv.h
+++ b/net/nimble/host/src/ble_att_priv.h
@@ -140,18 +140,18 @@ typedef int ble_att_svr_access_fn(uint16_t conn_handle, uint16_t attr_handle,
                                   struct os_mbuf **om, void *arg);
 
 int ble_att_svr_register(const uint8_t *uuid, uint8_t flags,
-                         uint16_t *handle_id,
+                         uint8_t min_key_size, uint16_t *handle_id,
                          ble_att_svr_access_fn *cb, void *cb_arg);
 int ble_att_svr_register_uuid16(uint16_t uuid16, uint8_t flags,
-                                uint16_t *handle_id, ble_att_svr_access_fn *cb,
-                                void *cb_arg);
+                                uint8_t min_key_size, uint16_t *handle_id,
+                                ble_att_svr_access_fn *cb, void *cb_arg);
 
 struct ble_att_svr_entry {
     STAILQ_ENTRY(ble_att_svr_entry) ha_next;
 
     uint8_t ha_uuid[16];
     uint8_t ha_flags;
-    uint8_t ha_pad1;
+    uint8_t ha_min_key_size;
     uint16_t ha_handle_id;
     ble_att_svr_access_fn *ha_cb;
     void *ha_cb_arg;

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -97,8 +97,9 @@ ble_att_svr_next_id(void)
  * @return 0 on success, non-zero error code on failure.
  */
 int
-ble_att_svr_register(const uint8_t *uuid, uint8_t flags, uint16_t *handle_id,
-                     ble_att_svr_access_fn *cb, void *cb_arg)
+ble_att_svr_register(const uint8_t *uuid, uint8_t flags, uint8_t min_key_size,
+                     uint16_t *handle_id,  ble_att_svr_access_fn *cb,
+                     void *cb_arg)
 {
     struct ble_att_svr_entry *entry;
 
@@ -109,6 +110,7 @@ ble_att_svr_register(const uint8_t *uuid, uint8_t flags, uint16_t *handle_id,
 
     memcpy(&entry->ha_uuid, uuid, sizeof entry->ha_uuid);
     entry->ha_flags = flags;
+    entry->ha_min_key_size = min_key_size;
     entry->ha_handle_id = ble_att_svr_next_id();
     entry->ha_cb = cb;
     entry->ha_cb_arg = cb_arg;
@@ -124,8 +126,8 @@ ble_att_svr_register(const uint8_t *uuid, uint8_t flags, uint16_t *handle_id,
 
 int
 ble_att_svr_register_uuid16(uint16_t uuid16, uint8_t flags,
-                            uint16_t *handle_id, ble_att_svr_access_fn *cb,
-                            void *cb_arg)
+                            uint8_t min_key_size, uint16_t *handle_id,
+                            ble_att_svr_access_fn *cb, void *cb_arg)
 {
     uint8_t uuid128[16];
     int rc;
@@ -135,7 +137,8 @@ ble_att_svr_register_uuid16(uint16_t uuid16, uint8_t flags,
         return rc;
     }
 
-    rc = ble_att_svr_register(uuid128, flags, handle_id, cb, cb_arg);
+    rc = ble_att_svr_register(uuid128, flags, min_key_size, handle_id, cb,
+                              cb_arg);
     if (rc != 0) {
         return rc;
     }

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -262,9 +262,14 @@ ble_att_svr_check_perms(uint16_t conn_handle, int is_read,
                         uint8_t *out_att_err)
 {
     struct ble_gap_sec_state sec_state;
+    struct ble_store_value_sec value_sec;
+    struct ble_store_key_sec key_sec;
+    struct ble_hs_conn_addrs addrs;
+    struct ble_hs_conn *conn;
     int author;
     int authen;
     int enc;
+    int rc;
 
     if (is_read) {
         if (!(entry->ha_flags & BLE_ATT_F_READ)) {
@@ -292,11 +297,25 @@ ble_att_svr_check_perms(uint16_t conn_handle, int is_read,
     }
 
     ble_att_svr_get_sec_state(conn_handle, &sec_state);
-    if (enc && !sec_state.encrypted) {
-        /* XXX: Check security database; if required key present, respond with
-         * insufficient encryption error code.
-         */
-        *out_att_err = BLE_ATT_ERR_INSUFFICIENT_AUTHEN;
+    if ((enc || authen) && !sec_state.encrypted) {
+        ble_hs_lock();
+        conn = ble_hs_conn_find(conn_handle);
+        if (conn != NULL) {
+            ble_hs_conn_addrs(conn, &addrs);
+
+            memset(&key_sec, 0, sizeof key_sec);
+            key_sec.peer_addr_type = addrs.peer_id_addr_type;
+            memcpy(key_sec.peer_addr, addrs.peer_id_addr, 6);
+        }
+        ble_hs_unlock();
+
+        rc = ble_store_read_peer_sec(&key_sec, &value_sec);
+        if (rc == 0 && value_sec.ltk_present) {
+            *out_att_err = BLE_ATT_ERR_INSUFFICIENT_ENC;
+        } else {
+            *out_att_err = BLE_ATT_ERR_INSUFFICIENT_AUTHEN;
+        }
+
         return BLE_HS_ATT_ERR(*out_att_err);
     }
 

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -324,6 +324,11 @@ ble_att_svr_check_perms(uint16_t conn_handle, int is_read,
         return BLE_HS_ATT_ERR(*out_att_err);
     }
 
+    if (entry->ha_min_key_size > sec_state.key_size) {
+        *out_att_err = BLE_ATT_ERR_INSUFFICIENT_KEY_SZ;
+        return BLE_HS_ATT_ERR(*out_att_err);
+    }
+
     if (author) {
         /* XXX: Prompt user for authorization. */
     }

--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -423,7 +423,7 @@ ble_gatts_register_inc(struct ble_gatts_svc_entry *entry)
     BLE_HS_DBG_ASSERT(entry->handle != 0);
     BLE_HS_DBG_ASSERT(entry->end_group_handle != 0xffff);
 
-    rc = ble_att_svr_register_uuid16(BLE_ATT_UUID_INCLUDE, BLE_ATT_F_READ,
+    rc = ble_att_svr_register_uuid16(BLE_ATT_UUID_INCLUDE, BLE_ATT_F_READ, 0,
                                      &handle, ble_gatts_inc_access, entry);
     if (rc != 0) {
         return rc;
@@ -516,8 +516,8 @@ ble_gatts_register_dsc(const struct ble_gatt_svc_def *svc,
         return BLE_HS_EINVAL;
     }
 
-    rc = ble_att_svr_register(dsc->uuid128, dsc->att_flags, &dsc_handle,
-                              ble_gatts_dsc_access, (void *)dsc);
+    rc = ble_att_svr_register(dsc->uuid128, dsc->att_flags, dsc->min_key_size,
+                              &dsc_handle, ble_gatts_dsc_access, (void *)dsc);
     if (rc != 0) {
         return rc;
     }
@@ -752,7 +752,7 @@ ble_gatts_register_clt_cfg_dsc(uint16_t *att_handle)
         return rc;
     }
 
-    rc = ble_att_svr_register(uuid128, BLE_ATT_F_READ | BLE_ATT_F_WRITE,
+    rc = ble_att_svr_register(uuid128, BLE_ATT_F_READ | BLE_ATT_F_WRITE, 0,
                               att_handle, ble_gatts_clt_cfg_access, NULL);
     if (rc != 0) {
         return rc;
@@ -791,7 +791,7 @@ ble_gatts_register_chr(const struct ble_gatt_svc_def *svc,
      * callback arg).
      */
     rc = ble_att_svr_register_uuid16(BLE_ATT_UUID_CHARACTERISTIC,
-                                     BLE_ATT_F_READ, &def_handle,
+                                     BLE_ATT_F_READ, 0, &def_handle,
                                      ble_gatts_chr_def_access, (void *)chr);
     if (rc != 0) {
         return rc;
@@ -801,8 +801,9 @@ ble_gatts_register_chr(const struct ble_gatt_svc_def *svc,
      * arg).
      */
     att_flags = ble_gatts_att_flags_from_chr_flags(chr->flags);
-    rc = ble_att_svr_register(chr->uuid128, att_flags, &val_handle,
-                              ble_gatts_chr_val_access, (void *)chr);
+    rc = ble_att_svr_register(chr->uuid128, att_flags, chr->min_key_size,
+                              &val_handle, ble_gatts_chr_val_access,
+                              (void *)chr);
     if (rc != 0) {
         return rc;
     }
@@ -907,7 +908,7 @@ ble_gatts_register_svc(const struct ble_gatt_svc_def *svc,
     /* Register service definition attribute (cast away const on callback
      * arg).
      */
-    rc = ble_att_svr_register_uuid16(uuid16, BLE_ATT_F_READ, out_handle,
+    rc = ble_att_svr_register_uuid16(uuid16, BLE_ATT_F_READ, 0, out_handle,
                                      ble_gatts_svc_access, (void *)svc);
     if (rc != 0) {
         return rc;

--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -446,6 +446,7 @@ ble_sm_fill_store_value(uint8_t peer_addr_type, uint8_t *peer_addr,
     memcpy(value_sec->peer_addr, peer_addr, sizeof value_sec->peer_addr);
 
     if (keys->ediv_rand_valid && keys->ltk_valid) {
+        value_sec->key_size = keys->key_size;
         value_sec->ediv = keys->ediv;
         value_sec->rand_num = keys->rand_val;
 

--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -416,7 +416,7 @@ ble_sm_proc_remove(struct ble_sm_proc *proc,
 
 static void
 ble_sm_update_sec_state(uint16_t conn_handle, int encrypted,
-                        int authenticated, int bonded)
+                        int authenticated, int bonded, int key_size)
 {
     struct ble_hs_conn *conn;
 
@@ -430,6 +430,10 @@ ble_sm_update_sec_state(uint16_t conn_handle, int encrypted,
         }
         if (bonded) {
             conn->bhc_sec_state.bonded = 1;
+        }
+
+        if (key_size) {
+            conn->bhc_sec_state.key_size = key_size;
         }
     }
 }
@@ -892,12 +896,14 @@ ble_sm_enc_event_rx(uint16_t conn_handle, uint8_t evt_status, int encrypted)
     struct ble_sm_proc *proc;
     int authenticated;
     int bonded;
+    int key_size;
 
     memset(&res, 0, sizeof res);
 
     /* Assume no change in authenticated and bonded statuses. */
     authenticated = 0;
     bonded = 0;
+    key_size = 0;
 
     ble_hs_lock();
 
@@ -918,6 +924,8 @@ ble_sm_enc_event_rx(uint16_t conn_handle, uint8_t evt_status, int encrypted)
 
                     res.execute = 1;
                 }
+
+                key_size = proc->key_size;
             } else {
                 /* Failure or no keys to exchange; procedure is complete. */
                 proc->state = BLE_SM_PROC_STATE_NONE;
@@ -939,6 +947,8 @@ ble_sm_enc_event_rx(uint16_t conn_handle, uint8_t evt_status, int encrypted)
             }
             bonded = 1;
             res.restore = 1;
+
+            key_size = proc->key_size;
             break;
 
         default:
@@ -956,7 +966,8 @@ ble_sm_enc_event_rx(uint16_t conn_handle, uint8_t evt_status, int encrypted)
         /* Set the encrypted state of the connection as indicated in the
          * event.
          */
-        ble_sm_update_sec_state(conn_handle, encrypted, authenticated, bonded);
+        ble_sm_update_sec_state(conn_handle, encrypted, authenticated, bonded,
+                                key_size);
     }
 
     /* Unless keys need to be exchanged, notify the application of the security
@@ -1656,7 +1667,7 @@ ble_sm_key_exch_success(struct ble_sm_proc *proc, struct ble_sm_result *res)
     /* The procedure is now complete.  Update connection bonded state and
      * terminate procedure.
      */
-    ble_sm_update_sec_state(proc->conn_handle, 1, 0, 1);
+    ble_sm_update_sec_state(proc->conn_handle, 1, 0, 1, proc->key_size);
     proc->state = BLE_SM_PROC_STATE_NONE;
 
     res->app_status = 0;

--- a/net/nimble/host/src/ble_sm_priv.h
+++ b/net/nimble/host/src/ble_sm_priv.h
@@ -242,6 +242,7 @@ struct ble_sm_keys {
     uint16_t ediv;
     uint64_t rand_val;
     uint8_t addr_type;
+    uint8_t key_size;
     uint8_t ltk[16];    /* Little endian. */
     uint8_t irk[16];    /* Little endian. */
     uint8_t csrk[16];   /* Little endian. */

--- a/net/nimble/host/test/src/ble_att_svr_test.c
+++ b/net/nimble/host/test/src/ble_att_svr_test.c
@@ -213,7 +213,7 @@ ble_att_svr_test_misc_register_uuid128(uint8_t *uuid128, uint8_t flags,
     uint16_t handle;
     int rc;
 
-    rc = ble_att_svr_register(uuid128, flags, &handle, fn, NULL);
+    rc = ble_att_svr_register(uuid128, flags, 0, &handle, fn, NULL);
     TEST_ASSERT_FATAL(rc == 0);
     TEST_ASSERT_FATAL(handle == expected_handle);
 }
@@ -804,7 +804,7 @@ TEST_CASE(ble_att_svr_test_read)
     /*** Successful read. */
     ble_att_svr_test_attr_r_1 = (uint8_t[]){0,1,2,3,4,5,6,7};
     ble_att_svr_test_attr_r_1_len = 8;
-    rc = ble_att_svr_register(uuid, HA_FLAG_PERM_RW, &attr_handle,
+    rc = ble_att_svr_register(uuid, HA_FLAG_PERM_RW, 0, &attr_handle,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -826,7 +826,7 @@ TEST_CASE(ble_att_svr_test_read)
 
     /*** Read requires encryption. */
     /* Insufficient authentication. */
-    rc = ble_att_svr_register(uuid_sec, BLE_ATT_F_READ | BLE_ATT_F_READ_ENC,
+    rc = ble_att_svr_register(uuid_sec, BLE_ATT_F_READ | BLE_ATT_F_READ_ENC, 0,
                               &attr_handle,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
@@ -880,7 +880,7 @@ TEST_CASE(ble_att_svr_test_read_blob)
         (uint8_t[]){0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,
                     22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39};
     ble_att_svr_test_attr_r_1_len = 40;
-    rc = ble_att_svr_register(uuid, HA_FLAG_PERM_RW, &attr_handle,
+    rc = ble_att_svr_register(uuid, HA_FLAG_PERM_RW, 0, &attr_handle,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -932,12 +932,12 @@ TEST_CASE(ble_att_svr_test_read_mult)
     ble_att_svr_test_attr_r_2 = attrs[1].value;
     ble_att_svr_test_attr_r_2_len = attrs[1].value_len;
 
-    rc = ble_att_svr_register(BLE_UUID16(0x1111), HA_FLAG_PERM_RW,
+    rc = ble_att_svr_register(BLE_UUID16(0x1111), HA_FLAG_PERM_RW, 0,
                               &attrs[0].handle,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
-    rc = ble_att_svr_register(BLE_UUID16(0x2222), HA_FLAG_PERM_RW,
+    rc = ble_att_svr_register(BLE_UUID16(0x2222), HA_FLAG_PERM_RW, 0,
                               &attrs[1].handle,
                               ble_att_svr_test_misc_attr_fn_r_2, NULL);
     TEST_ASSERT(rc == 0);
@@ -1005,7 +1005,7 @@ TEST_CASE(ble_att_svr_test_write)
 
     /*** Write not permitted if non-local. */
     /* Non-local write (fail). */
-    rc = ble_att_svr_register(uuid_r, BLE_ATT_F_READ, &attr_handle,
+    rc = ble_att_svr_register(uuid_r, BLE_ATT_F_READ, 0, &attr_handle,
                               ble_att_svr_test_misc_attr_fn_w_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1026,7 +1026,7 @@ TEST_CASE(ble_att_svr_test_write)
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /*** Successful write. */
-    rc = ble_att_svr_register(uuid_rw, HA_FLAG_PERM_RW, &attr_handle,
+    rc = ble_att_svr_register(uuid_rw, HA_FLAG_PERM_RW, 0, &attr_handle,
                               ble_att_svr_test_misc_attr_fn_w_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1038,7 +1038,7 @@ TEST_CASE(ble_att_svr_test_write)
     /*** Write requires encryption. */
     /* Insufficient authentication. */
     rc = ble_att_svr_register(uuid_sec, BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_ENC,
-                              &attr_handle,
+                              0, &attr_handle,
                               ble_att_svr_test_misc_attr_fn_w_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1105,7 +1105,7 @@ TEST_CASE(ble_att_svr_test_find_info)
         BLE_ATT_OP_FIND_INFO_REQ, 200, BLE_ATT_ERR_ATTR_NOT_FOUND);
 
     /*** Range too late. */
-    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, &handle1,
+    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, 0, &handle1,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1126,7 +1126,7 @@ TEST_CASE(ble_att_svr_test_find_info)
         } }));
 
     /*** Two 128-bit entries. */
-    rc = ble_att_svr_register(uuid2, HA_FLAG_PERM_RW, &handle2,
+    rc = ble_att_svr_register(uuid2, HA_FLAG_PERM_RW, 0, &handle2,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1144,7 +1144,7 @@ TEST_CASE(ble_att_svr_test_find_info)
         } }));
 
     /*** Two 128-bit entries; 16-bit entry doesn't get sent. */
-    rc = ble_att_svr_register(uuid3, HA_FLAG_PERM_RW, &handle3,
+    rc = ble_att_svr_register(uuid3, HA_FLAG_PERM_RW, 0, &handle3,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1227,7 +1227,7 @@ TEST_CASE(ble_att_svr_test_find_type_value)
         BLE_ATT_ERR_ATTR_NOT_FOUND);
 
     /*** Range too late. */
-    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, &handle1,
+    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, 0, &handle1,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1253,7 +1253,7 @@ TEST_CASE(ble_att_svr_test_find_type_value)
         } }));
 
     /*** One entry, two attributes. */
-    rc = ble_att_svr_register(uuid2, HA_FLAG_PERM_RW, &handle2,
+    rc = ble_att_svr_register(uuid2, HA_FLAG_PERM_RW, 0, &handle2,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 
@@ -1274,19 +1274,19 @@ TEST_CASE(ble_att_svr_test_find_type_value)
     ble_att_svr_test_attr_r_2 = (uint8_t[]){0x00, 0x00};
     ble_att_svr_test_attr_r_2_len = 2;
 
-    rc = ble_att_svr_register(uuid3, HA_FLAG_PERM_RW, &handle_desc,
+    rc = ble_att_svr_register(uuid3, HA_FLAG_PERM_RW, 0, &handle_desc,
                               ble_att_svr_test_misc_attr_fn_r_2, NULL);
     TEST_ASSERT(rc == 0);
 
-    rc = ble_att_svr_register(uuid2, HA_FLAG_PERM_RW, &handle3,
+    rc = ble_att_svr_register(uuid2, HA_FLAG_PERM_RW, 0, &handle3,
                               ble_att_svr_test_misc_attr_fn_r_2, NULL);
     TEST_ASSERT(rc == 0);
 
-    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, &handle4,
+    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, 0, &handle4,
                               ble_att_svr_test_misc_attr_fn_r_2, NULL);
     TEST_ASSERT(rc == 0);
 
-    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, &handle5,
+    rc = ble_att_svr_register(uuid1, HA_FLAG_PERM_RW, 0, &handle5,
                               ble_att_svr_test_misc_attr_fn_r_1, NULL);
     TEST_ASSERT(rc == 0);
 

--- a/net/nimble/host/test/src/ble_gatt_conn_test.c
+++ b/net/nimble/host/test/src/ble_gatt_conn_test.c
@@ -389,7 +389,7 @@ TEST_CASE(ble_gatt_conn_test_disconnect)
     ble_gatt_conn_test_util_init();
 
     /*** Register an attribute to allow indicatations to be sent. */
-    rc = ble_att_svr_register(BLE_UUID16(0x1212), BLE_ATT_F_READ,
+    rc = ble_att_svr_register(BLE_UUID16(0x1212), BLE_ATT_F_READ, 0,
                               &attr_handle,
                               ble_gatt_conn_test_attr_cb, NULL);
     TEST_ASSERT(rc == 0);
@@ -614,7 +614,7 @@ TEST_CASE(ble_gatt_conn_test_timeout)
     TEST_ASSERT(ticks_from_now == BLE_HS_FOREVER);
 
     /*** Register an attribute to allow indicatations to be sent. */
-    rc = ble_att_svr_register(BLE_UUID16(0x1212), BLE_ATT_F_READ,
+    rc = ble_att_svr_register(BLE_UUID16(0x1212), BLE_ATT_F_READ, 0,
                               &attr_handle,
                               ble_gatt_conn_test_attr_cb, NULL);
     TEST_ASSERT(rc == 0);


### PR DESCRIPTION
This adds proper support for encryption state in ATT code, i.e.
- attribute can have minimum encryption key size requirement
- "Insufficient Encryption" error code returned when LTK is present but encryption is not enabled
- "Insufficient Encryption Key Size" error code returned when encryption key size does not minimum requirement for given attribute

...and other changes which were required to run and test this code.