### PR TITLE
L2CAP LE COC signaling part plus some additional fixes

### DIFF
--- a/apps/bletiny/src/bletiny.h
+++ b/apps/bletiny/src/bletiny.h
@@ -78,9 +78,17 @@ struct bletiny_svc {
 
 SLIST_HEAD(bletiny_svc_list, bletiny_svc);
 
+struct bletiny_l2cap_coc {
+    SLIST_ENTRY(bletiny_l2cap_coc) next;
+    struct ble_l2cap_chan *chan;
+};
+
+SLIST_HEAD(bletiny_l2cap_coc_list, bletiny_l2cap_coc);
+
 struct bletiny_conn {
     uint16_t handle;
     struct bletiny_svc_list svcs;
+    struct bletiny_l2cap_coc_list coc_list;
 };
 
 extern struct bletiny_conn bletiny_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
@@ -182,7 +190,9 @@ int bletiny_sec_restart(uint16_t conn_handle, uint8_t *ltk, uint16_t ediv,
 int bletiny_tx_start(uint16_t handle, uint16_t len, uint16_t rate,
                      uint16_t num);
 int bletiny_rssi(uint16_t conn_handle, int8_t *out_rssi);
-
+int bletiny_l2cap_create_srv(uint16_t psm);
+int bletiny_l2cap_connect(uint16_t conn, uint16_t psm);
+int bletiny_l2cap_disconnect(uint16_t conn, uint16_t idx);
 #define BLETINY_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
 #define BLETINY_LOG(lvl, ...) \
     LOG_ ## lvl(&bletiny_log, BLETINY_LOG_MODULE, __VA_ARGS__)

--- a/kernel/os/include/os/queue.h
+++ b/kernel/os/include/os/queue.h
@@ -158,10 +158,11 @@ struct {                                                \
     }                                                       \
     else {                                                  \
         struct type *curelm = SLIST_FIRST((head));          \
-        while (SLIST_NEXT(curelm, field) != (elm))          \
-            curelm = SLIST_NEXT(curelm, field);             \
-        SLIST_NEXT(curelm, field) =                         \
-            SLIST_NEXT(SLIST_NEXT(curelm, field), field);   \
+        while (SLIST_NEXT(curelm, field) &&                 \
+               SLIST_NEXT(curelm, field) != (elm)) {        \
+              curelm = SLIST_NEXT(curelm, field);           \
+        }                                                   \
+        SLIST_NEXT(curelm, field) = SLIST_NEXT(elm, field); \
     }                                                       \
 } while (0)
 

--- a/net/nimble/host/include/host/ble_hs.h
+++ b/net/nimble/host/include/host/ble_hs.h
@@ -66,6 +66,10 @@ struct os_event;
 #define BLE_HS_ENOMEM_EVT           20
 #define BLE_HS_ENOADDR              21
 #define BLE_HS_ENOTSYNCED           22
+#define BLE_HS_EAUTHEN              23
+#define BLE_HS_EAUTHOR              24
+#define BLE_HS_EENCRYPT             25
+#define BLE_HS_EENCRYPT_KEY_SZ      26
 
 #define BLE_HS_ERR_ATT_BASE         0x100   /* 256 */
 #define BLE_HS_ATT_ERR(x)           ((x) ? BLE_HS_ERR_ATT_BASE + (x) : 0)

--- a/net/nimble/host/src/ble_att.c
+++ b/net/nimble/host/src/ble_att.c
@@ -436,7 +436,7 @@ ble_att_set_peer_mtu(struct ble_l2cap_chan *chan, uint16_t peer_mtu)
         peer_mtu = BLE_ATT_MTU_DFLT;
     }
 
-    chan->blc_peer_mtu = peer_mtu;
+    chan->peer_mtu = peer_mtu;
 }
 
 static int
@@ -517,8 +517,8 @@ ble_att_set_preferred_mtu(uint16_t mtu)
         chan = ble_hs_conn_chan_find(conn, BLE_L2CAP_CID_ATT);
         BLE_HS_DBG_ASSERT(chan != NULL);
 
-        if (!(chan->blc_flags & BLE_L2CAP_CHAN_F_TXED_MTU)) {
-            chan->blc_my_mtu = mtu;
+        if (!(chan->flags & BLE_L2CAP_CHAN_F_TXED_MTU)) {
+            chan->my_mtu = mtu;
         }
 
         i++;
@@ -539,10 +539,10 @@ ble_att_create_chan(void)
         return NULL;
     }
 
-    chan->blc_cid = BLE_L2CAP_CID_ATT;
-    chan->blc_my_mtu = ble_att_preferred_mtu_val;
-    chan->blc_default_mtu = BLE_ATT_MTU_DFLT;
-    chan->blc_rx_fn = ble_att_rx;
+    chan->scid = BLE_L2CAP_CID_ATT;
+    chan->my_mtu = ble_att_preferred_mtu_val;
+    chan->default_mtu = BLE_ATT_MTU_DFLT;
+    chan->rx_fn = ble_att_rx;
 
     return chan;
 }

