### PR TITLE
Expose os_dev_loookup()

### DIFF
--- a/kernel/os/include/os/os_dev.h
+++ b/kernel/os/include/os/os_dev.h
@@ -108,6 +108,7 @@ os_dev_resume(struct os_dev *dev)
 
 int os_dev_create(struct os_dev *dev, char *name, uint8_t stage,
         uint8_t priority, os_dev_init_func_t od_init, void *arg);
+struct os_dev *os_dev_lookup(char *name);
 int os_dev_initialize_all(uint8_t stage);
 int os_dev_suspend_all(os_time_t, uint8_t);
 int os_dev_resume_all(void);

--- a/kernel/os/src/os_dev.c
+++ b/kernel/os/src/os_dev.c
@@ -232,13 +232,16 @@ err:
 }
 
 /**
- * Lookup a device by name, internal function only.
+ * Lookup a device by name.
+ *
+ * WARNING: This should be called before any locking on the device is done, or
+ * the device list itself is modified in any context.  There is no locking.
  *
  * @param name The name of the device to look up.
  *
  * @return A pointer to the device corresponding to name, or NULL if not found.
  */
-static struct os_dev *
+struct os_dev *
 os_dev_lookup(char *name)
 {
     struct os_dev *dev;


### PR DESCRIPTION
This enables users who want to share a OS device during init to
access it using the device name.  This should not be called at
runtime.