### PR TITLE
pic32mz2048efg100: Add Peripheral Pin Select wrapper and configure CONSOLE_UART at boot

### DIFF
--- a/hw/bsp/pic32mz2048_wi-fire/src/os_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/os_bsp.c
@@ -20,7 +20,8 @@
 #include "hal/hal_bsp.h"
 #include "syscfg/syscfg.h"
 #include "uart/uart.h"
-#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || \
+    MYNEWT_VAL(UART_3) || MYNEWT_VAL(UART_4) || MYNEWT_VAL(UART_5)
 #include "uart_hal/uart_hal.h"
 #endif
 

--- a/hw/bsp/pic32mz2048_wi-fire/src/os_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/os_bsp.c
@@ -18,6 +18,8 @@
  */
 
 #include "hal/hal_bsp.h"
+#include "mcu/mcu.h"
+#include "mcu/mips_hal.h"
 #include "syscfg/syscfg.h"
 #include "uart/uart.h"
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || \
@@ -57,6 +59,10 @@ static struct uart_dev os_bsp_uart3;
 
 #if MYNEWT_VAL(UART_4)
 static struct uart_dev os_bsp_uart4;
+static const struct mips_uart_cfg uart4_cfg = {
+    .tx = MCU_GPIO_PORTF(8),
+    .rx = MCU_GPIO_PORTF(2)
+};
 #endif
 
 #if MYNEWT_VAL(UART_5)
@@ -90,7 +96,7 @@ hal_bsp_init(void)
 
     #if MYNEWT_VAL(UART_3)
         rc = os_dev_create((struct os_dev *) &os_bsp_uart3, "uart3",
-            OS_DEV_INIT_PRIMARY, 0, uart_hal_init, 0);
+            OS_DEV_INIT_PRIMARY, 0, uart_hal_init, &uart4_cfg);
         assert(rc == 0);
     #endif
 

--- a/hw/mcu/microchip/pic32mz2048efg100/include/mcu/mips_hal.h
+++ b/hw/mcu/microchip/pic32mz2048efg100/include/mcu/mips_hal.h
@@ -26,6 +26,12 @@
 extern "C" {
 #endif
 
+/* I/O pins for UART */
+struct mips_uart_cfg {
+    uint8_t tx;
+    uint8_t rx;
+};
+
 /* Helper functions to enable/disable interrupts. */
 #define __HAL_DISABLE_INTERRUPTS(__os_sr) do {__os_sr = __builtin_get_isr_state(); \
         __builtin_disable_interrupts();} while(0)

