### PR TITLE
Add bsp for Rigado BMD-200 module

### DIFF
--- a/hw/bsp/bmd200/boot-nrf51xxac.ld
+++ b/hw/bsp/bmd200/boot-nrf51xxac.ld
@@ -1,0 +1,27 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x4000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x8000
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;
+
+

--- a/hw/bsp/bmd200/bsp.yml
+++ b/hw/bsp/bmd200/bsp.yml
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.arch: cortex_m0
+bsp.compiler: compiler/arm-none-eabi-m0
+bsp.linkerscript:
+    - "hw/bsp/bmd200/nrf51xxac.ld"
+    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
+    - "hw/bsp/bmd200/boot-nrf51xxac.ld"
+    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+bsp.part2linkerscript: "hw/bsp/bmd200/split-nrf51dk.ld"
+bsp.downloadscript: "hw/bsp/bmd200/nrf51dk_download.sh"
+bsp.debugscript: "hw/bsp/bmd200/nrf51dk_debug.sh"
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x00000000
+            size: 16kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x00008000
+            size: 110kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x00023800
+            size: 110kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x0003f000
+            size: 2kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x00004000
+            size: 16kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x0003f800
+            size: 2kB

--- a/hw/bsp/bmd200/include/bsp/boards.h
+++ b/hw/bsp/bmd200/include/bsp/boards.h
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+

--- a/hw/bsp/bmd200/include/bsp/bsp.h
+++ b/hw/bsp/bmd200/include/bsp/bsp.h
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define special stackos sections */
+#define sec_data_core   __attribute__((section(".data.core")))
+#define sec_bss_core    __attribute__((section(".bss.core")))
+
+/* More convenient section placement macros. */
+#define bssnz_t
+
+extern uint8_t _ram_start;
+#define RAM_SIZE        0x8000
+
+/* LED pins */
+#define LED_BLINK_PIN   (21)
+#define LED_2           (22)
+
+/* UART info */
+#define CONSOLE_UART            "uart0"
+
+#define NFFS_AREA_MAX    (8)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/bmd200/include/bsp/cmsis_nvic.h
+++ b/hw/bsp/bmd200/include/bsp/cmsis_nvic.h
@@ -1,0 +1,30 @@
+/* mbed Microcontroller Library - cmsis_nvic
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#include <stdint.h>
+
+/* NOTE: the nrf51 SoC has 26 interrupts. */
+#define NVIC_USER_IRQ_OFFSET  16
+#define NVIC_NUM_VECTORS      (NVIC_USER_IRQ_OFFSET + 26)
+
+#include "nrf51.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_Relocate(void);
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/bsp/bmd200/nrf51dk_debug.sh
+++ b/hw/bsp/bmd200/nrf51dk_debug.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - RESET set if target should be reset when attaching
+#  - NO_GDB set if we should not start gdb to debug
+#
+
+. $CORE_PATH/hw/scripts/jlink.sh
+
+FILE_NAME=$BIN_BASENAME.elf
+JLINK_DEV="nRF51422_xxAC"
+
+jlink_debug

--- a/hw/bsp/bmd200/nrf51dk_download.sh
+++ b/hw/bsp/bmd200/nrf51dk_download.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+
+. $CORE_PATH/hw/scripts/jlink.sh
+
+if [ "$MFG_IMAGE" ]; then
+    FLASH_OFFSET=0x0
+fi
+
+JLINK_DEV="nRF51822_xxAC"
+
+common_file_to_load
+jlink_load

