### PR TITLE
Fix flash size in Red Bear BLE nano description

### DIFF
--- a/hw/bsp/nrf51-blenano/pkg.yml
+++ b/hw/bsp/nrf51-blenano/pkg.yml
@@ -19,7 +19,7 @@
 
 pkg.name: hw/bsp/nrf51-blenano
 pkg.type: bsp
-pkg.description: BSP definition for the RedBearLabs BLE Nano with 32kB flash based on Nordic nRF51.
+pkg.description: BSP definition for the RedBearLabs BLE Nano with 256kB flash based on Nordic nRF51.
 pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org> adapted by Jan Rüth <rueth@comsys.rwth-aachen.de>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:


### PR DESCRIPTION
According to manufacturer the chip has 256kB of flash. This is in
accordance with the linker scripts found for this target.