--- a/hw/mcu/microchip/pic32mz2048efg100/include/mcu/pps.h
+++ b/hw/mcu/microchip/pic32mz2048efg100/include/mcu/pps.h
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* This file defines the Periphal Pin Select module within this MCU */
+
+#ifndef __MCU_PPS_H__
+#define __MCU_PPS_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NO_CONNECT      (0)
+
+/* Input */
+#define INT3_IN_FUNC           (0)
+#define T2CK_IN_FUNC           (1)
+#define T6CK_IN_FUNC           (2)
+#define IC3_IN_FUNC            (3)
+#define IC7_IN_FUNC            (4)
+#define U1RX_IN_FUNC           (5)
+#define U2CTS_IN_FUNC          (6)
+#define U5RX_IN_FUNC           (7)
+#define U6CTS_IN_FUNC          (8)
+#define SDI1_IN_FUNC           (9)
+#define SDI3_IN_FUNC           (10)
+#define SDI5_IN_FUNC           (11)
+#define SS6_IN_FUNC            (12)
+#define REFCLKI1_IN_FUNC       (13)
+
+#define INT4_IN_FUNC            (16 + 0)
+#define T5CK_IN_FUNC            (16 + 1)
+#define T7CK_IN_FUNC            (16 + 2)
+#define IC4_IN_FUNC             (16 + 3)
+#define IC8_IN_FUNC             (16 + 4)
+#define U3RX_IN_FUNC            (16 + 5)
+#define U4CTS_IN_FUNC           (16 + 6)
+#define SDI2_IN_FUNC            (16 + 7)
+#define SDI4_IN_FUNC            (16 + 8)
+#define REFCLKI4_IN_FUNC        (16 + 10)
+
+#define INT2_IN_FUNC            (32 + 0)
+#define T3CK_IN_FUNC            (32 + 1)
+#define T8CK_IN_FUNC            (32 + 2)
+#define IC2_IN_FUNC             (32 + 3)
+#define IC5_IN_FUNC             (32 + 4)
+#define IC9_IN_FUNC             (32 + 5)
+#define U1CTS_IN_FUNC           (32 + 6)
+#define U2RX_IN_FUNC            (32 + 7)
+#define U5CTS_IN_FUNC           (32 + 8)
+#define SS1_IN_FUNC             (32 + 9)
+#define SS3_IN_FUNC             (32 + 10)
+#define SS4_IN_FUNC             (32 + 11)
+#define SS5_IN_FUNC             (32 + 12)
+
+#define INT1_IN_FUNC            (48 + 0)
+#define T4CK_IN_FUNC            (48 + 1)
+#define T9CK_IN_FUNC            (48 + 2)
+#define IC1_IN_FUNC             (48 + 3)
+#define IC6_IN_FUNC             (48 + 4)
+#define U3CTS_IN_FUNC           (48 + 5)
+#define U4RX_IN_FUNC            (48 + 6)
+#define U6RX_IN_FUNC            (48 + 7)
+#define SS2_IN_FUNC             (48 + 8)
+#define SDI6_IN_FUNC            (48 + 9)
+#define OCFA_IN_FUNC            (48 + 10)
+#define REFCLKI3_IN_FUNC        (48 + 11)
+
+
+/* Output */
+#define U3TX_OUT_FUNC           (0b0001)
+#define U4RTS_OUT_FUNC          (0b0010)
+#define SDO1_OUT_FUNC           (0b0101)
+#define SDO2_OUT_FUNC           (0b0110)
+#define SDO3_OUT_FUNC           (0b0111)
+#define SDO5_OUT_FUNC           (0b1001)
+#define SS6_OUT_FUNC            (0b1010)
+#define OC3_OUT_FUNC            (0b1011)
+#define OC6_OUT_FUNC            (0b1100)
+#define REFCLKO4_OUT_FUNC       (0b1101)
+#define C2OUT_OUT_FUNC          (0b1110)
+
+#define U1TX_OUT_FUNC           (0b0001)
+#define U2RTS_OUT_FUNC          (0b0010)
+#define U5TX_OUT_FUNC           (0b0011)
+#define U6RTS_OUT_FUNC          (0b0100)
+#define SDO1_OUT_FUNC           (0b0101)
+#define SDO2_OUT_FUNC           (0b0110)
+#define SDO3_OUT_FUNC           (0b0111)
+#define SDO4_OUT_FUNC           (0b1000)
+#define SDO5_OUT_FUNC           (0b1001)
+#define OC4_OUT_FUNC            (0b1011)
+#define OC7_OUT_FUNC            (0b1100)
+#define REFCLKO1_OUT_FUNC       (0b1111)
+
+#define U3RTS_OUT_FUNC          (0b0001)
+#define U4TX_OUT_FUNC           (0b0010)
+#define U6TX_OUT_FUNC           (0b0100)
+#define SS1_OUT_FUNC            (0b0101)
+#define SS3_OUT_FUNC            (0b0111)
+#define SS4_OUT_FUNC            (0b1000)
+#define SS5_OUT_FUNC            (0b1001)
+#define SDO6_OUT_FUNC           (0b1010)
+#define OC5_OUT_FUNC            (0b1011)
+#define OC8_OUT_FUNC            (0b1100)
+#define C1OUT_OUT_FUNC          (0b1110)
+#define REFCLKO3_OUT_FUNC       (0b1111)
+
+#define U1RTS_OUT_FUNC          (0b0001)
+#define U2TX_OUT_FUNC           (0b0010)
+#define U5RTS_OUT_FUNC          (0b0011)
+#define U6TX_OUT_FUNC           (0b0100)
+#define SS2_OUT_FUNC            (0b0110)
+#define SDO4_OUT_FUNC           (0b1000)
+#define SDO6_OUT_FUNC           (0b1010)
+#define OC2_OUT_FUNC            (0b1011)
+#define OC1_OUT_FUNC            (0b1100)
+#define OC9_OUT_FUNC            (0b1101)
+
+
+/**
+ * @brief Configure pin as a peripheral output
+ *
+ * @param pin
+ * @param func
+ * @return 0 if successful, -1 otherwise
+ */
+int pps_configure_output(uint8_t pin, uint8_t func);
+
+/**
+ * @brief Configure pin as a peripheral input
+ *
+ * @param pin
+ * @param func
+ * @return 0 if successful, -1 otherwise
+ */
+int pps_configure_input(uint8_t pin, uint8_t func);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_PPS_H__ */

