### PR TITLE
Fix invalid memory accesses in ble_uuid_cmp

### DIFF
--- a/net/nimble/host/src/ble_uuid.c
+++ b/net/nimble/host/src/ble_uuid.c
@@ -76,6 +76,10 @@ ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2)
     BLE_HS_DBG_ASSERT(verify_uuid(uuid1) == 0);
     BLE_HS_DBG_ASSERT(verify_uuid(uuid2) == 0);
 
+    if (uuid1->type != uuid2->type) {
+      return uuid1->type - uuid2->type;
+    }
+
     switch (uuid1->type) {
     case BLE_UUID_TYPE_16:
         return (int) BLE_UUID16(uuid1)->value - (int) BLE_UUID16(uuid2)->value;


### PR DESCRIPTION
When the two uuid values differ in type, one of two things can happen:

1. Access to unallocated or uninitialised memory
2. Unaligned access to 16/32-bit values

Both of these cause crashes, so always make sure we are comparing like types.