### PR TITLE
MYNEWT-745 Sim - deadlock involving system calls

### DIFF
--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -24,3 +24,24 @@ syscfg.defs:
             Specifies the required alignment for internal flash writes.
             Used internally by the newt tool.
         value: 1
+
+    MCU_NATIVE_USE_SIGNALS:
+        description: >
+            Whether to use POSIX signals to implement context switches.  Valid
+            values are as follows:
+                1: More correctness; less stability.  The OS tick timer will
+                   cause a high-priority task to preempt a low-priority task.
+                   This causes stability issues because a task can be preempted
+                   while it is in the middle of a system call, potentially
+                   causing deadlock or memory corruption.
+
+                0: Less correctness; more stability.  The OS tick timer only
+                   runs while the idle task is active.  Therefore, a sleeping
+                   high-priority task will not preempt a low-priority task due
+                   to a timing event (e.g., delay or callout expired).
+                   However, this version of sim does not suffer from the
+                   stability issues that affect the "signals" implementation.
+
+            Unit tests should use 1.  Long-running sim processes should use 0.
+
+        value: 1

--- a/kernel/os/src/arch/sim/os_arch_sim_gen.c
+++ b/kernel/os/src/arch/sim/os_arch_sim_gen.c
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This file contains code that is shared by both sim implementations (signals
+ * and no-signals).
+ */
+
+#include "os/os.h"
+#include "os_priv.h"
+
+#include <hal/hal_bsp.h>
+
+#ifdef __APPLE__
+#define _XOPEN_SOURCE
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <assert.h>
+#include "os_arch_sim_priv.h"
+
+#define sim_setjmp(__jb) sigsetjmp(__jb, 0)
+#define sim_longjmp(__jb, __ret) siglongjmp(__jb, __ret)
+
+pid_t os_arch_sim_pid;
+
+extern void os_arch_frame_init(struct stack_frame *sf);
+
+void
+os_arch_sim_ctx_sw(void)
+{
+    struct os_task *t, *next_t;
+    struct stack_frame *sf;
+    int rc;
+
+    OS_ASSERT_CRITICAL();
+
+    t = os_sched_get_current_task();
+    next_t = os_sched_next_task();
+    if (t == next_t) {
+        /*
+         * Context switch not needed - just return.
+         */
+        return;
+    }
+
+    if (t) {
+        sf = (struct stack_frame *) t->t_stackptr;
+
+        rc = sim_setjmp(sf->sf_jb);
+        if (rc != 0) {
+            OS_ASSERT_CRITICAL();
+            return;
+        }
+    }
+
+    os_sched_ctx_sw_hook(next_t);
+
+    os_sched_set_current_task(next_t);
+
+    sf = (struct stack_frame *) next_t->t_stackptr;
+    sim_longjmp(sf->sf_jb, 1);
+}
+
+void
+os_arch_sim_tick(void)
+{
+    struct timeval time_now, time_diff;
+    int ticks;
+
+    static struct timeval time_last;
+    static int time_inited;
+
+    OS_ASSERT_CRITICAL();
+
+    if (!time_inited) {
+        gettimeofday(&time_last, NULL);
+        time_inited = 1;
+    }
+
+    gettimeofday(&time_now, NULL);
+    if (timercmp(&time_now, &time_last, <)) {
+        /*
+         * System time going backwards.
+         */
+        time_last = time_now;
+    } else {
+        timersub(&time_now, &time_last, &time_diff);
+
+        ticks = time_diff.tv_sec * OS_TICKS_PER_SEC;
+        ticks += time_diff.tv_usec / OS_USEC_PER_TICK;
+
+        /*
+         * Update 'time_last' but account for the remainder usecs that did not
+         * contribute towards whole 'ticks'.
+         */
+        time_diff.tv_sec = 0;
+        time_diff.tv_usec %= OS_USEC_PER_TICK;
+        timersub(&time_now, &time_diff, &time_last);
+
+        os_time_advance(ticks);
+    }
+}
+
+static void
+os_arch_sim_start_timer(void)
+{
+    struct itimerval it;
+    int rc;
+
+    memset(&it, 0, sizeof(it));
+    it.it_value.tv_sec = 0;
+    it.it_value.tv_usec = OS_USEC_PER_TICK;
+    it.it_interval.tv_sec = 0;
+    it.it_interval.tv_usec = OS_USEC_PER_TICK;
+
+    rc = setitimer(ITIMER_REAL, &it, NULL);
+    assert(rc == 0);
+}
+
+static void
+os_arch_sim_stop_timer(void)
+{
+    struct itimerval it;
+    int rc;
+
+    memset(&it, 0, sizeof(it));
+
+    rc = setitimer(ITIMER_REAL, &it, NULL);
+    assert(rc == 0);
+}
+
+/*
+ * Called from 'os_arch_frame_init()' when setjmp returns indirectly via
+ * longjmp. The return value of setjmp is passed to this function as 'rc'.
+ */
+void
+os_arch_task_start(struct stack_frame *sf, int rc)
+{
+    struct os_task *task;
+
+    /*
+     * Interrupts are disabled when a task starts executing. This happens in
+     * two different ways:
+     * - via os_arch_os_start() for the first task.
+     * - via os_sched() for all other tasks.
+     *
+     * Enable interrupts before starting the task.
+     */
+    OS_EXIT_CRITICAL(0);
+
+    task = sf->sf_task;
+    task->t_func(task->t_arg);
+
+    /* This should never return */
+    assert(0);
+}
+
+os_stack_t *
+os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
+{
+    struct stack_frame *sf;
+
+    sf = (struct stack_frame *) ((uint8_t *) stack_top - sizeof(*sf));
+    sf->sf_task = t;
+
+    os_arch_frame_init(sf);
+
+    return ((os_stack_t *)sf);
+}
+
+os_error_t
+os_arch_os_start(void)
+{
+    struct stack_frame *sf;
+    struct os_task *t;
+    os_sr_t sr;
+
+    /*
+     * Disable interrupts before enabling any interrupt sources. Pending
+     * interrupts will be recognized when the first task starts executing.
+     */
+    OS_ENTER_CRITICAL(sr);
+    assert(sr == 0);
+
+    /* Enable the interrupt sources */
+    os_arch_sim_start_timer();
+
+    t = os_sched_next_task();
+    os_sched_set_current_task(t);
+
+    g_os_started = 1;
+
+    sf = (struct stack_frame *) t->t_stackptr;
+    sim_longjmp(sf->sf_jb, 1);
+
+    return 0;
+}
+
+/**
+ * Stops the tick timer and clears the "started" flag.  This function is only
+ * implemented for sim.
+ */
+void
+os_arch_os_stop(void)
+{
+    os_arch_sim_stop_timer();
+    os_arch_sim_signals_cleanup();
+    g_os_started = 0;
+}
+
+os_error_t
+os_arch_os_init(void)
+{
+    os_arch_sim_pid = getpid();
+    g_current_task = NULL;
+
+    STAILQ_INIT(&g_os_task_list);
+    TAILQ_INIT(&g_os_run_list);
+    TAILQ_INIT(&g_os_sleep_list);
+
+    os_arch_sim_signals_init();
+
+    os_init_idle_task();
+
+    return OS_OK;
+}

