### PR TITLE
mcu/stm32f4xx: Fix typo in porting map

### DIFF
--- a/hw/mcu/stm/stm32f4xx/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32f4xx/src/hal_gpio.c
@@ -102,13 +102,13 @@ static GPIO_TypeDef * const portmap[HAL_GPIO_NUM_PORTS] =
     GPIOH,
 #endif
 #if defined GPIOI_BASE
-    GPIOI
+    GPIOI,
 #endif
 #if defined GPIOJ_BASE
-    GPIOJ
+    GPIOJ,
 #endif
 #if defined GPIOK_BASE
-    GPIOK
+    GPIOK,
 #endif
 };
 


### PR DESCRIPTION
Fix typo in porting map.