### PR TITLE
Avoid hard-coding absolute compiler path

### DIFF
--- a/compiler/sim/compiler.yml
+++ b/compiler/sim/compiler.yml
@@ -41,8 +41,8 @@ compiler.flags.base.LINUX: >
 compiler.ld.flags.LINUX: -lutil
 
 # OS X.
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5"
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
 compiler.flags.base.DARWIN: >


### PR DESCRIPTION
Hard-coding the absolute path for cc & as is not only non-consistent
with the other definitions (none use absolute paths), but it is also
wrong, gcc-5 can be installed in any location (via homebrew or
otherwise).