### PR TITLE
Fixed accel/mag driver registration

### DIFF
--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -273,15 +273,9 @@ lsm303dlhc_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    /* Add the accelerometer */
-    rc = sensor_set_driver(sensor, SENSOR_TYPE_ACCELEROMETER,
-            (struct sensor_driver *) &g_lsm303dlhc_sensor_driver);
-    if (rc != 0) {
-        goto err;
-    }
-
-    /* Add the magnetometer */
-    rc = sensor_set_driver(sensor, SENSOR_TYPE_MAGNETIC_FIELD,
+    /* Add the accelerometer/magnetometer driver */
+    rc = sensor_set_driver(sensor, SENSOR_TYPE_ACCELEROMETER |
+            SENSOR_TYPE_MAGNETIC_FIELD,
             (struct sensor_driver *) &g_lsm303dlhc_sensor_driver);
     if (rc != 0) {
         goto err;


### PR DESCRIPTION
The `sensor_set_driver` call should have had both the accelerometer and magnetometer bits set at the same time (`SENSOR_TYPE_ACCELEROMETER | SENSOR_TYPE_MAGNETIC_FIELD`). This PR fixes this bug, where only the magnetometer will show up at present, overriding the accelerometer settings.