### PR TITLE
MYNEWT-526 + few Nimble/controller fixes

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/net/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -53,7 +53,7 @@ extern "C" {
  *  -> Opcode   (1 byte)
  *  -> Data     (0 - 26 bytes)
  */
-#define BLE_LL_CTRL_CONN_UPDATE_REQ     (0)
+#define BLE_LL_CTRL_CONN_UPDATE_IND     (0)
 #define BLE_LL_CTRL_CHANNEL_MAP_REQ     (1)
 #define BLE_LL_CTRL_TERMINATE_IND       (2)
 #define BLE_LL_CTRL_ENC_REQ             (3)

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -610,8 +610,8 @@ ble_ll_conn_hci_update(uint8_t *cmdbuf)
         return BLE_ERR_CMD_DISALLOWED;
     }
 
-    /* See if we support this feature */
-    if ((ble_ll_read_supp_features() & BLE_LL_FEAT_CONN_PARM_REQ) == 0) {
+    /* See if this feature is supported on both sides */
+    if ((connsm->common_features & BLE_LL_FEAT_CONN_PARM_REQ) == 0) {
         if (connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) {
             return BLE_ERR_UNKNOWN_HCI_CMD;
         }

--- a/net/nimble/controller/src/ble_ll_ctrl.c
+++ b/net/nimble/controller/src/ble_ll_ctrl.c
@@ -1283,6 +1283,7 @@ ble_ll_ctrl_proc_init(struct ble_ll_conn_sm *connsm, int ctrl_proc)
             } else {
                 opcode = BLE_LL_CTRL_SLAVE_FEATURE_REQ;
             }
+            memset(ctrdata, 0, BLE_LL_CTRL_FEATURE_LEN);
             ctrdata[0] = ble_ll_read_supp_features();
             break;
         case BLE_LL_CTRL_PROC_VERSION_XCHG:

--- a/net/nimble/controller/src/ble_ll_ctrl.c
+++ b/net/nimble/controller/src/ble_ll_ctrl.c
@@ -295,7 +295,7 @@ ble_ll_ctrl_proc_unk_rsp(struct ble_ll_conn_sm *connsm, uint8_t *dptr)
     case BLE_LL_CTRL_LENGTH_REQ:
         ctrl_proc = BLE_LL_CTRL_PROC_DATA_LEN_UPD;
         break;
-    case BLE_LL_CTRL_CONN_UPDATE_REQ:
+    case BLE_LL_CTRL_CONN_UPDATE_IND:
         ctrl_proc = BLE_LL_CTRL_PROC_CONN_UPDATE;
         break;
     case BLE_LL_CTRL_SLAVE_FEATURE_REQ:
@@ -911,7 +911,7 @@ ble_ll_ctrl_conn_param_reply(struct ble_ll_conn_sm *connsm, uint8_t *rsp,
     } else {
         /* Create a connection update pdu */
         ble_ll_ctrl_conn_upd_make(connsm, rsp + 1, req);
-        rsp_opcode = BLE_LL_CTRL_CONN_UPDATE_REQ;
+        rsp_opcode = BLE_LL_CTRL_CONN_UPDATE_IND;
     }
 
     return rsp_opcode;
@@ -1270,7 +1270,7 @@ ble_ll_ctrl_proc_init(struct ble_ll_conn_sm *connsm, int ctrl_proc)
 
         switch (ctrl_proc) {
         case BLE_LL_CTRL_PROC_CONN_UPDATE:
-            opcode = BLE_LL_CTRL_CONN_UPDATE_REQ;
+            opcode = BLE_LL_CTRL_CONN_UPDATE_IND;
             ble_ll_ctrl_conn_upd_make(connsm, ctrdata, NULL);
             break;
         case BLE_LL_CTRL_PROC_CHAN_MAP_UPD:
@@ -1628,7 +1628,7 @@ ble_ll_ctrl_rx_pdu(struct ble_ll_conn_sm *connsm, struct os_mbuf *om)
     /* Process opcode */
     rsp_opcode = BLE_ERR_MAX;
     switch (opcode) {
-    case BLE_LL_CTRL_CONN_UPDATE_REQ:
+    case BLE_LL_CTRL_CONN_UPDATE_IND:
         rsp_opcode = ble_ll_ctrl_rx_conn_update(connsm, dptr, rspbuf);
         break;
     case BLE_LL_CTRL_CHANNEL_MAP_REQ:

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -365,12 +365,13 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
      * request transmission. Note that adv_rxend is the end of the received
      * advertisement, so we need to add an IFS plus the time it takes to send
      * the connection request. The 1.25 msecs starts from the end of the conn
-     * request.
+     * request. Also include minimum WindowOffset value if configured.
      */
     dur = os_cputime_usecs_to_ticks(req_slots * BLE_LL_SCHED_USECS_PER_SLOT);
     earliest_start = adv_rxend +
         os_cputime_usecs_to_ticks(BLE_LL_IFS + BLE_LL_CONN_REQ_DURATION +
-                                  BLE_LL_CONN_INITIAL_OFFSET);
+                                  BLE_LL_CONN_INITIAL_OFFSET +
+                                  MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) * BLE_LL_CONN_TX_OFF_USECS);
     earliest_end = earliest_start + dur;
     itvl_t = os_cputime_usecs_to_ticks(connsm->conn_itvl * BLE_LL_CONN_ITVL_USECS);
 #endif
@@ -385,7 +386,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     if (!ble_ll_sched_insert_if_empty(sch)) {
         /* Nothing in schedule. Schedule as soon as possible */
         rc = 0;
-        connsm->tx_win_off = 0;
+        connsm->tx_win_off = MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET);
     } else {
         os_cputime_timer_stop(&g_ble_ll_sched_timer);
         TAILQ_FOREACH(entry, &g_ble_ll_sched_q, link) {

--- a/net/nimble/controller/syscfg.yml
+++ b/net/nimble/controller/syscfg.yml
@@ -128,6 +128,16 @@ syscfg.defs:
             scheduled items will be at least this far apart
         value: '4'
 
+    BLE_LL_CONN_INIT_MIN_WIN_OFFSET:
+        description: >
+            This is the minimum number of "slots" for WindowOffset value used for
+            CONNECT_IND when creating new connection as a master. Each slot is 1.25
+            msecs long. Increasing this value will delay first connection event after
+            connection is created. However, older TI CC254x controllers cannot change
+            connection parameters later if WindowOffset was set to 0 in CONNECT_IND. To
+            ensure interoperability with such devices set this value to 2 (or more).
+        value: '0'
+
     # The number of random bytes to store
     BLE_LL_RNG_BUFSIZE:
         description: >


### PR DESCRIPTION
This provides solution for MYNEWT-526 (connection timeout with Polar H7). This is not a fix, since there is no problem on our side - it's just an configuration option to adjust initial connection event scheduling in a way that broken TI CC254x (which Polar H7 is based on) can work properly. See commit message for details.

...and few minor fixes for LL in Nimble controller.