--- a/kernel/os/src/arch/sim/os_arch_sim_nosig.c
+++ b/kernel/os/src/arch/sim/os_arch_sim_nosig.c
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This file implements the "no-signals" version of sim.  This implementation
+ * does not use signals to perform context switches.  This is the less correct
+ * version of sim: the OS tick timer only runs while the idle task is active.
+ * Therefore, a sleeping high-priority task will not preempt a low-priority
+ * task due to a timing event (e.g., delay or callout expired).  However, this
+ * version of sim does not suffer from the stability issues that affect the
+ * "signals" implementation.
+ *
+ * To use this version of sim, disable the MCU_NATIVE_USE_SIGNALS syscfg
+ * setting.  
+ */
+
+#include "syscfg/syscfg.h"
+
+#if !MYNEWT_VAL(MCU_NATIVE_USE_SIGNALS)
+
+#include "os/os.h"
+#include "os_priv.h"
+
+#include <hal/hal_bsp.h>
+
+#ifdef __APPLE__
+#define _XOPEN_SOURCE
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <assert.h>
+#include "os_arch_sim_priv.h"
+
+static sigset_t nosigs;
+static sigset_t suspsigs;   /* signals delivered in sigsuspend() */
+
+static int ctx_sw_pending;
+static int interrupts_enabled = 1;
+
+void
+os_arch_ctx_sw(struct os_task *next_t)
+{
+    if (interrupts_enabled) {
+        /* Perform the context switch immediately. */
+        os_arch_sim_ctx_sw();
+    } else {
+        /* Remember that we want to perform a context switch.  Perform it when
+         * interrupts are re-enabled.
+         */
+        ctx_sw_pending = 1;
+    }
+}
+
+/*
+ * Enter a critical section.
+ *
+ * Returns 1 if interrupts were already disabled; 0 otherwise.
+ */
+os_sr_t
+os_arch_save_sr(void)
+{
+    if (!interrupts_enabled) {
+        return 1;
+    }
+
+    interrupts_enabled = 0;
+    return 0;
+}
+
+void
+os_arch_restore_sr(os_sr_t osr)
+{
+    OS_ASSERT_CRITICAL();
+    assert(osr == 0 || osr == 1);
+
+    if (osr == 1) {
+        /* Exiting a nested critical section */
+        return;
+    }
+
+    if (ctx_sw_pending) {
+        /* A context switch was requested while interrupts were disabled.
+         * Perform it now that interrupts are enabled again.
+         */
+        ctx_sw_pending = 0;
+        os_arch_sim_ctx_sw();
+    }
+    interrupts_enabled = 1;
+}
+
+int
+os_arch_in_critical(void)
+{
+    return !interrupts_enabled;
+}
+
+/**
+ * Unblocks the SIGALRM signal that is delivered by the OS tick timer.
+ */
+static void
+unblock_timer(void)
+{
+    sigset_t sigs;
+    int rc;
+
+    sigemptyset(&sigs);
+    sigaddset(&sigs, SIGALRM);
+
+    rc = sigprocmask(SIG_UNBLOCK, &sigs, NULL);
+    assert(rc == 0);
+}
+
+/**
+ * Blocks the SIGALRM signal that is delivered by the OS tick timer.
+ */
+static void
+block_timer(void)
+{
+    sigset_t sigs;
+    int rc;
+
+    sigemptyset(&sigs);
+    sigaddset(&sigs, SIGALRM);
+
+    rc = sigprocmask(SIG_BLOCK, &sigs, NULL);
+    assert(rc == 0);
+}
+
+static void
+sig_handler_alrm(int sig)
+{
+    /* Wake the idle task. */
+    sigaddset(&suspsigs, sig);
+}
+
+void
+os_tick_idle(os_time_t ticks)
+{
+    int rc;
+    struct itimerval it;
+
+    OS_ASSERT_CRITICAL();
+
+    if (ticks > 0) {
+        /*
+         * Enter tickless regime and set the timer to fire after 'ticks'
+         * worth of time has elapsed.
+         */
+        it.it_value.tv_sec = ticks / OS_TICKS_PER_SEC;
+        it.it_value.tv_usec = (ticks % OS_TICKS_PER_SEC) * OS_USEC_PER_TICK;
+        it.it_interval.tv_sec = 0;
+        it.it_interval.tv_usec = OS_USEC_PER_TICK;
+        rc = setitimer(ITIMER_REAL, &it, NULL);
+        assert(rc == 0);
+    }
+
+    unblock_timer();
+
+    sigemptyset(&suspsigs);
+    sigsuspend(&nosigs);        /* Wait for a signal to wake us up */
+
+    block_timer();
+
+    /*
+     * Call handlers for signals delivered to the process during sigsuspend().
+     * The SIGALRM handler is called before any other handlers to ensure that
+     * OS time is always correct.
+     */
+    if (sigismember(&suspsigs, SIGALRM)) {
+        os_arch_sim_tick();
+    }
+
+    if (ticks > 0) {
+        /*
+         * Enable the periodic timer interrupt.
+         */
+        it.it_value.tv_sec = 0;
+        it.it_value.tv_usec = OS_USEC_PER_TICK;
+        it.it_interval.tv_sec = 0;
+        it.it_interval.tv_usec = OS_USEC_PER_TICK;
+        rc = setitimer(ITIMER_REAL, &it, NULL);
+        assert(rc == 0);
+    }
+}
+
+void
+os_arch_sim_signals_init(void)
+{
+    sigset_t sigset_alrm;
+    struct sigaction sa;
+    int error;
+
+    block_timer();
+
+    sigemptyset(&nosigs);
+
+    sigemptyset(&sigset_alrm);
+    sigaddset(&sigset_alrm, SIGALRM);
+
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = sig_handler_alrm;
+    sa.sa_mask = sigset_alrm;
+    sa.sa_flags = SA_RESTART;
+    error = sigaction(SIGALRM, &sa, NULL);
+    assert(error == 0);
+}
+
+void
+os_arch_sim_signals_cleanup(void)
+{
+    int error;
+    struct sigaction sa;
+
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = SIG_DFL;
+    error = sigaction(SIGALRM, &sa, NULL);
+    assert(error == 0);
+}
+
+#endif /* !MYNEWT_VAL(MCU_NATIVE_USE_SIGNALS) */