--- a/hw/bsp/bmd200/nrf51dk_no_boot.ld
+++ b/hw/bsp/bmd200/nrf51dk_no_boot.ld
@@ -1,0 +1,179 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x40000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x8000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __bssnz_start__
+ *   __bssnz_end__
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))
+        __isr_vector_end = .;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+
+    .ARM.extab : 
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        . = ALIGN(4);
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    /* Keep first in RAM, as well as in bootloader */
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > RAM
+            
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        *(.preinit_array)
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        *(SORT(.init_array.*))
+        *(.init_array)
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    /* Heap starts after BSS */
+    __HeapBase = .;
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/hw/bsp/bmd200/nrf51xxac.ld
+++ b/hw/bsp/bmd200/nrf51xxac.ld
@@ -1,0 +1,25 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00008000, LENGTH = 0x1b800
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x8000
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/bmd200/pkg.yml
+++ b/hw/bsp/bmd200/pkg.yml
@@ -17,26 +17,25 @@
 # under the License.
 #
 
-pkg.name: hw/bsp/bmd300eval
+pkg.name: hw/bsp/bmd200
 pkg.type: bsp
-pkg.description: BSP definition for the Rigado BMD-300 evaluation board. The BMD-300 contains the nrf52.
+pkg.description: BSP definition for the Rigado BMD-200 module (nRF51).
 pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - nrf52
-    - bmd300eval
+    - nrf51
+    - bmd200
     - rigado
 
 pkg.cflags:
     # Nordic SDK files require these defines.
-    - '-DADC_ENABLED=0'
     - '-DCLOCK_ENABLED=1'
-    - '-DCOMP_ENABLED=1'
+    - '-DCOMP_ENABLED=0'
     - '-DEGU_ENABLED=0'
     - '-DGPIOTE_ENABLED=1'
-    - '-DI2S_ENABLED=1'
+    - '-DI2S_ENABLED=0'
     - '-DLPCOMP_ENABLED=1'
-    - '-DNRF52'
+    - '-DNRF51'
     - '-DPDM_ENABLED=0'
     - '-DPERIPHERAL_RESOURCE_SHARING_ENABLED=1'
     - '-DPWM0_ENABLED=1'
@@ -47,44 +46,42 @@ pkg.cflags:
     - '-DRTC0_ENABLED=0'
     - '-DRTC1_ENABLED=0'
     - '-DRTC2_ENABLED=0'
-    - '-DSAADC_ENABLED=1'
-    - '-DSPI0_CONFIG_MISO_PIN=25'
-    - '-DSPI0_CONFIG_MOSI_PIN=24'
-    - '-DSPI0_CONFIG_SCK_PIN=23'
+    - '-DSPI0_CONFIG_MISO_PIN=28'
+    - '-DSPI0_CONFIG_MOSI_PIN=25'
+    - '-DSPI0_CONFIG_SCK_PIN=29'
     - '-DSPI0_ENABLED=1'
-    - '-DSPI0_USE_EASY_DMA=1'
+    - '-DSPI0_USE_EASY_DMA=0'
     - '-DSPI1_ENABLED=0'
     - '-DSPI2_ENABLED=0'
-    - '-DSPIS0_CONFIG_MISO_PIN=25'
-    - '-DSPIS0_CONFIG_MOSI_PIN=24'
-    - '-DSPIS0_CONFIG_SCK_PIN=23'
-    - '-DSPIS0_ENABLED=1'
-    - '-DSPIS1_CONFIG_MISO_PIN=4'
-    - '-DSPIS1_CONFIG_MOSI_PIN=3'
-    - '-DSPIS1_CONFIG_SCK_PIN=2'
-    - '-DSPIS1_ENABLED=0'
+    - '-DSPIS0_CONFIG_MISO_PIN=4'
+    - '-DSPIS0_CONFIG_MOSI_PIN=3'
+    - '-DSPIS0_CONFIG_SCK_PIN=2'
+    - '-DSPIS0_ENABLED=0'
+    - '-DSPIS1_CONFIG_MISO_PIN=28'
+    - '-DSPIS1_CONFIG_MOSI_PIN=25'
+    - '-DSPIS1_CONFIG_SCK_PIN=29'
+    - '-DSPIS1_ENABLED=1'
     - '-DSPIS2_ENABLED=0'
