### PR TITLE
nimble/gatt: unify discovery api

### DIFF
--- a/apps/bletiny/src/bletiny.h
+++ b/apps/bletiny/src/bletiny.h
@@ -133,8 +133,8 @@ int bletiny_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
                            uint16_t end_handle);
 int bletiny_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
                                uint16_t end_handle, const ble_uuid_t *uuid);
-int bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t chr_val_handle,
-                           uint16_t chr_end_handle);
+int bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+                          uint16_t end_handle);
 int bletiny_disc_full(uint16_t conn_handle);
 int bletiny_find_inc_svcs(uint16_t conn_handle, uint16_t start_handle,
                            uint16_t end_handle);

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -694,7 +694,7 @@ bletiny_disc_full_dscs(uint16_t conn_handle)
                 bletiny_full_disc_prev_chr_val <= chr->chr.def_handle) {
 
                 rc = bletiny_disc_all_dscs(conn_handle,
-                                           chr->chr.val_handle + 1,
+                                           chr->chr.val_handle,
                                            chr_end_handle(svc, chr));
                 if (rc != 0) {
                     bletiny_full_disc_complete(rc);
@@ -1156,7 +1156,7 @@ bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
 {
     int rc;
 
-    rc = ble_gattc_disc_all_dscs(conn_handle, start_handle - 1, end_handle,
+    rc = ble_gattc_disc_all_dscs(conn_handle, start_handle, end_handle,
                                  bletiny_on_disc_d, NULL);
     return rc;
 }

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -155,8 +155,8 @@ int ble_gattc_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
 int ble_gattc_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
                                uint16_t end_handle, const ble_uuid_t *uuid,
                                ble_gatt_chr_fn *cb, void *cb_arg);
-int ble_gattc_disc_all_dscs(uint16_t conn_handle, uint16_t chr_val_handle,
-                            uint16_t chr_end_handle,
+int ble_gattc_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+                            uint16_t end_handle,
                             ble_gatt_dsc_fn *cb, void *cb_arg);
 int ble_gattc_read(uint16_t conn_handle, uint16_t attr_handle,
                    ble_gatt_attr_fn *cb, void *cb_arg);

--- a/net/nimble/host/pts/pts-gatt.txt
+++ b/net/nimble/host/pts/pts-gatt.txt
@@ -51,8 +51,8 @@ GATT/CL/GAD/BV-05-C	PASS	b conn peer_addr=<addr>
 				<repeat>
 GATT/CL/GAD/BV-06-C	PASS	b conn peer_addr=<addr>
 				b disc svc conn=<handle>
-				b disc chr conn=<handle> start=<svc-start-hdl> end=<svc-end-hdl>
-				b disc dsc conn=<handle> start=<start hdl> end=<end hdl>
+				b disc chr conn=<handle> start=<start-hdl> end=<end-hdl>
+				b disc dsc conn=<handle> start=<start-hdl> end=<end-hdl>
 				<answer YES>
 				b term conn=<handle>
 				<repeat>

--- a/net/nimble/host/src/ble_gattc.c
+++ b/net/nimble/host/src/ble_gattc.c
@@ -2818,8 +2818,8 @@ ble_gattc_disc_all_dscs_rx_complete(struct ble_gattc_proc *proc, int status)
  * @return                      0 on success; nonzero on failure.
  */
 int
-ble_gattc_disc_all_dscs(uint16_t conn_handle, uint16_t chr_val_handle,
-                        uint16_t chr_end_handle,
+ble_gattc_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+                        uint16_t end_handle,
                         ble_gatt_dsc_fn *cb, void *cb_arg)
 {
 #if !MYNEWT_VAL(BLE_GATT_DISC_ALL_DSCS)
@@ -2839,9 +2839,9 @@ ble_gattc_disc_all_dscs(uint16_t conn_handle, uint16_t chr_val_handle,
 
     proc->op = BLE_GATT_OP_DISC_ALL_DSCS;
     proc->conn_handle = conn_handle;
-    proc->disc_all_dscs.chr_val_handle = chr_val_handle;
-    proc->disc_all_dscs.prev_handle = chr_val_handle;
-    proc->disc_all_dscs.end_handle = chr_end_handle;
+    proc->disc_all_dscs.chr_val_handle = start_handle;
+    proc->disc_all_dscs.prev_handle = start_handle;
+    proc->disc_all_dscs.end_handle = end_handle;
     proc->disc_all_dscs.cb = cb;
     proc->disc_all_dscs.cb_arg = cb_arg;
 


### PR DESCRIPTION
This patch unifies api to make it consistent across all discovery
methods. Always pass true range of attributes to search (start-handle,
end-handle).