### PR TITLE
bsp: wifire: Implement hal_bsp_hw_id

### DIFF
--- a/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
@@ -19,9 +19,21 @@
 #include "hal/hal_bsp.h"
 #include "bsp/bsp.h"
 #include <assert.h>
+#include <xc.h>
 
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)
 {
     return 0;
+}
+
+int
+hal_bsp_hw_id(uint8_t *id, int max_len)
+{
+    if (max_len > sizeof(DEVID)) {
+        max_len = sizeof(DEVID);
+    }
+
+    memcpy(id, &DEVID, max_len);
+    return max_len;
 }


### PR DESCRIPTION
This function reads the DEVID register which
contains the revision (upper 4 bits) and the
device id (lower 28 bits).

Signed-off-by: Francois Berder <fberder@outlook.fr>