### PR TITLE
Fix printing not found image and tabulation

### DIFF
--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -21,11 +21,10 @@
 #
 common_file_to_load () {
     if [ "$MFG_IMAGE" ]; then
-	FILE_NAME=$BIN_BASENAME.bin
+        FILE_NAME=$BIN_BASENAME.bin
     elif [ "$BOOT_LOADER" ]; then
-	FILE_NAME=$BIN_BASENAME.elf.bin
+        FILE_NAME=$BIN_BASENAME.elf.bin
     else
-	FILE_NAME=$BIN_BASENAME.img
+        FILE_NAME=$BIN_BASENAME.img
     fi
 }
-    

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -31,23 +31,25 @@ openocd_load () {
     echo "flash write_image erase $FILE_NAME $FLASH_OFFSET" >> $OCD_CMD_FILE
 
     if [ -z $FILE_NAME ]; then
-	echo "Missing filename"
-	exit 1
+        echo "Missing filename"
+        exit 1
     fi
     if [ ! -f "$FILE_NAME" ]; then
-	echo "Cannot find file" $FILE
-	exit 1
+        # tries stripping current path for readability
+        FILE=${FILE_NAME##$(pwd)/}
+        echo "Cannot find file" $FILE
+        exit 1
     fi
     if [ -z $FLASH_OFFSET ]; then
-	echo "Missing flash offset"
-	exit 1
+        echo "Missing flash offset"
+        exit 1
     fi
 
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
     openocd $CFG -f $OCD_CMD_FILE -c shutdown
     if [ $? -ne 0 ]; then
-	exit 1
+        exit 1
     fi
     rm $OCD_CMD_FILE
     return 0
@@ -65,34 +67,34 @@ openocd_debug () {
     echo "$EXTRA_JTAG_CMD" >> $OCD_CMD_FILE
 
     if [ -z "$NO_GDB" ]; then
-	if [ -z $FILE_NAME ]; then
-	    echo "Missing filename"
-	    exit 1
-	fi
-	if [ ! -f "$FILE_NAME" ]; then
-	    echo "Cannot find file" $FILE_NAME
-	    exit 1
-	fi
+        if [ -z $FILE_NAME ]; then
+            echo "Missing filename"
+            exit 1
+        fi
+        if [ ! -f "$FILE_NAME" ]; then
+            echo "Cannot find file" $FILE_NAME
+            exit 1
+        fi
 
-	#
-	# Block Ctrl-C from getting passed to openocd.
-	#
-	set -m
-	openocd $CFG -f $OCD_CMD_FILE -c init -c halt &
-	set +m
+        #
+        # Block Ctrl-C from getting passed to openocd.
+        #
+        set -m
+        openocd $CFG -f $OCD_CMD_FILE -c init -c halt &
+        set +m
 
-    	GDB_CMD_FILE=.gdb_cmds
+        GDB_CMD_FILE=.gdb_cmds
 
-    	echo "target remote localhost:3333" > $GDB_CMD_FILE
-	if [ ! -z "$RESET" ]; then
-    	    echo "mon reset halt" >> $GDB_CMD_FILE
-	fi
-	arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
-	rm $GDB_CMD_FILE
+        echo "target remote localhost:3333" > $GDB_CMD_FILE
+        if [ ! -z "$RESET" ]; then
+            echo "mon reset halt" >> $GDB_CMD_FILE
+        fi
+        arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
+        rm $GDB_CMD_FILE
     else
-	# No GDB, wait for openocd to exit
-	openocd $CFG -f $OCD_CMD_FILE -c init -c halt
-	return $?
+        # No GDB, wait for openocd to exit
+        openocd $CFG -f $OCD_CMD_FILE -c init -c halt
+        return $?
     fi
 
     rm $OCD_CMD_FILE


### PR DESCRIPTION
- This fixes printing the name of an image when it is not found (eg user forgot to run `create-image`).
- I changed the mix of tabs/spaces to space only which is responsible for the somewhat messy diff.