-    - '-DSPI_MASTER_0_ENABLE'
     - '-DTIMER0_ENABLED=1'
     - '-DTIMER1_ENABLED=0'
     - '-DTIMER2_ENABLED=0'
     - '-DTIMER3_ENABLED=0'
     - '-DTIMER4_ENABLED=0'
-    - '-DTWI0_CONFIG_SCL=0'
-    - '-DTWI0_CONFIG_SDA=1'
+    - '-DTWI0_CONFIG_SCL=7'
+    - '-DTWI0_CONFIG_SDA=30'
     - '-DTWI0_ENABLED=1'
-    - '-DTWI1_ENABLED=1'
-    - '-DTWIS0_ENABLED=1'
+    - '-DTWI1_ENABLED=0'
+    - '-DTWIS0_ENABLED=0'
     - '-DTWIS1_ENABLED=0'
     - '-DUART0_ENABLED=1'
     - '-DWDT_ENABLED=1'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
+    - hw/mcu/nordic/nrf51xxx
     - libc/baselibc
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - hw/drivers/nimble/nrf51
 
 pkg.deps.UART_0:
     - hw/drivers/uart/uart_hal

--- a/hw/bsp/bmd200/split-nrf51dk.ld
+++ b/hw/bsp/bmd200/split-nrf51dk.ld
@@ -1,0 +1,185 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00023800, LENGTH = 0x1b800
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x8000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler_split : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __bssnz_start__
+ *   __bssnz_end__
+ */
+ENTRY(Reset_Handler_split)
+
+SECTIONS
+{
+    .imghdr (NOLOAD):
+    {
+    	. = . + 0x20;
+    } > FLASH
+
+    .text :
+    {
+        __split_isr_vector_start = .;
+        KEEP(*(.isr_vector_split))
+        __split_isr_vector_end = .;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        . = ALIGN(4);
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    /* save RAM used by the split image. This assumes that
+     * the loader uses all the RAM up to its HeapBase  */
+    .loader_ram_contents :
+    {
+        _loader_ram_start = .;
+         /* this symbol comes from the loader linker */
+          . = . + (ABSOLUTE(__HeapBase_loader) - _loader_ram_start);
+         _loader_ram_end = .;
+    } > RAM
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        *(.preinit_array)
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        *(SORT(.init_array.*))
+        *(.init_array)
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    /* Heap starts after BSS */
+    __HeapBase = .;
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/hw/bsp/bmd200/src/arch/cortex_m0/gcc_startup_nrf51.s
+++ b/hw/bsp/bmd200/src/arch/cortex_m0/gcc_startup_nrf51.s
@@ -1,0 +1,280 @@
+/*
+Copyright (c) 2015, Nordic Semiconductor ASA
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Nordic Semiconductor ASA nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+NOTE: Template files (including this one) are application specific and therefore
+expected to be copied into the application project folder prior to its use!
+*/
+
+    .syntax unified
+    .arch armv6-m
+
+    .section .stack
+    .align 3
+    .equ    Stack_Size, 432
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop                 /* Top of Stack */
+    .long   Reset_Handler               /* Reset Handler */
+    .long   _NMI_Handler                /* NMI Handler */
+    .long   _HardFault_Handler          /* Hard Fault Handler */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   _SVC_Handler                /* SVCall Handler */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   _PendSV_Handler             /* PendSV Handler */
+    .long   _SysTick_Handler            /* SysTick Handler */
+
+  /* External Interrupts */
+    .long   _POWER_CLOCK_IRQHandler
+    .long   _RADIO_IRQHandler
+    .long   _UART0_IRQHandler
+    .long   _SPI0_TWI0_IRQHandler
+    .long   _SPI1_TWI1_IRQHandler
+    .long   0                         /*Reserved */
+    .long   _GPIOTE_IRQHandler
+    .long   ADC_IRQHandler
+    .long   _TIMER0_IRQHandler
+    .long   _TIMER1_IRQHandler
+    .long   _TIMER2_IRQHandler
+    .long   _RTC0_IRQHandler
+    .long   _TEMP_IRQHandler
+    .long   _RNG_IRQHandler
+    .long   _ECB_IRQHandler
+    .long   _CCM_AAR_IRQHandler
+    .long   _WDT_IRQHandler
+    .long   _RTC1_IRQHandler
+    .long   _QDEC_IRQHandler
+    .long   _LPCOMP_IRQHandler
+    .long   _SWI0_IRQHandler
+    .long   _SWI1_IRQHandler
+    .long   _SWI2_IRQHandler
+    .long   _SWI3_IRQHandler
+    .long   _SWI4_IRQHandler
+    .long   _SWI5_IRQHandler
+    .long   0                         /*Reserved */
+    .long   0                         /*Reserved */
+    .long   0                         /*Reserved */
+    .long   0                         /*Reserved */
+    .long   0                         /*Reserved */
+    .long   0                         /*Reserved */
+
+    .size    __isr_vector, . - __isr_vector
+
+/* Reset Handler */
+
+    .equ    NRF_POWER_RAMON_ADDRESS,             0x40000524
+    .equ    NRF_POWER_RAMONB_ADDRESS,            0x40000554
+    .equ    NRF_POWER_RAMONx_RAMxON_ONMODE_Msk,  0x3
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    .fnstart
+
+/* Make sure ALL RAM banks are powered on */
+    MOVS    R1, #NRF_POWER_RAMONx_RAMxON_ONMODE_Msk
+
+    LDR     R0, =NRF_POWER_RAMON_ADDRESS
+    LDR     R2, [R0]
+    ORRS    R2, R1
+    STR     R2, [R0]
+
+    LDR     R0, =NRF_POWER_RAMONB_ADDRESS
+    LDR     R2, [R0]
+    ORRS    R2, R1
+    STR     R2, [R0]
+
+    /* Clear BSS */
+    subs    r0, r0
+    ldr     r2, =__bss_start__
+    ldr     r3, =__bss_end__
+.bss_zero_loop:
+    cmp     r2, r3
+    bhs     .data_copy_loop
+    stmia   r2!, {r0}
+    b    .bss_zero_loop
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+.data_copy_loop:
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble     .LC0
+
+.LC1:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC1
+.LC0:
+    LDR     R0, =__HeapBase
+    LDR     R1, =__HeapLimit
+    BL      _sbrkInit
+
+    LDR     R0, =SystemInit
+    BLX     R0
+    LDR     R0, =_start
+    BX      R0
+
+    .pool
+    .cantunwind
+    .fnend
+    .size   Reset_Handler,.-Reset_Handler
+
+    .section ".text"
+
+
+/* Dummy Exception Handlers (infinite loops which can be modified) */
+
+    .weak   NMI_Handler
+    .type   NMI_Handler, %function
+NMI_Handler:
+    B       .
+    .size   NMI_Handler, . - NMI_Handler
+
+    .weak   SVC_Handler
+    .type   SVC_Handler, %function
+SVC_Handler:
+    B       .
+    .size   SVC_Handler, . - SVC_Handler
+
+
+    .weak   PendSV_Handler
+    .type   PendSV_Handler, %function
+PendSV_Handler:
+    B       .
+    .size   PendSV_Handler, . - PendSV_Handler
+
+
+    .weak   SysTick_Handler
+    .type   SysTick_Handler, %function
+SysTick_Handler:
+    B       .
+    .size   SysTick_Handler, . - SysTick_Handler
+
+/* Default handler. This uses the vector in the relocated vector table */
+    .globl  Default_Handler
+    .type   Default_Handler, %function
+Default_Handler:
+    LDR     R2, =__vector_tbl_reloc__
+    MRS     R0, PSR
+    MOVS    R1, #0x3F
+    ANDS    R0, R1
+    LSLS    R0, R0, #2
+    LDR     R0, [R0, R2]
+    BX      R0
+    .size   Default_Handler, . - Default_Handler
+
+/*
+ * All of the following IRQ Handlers will point to the default handler unless
+ * they are defined elsewhere.
+ */
+    .macro  IRQ handler
+    .weak   \handler
+    .set    \handler, Default_Handler
+    .endm
+
+    IRQ  _NMI_Handler
+    IRQ  _HardFault_Handler
+    IRQ  _SVC_Handler
+    IRQ  _PendSV_Handler
+    IRQ  _SysTick_Handler
+    IRQ  _POWER_CLOCK_IRQHandler
+    IRQ  _RADIO_IRQHandler
+    IRQ  _UART0_IRQHandler
+    IRQ  _SPI0_TWI0_IRQHandler
+    IRQ  _SPI1_TWI1_IRQHandler
+    IRQ  _GPIOTE_IRQHandler
+    IRQ  ADC_IRQHandler
+    IRQ  _TIMER0_IRQHandler
+    IRQ  _TIMER1_IRQHandler
+    IRQ  _TIMER2_IRQHandler
+    IRQ  _RTC0_IRQHandler
+    IRQ  _TEMP_IRQHandler
+    IRQ  _RNG_IRQHandler
+    IRQ  _ECB_IRQHandler
+    IRQ  _CCM_AAR_IRQHandler
+    IRQ  _WDT_IRQHandler
+    IRQ  _RTC1_IRQHandler
+    IRQ  _QDEC_IRQHandler
+    IRQ  _LPCOMP_IRQHandler
+    IRQ  _SWI0_IRQHandler
+    IRQ  _SWI1_IRQHandler
+    IRQ  _SWI2_IRQHandler
+    IRQ  _SWI3_IRQHandler
+    IRQ  _SWI4_IRQHandler
+    IRQ  _SWI5_IRQHandler
+
+  .end

--- a/hw/bsp/bmd200/src/arch/cortex_m0/gcc_startup_nrf51_split.s
+++ b/hw/bsp/bmd200/src/arch/cortex_m0/gcc_startup_nrf51_split.s
@@ -1,0 +1,182 @@
+/*
+Copyright (c) 2015, Nordic Semiconductor ASA
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Nordic Semiconductor ASA nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+NOTE: Template files (including this one) are application specific and therefore
+expected to be copied into the application project folder prior to its use!
+*/
+
+    .syntax unified
+    .arch armv6-m
+
+    .section .stack
+    .align 3
+    .equ    Stack_Size, 432
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector_split
+    .align 2
+    .globl __isr_vector_split
+__isr_vector_split:
+    .long    __StackTop                 /* Top of Stack */
+    .long   Reset_Handler_split         /* Reset Handler */
+
+    .size    __isr_vector_split, . - __isr_vector_split
+
+/* Reset Handler */
+
+    .equ    NRF_POWER_RAMON_ADDRESS,             0x40000524
+    .equ    NRF_POWER_RAMONB_ADDRESS,            0x40000554
+    .equ    NRF_POWER_RAMONx_RAMxON_ONMODE_Msk,  0x3
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl    Reset_Handler_split
+    .type    Reset_Handler_split, %function
+Reset_Handler_split:
+    .fnstart
+
+/* Clear CPU state before proceeding */
+    SUBS    r0, r0
+    MSR     CONTROL, r0
+    MSR     PRIMASK, r0
+
+/* Make sure ALL RAM banks are powered on */
+    MOVS    R1, #NRF_POWER_RAMONx_RAMxON_ONMODE_Msk
+
+    LDR     R0, =NRF_POWER_RAMON_ADDRESS
+    LDR     R2, [R0]
+    ORRS    R2, R1
+    STR     R2, [R0]
+
+    LDR     R0, =NRF_POWER_RAMONB_ADDRESS
+    LDR     R2, [R0]
+    ORRS    R2, R1
+    STR     R2, [R0]
+
+    /* Clear BSS */
+    subs    r0, r0
+    ldr     r2, =__bss_start__
+    ldr     r3, =__bss_end__
+.bss_zero_loop:
+    cmp     r2, r3
+    bhs     .data_copy_loop
+    stmia   r2!, {r0}
+    b    .bss_zero_loop
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+.data_copy_loop:
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble     .LC0
+
+.LC1:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC1
+.LC0:
+    ldr    r1, =__etext_loader
+    ldr    r2, =__data_start___loader
+    ldr    r3, =__data_end___loader
+
+    subs    r3, r2
+    ble     .LC2
+
+.LC3:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC3
+.LC2:
+
+    subs    r0, r0
+    ldr    r2, =__bss_start___loader
+    ldr    r3, =__bss_end___loader
+
+    subs    r3, r2
+    ble     .LC4
+
+.LC5:
+    subs    r3, 4
+    str    r0, [r2,r3]
+    bgt    .LC5
+.LC4:
+    LDR     R0, =__HeapBase
+    LDR     R1, =__HeapLimit
+    BL      _sbrkInit
+
+    LDR     R0, =SystemInit
+    BLX     R0
+    LDR     R0, =_start_split
+    BX      R0
+
+    .pool
+    .cantunwind
+    .fnend
+    .size   Reset_Handler_split,.-Reset_Handler_split
+
+    .section ".text"
+
+  .end

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <assert.h>
+#include "syscfg/syscfg.h"
+#include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
+#include "mcu/nrf51_hal.h"
+#include "bsp/bsp.h"
+#include "os/os_dev.h"
+#include "os/os_cputime.h"
+#include "flash_map/flash_map.h"
+#include "hal/hal_flash.h"
+#include "hal/hal_spi.h"
+#include "hal/hal_i2c.h"
+#include "uart/uart.h"
+#include "uart_hal/uart_hal.h"
+
+#if MYNEWT_VAL(UART_0)
+static struct uart_dev os_bsp_uart0;
+static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
+    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
+};
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+/*
+ * NOTE: Our HAL expects that the SS pin, if used, is treated as a gpio line
+ * and is handled outside the SPI routines.
+ */
+static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
+    .sck_pin      = 29,
+    .mosi_pin     = 25,
+    .miso_pin     = 28
+};
+#endif
+
+#if MYNEWT_VAL(SPI_1_SLAVE)
+static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
+    .sck_pin      = 29,
+    .mosi_pin     = 25,
+    .miso_pin     = 28,
+    .ss_pin       = 24
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
+    .scl_pin = 7,
+    .sda_pin = 30,
+    .i2c_frequency = 100    /* 100 kHz */
+};
+#endif
+
+/*
+ * What memory to include in coredump.
+ */
+static const struct hal_bsp_mem_dump dump_cfg[] = {
+    [0] = {
+        .hbmd_start = &_ram_start,
+        .hbmd_size = RAM_SIZE
+    }
+};
+
+const struct hal_flash *
+hal_bsp_flash_dev(uint8_t id)
+{
+    /*
+     * Internal flash mapped to id 0.
+     */
+    if (id != 0) {
+        return NULL;
+    }
+    return &nrf51_flash_dev;
+}
+
+const struct hal_bsp_mem_dump *
+hal_bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
+    return dump_cfg;
+}
+
+int
+hal_bsp_power_state(int state)
+{
+    return (0);
+}
+
+/**
+ * Returns the configured priority for the given interrupt. If no priority
+ * configured, return the priority passed in
+ *
+ * @param irq_num
+ * @param pri
+ *
+ * @return uint32_t
+ */
+uint32_t
+hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
+{
+    uint32_t cfg_pri;
+
+    switch (irq_num) {
+    /* Radio gets highest priority */
+    case RADIO_IRQn:
+        cfg_pri = 0;
+        break;
+    default:
+        cfg_pri = pri;
+    }
+    return cfg_pri;
+}
+
+void
+hal_bsp_init(void)
+{
+    int rc;
+
+    (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
+#if MYNEWT_VAL(UART_0)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *)&os_bsp_uart0_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(TIMER_0)
+    rc = hal_timer_init(0, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_1)
+    rc = hal_timer_init(1, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_2)
+    rc = hal_timer_init(2, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(TIMER_3)
+    rc = hal_timer_init(3, NULL);
+    assert(rc == 0);
+#endif
+
+#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+    rc = hal_spi_init(0, (void *)&os_bsp_spi0m_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_1_SLAVE)
+    rc = hal_spi_init(1, (void *)&os_bsp_spi1s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
+    assert(rc == 0);
+#endif
+}

--- a/hw/bsp/bmd200/src/sbrk.c
+++ b/hw/bsp/bmd200/src/sbrk.c
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <hal/hal_bsp.h>
+
+/* put these in the data section so they are not cleared by _start */
+static char *sbrkBase __attribute__ ((section (".data")));
+static char *sbrkLimit __attribute__ ((section (".data")));
+static char *brk __attribute__ ((section (".data")));
+
+void
+_sbrkInit(char *base, char *limit) {
+    sbrkBase = base;
+    sbrkLimit = limit;
+    brk = base;
+}
+
+void *
+_sbrk(int incr)
+{
+    void *prev_brk;
+
+    if (incr < 0) {
+        /* Returning memory to the heap. */
+        incr = -incr;
+        if (brk - incr < sbrkBase) {
+            prev_brk = (void *)-1;
+        } else {
+            prev_brk = brk;
+            brk -= incr;
+        }
+    } else {
+        /* Allocating memory from the heap. */
+        if (sbrkLimit - brk >= incr) {
+            prev_brk = brk;
+            brk += incr;
+        } else {
+            prev_brk = (void *)-1;
+        }
+    }
+
+    return prev_brk;
+}

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: hw/bsp/bmd200
+
+syscfg.defs:
+    BSP_NRF51:
+        description: 'TBD'
+        value: 1
+
+    XTAL_32768:
+        description: 'TBD'
+        value: 0
+    XTAL_32768_SYNTH:
+        description: 'TBD'
+        value: 1
+
+    UART_0:
+        description: 'TBD'
+        value: 1
+    UART_0_PIN_TX:
+        description: 'TBD'
+        value: 10
+    UART_0_PIN_RX:
+        description: 'TBD'
+        value: 9
+    UART_0_PIN_RTS:
+        description: 'TBD'
+        value: 11
+    UART_0_PIN_CTS:
+        description: 'TBD'
+        value: 8
+
+    SPI_0_MASTER:
+        description: 'SPI 0 master'
+        value:  0
+    SPI_0_MASTER_SS_PIN:
+        description: 'SPI 0 (master) SS pin number.'
+        value:  24
+    SPI_1_MASTER:
+        description: 'SPI 1 master'
+        value:  0
+        restrictions:
+            - "!SPI_1_SLAVE"
+    SPI_1_MASTER_SS_PIN:
+        description: 'SPI 1 (master) SS pin number.'
+        value:  -1
+    SPI_1_SLAVE:
+        description: 'SPI 1 slave'
+        value:  0
+        restrictions:
+            - "!SPI_1_MASTER"
+
+    TIMER_0:
+        description: 'NRF51 Timer 0'
+        value:  1
+    TIMER_1:
+        description: 'NRF51 Timer 1'
+        value:  0
+    TIMER_2:
+        description: 'NRF51 Timer 2'
+        value:  0
+    TIMER_3:
+        description: 'NRF51 RTC0'
+        value:  0
+
+    I2C_0:
+        description: 'NRF51 I2C (TWI) interface 0'
+        value:  '0'
+
+syscfg.vals:
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1


### PR DESCRIPTION
Based on nrf51dk bsp, with the following changes:
- Program as J-Link device nRF51822
- Default to internally synthesized LF clock
- Default to UART pins used by the factory firmware

See: http://go.rigado.com/BMD-200-Data-Sheet

```diff
diff -ur hw/bsp/nrf51dk/bsp.yml hw/bsp/bmd200/bsp.yml
--- hw/bsp/nrf51dk/bsp.yml      2017-01-27 01:42:42.863797000 -0800
+++ hw/bsp/bmd200/bsp.yml       2017-01-27 01:52:59.069718800 -0800
@@ -20,14 +20,14 @@
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
-    - "hw/bsp/nrf51dk/nrf51xxac.ld"
+    - "hw/bsp/bmd200/nrf51xxac.ld"
     - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
-    - "hw/bsp/nrf51dk/boot-nrf51xxac.ld"
+    - "hw/bsp/bmd200/boot-nrf51xxac.ld"
     - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
-bsp.part2linkerscript: "hw/bsp/nrf51dk/split-nrf51dk.ld"
-bsp.downloadscript: "hw/bsp/nrf51dk/nrf51dk_download.sh"
-bsp.debugscript: "hw/bsp/nrf51dk/nrf51dk_debug.sh"
+bsp.part2linkerscript: "hw/bsp/bmd200/split-nrf51dk.ld"
+bsp.downloadscript: "hw/bsp/bmd200/nrf51dk_download.sh"
+bsp.debugscript: "hw/bsp/bmd200/nrf51dk_debug.sh"

 bsp.flash_map:
     areas:
Only in hw/bsp/nrf51dk: nrf51dk_debug.cmd
Only in hw/bsp/nrf51dk: nrf51dk_download.cmd
diff -ur hw/bsp/nrf51dk/nrf51dk_download.sh hw/bsp/bmd200/nrf51dk_download.sh
--- hw/bsp/nrf51dk/nrf51dk_download.sh  2017-01-18 11:48:47.384292900 -0800
+++ hw/bsp/bmd200/nrf51dk_download.sh   2017-01-27 01:52:59.109714300 -0800
@@ -35,7 +35,7 @@
     FLASH_OFFSET=0x0
 fi

-JLINK_DEV="nRF51422_xxAC"
+JLINK_DEV="nRF51822_xxAC"

 common_file_to_load
 jlink_load
diff -ur hw/bsp/nrf51dk/pkg.yml hw/bsp/bmd200/pkg.yml
--- hw/bsp/nrf51dk/pkg.yml      2017-01-18 11:48:47.390292800 -0800
+++ hw/bsp/bmd200/pkg.yml       2017-01-27 01:52:59.119723400 -0800
@@ -17,14 +17,15 @@
 # under the License.
 #

-pkg.name: hw/bsp/nrf51dk
+pkg.name: hw/bsp/bmd200
 pkg.type: bsp
-pkg.description: BSP definition for the Nordic nRF51 DK SoC.
+pkg.description: BSP definition for the Rigado BMD-200 module (nRF51).
 pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - nrf51
-    - nrf51dk
+    - bmd200
+    - rigado

 pkg.cflags:
     # Nordic SDK files require these defines.
diff -ur hw/bsp/nrf51dk/syscfg.yml hw/bsp/bmd200/syscfg.yml
--- hw/bsp/nrf51dk/syscfg.yml   2017-01-27 01:29:40.916091700 -0800
+++ hw/bsp/bmd200/syscfg.yml    2017-01-27 01:52:59.141732500 -0800
@@ -17,7 +17,7 @@
 # under the License.
 #

-# Package: hw/bsp/nrf51dk
+# Package: hw/bsp/bmd200

 syscfg.defs:
     BSP_NRF51:
@@ -26,6 +26,9 @@

     XTAL_32768:
         description: 'TBD'
+        value: 0
+    XTAL_32768_SYNTH:
+        description: 'TBD'
         value: 1

     UART_0:
@@ -33,16 +36,16 @@
         value: 1
     UART_0_PIN_TX:
         description: 'TBD'
-        value: 9
+        value: 10
     UART_0_PIN_RX:
         description: 'TBD'
-        value: 11
+        value: 9
     UART_0_PIN_RTS:
         description: 'TBD'
-        value: 8
+        value: 11
     UART_0_PIN_CTS:
         description: 'TBD'
-        value: 10
+        value: 8

     SPI_0_MASTER:
         description: 'SPI 0 master'
```