### PR TITLE
Fix stm32f429 nvic num vectors

### DIFF
--- a/hw/bsp/stm32f429discovery/include/bsp/cmsis_nvic.h
+++ b/hw/bsp/stm32f429discovery/include/bsp/cmsis_nvic.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-#define NVIC_NUM_VECTORS      (16 + 81)   // CORE + MCU Peripherals
+#define NVIC_NUM_VECTORS      (16 + 91)   // CORE + MCU Peripherals
 #define NVIC_USER_IRQ_OFFSET  16
 
 #include "stm32f429xx.h"


### PR DESCRIPTION
From st datasheet page 24:

    The devices embed a nested vectored interrupt controller
    able to manage 16 priority levels, and handle up to 91
    maskable interrupt channels plus the 16 interrupt lines
    of the Cortex®-M4 with FPU core.
