### PR TITLE
BLE Host - Fix peer OTA addr and type on pairing.

### DIFF
--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -519,6 +519,7 @@ ble_sm_persist_keys(struct ble_sm_proc *proc)
         peer_addr.type = proc->peer_keys.addr_type;
         memcpy(peer_addr.val, proc->peer_keys.addr, sizeof peer_addr.val);
 
+        conn->bhc_peer_addr = peer_addr;
         /* Update identity address in conn.
          * If peer's address was an RPA, we store it as RPA since peer's address
          * will not be an identity address. The peer's address type has to be
@@ -527,20 +528,18 @@ ble_sm_persist_keys(struct ble_sm_proc *proc)
          */
         if (BLE_ADDR_IS_RPA(&conn->bhc_peer_addr)) {
             conn->bhc_peer_rpa_addr = conn->bhc_peer_addr;
-        }
 
-        conn->bhc_peer_addr = peer_addr;
+            switch (peer_addr.type) {
+            case BLE_ADDR_PUBLIC:
+            case BLE_ADDR_PUBLIC_ID:
+                conn->bhc_peer_addr.type = BLE_ADDR_PUBLIC_ID;
+                break;
 
-        switch (peer_addr.type) {
-        case BLE_ADDR_PUBLIC:
-        case BLE_ADDR_PUBLIC_ID:
-            conn->bhc_peer_addr.type = BLE_ADDR_PUBLIC_ID;
-            break;
-
-        case BLE_ADDR_RANDOM:
-        case BLE_ADDR_RANDOM_ID:
-            conn->bhc_peer_addr.type = BLE_ADDR_RANDOM_ID;
-            break;
+            case BLE_ADDR_RANDOM:
+            case BLE_ADDR_RANDOM_ID:
+                conn->bhc_peer_addr.type = BLE_ADDR_RANDOM_ID;
+                break;
+            }
         }
 
         identity_ev = 1;


### PR DESCRIPTION
I may be missing something, so please don't hesitate to yell at me if this change breaks some expected use case.

This change address the following scenario:

* Both devices using public addresses; no privacy.

1. A connects to B.
2. A initiates pairing.
3. Pairing succeeds; B indicates that its ID address is the same public
   or static random address it was advertising with (i.e., no change in
   address).

After this sequence completes, the connection object should be populated
as follows (from A's perspective):

    * bhc_peer_addr.type: BLE_ADDR_PUBLIC

However, I see the following instead:

    * bhc_peer_addr.type: BLE_ADDR_PUBLIC_ID

This is problematic because BLE_ADDR_PUBLIC_ID indicates that the peer
is using an RPA ("Public Identity Address (Corresponds to Resolved
Private Address)").  The ble_hs_addrs() function uses the address type
to determine the peer's OTA (over-the-air) address.  If the peer's
address type is an "_ID" type, the rpa field is used for the OTA
address.  In this case, the peer is not using an RPA, so its OTA address
is identical to its identity address.

The change is to only set the peer's address type to "_ID" if it is
using an RPA.