### PR TITLE
Fixes MYNEWT-563

### DIFF
--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -97,7 +97,10 @@ static struct bletiny_tx_data_s bletiny_tx_data;
 int bletiny_full_disc_prev_chr_val;
 
 #define XSTR(s) STR(s)
+#ifndef STR
 #define STR(s) #s
+#endif
+
 
 #ifdef DEVICE_NAME
 #define BLETINY_AUTO_DEVICE_NAME    XSTR(DEVICE_NAME)

--- a/test/runtest/pkg.yml
+++ b/test/runtest/pkg.yml
@@ -28,9 +28,8 @@ pkg.req_apis.RUNTEST_CLI:
     - console
 pkg.deps.RUNTEST_NEWTMGR:
     - mgmt/mgmt
-
-pkg.deps.RUNTEST_NEWTMGR:
     - encoding/json
+    - test/testutil
 
 pkg.init:
     runtest_init: 500


### PR DESCRIPTION
1) Added #ifndef around #define STR(x) to avoid duplicate define when
   including <mgmt/mgmt.h> to enable Newt Manager
2) Added test/testutil package to test/runtest pkg.deps to fix not
   able to find include "testutil/testutil.h" in runtest_nmgr.c compile error when
  RUNTEST_NEWTMGR is enabled