### PR TITLE
bletiny: Fix for characteristic discovery

### DIFF
--- a/apps/bletiny/src/bletiny.h
+++ b/apps/bletiny/src/bletiny.h
@@ -72,7 +72,7 @@ SLIST_HEAD(bletiny_chr_list, bletiny_chr);
 struct bletiny_svc {
     SLIST_ENTRY(bletiny_svc) next;
     struct ble_gatt_svc svc;
-
+    bool char_disc_sent;
     struct bletiny_chr_list chrs;
 };
 

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -726,7 +726,12 @@ bletiny_disc_full_chrs(uint16_t conn_handle)
     }
 
     SLIST_FOREACH(svc, &conn->svcs, next) {
-        if (!svc_is_empty(svc) && SLIST_EMPTY(&svc->chrs)) {
+        if (!svc_is_empty(svc) && !svc->char_disc_sent) {
+            /* Since it might happen that service does not have characteristics
+             * for some reason, lets keep track on services for which we send
+             * characteristic discovery
+             */
+            svc->char_disc_sent = true;
             rc = bletiny_disc_all_chrs(conn_handle, svc->svc.start_handle,
                                        svc->svc.end_handle);
             if (rc != 0) {


### PR DESCRIPTION
This patch fixes scenario when remote device has empty service in his
database. Without that patch bletiny keep searching for characteristics
in same service in infinite loop.