### PR TITLE
Add back the 2nd explict COMSPEC /C.

### DIFF
--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -125,7 +125,7 @@ jlink_debug() {
             # Launch jlink server in a separate command interpreter, to make
             # sure it doesn't get killed by Ctrl-C signal from bash.
             #
-            $COMSPEC /C "start $JLINK_GDB_SERVER $EXTRA_JTAG_CMD -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun"
+            $COMSPEC /C "start $COMSPEC /C $JLINK_GDB_SERVER $EXTRA_JTAG_CMD -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun"
         else
             #
             # Block Ctrl-C from getting passed to jlink server.
@@ -145,7 +145,7 @@ jlink_debug() {
 
 	if [ $WINDOWS -eq 1 ]; then
 	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
-	    $COMSPEC /C "start arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
+	    $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
 	else
             arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -85,7 +85,7 @@ openocd_debug () {
             #
 
             CFG=`echo $CFG | sed 's/\//\\\\/g'`
-            $COMSPEC /C "start openocd -l openocd.log $CFG -f $OCD_CMD_FILE -c init -c halt"
+            $COMSPEC /C "start $COMSPEC /C openocd -l openocd.log $CFG -f $OCD_CMD_FILE -c init -c halt"
         else
             #
             # Block Ctrl-C from getting passed to openocd.
@@ -104,7 +104,7 @@ openocd_debug () {
 	echo "FILENAME" $FILE_NAME >>out
 	if [ $WINDOWS -eq 1 ]; then
 	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
-            $COMSPEC /C "start arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
+            $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
 	else
             arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE


### PR DESCRIPTION
Simon's msys2 environment doesn't work without it.
My msys2 works with and without the 2nd explicit COMPSEC /C/
Looks like the only fix that was needed is to move the opening "