### PR TITLE
nimble/controller: MYNEWT-726

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -102,7 +102,7 @@ union ble_ll_conn_sm_flags {
         uint32_t allow_slave_latency:1;
         uint32_t slave_set_last_anchor:1;
         uint32_t awaiting_host_reply:1;
-        uint32_t send_conn_upd_event:1;
+        uint32_t terminate_started:1;
         uint32_t conn_update_sched:1;
         uint32_t host_expects_upd_event:1;
         uint32_t version_ind_sent:1;
@@ -270,6 +270,7 @@ struct ble_ll_conn_sm
 #define CONN_F_ENCRYPTED(csm)       ((csm)->csmflags.cfbit.encrypted)
 #define CONN_F_ENC_CHANGE_SENT(csm) ((csm)->csmflags.cfbit.encrypt_chg_sent)
 #define CONN_F_LE_PING_SUPP(csm)    ((csm)->csmflags.cfbit.le_ping_supp)
+#define CONN_F_TERMINATE_STARTED(csm) ((csm)->csmflags.cfbit.terminate_started)
 
 /* Role */
 #define CONN_IS_MASTER(csm)         (csm->conn_role == BLE_LL_CONN_ROLE_MASTER)

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -1738,9 +1738,13 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
     uint32_t usecs;
 #endif
 
-
     /* XXX: deal with connection request procedure here as well */
     ble_ll_conn_chk_csm_flags(connsm);
+
+    /* If unable to start terminate procedure, start it now */
+    if (connsm->disconnect_reason && !CONN_F_TERMINATE_STARTED(connsm)) {
+        ble_ll_ctrl_terminate_start(connsm);
+    }
 
     /* Set event counter to the next connection event that we will tx/rx in */
     itvl = connsm->conn_itvl * BLE_LL_CONN_ITVL_USECS;
@@ -1867,7 +1871,7 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
      * passed the termination timeout. If so, no need to continue with
      * connection as we will time out anyway.
      */
-    if (connsm->pending_ctrl_procs & (1 << BLE_LL_CTRL_PROC_TERMINATE)) {
+    if (CONN_F_TERMINATE_STARTED(connsm)) {
         if ((int32_t)(connsm->terminate_timeout - connsm->anchor_point) <= 0) {
             return -1;
         }

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -822,7 +822,7 @@ ble_ll_conn_hci_disconnect_cmd(uint8_t *cmdbuf)
                     rc = BLE_ERR_CMD_DISALLOWED;
                 } else {
                     /* This control procedure better not be pending! */
-                    assert(!IS_PENDING_CTRL_PROC(connsm, BLE_LL_CTRL_PROC_TERMINATE));
+                    assert(CONN_F_TERMINATE_STARTED(connsm) == 0);
 
                     /* Record the disconnect reason */
                     connsm->disconnect_reason = reason;

--- a/net/nimble/controller/src/ble_ll_ctrl.c
+++ b/net/nimble/controller/src/ble_ll_ctrl.c
@@ -1394,7 +1394,7 @@ ble_ll_ctrl_terminate_start(struct ble_ll_conn_sm *connsm)
     ctrl_proc = BLE_LL_CTRL_PROC_TERMINATE;
     om = ble_ll_ctrl_proc_init(connsm, ctrl_proc);
     if (om) {
-        connsm->pending_ctrl_procs |= (1 << ctrl_proc);
+        CONN_F_TERMINATE_STARTED(connsm) = 1;
 
         /* Set terminate "timeout" */
         usecs = connsm->supervision_tmo * BLE_HCI_CONN_SPVN_TMO_UNITS * 1000;
@@ -1458,14 +1458,19 @@ ble_ll_ctrl_chk_proc_start(struct ble_ll_conn_sm *connsm)
 {
     int i;
 
-    /* If we are terminating, dont start any new procedures */
+    /*
+     * If we are terminating, dont start any new procedures but start
+     * terminate if needed
+     */
     if (connsm->disconnect_reason) {
-        /*
-         * If the terminate procedure is not pending it means we were not
-         * able to start it right away (no control pdu was available).
-         * Start it now.
-         */
-        ble_ll_ctrl_terminate_start(connsm);
+        if (!CONN_F_TERMINATE_STARTED(connsm)) {
+            /*
+             * If the terminate procedure has not started it means we were not
+             * able to start it right away (no control pdu was available).
+             * Start it now. No need to start any other procedures.
+             */
+            ble_ll_ctrl_terminate_start(connsm);
+        }
         return;
     }
 


### PR DESCRIPTION
Modify how the controller deals with the terminate procedure. The
old method set a pending control procedure bit and it was not the
best way to deal with this since the terminate procedure can
occur while another control procedure is in process. The
new method uses a flag in the connection state machine flags
to denote that the terminate procedure was started. Started means
a control pdu was allocated and enqueued. The disconnect reason
being non-zero means that the connection is to be terminated.

NOTE: I replaced the flag send_conn_upd_event since it was not used.