--- a/hw/mcu/microchip/pic32mz2048efg100/src/ppc.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/ppc.c
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <xc.h>
+#include "mcu/mcu.h"
+#include "mcu/pps.h"
+
+#define MCU_GPIO_UNDEF                  (0xFF)
+#define PPS_BASE_ADDRESS                (0xBF801500)
+#define PPS_PORT_SPACING                (0x40)
+
+static volatile uint32_t *input_regs[4][16] = {
+    {
+        &INT3R,
+        &T2CKR,
+        &T6CKR,
+        &IC3R,
+        &IC7R,
+        &U1RXR,
+        &U2CTSR,
+        &U5RXR,
+        &U6CTSR,
+        &SDI1R,
+        &SDI3R,
+        &SDI5R,
+        &SS6R,
+        &REFCLKI1R
+    },
+    {
+        &INT4R,
+        &T5CKR,
+        &T7CKR,
+        &IC4R,
+        &IC8R,
+        &U3RXR,
+        &U4CTSR,
+        &SDI2R,
+        &SDI4R,
+        NULL,
+        &REFCLKI4R
+    },
+    {
+        &INT2R,
+        &T3CKR,
+        &T8CKR,
+        &IC2R,
+        &IC5R,
+        &IC9R,
+        &U1CTSR,
+        &SS1R,
+        &SS3R,
+        &SS4R,
+        &SS5R,
+        NULL
+    },
+    {
+        &INT1R,
+        &T4CKR,
+        &T9CKR,
+        &IC1R,
+        &IC6R,
+        &U3CTSR,
+        &U4RXR,
+        &U6RXR,
+        &SS2R,
+        &SDI6R,
+        &OCFAR,
+        &REFCLKI3R
+    }
+};
+
+static const uint8_t output_pins[4][16] = {
+    {
+        MCU_GPIO_PORTD(2),
+        MCU_GPIO_PORTG(8),
+        MCU_GPIO_PORTF(4),
+        MCU_GPIO_PORTD(10),
+        MCU_GPIO_PORTF(1),
+        MCU_GPIO_PORTB(9),
+        MCU_GPIO_PORTB(10),
+        MCU_GPIO_PORTC(14),
+        MCU_GPIO_PORTB(5),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_PORTC(1),
+        MCU_GPIO_PORTD(14),
+        MCU_GPIO_PORTG(1),
+        MCU_GPIO_PORTA(14),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    },
+    {
+        MCU_GPIO_PORTD(3),
+        MCU_GPIO_PORTG(7),
+        MCU_GPIO_PORTF(5),
+        MCU_GPIO_PORTD(11),
+        MCU_GPIO_PORTF(0),
+        MCU_GPIO_PORTB(1),
+        MCU_GPIO_PORTE(5),
+        MCU_GPIO_PORTC(13),
+        MCU_GPIO_PORTB(3),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_PORTC(4),
+        MCU_GPIO_PORTD(15),
+        MCU_GPIO_PORTG(0),
+        MCU_GPIO_PORTA(15),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    },
+    {
+        MCU_GPIO_PORTD(9),
+        MCU_GPIO_PORTG(6),
+        MCU_GPIO_PORTB(8),
+        MCU_GPIO_PORTB(15),
+        MCU_GPIO_PORTD(4),
+        MCU_GPIO_PORTB(0),
+        MCU_GPIO_PORTE(3),
+        MCU_GPIO_PORTB(7),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_PORTF(12),
+        MCU_GPIO_PORTD(12),
+        MCU_GPIO_PORTF(8),
+        MCU_GPIO_PORTC(3),
+        MCU_GPIO_PORTE(9),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    },
+    {
+        MCU_GPIO_PORTD(1),
+        MCU_GPIO_PORTG(9),
+        MCU_GPIO_PORTB(14),
+        MCU_GPIO_PORTD(0),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_PORTB(6),
+        MCU_GPIO_PORTD(5),
+        MCU_GPIO_PORTB(2),
+        MCU_GPIO_PORTF(3),
+        MCU_GPIO_PORTF(13),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_PORTF(2),
+        MCU_GPIO_PORTC(2),
+        MCU_GPIO_PORTE(8),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    }
+};
+
+int
+pps_configure_output(uint8_t pin, uint8_t func)
+{
+    uint32_t port = pin >> 4;
+    uint32_t index = pin & 0xF;
+    volatile uint32_t *ptr;
+
+    if (func >= 16) {
+        return -1;
+    }
+
+    ptr = (volatile uint32_t *) (PPS_BASE_ADDRESS +
+                                 (port * PPS_PORT_SPACING) + index * 4);
+
+    *ptr = func;
+    return 0;
+}
+
+int
+pps_configure_input(uint8_t pin, uint8_t func)
+{
+    uint8_t index = func >> 4;
+    uint8_t val;
+
+    if (index > 3) {
+        return -1;
+    }
+
+    func &= 0xF;
+    if (input_regs[index][func]  == NULL) {
+        return -1;
+    }
+
+    for (val = 0; val < 16; ++val) {
+        if (output_pins[index][val] == pin) {
+            break;
+        }
+    }
+    if (val == 16) {
+        return -1;
+    }
+
+    *input_regs[index][func] = val;
+    return 0;
+}


### PR DESCRIPTION
This pull requests adds:
  - A wrapper to configure pins as a peripheral output or input.
  - Modify hal_uart to be able to configure pins in ```hal_uart_config```
  - Set the UART4 (=CONSOLE_UART) pins at initialization for the Wi-Fire board. This means that no board specific code needs to be written in the user application to get the console uart fully working.

It has been tested on a Wi-Fire board.