--- a/net/nimble/host/src/ble_att_clt.c
+++ b/net/nimble/host/src/ble_att_clt.c
@@ -132,7 +132,7 @@ ble_att_clt_tx_mtu(uint16_t conn_handle, const struct ble_att_mtu_cmd *req)
     ble_att_conn_chan_find(conn_handle, &conn, &chan);
     if (chan == NULL) {
         rc = BLE_HS_ENOTCONN;
-    } else if (chan->blc_flags & BLE_L2CAP_CHAN_F_TXED_MTU) {
+    } else if (chan->flags & BLE_L2CAP_CHAN_F_TXED_MTU) {
         rc = BLE_HS_EALREADY;
     } else {
         rc = 0;
@@ -159,7 +159,7 @@ ble_att_clt_tx_mtu(uint16_t conn_handle, const struct ble_att_mtu_cmd *req)
     ble_hs_lock();
 
     ble_att_conn_chan_find(conn_handle, &conn, &chan);
-    chan->blc_flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
+    chan->flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
 
     ble_hs_unlock();
 

--- a/net/nimble/host/src/ble_att_clt.c
+++ b/net/nimble/host/src/ble_att_clt.c
@@ -185,7 +185,7 @@ ble_att_clt_rx_mtu(uint16_t conn_handle, struct os_mbuf **rxom)
 
         ble_att_conn_chan_find(conn_handle, NULL, &chan);
         ble_att_set_peer_mtu(chan, cmd.bamc_mtu);
-        mtu = ble_l2cap_chan_mtu(chan);
+        mtu = ble_att_chan_mtu(chan);
 
         ble_hs_unlock();
 

--- a/net/nimble/host/src/ble_att_priv.h
+++ b/net/nimble/host/src/ble_att_priv.h
@@ -166,6 +166,7 @@ void ble_att_inc_tx_stat(uint8_t att_op);
 void ble_att_truncate_to_mtu(const struct ble_l2cap_chan *att_chan,
                              struct os_mbuf *txom);
 void ble_att_set_peer_mtu(struct ble_l2cap_chan *chan, uint16_t peer_mtu);
+uint16_t ble_att_chan_mtu(const struct ble_l2cap_chan *chan);
 int ble_att_init(void);
 
 #define BLE_ATT_LOG_CMD(is_tx, cmd_name, conn_handle, log_cb, cmd) \

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -766,7 +766,7 @@ done:
         ble_att_conn_chan_find(conn_handle, &conn, &chan);
         ble_att_set_peer_mtu(chan, cmd.bamc_mtu);
         chan->flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
-        mtu = ble_l2cap_chan_mtu(chan);
+        mtu = ble_att_chan_mtu(chan);
 
         ble_hs_unlock();
 

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -702,7 +702,7 @@ ble_att_svr_build_mtu_rsp(uint16_t conn_handle, struct os_mbuf **rxom,
 
     ble_hs_lock();
     ble_att_conn_chan_find(conn_handle, NULL, &chan);
-    mtu = chan->blc_my_mtu;
+    mtu = chan->my_mtu;
     ble_hs_unlock();
 
     /* Just reuse the request buffer for the response. */
@@ -765,7 +765,7 @@ done:
 
         ble_att_conn_chan_find(conn_handle, &conn, &chan);
         ble_att_set_peer_mtu(chan, cmd.bamc_mtu);
-        chan->blc_flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
+        chan->flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
         mtu = ble_l2cap_chan_mtu(chan);
 
         ble_hs_unlock();

--- a/net/nimble/host/src/ble_gattc.c
+++ b/net/nimble/host/src/ble_gattc.c
@@ -1271,7 +1271,7 @@ ble_gattc_mtu_tx(struct ble_gattc_proc *proc)
 
     ble_hs_lock();
     ble_att_conn_chan_find(proc->conn_handle, &conn, &chan);
-    req.bamc_mtu = chan->blc_my_mtu;
+    req.bamc_mtu = chan->my_mtu;
     ble_hs_unlock();
 
     rc = ble_att_clt_tx_mtu(proc->conn_handle, &req);

--- a/net/nimble/host/src/ble_hs_conn.c
+++ b/net/nimble/host/src/ble_hs_conn.c
@@ -58,11 +58,11 @@ ble_hs_conn_chan_find(struct ble_hs_conn *conn, uint16_t cid)
 
     struct ble_l2cap_chan *chan;
 
-    SLIST_FOREACH(chan, &conn->bhc_channels, blc_next) {
-        if (chan->blc_cid == cid) {
+    SLIST_FOREACH(chan, &conn->bhc_channels, next) {
+        if (chan->scid == cid) {
             return chan;
         }
-        if (chan->blc_cid > cid) {
+        if (chan->scid > cid) {
             return NULL;
         }
     }
@@ -81,11 +81,11 @@ ble_hs_conn_chan_insert(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan)
     struct ble_l2cap_chan *cur;
 
     prev = NULL;
-    SLIST_FOREACH(cur, &conn->bhc_channels, blc_next) {
-        if (cur->blc_cid == chan->blc_cid) {
+    SLIST_FOREACH(cur, &conn->bhc_channels, next) {
+        if (cur->scid == chan->scid) {
             return BLE_HS_EALREADY;
         }
-        if (cur->blc_cid > chan->blc_cid) {
+        if (cur->scid > chan->scid) {
             break;
         }
 
@@ -93,9 +93,9 @@ ble_hs_conn_chan_insert(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan)
     }
 
     if (prev == NULL) {
-        SLIST_INSERT_HEAD(&conn->bhc_channels, chan, blc_next);
+        SLIST_INSERT_HEAD(&conn->bhc_channels, chan, next);
     } else {
-        SLIST_INSERT_AFTER(prev, chan, blc_next);
+        SLIST_INSERT_AFTER(prev, chan, next);
     }
 
     return 0;
@@ -164,14 +164,14 @@ err:
     return NULL;
 }
 
-static void
+void
 ble_hs_conn_delete_chan(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan)
 {
     if (conn->bhc_rx_chan == chan) {
         conn->bhc_rx_chan = NULL;
     }
 
-    SLIST_REMOVE(&conn->bhc_channels, chan, ble_l2cap_chan, blc_next);
+    SLIST_REMOVE(&conn->bhc_channels, chan, ble_l2cap_chan, next);
     ble_l2cap_chan_free(chan);
 }
 

--- a/net/nimble/host/src/ble_hs_conn_priv.h
+++ b/net/nimble/host/src/ble_hs_conn_priv.h
@@ -88,6 +88,9 @@ struct ble_l2cap_chan *ble_hs_conn_chan_find(struct ble_hs_conn *conn,
                                              uint16_t cid);
 int ble_hs_conn_chan_insert(struct ble_hs_conn *conn,
                             struct ble_l2cap_chan *chan);
+void
+ble_hs_conn_delete_chan(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan);
+
 void ble_hs_conn_addrs(const struct ble_hs_conn *conn,
                        struct ble_hs_conn_addrs *addrs);
 int32_t ble_hs_conn_timer(void);

--- a/net/nimble/host/src/ble_hs_priv.h
+++ b/net/nimble/host/src/ble_hs_priv.h
@@ -37,6 +37,7 @@
 #include "ble_hs_startup_priv.h"
 #include "ble_l2cap_priv.h"
 #include "ble_l2cap_sig_priv.h"
+#include "ble_l2cap_coc_priv.h"
 #include "ble_sm_priv.h"
 #include "ble_hs_adv_priv.h"
 #include "ble_hs_pvcy_priv.h"

--- a/net/nimble/host/src/ble_l2cap.c
+++ b/net/nimble/host/src/ble_l2cap.c
@@ -81,25 +81,10 @@ ble_l2cap_chan_free(struct ble_l2cap_chan *chan)
     STATS_INC(ble_l2cap_stats, chan_delete);
 }
 
-uint16_t
-ble_l2cap_chan_mtu(const struct ble_l2cap_chan *chan)
+bool
+ble_l2cap_is_mtu_req_sent(const struct ble_l2cap_chan *chan)
 {
-    uint16_t mtu;
-
-    /* If either side has not exchanged MTU size, use the default.  Otherwise,
-     * use the lesser of the two exchanged values.
-     */
-    if (!(chan->flags & BLE_L2CAP_CHAN_F_TXED_MTU) ||
-        chan->peer_mtu == 0) {
-
-        mtu = chan->default_mtu;
-    } else {
-        mtu = min(chan->my_mtu, chan->peer_mtu);
-    }
-
-    BLE_HS_DBG_ASSERT(mtu >= chan->default_mtu);
-
-    return mtu;
+    return (chan->flags & BLE_L2CAP_CHAN_F_TXED_MTU);
 }
 
 int

--- a/net/nimble/host/src/ble_l2cap.c
+++ b/net/nimble/host/src/ble_l2cap.c
@@ -24,6 +24,7 @@
 #include "nimble/ble.h"
 #include "nimble/hci_common.h"
 #include "ble_hs_priv.h"
+#include "ble_l2cap_coc_priv.h"
 
 _Static_assert(sizeof (struct ble_l2cap_hdr) == BLE_L2CAP_HDR_SZ,
                "struct ble_l2cap_hdr must be 4 bytes");
@@ -127,19 +128,14 @@ int
 ble_l2cap_create_server(uint16_t psm, uint16_t mtu,
                         ble_l2cap_event_fn *cb, void *cb_arg)
 {
-    /*TODO: Create server object and put it on the queue */
-    return BLE_HS_ENOTSUP;
+    return ble_l2cap_coc_create_server(psm, mtu, cb, cb_arg);
 }
 
 int
 ble_l2cap_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
                   struct os_mbuf *sdu_rx, ble_l2cap_event_fn *cb, void *cb_arg)
 {
-    /*
-     * TODO In here we are going to create l2cap channel and send
-     * BLE_L2CAP_SIG_OP_CREDIT_CONNECT_REQ
-     */
-    return BLE_HS_ENOTSUP;
+    return ble_l2cap_sig_coc_connect(conn_handle, psm, mtu, sdu_rx, cb, cb_arg);
 }
 
 int ble_l2cap_disconnect(struct ble_l2cap_chan *chan)
@@ -371,6 +367,11 @@ ble_l2cap_init(void)
     }
 
     rc = ble_l2cap_sig_init();
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = ble_l2cap_coc_init();
     if (rc != 0) {
         return rc;
     }

--- a/net/nimble/host/src/ble_l2cap.c
+++ b/net/nimble/host/src/ble_l2cap.c
@@ -31,8 +31,9 @@ _Static_assert(sizeof (struct ble_l2cap_hdr) == BLE_L2CAP_HDR_SZ,
 struct os_mempool ble_l2cap_chan_pool;
 
 static os_membuf_t ble_l2cap_chan_mem[
-    OS_MEMPOOL_SIZE(MYNEWT_VAL(BLE_L2CAP_MAX_CHANS),
-                     sizeof (struct ble_l2cap_chan))
+    OS_MEMPOOL_SIZE(MYNEWT_VAL(BLE_L2CAP_MAX_CHANS) +
+                    MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                    sizeof (struct ble_l2cap_chan))
 ];
 
 STATS_SECT_DECL(ble_l2cap_stats) ble_l2cap_stats;
@@ -120,6 +121,44 @@ ble_l2cap_prepend_hdr(struct os_mbuf *om, uint16_t cid, uint16_t len)
     memcpy(om->om_data, &hdr, sizeof hdr);
 
     return om;
+}
+
+int
+ble_l2cap_create_server(uint16_t psm, uint16_t mtu,
+                        ble_l2cap_event_fn *cb, void *cb_arg)
+{
+    /*TODO: Create server object and put it on the queue */
+    return BLE_HS_ENOTSUP;
+}
+
+int
+ble_l2cap_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
+                  struct os_mbuf *sdu_rx, ble_l2cap_event_fn *cb, void *cb_arg)
+{
+    /*
+     * TODO In here we are going to create l2cap channel and send
+     * BLE_L2CAP_SIG_OP_CREDIT_CONNECT_REQ
+     */
+    return BLE_HS_ENOTSUP;
+}
+
+int ble_l2cap_disconnect(struct ble_l2cap_chan *chan)
+{
+    /*TODO Implement */
+    return BLE_HS_ENOTSUP;
+}
+
+int
+ble_l2cap_send(struct ble_l2cap_chan *chan, struct os_mbuf *sdu)
+{
+    /*TODO Implement */
+    return BLE_HS_ENOTSUP;
+}
+
+void
+ble_l2cap_recv_ready(struct ble_l2cap_chan *chan, struct os_mbuf *sdu_rx)
+{
+    /*TODO In here we going to update sdu_rx buffer */
 }
 
 static void
@@ -322,7 +361,9 @@ ble_l2cap_init(void)
 {
     int rc;
 
-    rc = os_mempool_init(&ble_l2cap_chan_pool, MYNEWT_VAL(BLE_L2CAP_MAX_CHANS),
+    rc = os_mempool_init(&ble_l2cap_chan_pool,
+                         MYNEWT_VAL(BLE_L2CAP_MAX_CHANS) +
+                         MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
                          sizeof (struct ble_l2cap_chan),
                          ble_l2cap_chan_mem, "ble_l2cap_chan_pool");
     if (rc != 0) {

--- a/net/nimble/host/src/ble_l2cap.c
+++ b/net/nimble/host/src/ble_l2cap.c
@@ -140,8 +140,7 @@ ble_l2cap_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
 
 int ble_l2cap_disconnect(struct ble_l2cap_chan *chan)
 {
-    /*TODO Implement */
-    return BLE_HS_ENOTSUP;
+    return ble_l2cap_sig_disconnect(chan);
 }
 
 int

--- a/net/nimble/host/src/ble_l2cap_coc.c
+++ b/net/nimble/host/src/ble_l2cap_coc.c
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <errno.h>
+#include "console/console.h"
+#include "nimble/ble.h"
+#include "ble_hs_priv.h"
+#include "ble_l2cap_priv.h"
+#include "ble_l2cap_coc_priv.h"
+#include "ble_l2cap_sig_priv.h"
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+
+STAILQ_HEAD(ble_l2cap_coc_srv_list, ble_l2cap_coc_srv);
+
+static struct ble_l2cap_coc_srv_list ble_l2cap_coc_srvs;
+
+static os_membuf_t ble_l2cap_coc_srv_mem[
+    OS_MEMPOOL_SIZE(MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                    sizeof (struct ble_l2cap_coc_srv))
+];
+
+static struct os_mempool ble_l2cap_coc_srv_pool;
+
+static void
+ble_l2cap_coc_dbg_assert_srv_not_inserted(struct ble_l2cap_coc_srv *srv)
+{
+#if MYNEWT_VAL(BLE_HS_DEBUG)
+    struct ble_l2cap_coc_srv *cur;
+
+    STAILQ_FOREACH(cur, &ble_l2cap_coc_srvs, next) {
+        BLE_HS_DBG_ASSERT(cur != srv);
+    }
+#endif
+}
+
+static struct ble_l2cap_coc_srv *
+ble_l2cap_coc_srv_alloc(void)
+{
+    struct ble_l2cap_coc_srv *srv;
+
+    srv = os_memblock_get(&ble_l2cap_coc_srv_pool);
+    if (srv != NULL) {
+        memset(srv, 0, sizeof(*srv));
+    }
+
+    return srv;
+}
+
+int
+ble_l2cap_coc_create_server(uint16_t psm, uint16_t mtu,
+                                        ble_l2cap_event_fn *cb, void *cb_arg)
+{
+    struct ble_l2cap_coc_srv * srv;
+
+    srv = ble_l2cap_coc_srv_alloc();
+    if (!srv) {
+            return BLE_HS_ENOMEM;
+    }
+
+    srv->psm = psm;
+    srv->mtu = mtu;
+    srv->cb = cb;
+    srv->cb_arg = cb_arg;
+
+    ble_l2cap_coc_dbg_assert_srv_not_inserted(srv);
+
+    STAILQ_INSERT_HEAD(&ble_l2cap_coc_srvs, srv, next);
+
+    return 0;
+}
+
+uint16_t
+ble_l2cap_coc_get_cid(void)
+{
+    static uint16_t next_cid = BLE_L2CAP_COC_CID_START;
+
+    if (next_cid > BLE_L2CAP_COC_CID_END) {
+            next_cid = BLE_L2CAP_COC_CID_START;
+    }
+
+    /*TODO: Make it smarter*/
+    return next_cid++;
+}
+
+struct ble_l2cap_coc_srv *
+ble_l2cap_coc_srv_find(uint16_t psm)
+{
+    struct ble_l2cap_coc_srv *cur, *srv;
+
+    srv = NULL;
+    STAILQ_FOREACH(cur, &ble_l2cap_coc_srvs, next) {
+        if (cur->psm == psm) {
+                srv = cur;
+                break;
+        }
+    }
+
+    return srv;
+}
+
+int
+ble_l2cap_coc_init(void)
+{
+    STAILQ_INIT(&ble_l2cap_coc_srvs);
+
+    return os_mempool_init(&ble_l2cap_coc_srv_pool,
+                         MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                         sizeof (struct ble_l2cap_coc_srv),
+                         ble_l2cap_coc_srv_mem,
+                         "ble_l2cap_coc_srv_pool");
+}
+
+#endif

--- a/net/nimble/host/src/ble_l2cap_coc_priv.h
+++ b/net/nimble/host/src/ble_l2cap_coc_priv.h
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_L2CAP_COC_PRIV_
+#define H_L2CAP_COC_PRIV_
+
+#include <inttypes.h>
+#include "syscfg/syscfg.h"
+#include "os/queue.h"
+#include "host/ble_l2cap.h"
+#include "ble_l2cap_sig_priv.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLE_L2CAP_COC_MTU                       100
+#define BLE_L2CAP_COC_CID_START                 0x0040
+#define BLE_L2CAP_COC_CID_END                   0x007F
+
+struct ble_l2cap_chan;
+
+struct ble_l2cap_coc_endpoint {
+    uint16_t mtu;
+    uint16_t credits;
+    struct os_mbuf *sdu;
+};
+
+struct ble_l2cap_coc_srv {
+    STAILQ_ENTRY(ble_l2cap_coc_srv) next;
+    uint16_t psm;
+    uint16_t mtu;
+    ble_l2cap_event_fn *cb;
+    void *cb_arg;
+};
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+int ble_l2cap_coc_init(void);
+uint16_t ble_l2cap_coc_get_cid(void);
+int ble_l2cap_coc_create_server(uint16_t psm, uint16_t mtu,
+                                ble_l2cap_event_fn *cb, void *cb_arg);
+struct ble_l2cap_coc_srv * ble_l2cap_coc_srv_find(uint16_t psm);
+#else
+#define ble_l2cap_coc_init()                                    0
+#define ble_l2cap_coc_create_server(psm, mtu, cb, cb_arg)       BLE_HS_ENOTSUP
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_L2CAP_COC_PRIV_ */

--- a/net/nimble/host/src/ble_l2cap_priv.h
+++ b/net/nimble/host/src/ble_l2cap_priv.h
@@ -68,7 +68,6 @@ struct ble_l2cap_chan {
     uint16_t scid;
     uint16_t my_mtu;
     uint16_t peer_mtu;      /* 0 if not exchanged. */
-    uint16_t default_mtu;
     ble_l2cap_chan_flags flags;
 
     struct os_mbuf *rx_buf;
@@ -97,8 +96,7 @@ struct os_mbuf *ble_l2cap_prepend_hdr(struct os_mbuf *om, uint16_t cid,
 struct ble_l2cap_chan *ble_l2cap_chan_alloc(void);
 void ble_l2cap_chan_free(struct ble_l2cap_chan *chan);
 
-uint16_t ble_l2cap_chan_mtu(const struct ble_l2cap_chan *chan);
-
+bool ble_l2cap_is_mtu_req_sent(const struct ble_l2cap_chan *chan);
 
 int ble_l2cap_rx(struct ble_hs_conn *conn,
                  struct hci_data_hdr *hci_hdr,

--- a/net/nimble/host/src/ble_l2cap_priv.h
+++ b/net/nimble/host/src/ble_l2cap_priv.h
@@ -63,6 +63,14 @@ typedef uint8_t ble_l2cap_chan_flags;
 
 typedef int ble_l2cap_rx_fn(uint16_t conn_handle, struct os_mbuf **rxom);
 
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+struct ble_l2cap_coc_endpoint {
+    uint16_t mtu;
+    uint16_t credits;
+    struct os_mbuf *sdu;
+};
+#endif
+
 struct ble_l2cap_chan {
     SLIST_ENTRY(ble_l2cap_chan) next;
     uint16_t scid;
@@ -74,6 +82,16 @@ struct ble_l2cap_chan {
     uint16_t rx_len;        /* Length of current reassembled rx packet. */
 
     ble_l2cap_rx_fn *rx_fn;
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+    uint16_t conn_handle;
+    uint16_t dcid;
+    uint16_t psm;
+    struct ble_l2cap_coc_endpoint coc_rx;
+    struct ble_l2cap_coc_endpoint coc_tx;
+    ble_l2cap_event_fn *cb;
+    void *cb_arg;
+#endif
 };
 
 struct ble_l2cap_hdr {

--- a/net/nimble/host/src/ble_l2cap_priv.h
+++ b/net/nimble/host/src/ble_l2cap_priv.h
@@ -64,22 +64,22 @@ typedef uint8_t ble_l2cap_chan_flags;
 typedef int ble_l2cap_rx_fn(uint16_t conn_handle, struct os_mbuf **rxom);
 
 struct ble_l2cap_chan {
-    SLIST_ENTRY(ble_l2cap_chan) blc_next;
-    uint16_t blc_cid;
-    uint16_t blc_my_mtu;
-    uint16_t blc_peer_mtu;      /* 0 if not exchanged. */
-    uint16_t blc_default_mtu;
-    ble_l2cap_chan_flags blc_flags;
+    SLIST_ENTRY(ble_l2cap_chan) next;
+    uint16_t scid;
+    uint16_t my_mtu;
+    uint16_t peer_mtu;      /* 0 if not exchanged. */
+    uint16_t default_mtu;
+    ble_l2cap_chan_flags flags;
 
-    struct os_mbuf *blc_rx_buf;
-    uint16_t blc_rx_len;        /* Length of current reassembled rx packet. */
+    struct os_mbuf *rx_buf;
+    uint16_t rx_len;        /* Length of current reassembled rx packet. */
 
-    ble_l2cap_rx_fn *blc_rx_fn;
+    ble_l2cap_rx_fn *rx_fn;
 };
 
 struct ble_l2cap_hdr {
-    uint16_t blh_len;
-    uint16_t blh_cid;
+    uint16_t len;
+    uint16_t cid;
 };
 
 typedef int ble_l2cap_tx_fn(struct ble_hs_conn *conn,

--- a/net/nimble/host/src/ble_l2cap_priv.h
+++ b/net/nimble/host/src/ble_l2cap_priv.h
@@ -20,6 +20,7 @@
 #ifndef H_L2CAP_PRIV_
 #define H_L2CAP_PRIV_
 
+#include "ble_l2cap_coc_priv.h"
 #include "host/ble_l2cap.h"
 #include <inttypes.h>
 #include "stats/stats.h"
@@ -62,14 +63,6 @@ extern struct os_mempool ble_l2cap_chan_pool;
 typedef uint8_t ble_l2cap_chan_flags;
 
 typedef int ble_l2cap_rx_fn(uint16_t conn_handle, struct os_mbuf **rxom);
-
-#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
-struct ble_l2cap_coc_endpoint {
-    uint16_t mtu;
-    uint16_t credits;
-    struct os_mbuf *sdu;
-};
-#endif
 
 struct ble_l2cap_chan {
     SLIST_ENTRY(ble_l2cap_chan) next;

--- a/net/nimble/host/src/ble_l2cap_sig.c
+++ b/net/nimble/host/src/ble_l2cap_sig.c
@@ -525,7 +525,6 @@ ble_l2cap_sig_create_chan(void)
 
     chan->scid = BLE_L2CAP_CID_SIG;
     chan->my_mtu = BLE_L2CAP_SIG_MTU;
-    chan->default_mtu = BLE_L2CAP_SIG_MTU;
     chan->rx_fn = ble_l2cap_sig_rx;
 
     return chan;

--- a/net/nimble/host/src/ble_l2cap_sig.c
+++ b/net/nimble/host/src/ble_l2cap_sig.c
@@ -890,7 +890,8 @@ ble_l2cap_sig_disc_req_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
     ble_hs_conn_delete_chan(conn, chan);
     ble_hs_unlock();
 
-    return ble_l2cap_sig_tx(conn_handle, txom);
+    ble_l2cap_sig_tx(conn_handle, txom);
+    return 0;
 }
 
 static void
@@ -929,7 +930,7 @@ done:
 }
 
 static int
-ble_l2cap_sig_disc_rsp_rx (uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
+ble_l2cap_sig_disc_rsp_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
                            struct os_mbuf **om)
 {
     struct ble_l2cap_sig_disc_rsp *rsp;

--- a/net/nimble/host/src/ble_l2cap_sig.c
+++ b/net/nimble/host/src/ble_l2cap_sig.c
@@ -523,10 +523,10 @@ ble_l2cap_sig_create_chan(void)
         return NULL;
     }
 
-    chan->blc_cid = BLE_L2CAP_CID_SIG;
-    chan->blc_my_mtu = BLE_L2CAP_SIG_MTU;
-    chan->blc_default_mtu = BLE_L2CAP_SIG_MTU;
-    chan->blc_rx_fn = ble_l2cap_sig_rx;
+    chan->scid = BLE_L2CAP_CID_SIG;
+    chan->my_mtu = BLE_L2CAP_SIG_MTU;
+    chan->default_mtu = BLE_L2CAP_SIG_MTU;
+    chan->rx_fn = ble_l2cap_sig_rx;
 
     return chan;
 }

--- a/net/nimble/host/src/ble_l2cap_sig_cmd.c
+++ b/net/nimble/host/src/ble_l2cap_sig_cmd.c
@@ -138,20 +138,13 @@ ble_l2cap_sig_reject_tx(uint16_t conn_handle, uint8_t id, uint16_t reason,
                                data, data_len);
 
     STATS_INC(ble_l2cap_stats, sig_rx);
-    rc = ble_l2cap_sig_tx(conn_handle, txom);
-    if (rc != 0) {
-        return rc;
-    }
-
-    return 0;
+    return ble_l2cap_sig_tx(conn_handle, txom);
 }
 
 int
 ble_l2cap_sig_reject_invalid_cid_tx(uint16_t conn_handle, uint8_t id,
                                     uint16_t src_cid, uint16_t dst_cid)
 {
-    int rc;
-
     struct {
         uint16_t local_cid;
         uint16_t remote_cid;
@@ -160,10 +153,9 @@ ble_l2cap_sig_reject_invalid_cid_tx(uint16_t conn_handle, uint8_t id,
         .remote_cid = src_cid,
     };
 
-    rc = ble_l2cap_sig_reject_tx(conn_handle, id,
+    return ble_l2cap_sig_reject_tx(conn_handle, id,
                                  BLE_L2CAP_SIG_ERR_INVALID_CID,
                                  &data, sizeof data);
-    return rc;
 }
 
 static void
@@ -210,12 +202,7 @@ ble_l2cap_sig_update_req_tx(uint16_t conn_handle, uint8_t id,
     ble_l2cap_sig_update_req_write(payload_buf, BLE_L2CAP_SIG_UPDATE_REQ_SZ,
                                    req);
 
-    rc = ble_l2cap_sig_tx(conn_handle, txom);
-    if (rc != 0) {
-        return rc;
-    }
-
-    return 0;
+    return ble_l2cap_sig_tx(conn_handle, txom);
 }
 
 static void
@@ -260,10 +247,5 @@ ble_l2cap_sig_update_rsp_tx(uint16_t conn_handle, uint8_t id, uint16_t result)
     ble_l2cap_sig_update_rsp_write(payload_buf, BLE_L2CAP_SIG_UPDATE_RSP_SZ,
                                    &rsp);
 
-    rc = ble_l2cap_sig_tx(conn_handle, txom);
-    if (rc != 0) {
-        return rc;
-    }
-
-    return 0;
+    return ble_l2cap_sig_tx(conn_handle, txom);
 }

--- a/net/nimble/host/src/ble_l2cap_sig_priv.h
+++ b/net/nimble/host/src/ble_l2cap_sig_priv.h
@@ -20,6 +20,8 @@
 #ifndef H_BLE_L2CAP_SIG_
 #define H_BLE_L2CAP_SIG_
 
+#include "syscfg/syscfg.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,6 +33,7 @@ struct ble_l2cap_sig_hdr {
     uint8_t op;
     uint8_t identifier;
     uint16_t length;
+    uint8_t data[0];
 } __attribute__((packed));
 
 #define BLE_L2CAP_SIG_REJECT_MIN_SZ         2
@@ -54,6 +57,22 @@ struct ble_l2cap_sig_update_rsp {
 #define BLE_L2CAP_SIG_UPDATE_RSP_RESULT_ACCEPT  0x0000
 #define BLE_L2CAP_SIG_UPDATE_RSP_RESULT_REJECT  0x0001
 
+struct ble_l2cap_sig_le_con_req {
+    uint16_t psm;
+    uint16_t scid;
+    uint16_t mtu;
+    uint16_t mps;
+    uint16_t credits;
+} __attribute__((packed));
+
+struct ble_l2cap_sig_le_con_rsp {
+    uint16_t dcid;
+    uint16_t mtu;
+    uint16_t mps;
+    uint16_t credits;
+    uint16_t result;
+} __attribute__((packed));
+
 int ble_l2cap_sig_init_cmd(uint8_t op, uint8_t id, uint8_t payload_len,
                            struct os_mbuf **out_om, void **out_payload_buf);
 void ble_l2cap_sig_hdr_parse(void *payload, uint16_t len,
@@ -75,9 +94,19 @@ void ble_l2cap_sig_update_rsp_write(void *payload, int len,
                                     struct ble_l2cap_sig_update_rsp *src);
 int ble_l2cap_sig_update_rsp_tx(uint16_t conn_handle, uint8_t id,
                                 uint16_t result);
-
 int ble_l2cap_sig_reject_invalid_cid_tx(uint16_t conn_handle, uint8_t id,
                                         uint16_t src_cid, uint16_t dst_cid);
+int ble_l2cap_sig_tx(uint16_t conn_handle, struct os_mbuf *txom);
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+int ble_l2cap_sig_coc_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
+                              struct os_mbuf *sdu_rx,
+                              ble_l2cap_event_fn *cb, void *cb_arg);
+void *ble_l2cap_sig_cmd_get(uint8_t opcode, uint8_t id, uint16_t len,
+                            struct os_mbuf **txom);
+#else
+#define ble_l2cap_sig_coc_connect(conn_handle, psm, mtu, sdu_rx, cb, cb_arg) \
+                                                                BLE_HS_ENOTSUP
+#endif
 
 void ble_l2cap_sig_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_l2cap_sig_timer(void);

--- a/net/nimble/host/src/ble_l2cap_sig_priv.h
+++ b/net/nimble/host/src/ble_l2cap_sig_priv.h
@@ -73,6 +73,16 @@ struct ble_l2cap_sig_le_con_rsp {
     uint16_t result;
 } __attribute__((packed));
 
+struct ble_l2cap_sig_disc_req {
+    uint16_t dcid;
+    uint16_t scid;
+} __attribute__((packed));
+
+struct ble_l2cap_sig_disc_rsp {
+    uint16_t dcid;
+    uint16_t scid;
+} __attribute__((packed));
+
 int ble_l2cap_sig_init_cmd(uint8_t op, uint8_t id, uint8_t payload_len,
                            struct os_mbuf **out_om, void **out_payload_buf);
 void ble_l2cap_sig_hdr_parse(void *payload, uint16_t len,
@@ -103,9 +113,12 @@ int ble_l2cap_sig_coc_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
                               ble_l2cap_event_fn *cb, void *cb_arg);
 void *ble_l2cap_sig_cmd_get(uint8_t opcode, uint8_t id, uint16_t len,
                             struct os_mbuf **txom);
+
+int ble_l2cap_sig_disconnect(struct ble_l2cap_chan *chan);
 #else
 #define ble_l2cap_sig_coc_connect(conn_handle, psm, mtu, sdu_rx, cb, cb_arg) \
                                                                 BLE_HS_ENOTSUP
+#define ble_l2cap_sig_disconnect(chan)                          BLE_HS_ENOTSUP
 #endif
 
 void ble_l2cap_sig_conn_broken(uint16_t conn_handle, int reason);

--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -2510,7 +2510,6 @@ ble_sm_create_chan(void)
 
     chan->scid = BLE_L2CAP_CID_SM;
     chan->my_mtu = BLE_SM_MTU;
-    chan->default_mtu = BLE_SM_MTU;
     chan->rx_fn = ble_sm_rx;
 
     return chan;

--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -2508,10 +2508,10 @@ ble_sm_create_chan(void)
         return NULL;
     }
 
-    chan->blc_cid = BLE_L2CAP_CID_SM;
-    chan->blc_my_mtu = BLE_SM_MTU;
-    chan->blc_default_mtu = BLE_SM_MTU;
-    chan->blc_rx_fn = ble_sm_rx;
+    chan->scid = BLE_L2CAP_CID_SM;
+    chan->my_mtu = BLE_SM_MTU;
+    chan->default_mtu = BLE_SM_MTU;
+    chan->rx_fn = ble_sm_rx;
 
     return chan;
 }

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -52,6 +52,11 @@ syscfg.defs:
             passes since the previous fragment was received, the connection is
             terminated.  A value of 0 means no timeout.
         value: 30000
+    BLE_L2CAP_COC_MAX_NUM:
+        description: >
+            Defines maximum number of LE Connection Oriented Channels channels.
+            When set to (0), LE COC is not compiled in.
+        value: 0
 
     # Security manager settings.
     BLE_SM_LEGACY:

--- a/net/nimble/host/test/src/ble_att_svr_test.c
+++ b/net/nimble/host/test/src/ble_att_svr_test.c
@@ -398,7 +398,7 @@ ble_att_svr_test_misc_verify_tx_read_mult_rsp(
     rc = ble_hs_misc_conn_chan_find(conn_handle, BLE_L2CAP_CID_ATT,
                                     NULL, &chan);
     TEST_ASSERT_FATAL(rc == 0);
-    mtu = ble_l2cap_chan_mtu(chan);
+    mtu = ble_att_chan_mtu(chan);
 
     ble_hs_unlock();
 
@@ -609,7 +609,7 @@ ble_att_svr_test_misc_mtu_exchange(uint16_t my_mtu, uint16_t peer_sent,
                                     &conn, &chan);
     TEST_ASSERT_FATAL(rc == 0);
     TEST_ASSERT(chan->peer_mtu == peer_actual);
-    TEST_ASSERT(ble_l2cap_chan_mtu(chan) == chan_mtu);
+    TEST_ASSERT(ble_att_chan_mtu(chan) == chan_mtu);
     ble_hs_unlock();
 
 }

--- a/net/nimble/host/test/src/ble_att_svr_test.c
+++ b/net/nimble/host/test/src/ble_att_svr_test.c
@@ -83,9 +83,9 @@ ble_att_svr_test_misc_init(uint16_t mtu)
     TEST_ASSERT_FATAL(rc == 0);
 
     if (mtu != 0) {
-        chan->blc_my_mtu = mtu;
-        chan->blc_peer_mtu = mtu;
-        chan->blc_flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
+        chan->my_mtu = mtu;
+        chan->peer_mtu = mtu;
+        chan->flags |= BLE_L2CAP_CHAN_F_TXED_MTU;
     }
 
     ble_hs_unlock();
@@ -443,7 +443,7 @@ ble_att_svr_test_misc_verify_tx_mtu_rsp(uint16_t conn_handle)
 
     ble_hs_lock();
     ble_att_conn_chan_find(conn_handle, &conn, &chan);
-    my_mtu = chan->blc_my_mtu;
+    my_mtu = chan->my_mtu;
     ble_hs_unlock();
 
     ble_hs_test_util_verify_tx_mtu_cmd(0, my_mtu);
@@ -608,7 +608,7 @@ ble_att_svr_test_misc_mtu_exchange(uint16_t my_mtu, uint16_t peer_sent,
     rc = ble_hs_misc_conn_chan_find(conn_handle, BLE_L2CAP_CID_ATT,
                                     &conn, &chan);
     TEST_ASSERT_FATAL(rc == 0);
-    TEST_ASSERT(chan->blc_peer_mtu == peer_actual);
+    TEST_ASSERT(chan->peer_mtu == peer_actual);
     TEST_ASSERT(ble_l2cap_chan_mtu(chan) == chan_mtu);
     ble_hs_unlock();
 

--- a/net/nimble/host/test/src/ble_hs_conn_test.c
+++ b/net/nimble/host/test/src/ble_hs_conn_test.c
@@ -81,7 +81,6 @@ TEST_CASE(ble_hs_conn_test_direct_connect_success)
     TEST_ASSERT_FATAL(chan != NULL);
     TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
     TEST_ASSERT(chan->peer_mtu == 0);
-    TEST_ASSERT(chan->default_mtu == BLE_ATT_MTU_DFLT);
 
     ble_hs_unlock();
 }
@@ -136,7 +135,6 @@ TEST_CASE(ble_hs_conn_test_direct_connectable_success)
     TEST_ASSERT_FATAL(chan != NULL);
     TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
     TEST_ASSERT(chan->peer_mtu == 0);
-    TEST_ASSERT(chan->default_mtu == BLE_ATT_MTU_DFLT);
 
     ble_hs_unlock();
 }
@@ -198,7 +196,6 @@ TEST_CASE(ble_hs_conn_test_undirect_connectable_success)
     TEST_ASSERT_FATAL(chan != NULL);
     TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
     TEST_ASSERT(chan->peer_mtu == 0);
-    TEST_ASSERT(chan->default_mtu == BLE_ATT_MTU_DFLT);
 
     ble_hs_unlock();
 }

--- a/net/nimble/host/test/src/ble_hs_conn_test.c
+++ b/net/nimble/host/test/src/ble_hs_conn_test.c
@@ -79,9 +79,9 @@ TEST_CASE(ble_hs_conn_test_direct_connect_success)
 
     chan = ble_hs_conn_chan_find(conn, BLE_L2CAP_CID_ATT);
     TEST_ASSERT_FATAL(chan != NULL);
-    TEST_ASSERT(chan->blc_my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
-    TEST_ASSERT(chan->blc_peer_mtu == 0);
-    TEST_ASSERT(chan->blc_default_mtu == BLE_ATT_MTU_DFLT);
+    TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
+    TEST_ASSERT(chan->peer_mtu == 0);
+    TEST_ASSERT(chan->default_mtu == BLE_ATT_MTU_DFLT);
 
     ble_hs_unlock();
 }
@@ -134,9 +134,9 @@ TEST_CASE(ble_hs_conn_test_direct_connectable_success)
 
     chan = ble_hs_conn_chan_find(conn, BLE_L2CAP_CID_ATT);
     TEST_ASSERT_FATAL(chan != NULL);
-    TEST_ASSERT(chan->blc_my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
-    TEST_ASSERT(chan->blc_peer_mtu == 0);
-    TEST_ASSERT(chan->blc_default_mtu == BLE_ATT_MTU_DFLT);
+    TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
+    TEST_ASSERT(chan->peer_mtu == 0);
+    TEST_ASSERT(chan->default_mtu == BLE_ATT_MTU_DFLT);
 
     ble_hs_unlock();
 }
@@ -196,9 +196,9 @@ TEST_CASE(ble_hs_conn_test_undirect_connectable_success)
 
     chan = ble_hs_conn_chan_find(conn, BLE_L2CAP_CID_ATT);
     TEST_ASSERT_FATAL(chan != NULL);
-    TEST_ASSERT(chan->blc_my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
-    TEST_ASSERT(chan->blc_peer_mtu == 0);
-    TEST_ASSERT(chan->blc_default_mtu == BLE_ATT_MTU_DFLT);
+    TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
+    TEST_ASSERT(chan->peer_mtu == 0);
+    TEST_ASSERT(chan->default_mtu == BLE_ATT_MTU_DFLT);
 
     ble_hs_unlock();
 }

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -125,7 +125,7 @@ ble_hs_test_util_prev_tx_dequeue(void)
 
         ble_hs_test_util_prev_tx_cur = om;
         while (OS_MBUF_PKTLEN(ble_hs_test_util_prev_tx_cur) <
-               l2cap_hdr.blh_len) {
+               l2cap_hdr.len) {
 
             om = ble_hs_test_util_prev_tx_dequeue_once(&hci_hdr);
             TEST_ASSERT_FATAL(om != NULL);
@@ -2039,8 +2039,8 @@ ble_hs_test_util_mbuf_count(const struct ble_hs_test_util_mbuf_params *params)
         }
 
         if (params->rx_queue) {
-            SLIST_FOREACH(chan, &conn->bhc_channels, blc_next) {
-                count += ble_hs_test_util_mbuf_chain_len(chan->blc_rx_buf);
+            SLIST_FOREACH(chan, &conn->bhc_channels, next) {
+                count += ble_hs_test_util_mbuf_chain_len(chan->rx_buf);
             }
         }
 

--- a/net/nimble/host/test/src/ble_l2cap_test.c
+++ b/net/nimble/host/test/src/ble_l2cap_test.c
@@ -118,10 +118,10 @@ ble_l2cap_test_util_create_conn(uint16_t conn_handle, uint8_t *addr,
     chan = ble_l2cap_chan_alloc();
     TEST_ASSERT_FATAL(chan != NULL);
 
-    chan->blc_cid = BLE_L2CAP_TEST_CID;
-    chan->blc_my_mtu = 240;
-    chan->blc_default_mtu = 240;
-    chan->blc_rx_fn = ble_l2cap_test_util_dummy_rx;
+    chan->scid = BLE_L2CAP_TEST_CID;
+    chan->my_mtu = 240;
+    chan->default_mtu = 240;
+    chan->rx_fn = ble_l2cap_test_util_dummy_rx;
 
     ble_hs_conn_chan_insert(conn, chan);
 
@@ -194,7 +194,7 @@ ble_l2cap_test_util_verify_first_frag(uint16_t conn_handle,
     conn = ble_hs_conn_find(conn_handle);
     TEST_ASSERT_FATAL(conn != NULL);
     TEST_ASSERT(conn->bhc_rx_chan != NULL &&
-                conn->bhc_rx_chan->blc_cid == BLE_L2CAP_TEST_CID);
+                conn->bhc_rx_chan->scid == BLE_L2CAP_TEST_CID);
 
     ble_hs_unlock();
 }
@@ -214,7 +214,7 @@ ble_l2cap_test_util_verify_middle_frag(uint16_t conn_handle,
     conn = ble_hs_conn_find(conn_handle);
     TEST_ASSERT_FATAL(conn != NULL);
     TEST_ASSERT(conn->bhc_rx_chan != NULL &&
-                conn->bhc_rx_chan->blc_cid == BLE_L2CAP_TEST_CID);
+                conn->bhc_rx_chan->scid == BLE_L2CAP_TEST_CID);
 
     ble_hs_unlock();
 }
@@ -352,7 +352,7 @@ TEST_CASE(ble_l2cap_test_case_frag_channels)
     conn = ble_hs_conn_find(2);
     TEST_ASSERT_FATAL(conn != NULL);
     TEST_ASSERT(conn->bhc_rx_chan != NULL &&
-                conn->bhc_rx_chan->blc_cid == BLE_L2CAP_TEST_CID);
+                conn->bhc_rx_chan->scid == BLE_L2CAP_TEST_CID);
     ble_hs_unlock();
 
     /* Receive a starting fragment on a different channel.  The first fragment
@@ -365,7 +365,7 @@ TEST_CASE(ble_l2cap_test_case_frag_channels)
     conn = ble_hs_conn_find(2);
     TEST_ASSERT_FATAL(conn != NULL);
     TEST_ASSERT(conn->bhc_rx_chan != NULL &&
-                conn->bhc_rx_chan->blc_cid == BLE_L2CAP_CID_ATT);
+                conn->bhc_rx_chan->scid == BLE_L2CAP_CID_ATT);
     ble_hs_unlock();
 }
 

--- a/net/nimble/host/test/src/ble_l2cap_test.c
+++ b/net/nimble/host/test/src/ble_l2cap_test.c
@@ -120,7 +120,6 @@ ble_l2cap_test_util_create_conn(uint16_t conn_handle, uint8_t *addr,
 
     chan->scid = BLE_L2CAP_TEST_CID;
     chan->my_mtu = 240;
-    chan->default_mtu = 240;
     chan->rx_fn = ble_l2cap_test_util_dummy_rx;
 
     ble_hs_conn_chan_insert(conn, chan);


### PR DESCRIPTION
In this pull LE COC signaling part has been implemented together with extensions to Bletiny app needed to test it. It is tested against BlueZ and PTS and works fine.

Note: This pull will not enable LE COC,  BLE_L2CAP_COC_MAX_NUM is 0

As you will notice I change a way of creating and sending signal commands. It is now done similar to what BLE_SM does. I plan to do same for l2cap update command.

Please have a look on API as I change it a bit comparing to what we discussed on mailing list. I found it more useful when writing Bletiny extensions.

In addition in this pull you can find some fixes and cleaning.

