### PR TITLE
Fix problems with starting debuggers on MSYS2/MINGW

### DIFF
--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -125,7 +125,7 @@ jlink_debug() {
             # Launch jlink server in a separate command interpreter, to make
             # sure it doesn't get killed by Ctrl-C signal from bash.
             #
-            $COMSPEC "/C start $COMSPEC /C $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun"
+            $COMSPEC /C "start $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun"
         else
             #
             # Block Ctrl-C from getting passed to jlink server.
@@ -145,7 +145,7 @@ jlink_debug() {
 
 	if [ $WINDOWS -eq 1 ]; then
 	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
-	    $COMSPEC "/C start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
+	    $COMSPEC /C "start arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
 	else
             arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -83,8 +83,9 @@ openocd_debug () {
             # Launch openocd in a separate command interpreter, to make sure
             # it doesn't get killed by Ctrl-C signal from bash.
             #
+
             CFG=`echo $CFG | sed 's/\//\\\\/g'`
-            $COMSPEC "/C start $COMSPEC /C openocd -l openocd.log $CFG -f $OCD_CMD_FILE -c init -c halt"
+            $COMSPEC /C "start openocd -l openocd.log $CFG -f $OCD_CMD_FILE -c init -c halt"
         else
             #
             # Block Ctrl-C from getting passed to openocd.
@@ -100,9 +101,10 @@ openocd_debug () {
         if [ ! -z "$RESET" ]; then
             echo "mon reset halt" >> $GDB_CMD_FILE
         fi
+	echo "FILENAME" $FILE_NAME >>out
 	if [ $WINDOWS -eq 1 ]; then
 	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
-            $COMSPEC "/C start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
+            $COMSPEC /C "start arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
 	else
             arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE


### PR DESCRIPTION
1) Fixed launch hanging problem for openocd and jlink gdbserver when
newt debug is run from mingw/bash (installed with msys2).
openocd now starts in a new cmd prompt window.
2) Fixed  to start gdb in a new cmd prompt when newt debug is run
from mingw/bash (installed with msys2). Before the fix, gdb did not
start in a new window and Control-C would cause gdb to exit.

Theses fixes should preserve the same behavior when running newt command
from git-bash, git-cmd, or cmd prompt.