--- a/kernel/os/src/arch/sim/os_arch_sim_priv.h
+++ b/kernel/os/src/arch/sim/os_arch_sim_priv.h
@@ -1,0 +1,29 @@
+#ifndef H_OS_ARCH_SIM_PRIV_
+#define H_OS_ARCH_SIM_PRIV_
+
+#include <setjmp.h>
+#include <os/os.h>
+
+struct stack_frame {
+    int sf_mainsp;              /* stack on which main() is executing */
+    sigjmp_buf sf_jb;
+    struct os_task *sf_task;
+};
+
+/*
+ * Assert that 'sf_mainsp' and 'sf_jb' are at the specific offsets where
+ * os_arch_frame_init() expects them to be.
+ */
+CTASSERT(offsetof(struct stack_frame, sf_mainsp) == 0);
+CTASSERT(offsetof(struct stack_frame, sf_jb) == 4);
+
+#define OS_USEC_PER_TICK    (1000000 / OS_TICKS_PER_SEC)
+
+void os_arch_sim_ctx_sw(void);
+void os_arch_sim_tick(void);
+void os_arch_sim_signals_init(void);
+void os_arch_sim_signals_cleanup(void);
+
+extern pid_t os_arch_sim_pid;
+
+#endif

--- a/net/ip/native_sockets/src/native_sock.c
+++ b/net/ip/native_sockets/src/native_sock.c
@@ -250,6 +250,7 @@ native_sock_create(struct mn_socket **sp, uint8_t domain,
     struct native_sock_state *nss = &native_sock_state;
     struct native_sock *ns;
     int idx;
+    int rc;
 
     switch (domain) {
     case MN_PF_INET:
@@ -283,6 +284,11 @@ native_sock_create(struct mn_socket **sp, uint8_t domain,
     }
     os_sem_init(&ns->ns_sem, 0);
     idx = socket(domain, type, proto);
+
+    /* Make the socket nonblocking. */
+    rc = fcntl(idx, F_SETFL, fcntl(idx, F_GETFL, 0) | O_NONBLOCK);
+    assert(rc == 0);
+
     ns->ns_fd = idx;
     ns->ns_pf = domain;
     ns->ns_type = type;


### PR DESCRIPTION
This commit splits sim into two separate implementations:
    * "signals"
    * "no-signals"

The user chooses which implementation to use via the
MCU_NATIVE_USE_SIGNALS syscfg setting (defined in hw/mcu/native).  The
two implementations are described below:

signals:
    More correctness; less stability.  The OS tick timer will
    cause a high-priority task to preempt a low-priority task.
    This causes stability issues because a task can be preempted
    while it is in the middle of a system call, potentially
    causing deadlock or memory corruption.

no-signals:
    Less correctness; more stability.  The OS tick timer only
    runs while the idle task is active.  Therefore, a sleeping
    high-priority task will not preempt a low-priority task due
    to a timing event (e.g., delay or callout expired).
    However, this version of sim does not suffer from the
    stability issues that affect the "signals" implementation.