### PR TITLE
Nimble: update advertising API

### DIFF
--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -279,7 +279,7 @@ blecent_should_connect(const struct ble_gap_disc_desc *disc)
      * service (0x1811).
      */
     for (i = 0; i < fields.num_uuids16; i++) {
-        if (fields.uuids16[i] == BLECENT_SVC_ALERT_UUID) {
+        if (ble_uuid_u16(&fields.uuids16[i].u) == BLECENT_SVC_ALERT_UUID) {
             return 1;
         }
     }

--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -259,6 +259,8 @@ blecent_scan(void)
 static int
 blecent_should_connect(const struct ble_gap_disc_desc *disc)
 {
+    struct ble_hs_adv_fields fields;
+    int rc;
     int i;
 
     /* The device has to be advertising connectability. */
@@ -268,11 +270,16 @@ blecent_should_connect(const struct ble_gap_disc_desc *disc)
         return 0;
     }
 
+    rc = ble_hs_adv_parse_fields(&fields, disc->data, disc->length_data);
+    if (rc != 0) {
+        return rc;
+    }
+
     /* The device has to advertise support for the Alert Notification
      * service (0x1811).
      */
-    for (i = 0; i < disc->fields->num_uuids16; i++) {
-        if (disc->fields->uuids16[i] == BLECENT_SVC_ALERT_UUID) {
+    for (i = 0; i < fields.num_uuids16; i++) {
+        if (fields.uuids16[i] == BLECENT_SVC_ALERT_UUID) {
             return 1;
         }
     }
@@ -332,12 +339,19 @@ static int
 blecent_gap_event(struct ble_gap_event *event, void *arg)
 {
     struct ble_gap_conn_desc desc;
+    struct ble_hs_adv_fields fields;
     int rc;
 
     switch (event->type) {
     case BLE_GAP_EVENT_DISC:
+        rc = ble_hs_adv_parse_fields(&fields, event->disc.data,
+                                     event->disc.length_data);
+        if (rc != 0) {
+            return 0;
+        }
+
         /* An advertisment report was received during GAP discovery. */
-        print_adv_fields(event->disc.fields);
+        print_adv_fields(&fields);
 
         /* Try to connect to the advertiser if it looks interesting. */
         blecent_connect_if_interesting(&event->disc);

--- a/apps/blecent/src/misc.c
+++ b/apps/blecent/src/misc.c
@@ -155,12 +155,6 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
         BLECENT_LOG(DEBUG, "    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
     }
 
-    if (fields->device_class != NULL) {
-        BLECENT_LOG(DEBUG, "    device_class=");
-        print_bytes(fields->device_class, BLE_HS_ADV_DEVICE_CLASS_LEN);
-        BLECENT_LOG(DEBUG, "\n");
-    }
-
     if (fields->slave_itvl_range != NULL) {
         BLECENT_LOG(DEBUG, "    slave_itvl_range=");
         print_bytes(fields->slave_itvl_range, BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
@@ -189,14 +183,6 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
 
     if (fields->adv_itvl_is_present) {
         BLECENT_LOG(DEBUG, "    adv_itvl=0x%04x\n", fields->adv_itvl);
-    }
-
-    if (fields->le_addr != NULL) {
-        BLECENT_LOG(DEBUG, "    le_addr=%s\n", addr_str(fields->le_addr));
-    }
-
-    if (fields->le_role_is_present) {
-        BLECENT_LOG(DEBUG, "    le_role=0x%02x\n", fields->le_role);
     }
 
     if (fields->svc_data_uuid32 != NULL) {

--- a/apps/blecent/src/misc.c
+++ b/apps/blecent/src/misc.c
@@ -105,7 +105,6 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
 {
     char s[BLE_HS_ADV_MAX_SZ];
     const uint8_t *u8p;
-    ble_uuid_any_t uuid;
     int i;
 
     if (fields->flags != 0) {
@@ -116,7 +115,8 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
         BLECENT_LOG(DEBUG, "    uuids16(%scomplete)=",
                     fields->uuids16_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids16; i++) {
-            BLECENT_LOG(DEBUG, "0x%04x ", fields->uuids16[i]);
+            print_uuid(&fields->uuids16[i].u);
+            BLECENT_LOG(DEBUG, " ");
         }
         BLECENT_LOG(DEBUG, "\n");
     }
@@ -125,7 +125,8 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
         BLECENT_LOG(DEBUG, "    uuids32(%scomplete)=",
                     fields->uuids32_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids32; i++) {
-            BLECENT_LOG(DEBUG, "0x%08x ", fields->uuids32[i]);
+            print_uuid(&fields->uuids32[i].u);
+            BLECENT_LOG(DEBUG, " ");
         }
         BLECENT_LOG(DEBUG, "\n");
     }
@@ -133,12 +134,9 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
     if (fields->uuids128 != NULL) {
         BLECENT_LOG(DEBUG, "    uuids128(%scomplete)=",
                     fields->uuids128_is_complete ? "" : "in");
-        u8p = fields->uuids128;
         for (i = 0; i < fields->num_uuids128; i++) {
-            ble_uuid_init_from_buf(&uuid, u8p, 16);
-            print_uuid(&uuid.u);
+            print_uuid(&fields->uuids128[i].u);
             BLECENT_LOG(DEBUG, " ");
-            u8p += 16;
         }
         BLECENT_LOG(DEBUG, "\n");
     }

--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -113,7 +113,9 @@ bleprph_advertise(void)
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
 
-    fields.uuids16 = (uint16_t[]){ GATT_SVR_SVC_ALERT_UUID };
+    fields.uuids16 = (ble_uuid16_t[]){
+        BLE_UUID16_INIT(GATT_SVR_SVC_ALERT_UUID)
+    };
     fields.num_uuids16 = 1;
     fields.uuids16_is_complete = 1;
 

--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -117,8 +117,9 @@ bleprph_advertise(void)
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
 
-    fields.uuids128 =
-        BLE_UUID128(BLE_UUID128_DECLARE(OC_GATT_SERVICE_UUID))->value;
+    fields.uuids128 = (ble_uuid128_t []) {
+        BLE_UUID128_INIT(OC_GATT_SERVICE_UUID)
+    };
     fields.num_uuids128 = 1;
     fields.uuids128_is_complete = 1;
 

--- a/apps/bletiny/src/cmd.c
+++ b/apps/bletiny/src/cmd.c
@@ -1883,9 +1883,9 @@ bletiny_set_adv_data_help(void)
 static int
 cmd_set_adv_data(void)
 {
-    static bssnz_t uint16_t uuids16[CMD_ADV_DATA_MAX_UUIDS16];
-    static bssnz_t uint32_t uuids32[CMD_ADV_DATA_MAX_UUIDS32];
-    static bssnz_t uint8_t uuids128[CMD_ADV_DATA_MAX_UUIDS128][16];
+    static bssnz_t ble_uuid16_t uuids16[CMD_ADV_DATA_MAX_UUIDS16];
+    static bssnz_t ble_uuid32_t uuids32[CMD_ADV_DATA_MAX_UUIDS32];
+    static bssnz_t ble_uuid128_t uuids128[CMD_ADV_DATA_MAX_UUIDS128];
     static bssnz_t uint8_t
         public_tgt_addrs[CMD_ADV_DATA_MAX_PUBLIC_TGT_ADDRS]
                         [BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN];
@@ -1935,7 +1935,7 @@ cmd_set_adv_data(void)
                 help_cmd_uint16("uuid16");
                 return EINVAL;
             }
-            uuids16[adv_fields.num_uuids16] = uuid16;
+            uuids16[adv_fields.num_uuids16] = (ble_uuid16_t) BLE_UUID16_INIT(uuid16);
             adv_fields.num_uuids16++;
         } else if (rc == ENOENT) {
             break;
@@ -1966,7 +1966,7 @@ cmd_set_adv_data(void)
                 help_cmd_uint32("uuid32");
                 return EINVAL;
             }
-            uuids32[adv_fields.num_uuids32] = uuid32;
+            uuids32[adv_fields.num_uuids32] = (ble_uuid32_t) BLE_UUID32_INIT(uuid32);
             adv_fields.num_uuids32++;
         } else if (rc == ENOENT) {
             break;
@@ -1997,7 +1997,8 @@ cmd_set_adv_data(void)
                 help_cmd_byte_stream_exact_length("uuid128", 16);
                 return EINVAL;
             }
-            memcpy(uuids128[adv_fields.num_uuids128], uuid128, 16);
+            ble_uuid_init_from_buf((ble_uuid_any_t *) &uuids128[adv_fields.num_uuids128],
+                                   uuid128, 16);
             adv_fields.num_uuids128++;
         } else if (rc == ENOENT) {
             break;

--- a/apps/bletiny/src/cmd.c
+++ b/apps/bletiny/src/cmd.c
@@ -1866,8 +1866,6 @@ bletiny_set_adv_data_help(void)
     help_cmd_byte_stream_exact_length("uuid128", 16);
     help_cmd_long("uuids128_is_complete");
     help_cmd_long_bounds("tx_pwr_lvl", INT8_MIN, INT8_MAX);
-    help_cmd_byte_stream_exact_length("device_class",
-                                      BLE_HS_ADV_DEVICE_CLASS_LEN);
     help_cmd_byte_stream_exact_length("slave_itvl_range",
                                       BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
     help_cmd_byte_stream("svc_data_uuid16");
@@ -1876,8 +1874,6 @@ bletiny_set_adv_data_help(void)
     help_cmd_uint16("appearance");
     help_cmd_extract("name");
     help_cmd_uint16("adv_itvl");
-    help_cmd_byte_stream_exact_length("le_addr", BLE_HS_ADV_LE_ADDR_LEN);
-    help_cmd_long_bounds("le_role", 0, 0xff);
     help_cmd_byte_stream("svc_data_uuid32");
     help_cmd_byte_stream("svc_data_uuid128");
     help_cmd_byte_stream("uri");
@@ -1893,7 +1889,6 @@ cmd_set_adv_data(void)
     static bssnz_t uint8_t
         public_tgt_addrs[CMD_ADV_DATA_MAX_PUBLIC_TGT_ADDRS]
                         [BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN];
-    static bssnz_t uint8_t device_class[BLE_HS_ADV_DEVICE_CLASS_LEN];
     static bssnz_t uint8_t slave_itvl_range[BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN];
     static bssnz_t uint8_t
         svc_data_uuid16[CMD_ADV_DATA_SVC_DATA_UUID16_MAX_LEN];
@@ -1901,7 +1896,6 @@ cmd_set_adv_data(void)
         svc_data_uuid32[CMD_ADV_DATA_SVC_DATA_UUID32_MAX_LEN];
     static bssnz_t uint8_t
         svc_data_uuid128[CMD_ADV_DATA_SVC_DATA_UUID128_MAX_LEN];
-    static bssnz_t uint8_t le_addr[BLE_HS_ADV_LE_ADDR_LEN];
     static bssnz_t uint8_t uri[CMD_ADV_DATA_URI_MAX_LEN];
     static bssnz_t uint8_t mfg_data[CMD_ADV_DATA_MFG_DATA_MAX_LEN];
     struct ble_hs_adv_fields adv_fields;
@@ -2041,17 +2035,6 @@ cmd_set_adv_data(void)
         return rc;
     }
 
-    rc = parse_arg_byte_stream_exact_length("device_class", device_class,
-                                            BLE_HS_ADV_DEVICE_CLASS_LEN);
-    if (rc == 0) {
-        adv_fields.device_class = device_class;
-    } else if (rc != ENOENT) {
-        console_printf("invalid 'device_class' parameter\n");
-        help_cmd_byte_stream_exact_length("device_class",
-                                          BLE_HS_ADV_DEVICE_CLASS_LEN);
-        return rc;
-    }
-
     rc = parse_arg_byte_stream_exact_length("slave_itvl_range",
                                             slave_itvl_range,
                                             BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
@@ -2120,25 +2103,6 @@ cmd_set_adv_data(void)
     } else if (rc != ENOENT) {
         console_printf("invalid 'adv_itvl' parameter\n");
         help_cmd_uint16("adv_itvl");
-        return rc;
-    }
-
-    rc = parse_arg_byte_stream_exact_length("le_addr", le_addr,
-                                            BLE_HS_ADV_LE_ADDR_LEN);
-    if (rc == 0) {
-        adv_fields.le_addr = le_addr;
-    } else if (rc != ENOENT) {
-        console_printf("invalid 'le_addr' parameter\n");
-        help_cmd_byte_stream_exact_length("le_addr", BLE_HS_ADV_LE_ADDR_LEN);
-        return rc;
-    }
-
-    adv_fields.le_role = parse_arg_long_bounds("le_role", 0, 0xff, &rc);
-    if (rc == 0) {
-        adv_fields.le_role_is_present = 1;
-    } else if (rc != ENOENT) {
-        console_printf("invalid 'le_role' parameter\n");
-        help_cmd_long_bounds("le_role", 0, 0xff);
         return rc;
     }
 

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -190,13 +190,6 @@ bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
         console_printf("    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
     }
 
-    if (fields->device_class != NULL) {
-        console_printf("    device_class=");
-        print_bytes(fields->device_class,
-                            BLE_HS_ADV_DEVICE_CLASS_LEN);
-        console_printf("\n");
-    }
-
     if (fields->slave_itvl_range != NULL) {
         console_printf("    slave_itvl_range=");
         print_bytes(fields->slave_itvl_range,
@@ -227,16 +220,6 @@ bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
 
     if (fields->adv_itvl_is_present) {
         console_printf("    adv_itvl=0x%04x\n", fields->adv_itvl);
-    }
-
-    if (fields->le_addr != NULL) {
-        console_printf("    le_addr=");
-        print_addr(fields->le_addr);
-        console_printf("\n");
-    }
-
-    if (fields->le_role_is_present) {
-        console_printf("    le_role=0x%02x\n", fields->le_role);
     }
 
     if (fields->svc_data_uuid32 != NULL) {

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -124,7 +124,6 @@ static void
 bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
 {
     uint8_t *u8p;
-    ble_uuid_any_t uuid;
     int i;
 
     if (fields->flags != 0) {
@@ -152,7 +151,8 @@ bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
         console_printf("    uuids16(%scomplete)=",
                        fields->uuids16_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids16; i++) {
-            console_printf("0x%04x ", fields->uuids16[i]);
+            print_uuid(&fields->uuids16[i].u);
+            console_printf(" ");
         }
         console_printf("\n");
     }
@@ -161,7 +161,8 @@ bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
         console_printf("    uuids32(%scomplete)=",
                        fields->uuids32_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids32; i++) {
-            console_printf("0x%08x ", (unsigned int)fields->uuids32[i]);
+            print_uuid(&fields->uuids32[i].u);
+            console_printf(" ");
         }
         console_printf("\n");
     }
@@ -169,12 +170,9 @@ bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
     if (fields->uuids128 != NULL) {
         console_printf("    uuids128(%scomplete)=",
                        fields->uuids128_is_complete ? "" : "in");
-        u8p = fields->uuids128;
         for (i = 0; i < fields->num_uuids128; i++) {
-            ble_uuid_init_from_buf(&uuid, u8p, 16);
-            print_uuid(&uuid.u);
+            print_uuid(&fields->uuids128[i].u);
             console_printf(" ");
-            u8p += 16;
         }
         console_printf("\n");
     }

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -879,6 +879,7 @@ static int
 bletiny_gap_event(struct ble_gap_event *event, void *arg)
 {
     struct ble_gap_conn_desc desc;
+    struct ble_hs_adv_fields fields;
     int conn_idx;
     int rc;
 
@@ -926,7 +927,9 @@ bletiny_gap_event(struct ble_gap_event *event, void *arg)
                                event->disc.length_data);
         print_bytes(event->disc.data, event->disc.length_data);
         console_printf(" fields:\n");
-        bletiny_print_adv_fields(event->disc.fields);
+        ble_hs_adv_parse_fields(&fields, event->disc.data,
+                                event->disc.length_data);
+        bletiny_print_adv_fields(&fields);
         console_printf("\n");
         return 0;
 

--- a/apps/bleuart/src/main.c
+++ b/apps/bleuart/src/main.c
@@ -89,7 +89,7 @@ bleuart_advertise(void)
     fields.tx_pwr_lvl_is_present = 1;
     fields.tx_pwr_lvl = BLE_HS_ADV_TX_PWR_LVL_AUTO;
 
-    fields.uuids128 = BLE_UUID128(&gatt_svr_svc_uart_uuid.u)->value;
+    fields.uuids128 = BLE_UUID128(&gatt_svr_svc_uart_uuid.u);
     fields.num_uuids128 = 1;
     fields.uuids128_is_complete = 1;
 

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -22,6 +22,7 @@
 
 #include <inttypes.h>
 #include "host/ble_hs.h"
+#include "host/ble_hs_adv.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -222,10 +223,7 @@ struct ble_gap_disc_desc {
     uint8_t length_data;
     int8_t rssi;
     uint8_t addr[6];
-
-    /*** LE advertising report fields; both null if no data present. */
     uint8_t *data;
-    struct ble_hs_adv_fields *fields;
 
     /***
      * LE direct advertising report fields; direct_addr_type is

--- a/net/nimble/host/include/host/ble_hs_adv.h
+++ b/net/nimble/host/include/host/ble_hs_adv.h
@@ -59,9 +59,6 @@ struct ble_hs_adv_fields {
     int8_t tx_pwr_lvl;
     unsigned tx_pwr_lvl_is_present:1;
 
-    /*** 0x0d - Class of device. */
-    uint8_t *device_class;
-
     /*** 0x0d - Slave connection interval range. */
     uint8_t *slave_itvl_range;
 
@@ -80,13 +77,6 @@ struct ble_hs_adv_fields {
     /*** 0x1a - Advertising interval. */
     uint16_t adv_itvl;
     unsigned adv_itvl_is_present:1;
-
-    /*** 0x1b - LE bluetooth device address. */
-    uint8_t *le_addr;
-
-    /*** 0x1c - LE role. */
-    uint8_t le_role;
-    unsigned le_role_is_present:1;
 
     /*** 0x20 - Service data - 32-bit UUID. */
     uint8_t *svc_data_uuid32;
@@ -115,11 +105,6 @@ struct ble_hs_adv_fields {
 #define BLE_HS_ADV_TYPE_INCOMP_NAME             0x08
 #define BLE_HS_ADV_TYPE_COMP_NAME               0x09
 #define BLE_HS_ADV_TYPE_TX_PWR_LVL              0x0a
-#define BLE_HS_ADV_TYPE_DEVICE_CLASS            0x0d
-#define BLE_HS_ADV_TYPE_SIMPLE_PAIR_HASH192     0x0e
-#define BLE_HS_ADV_TYPE_SIMPLE_PAIR_RAND192     0x0f
-#define BLE_HS_ADV_TYPE_SM_TK_VALUE             0x10
-#define BLE_HS_ADV_TYPE_SM_OOB_FLAGS            0x11
 #define BLE_HS_ADV_TYPE_SLAVE_ITVL_RANGE        0x12
 #define BLE_HS_ADV_TYPE_SOL_UUIDS16             0x14
 #define BLE_HS_ADV_TYPE_SOL_UUIDS128            0x15
@@ -128,18 +113,9 @@ struct ble_hs_adv_fields {
 #define BLE_HS_ADV_TYPE_RANDOM_TGT_ADDR         0x18
 #define BLE_HS_ADV_TYPE_APPEARANCE              0x19
 #define BLE_HS_ADV_TYPE_ADV_ITVL                0x1a
-#define BLE_HS_ADV_TYPE_LE_ADDR                 0x1b
-#define BLE_HS_ADV_TYPE_LE_ROLE                 0x1c
-#define BLE_HS_ADV_TYPE_SIMPLE_PAIR_HASH256     0x1d
-#define BLE_HS_ADV_TYPE_SIMPLE_PAIR_RAND256     0x1e
 #define BLE_HS_ADV_TYPE_SVC_DATA_UUID32         0x20
 #define BLE_HS_ADV_TYPE_SVC_DATA_UUID128        0x21
-#define BLE_HS_ADV_TYPE_LE_SECURE_CONFIRM       0x22
-#define BLE_HS_ADV_TYPE_LE_SECURE_RANDOM        0x23
 #define BLE_HS_ADV_TYPE_URI                     0x24
-#define BLE_HS_ADV_TYPE_INDOOR_POS              0x25
-#define BLE_HS_ADV_TYPE_TRANS_DISC_DATA         0x26
-#define BLE_HS_ADV_TYPE_3D_INFO_DATA            0x3d
 #define BLE_HS_ADV_TYPE_MFG_DATA                0xff
 
 #define BLE_HS_ADV_FLAGS_LEN                    1
@@ -155,8 +131,6 @@ struct ble_hs_adv_fields {
  */
 #define BLE_HS_ADV_TX_PWR_LVL_AUTO              (-128)
 
-#define BLE_HS_ADV_DEVICE_CLASS_LEN             3
-
 #define BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN         4
 
 #define BLE_HS_ADV_SVC_DATA_UUID16_MIN_LEN      2
@@ -166,14 +140,6 @@ struct ble_hs_adv_fields {
 #define BLE_HS_ADV_APPEARANCE_LEN               2
 
 #define BLE_HS_ADV_ADV_ITVL_LEN                 2
-
-#define BLE_HS_ADV_LE_ADDR_LEN                  7
-
-#define BLE_HS_ADV_LE_ROLE_LEN                  1
-#define BLE_HS_ADV_LE_ROLE_PERIPH               0x00
-#define BLE_HS_ADV_LE_ROLE_CENTRAL              0x01
-#define BLE_HS_ADV_LE_ROLE_BOTH_PERIPH_PREF     0x02
-#define BLE_HS_ADV_LE_ROLE_BOTH_CENTRAL_PREF    0x03
 
 #define BLE_HS_ADV_SVC_DATA_UUID32_MIN_LEN      4
 

--- a/net/nimble/host/include/host/ble_hs_adv.h
+++ b/net/nimble/host/include/host/ble_hs_adv.h
@@ -31,6 +31,15 @@ extern "C" {
 /** Max field payload size (account for 2-byte header). */
 #define BLE_HS_ADV_MAX_FIELD_SZ     (BLE_HS_ADV_MAX_SZ - 2)
 
+struct ble_hs_adv_field {
+    uint8_t length;
+    uint8_t type;
+    uint8_t value[];
+};
+
+typedef int (* ble_hs_adv_parse_func_t) (const struct ble_hs_adv_field *,
+                                         void *);
+
 struct ble_hs_adv_fields {
     /*** 0x01 - Flags. */
     uint8_t flags;
@@ -147,6 +156,12 @@ struct ble_hs_adv_fields {
 
 int ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
                           uint8_t *dst, uint8_t *dst_len, uint8_t max_len);
+
+int ble_hs_adv_parse_fields(struct ble_hs_adv_fields *adv_fields, uint8_t *src,
+                            uint8_t src_len);
+
+int ble_hs_adv_parse(const uint8_t *data, uint8_t length,
+                     ble_hs_adv_parse_func_t func, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/include/host/ble_hs_adv.h
+++ b/net/nimble/host/include/host/ble_hs_adv.h
@@ -21,6 +21,7 @@
 #define H_BLE_HS_ADV_
 
 #include <inttypes.h>
+#include "host/ble_uuid.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,17 +46,17 @@ struct ble_hs_adv_fields {
     uint8_t flags;
 
     /*** 0x02,0x03 - 16-bit service class UUIDs. */
-    uint16_t *uuids16;
+    ble_uuid16_t *uuids16;
     uint8_t num_uuids16;
     unsigned uuids16_is_complete:1;
 
     /*** 0x04,0x05 - 32-bit service class UUIDs. */
-    uint32_t *uuids32;
+    ble_uuid32_t *uuids32;
     uint8_t num_uuids32;
     unsigned uuids32_is_complete:1;
 
     /*** 0x06,0x07 - 128-bit service class UUIDs. */
-    void *uuids128;
+    ble_uuid128_t *uuids128;
     uint8_t num_uuids128;
     unsigned uuids128_is_complete:1;
 

--- a/net/nimble/host/src/ble_eddystone.c
+++ b/net/nimble/host/src/ble_eddystone.c
@@ -30,7 +30,7 @@
 #define BLE_EDDYSTONE_FRAME_TYPE_UID    0x00
 #define BLE_EDDYSTONE_FRAME_TYPE_URL    0x10
 
-static uint16_t ble_eddystone_uuids16[BLE_EDDYSTONE_MAX_UUIDS16 + 1];
+static ble_uuid16_t ble_eddystone_uuids16[BLE_EDDYSTONE_MAX_UUIDS16 + 1];
 static uint8_t ble_eddystone_svc_data[BLE_EDDYSTONE_MAX_SVC_DATA_LEN];
 
 /**
@@ -85,9 +85,9 @@ ble_eddystone_set_adv_data_gen(struct ble_hs_adv_fields *adv_fields,
         return BLE_HS_EINVAL;
     }
 
-    ble_eddystone_uuids16[0] = BLE_EDDYSTONE_SERVICE_UUID;
+    ble_eddystone_uuids16[0] = (ble_uuid16_t) BLE_UUID16_INIT(BLE_EDDYSTONE_SERVICE_UUID);
     memcpy(ble_eddystone_uuids16 + 1, adv_fields->uuids16,
-           adv_fields->num_uuids16 * 2);
+           adv_fields->num_uuids16 * sizeof(ble_uuid16_t));
     adv_fields->uuids16 = ble_eddystone_uuids16;
     adv_fields->num_uuids16++;
     adv_fields->uuids16_is_complete = 1;

--- a/net/nimble/host/src/ble_hs_adv.c
+++ b/net/nimble/host/src/ble_hs_adv.c
@@ -222,17 +222,6 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         }
     }
 
-    /*** 0x0d - Class of device. */
-    if (adv_fields->device_class != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_DEVICE_CLASS,
-                                 BLE_HS_ADV_DEVICE_CLASS_LEN,
-                                 adv_fields->device_class, dst, dst_len,
-                                 max_len);
-        if (rc != 0) {
-            return rc;
-        }
-    }
-
     /*** 0x12 - Slave connection interval range. */
     if (adv_fields->slave_itvl_range != NULL) {
         rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_SLAVE_ITVL_RANGE,
@@ -285,27 +274,6 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         rc = ble_hs_adv_set_array16(BLE_HS_ADV_TYPE_ADV_ITVL, 1,
                                     &adv_fields->adv_itvl, dst, dst_len,
                                     max_len);
-        if (rc != 0) {
-            return rc;
-        }
-    }
-
-    /*** 0x1b - LE bluetooth device address. */
-    if (adv_fields->le_addr != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_LE_ADDR,
-                                 BLE_HS_ADV_LE_ADDR_LEN,
-                                 adv_fields->le_addr, dst, dst_len,
-                                 max_len);
-        if (rc != 0) {
-            return rc;
-        }
-    }
-
-    /*** 0x1c - LE role. */
-    if (adv_fields->le_role_is_present) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_LE_ROLE,
-                                 BLE_HS_ADV_LE_ROLE_LEN,
-                                 &adv_fields->le_role, dst, dst_len, max_len);
         if (rc != 0) {
             return rc;
         }
@@ -499,13 +467,6 @@ ble_hs_adv_parse_one_field(struct ble_hs_adv_fields *adv_fields,
         adv_fields->tx_pwr_lvl_is_present = 1;
         break;
 
-    case BLE_HS_ADV_TYPE_DEVICE_CLASS:
-        if (data_len != BLE_HS_ADV_DEVICE_CLASS_LEN) {
-            return BLE_HS_EBADDATA;
-        }
-        adv_fields->device_class = data;
-        break;
-
     case BLE_HS_ADV_TYPE_SLAVE_ITVL_RANGE:
         if (data_len != BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN) {
             return BLE_HS_EBADDATA;
@@ -544,21 +505,6 @@ ble_hs_adv_parse_one_field(struct ble_hs_adv_fields *adv_fields,
         }
         adv_fields->adv_itvl = get_le16(data);
         adv_fields->adv_itvl_is_present = 1;
-        break;
-
-    case BLE_HS_ADV_TYPE_LE_ADDR:
-        if (data_len != BLE_HS_ADV_LE_ADDR_LEN) {
-            return BLE_HS_EBADDATA;
-        }
-        adv_fields->le_addr = data;
-        break;
-
-    case BLE_HS_ADV_TYPE_LE_ROLE:
-        if (data_len != BLE_HS_ADV_LE_ROLE_LEN) {
-            return BLE_HS_EBADDATA;
-        }
-        adv_fields->le_role = *data;
-        adv_fields->le_role_is_present = 1;
         break;
 
     case BLE_HS_ADV_TYPE_SVC_DATA_UUID32:

--- a/net/nimble/host/src/ble_hs_adv_priv.h
+++ b/net/nimble/host/src/ble_hs_adv_priv.h
@@ -26,8 +26,8 @@ extern "C" {
 
 int ble_hs_adv_set_flat(uint8_t type, int data_len, const void *data,
                         uint8_t *dst, uint8_t *dst_len, uint8_t max_len);
-int ble_hs_adv_parse_fields(struct ble_hs_adv_fields *adv_fields, uint8_t *src,
-                            uint8_t src_len);
+int ble_hs_adv_find_field(uint8_t type, const uint8_t *data, uint8_t length,
+                          const struct ble_hs_adv_field **out);
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/src/ble_hs_hci_evt.c
+++ b/net/nimble/host/src/ble_hs_hci_evt.c
@@ -434,7 +434,6 @@ ble_hs_hci_evt_le_dir_adv_rpt(uint8_t subevent, uint8_t *data, int len)
 
     /* Data fields not present in a direct advertising report. */
     desc.data = NULL;
-    desc.fields = NULL;
 
     for (i = 0; i < num_reports; i++) {
         suboff = 0;

--- a/net/nimble/host/test/src/ble_gap_test.c
+++ b/net/nimble/host/test/src/ble_gap_test.c
@@ -630,7 +630,7 @@ TEST_CASE(ble_gap_test_case_disc_ltd_mismatch)
     struct ble_gap_disc_desc desc = {
         .event_type = BLE_HCI_ADV_TYPE_ADV_IND,
         .addr_type = BLE_ADDR_TYPE_PUBLIC,
-        .length_data = 0,
+        .length_data = 3,
         .rssi = 0,
         .addr = { 1, 2, 3, 4, 5, 6 },
         .data = (uint8_t[BLE_HS_ADV_MAX_SZ]){

--- a/net/nimble/host/test/src/ble_hs_adv_test.c
+++ b/net/nimble/host/test/src/ble_hs_adv_test.c
@@ -189,7 +189,11 @@ TEST_CASE(ble_hs_adv_test_case_user)
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
     adv_fields.tx_pwr_lvl_is_present = 1;
     adv_fields.tx_pwr_lvl = BLE_HS_ADV_TX_PWR_LVL_AUTO;
-    adv_fields.uuids16 = (uint16_t[]) { 0x0001, 0x1234, 0x54ab };
+    adv_fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(0x0001),
+        BLE_UUID16_INIT(0x1234),
+        BLE_UUID16_INIT(0x54ab)
+    };
     adv_fields.num_uuids16 = 3;
     adv_fields.uuids16_is_complete = 1;
 
@@ -217,7 +221,11 @@ TEST_CASE(ble_hs_adv_test_case_user)
     memset(&adv_fields, 0, sizeof adv_fields);
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
     adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.uuids16 = (uint16_t[]) { 0x0001, 0x1234, 0x54ab };
+    adv_fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(0x0001),
+        BLE_UUID16_INIT(0x1234),
+        BLE_UUID16_INIT(0x54ab)
+    };
     adv_fields.num_uuids16 = 3;
     adv_fields.uuids16_is_complete = 0;
 
@@ -245,7 +253,10 @@ TEST_CASE(ble_hs_adv_test_case_user)
     memset(&adv_fields, 0, sizeof adv_fields);
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
     adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.uuids32 = (uint32_t[]) { 0x12345678, 0xabacadae };
+    adv_fields.uuids32 = (ble_uuid32_t[]) {
+        BLE_UUID32_INIT(0x12345678),
+        BLE_UUID32_INIT(0xabacadae)
+    };
     adv_fields.num_uuids32 = 2;
     adv_fields.uuids32_is_complete = 1;
 
@@ -273,7 +284,10 @@ TEST_CASE(ble_hs_adv_test_case_user)
     memset(&adv_fields, 0, sizeof adv_fields);
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
     adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.uuids32 = (uint32_t[]) { 0x12345678, 0xabacadae };
+    adv_fields.uuids32 = (ble_uuid32_t[]) {
+        BLE_UUID32_INIT(0x12345678),
+        BLE_UUID32_INIT(0xabacadae)
+    };
     adv_fields.num_uuids32 = 2;
     adv_fields.uuids32_is_complete = 0;
 
@@ -301,9 +315,9 @@ TEST_CASE(ble_hs_adv_test_case_user)
     memset(&adv_fields, 0, sizeof adv_fields);
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
     adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.uuids128 = (uint8_t[]) {
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    adv_fields.uuids128 = (ble_uuid128_t[]) {
+        BLE_UUID128_INIT(0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                         0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)
     };
     adv_fields.num_uuids128 = 1;
     adv_fields.uuids128_is_complete = 1;
@@ -335,10 +349,10 @@ TEST_CASE(ble_hs_adv_test_case_user)
     memset(&adv_fields, 0, sizeof adv_fields);
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
     adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.uuids128 = (uint8_t[]) {
+    adv_fields.uuids128 = BLE_UUID128(BLE_UUID128_DECLARE(
         0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
         0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
-    };
+    ));
     adv_fields.num_uuids128 = 1;
     adv_fields.uuids128_is_complete = 0;
 
@@ -677,7 +691,11 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
 
     /*** Complete 16-bit service class UUIDs. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.uuids16 = (uint16_t[]) { 0x0001, 0x1234, 0x54ab };
+    rsp_fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(0x0001),
+        BLE_UUID16_INIT(0x1234),
+        BLE_UUID16_INIT(0x54ab)
+    };
     rsp_fields.num_uuids16 = 3;
     rsp_fields.uuids16_is_complete = 1;
 
@@ -707,7 +725,11 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
 
     /*** Incomplete 16-bit service class UUIDs. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.uuids16 = (uint16_t[]) { 0x0001, 0x1234, 0x54ab };
+    rsp_fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(0x0001),
+        BLE_UUID16_INIT(0x1234),
+        BLE_UUID16_INIT(0x54ab)
+    };
     rsp_fields.num_uuids16 = 3;
     rsp_fields.uuids16_is_complete = 0;
 
@@ -737,7 +759,10 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
 
     /*** Complete 32-bit service class UUIDs. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.uuids32 = (uint32_t[]) { 0x12345678, 0xabacadae };
+    rsp_fields.uuids32 = (ble_uuid32_t[]) {
+        BLE_UUID32_INIT(0x12345678),
+        BLE_UUID32_INIT(0xabacadae)
+    };
     rsp_fields.num_uuids32 = 2;
     rsp_fields.uuids32_is_complete = 1;
 
@@ -767,7 +792,10 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
 
     /*** Incomplete 32-bit service class UUIDs. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.uuids32 = (uint32_t[]) { 0x12345678, 0xabacadae };
+    rsp_fields.uuids32 = (ble_uuid32_t[]) {
+        BLE_UUID32_INIT(0x12345678),
+        BLE_UUID32_INIT(0xabacadae)
+    };
     rsp_fields.num_uuids32 = 2;
     rsp_fields.uuids32_is_complete = 0;
 
@@ -797,9 +825,9 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
 
     /*** Complete 128-bit service class UUIDs. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.uuids128 = (uint8_t[]) {
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    rsp_fields.uuids128 = (ble_uuid128_t[]) {
+        BLE_UUID128_INIT(0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                         0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)
     };
     rsp_fields.num_uuids128 = 1;
     rsp_fields.uuids128_is_complete = 1;
@@ -833,9 +861,9 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
 
     /*** Incomplete 128-bit service class UUIDs. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.uuids128 = (uint8_t[]) {
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    rsp_fields.uuids128 = (ble_uuid128_t[]) {
+        BLE_UUID128_INIT(0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                         0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)
     };
     rsp_fields.num_uuids128 = 1;
     rsp_fields.uuids128_is_complete = 0;

--- a/net/nimble/host/test/src/ble_hs_adv_test.c
+++ b/net/nimble/host/test/src/ble_hs_adv_test.c
@@ -421,32 +421,6 @@ TEST_CASE(ble_hs_adv_test_case_user)
             { 0 },
         }, &rsp_fields, NULL);
 
-    /*** Class of device. */
-    memset(&adv_fields, 0, sizeof adv_fields);
-    adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
-    adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.device_class = (uint8_t[]){ 1,2,3 };
-
-    ble_hs_adv_test_misc_tx_and_verify_data(BLE_GAP_DISC_MODE_NON, &adv_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_FLAGS,
-                .val = (uint8_t[]){ BLE_HS_ADV_F_BREDR_UNSUP },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_TX_PWR_LVL,
-                .val = (uint8_t[]){ 0 },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_DEVICE_CLASS,
-                .val = (uint8_t[]) { 1,2,3 },
-                .val_len = BLE_HS_ADV_DEVICE_CLASS_LEN,
-            },
-            { 0 },
-        }, &rsp_fields, NULL);
-
     /*** Slave interval range. */
     memset(&adv_fields, 0, sizeof adv_fields);
     adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
@@ -577,59 +551,6 @@ TEST_CASE(ble_hs_adv_test_case_user)
                 .type = BLE_HS_ADV_TYPE_ADV_ITVL,
                 .val = (uint8_t[]){ 0x34, 0x12 },
                 .val_len = BLE_HS_ADV_ADV_ITVL_LEN,
-            },
-            { 0 },
-        }, &rsp_fields, NULL);
-
-    /*** 0x1b - LE bluetooth device address. */
-    memset(&adv_fields, 0, sizeof adv_fields);
-    adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
-    adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.le_addr = (uint8_t[]){ 1,2,3,4,5,6,7 };
-
-    ble_hs_adv_test_misc_tx_and_verify_data(BLE_GAP_DISC_MODE_NON, &adv_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_FLAGS,
-                .val = (uint8_t[]){ BLE_HS_ADV_F_BREDR_UNSUP },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_TX_PWR_LVL,
-                .val = (uint8_t[]){ 0 },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_LE_ADDR,
-                .val = (uint8_t[]) { 1,2,3,4,5,6,7 },
-                .val_len = BLE_HS_ADV_LE_ADDR_LEN,
-            },
-            { 0 },
-        }, &rsp_fields, NULL);
-
-    /*** 0x1c - LE role. */
-    memset(&adv_fields, 0, sizeof adv_fields);
-    adv_fields.flags = BLE_HS_ADV_F_BREDR_UNSUP;
-    adv_fields.tx_pwr_lvl_is_present = 1;
-    adv_fields.le_role = BLE_HS_ADV_LE_ROLE_BOTH_PERIPH_PREF;
-    adv_fields.le_role_is_present = 1;
-
-    ble_hs_adv_test_misc_tx_and_verify_data(BLE_GAP_DISC_MODE_NON, &adv_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_FLAGS,
-                .val = (uint8_t[]){ BLE_HS_ADV_F_BREDR_UNSUP },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_TX_PWR_LVL,
-                .val = (uint8_t[]){ 0 },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_LE_ROLE,
-                .val = (uint8_t[]) { BLE_HS_ADV_LE_ROLE_BOTH_PERIPH_PREF },
-                .val_len = 1,
             },
             { 0 },
         }, &rsp_fields, NULL);
@@ -1006,34 +927,6 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
             { 0 },
         });
 
-    /*** Class of device. */
-    memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.device_class = (uint8_t[]){ 1,2,3 };
-
-    ble_hs_adv_test_misc_tx_and_verify_data(BLE_GAP_DISC_MODE_NON, &adv_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_FLAGS,
-                .val = (uint8_t[]){ BLE_HS_ADV_F_BREDR_UNSUP },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_TX_PWR_LVL,
-                .val = (uint8_t[]){ 0 },
-                .val_len = 1,
-            },
-            { 0 },
-        },
-        &rsp_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_DEVICE_CLASS,
-                .val = (uint8_t[]) { 1,2,3 },
-                .val_len = BLE_HS_ADV_DEVICE_CLASS_LEN,
-            },
-            { 0 },
-        });
-
     /*** Slave interval range. */
     memset(&rsp_fields, 0, sizeof rsp_fields);
     rsp_fields.slave_itvl_range = (uint8_t[]){ 1,2,3,4 };
@@ -1174,63 +1067,6 @@ TEST_CASE(ble_hs_adv_test_case_user_rsp)
                 .type = BLE_HS_ADV_TYPE_ADV_ITVL,
                 .val = (uint8_t[]){ 0x34, 0x12 },
                 .val_len = BLE_HS_ADV_ADV_ITVL_LEN,
-            },
-            { 0 },
-        });
-
-    /*** 0x1b - LE bluetooth device address. */
-    memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.le_addr = (uint8_t[]){ 1,2,3,4,5,6,7 };
-
-    ble_hs_adv_test_misc_tx_and_verify_data(BLE_GAP_DISC_MODE_NON, &adv_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_FLAGS,
-                .val = (uint8_t[]){ BLE_HS_ADV_F_BREDR_UNSUP },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_TX_PWR_LVL,
-                .val = (uint8_t[]){ 0 },
-                .val_len = 1,
-            },
-            { 0 },
-        },
-        &rsp_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_LE_ADDR,
-                .val = (uint8_t[]) { 1,2,3,4,5,6,7 },
-                .val_len = BLE_HS_ADV_LE_ADDR_LEN,
-            },
-            { 0 },
-        });
-
-    /*** 0x1c - LE role. */
-    memset(&rsp_fields, 0, sizeof rsp_fields);
-    rsp_fields.le_role = BLE_HS_ADV_LE_ROLE_BOTH_PERIPH_PREF;
-    rsp_fields.le_role_is_present = 1;
-
-    ble_hs_adv_test_misc_tx_and_verify_data(BLE_GAP_DISC_MODE_NON, &adv_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_FLAGS,
-                .val = (uint8_t[]){ BLE_HS_ADV_F_BREDR_UNSUP },
-                .val_len = 1,
-            },
-            {
-                .type = BLE_HS_ADV_TYPE_TX_PWR_LVL,
-                .val = (uint8_t[]){ 0 },
-                .val_len = 1,
-            },
-            { 0 },
-        },
-        &rsp_fields,
-        (struct ble_hs_adv_test_field[]) {
-            {
-                .type = BLE_HS_ADV_TYPE_LE_ROLE,
-                .val = (uint8_t[]) { BLE_HS_ADV_LE_ROLE_BOTH_PERIPH_PREF },
-                .val_len = 1,
             },
             { 0 },
         });


### PR DESCRIPTION
This does some more fixing for advertising API:
- remove unused/invalid data types from adv data
- use raw data for reports from host to app (so the same as from app to host)
- use ble_uuid types in ble_hs_adv_fields struct (remaining item after ble_uuid refactor)