### PR TITLE
BLE Host - Store management API additions

### DIFF
--- a/net/nimble/host/include/host/ble_hs_test.h
+++ b/net/nimble/host/include/host/ble_hs_test.h
@@ -48,6 +48,7 @@ int ble_os_test_all(void);
 int ble_sm_lgcy_test_suite(void);
 int ble_sm_sc_test_suite(void);
 int ble_sm_test_all(void);
+int ble_store_test_all(void);
 int ble_uuid_test_all(void);
 
 #ifdef __cplusplus

--- a/net/nimble/host/include/host/ble_store.h
+++ b/net/nimble/host/include/host/ble_store.h
@@ -205,6 +205,10 @@ void ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
 void ble_store_key_from_value_cccd(struct ble_store_key_cccd *out_key,
                                    struct ble_store_value_cccd *value);
 
+void ble_store_key_from_value(int obj_type,
+                              union ble_store_key *out_key,
+                              union ble_store_value *value);
+
 typedef int ble_store_iterator_fn(int obj_type,
                                   union ble_store_value *val,
                                   void *cookie);
@@ -212,6 +216,14 @@ typedef int ble_store_iterator_fn(int obj_type,
 int ble_store_iterate(int obj_type,
                       ble_store_iterator_fn *callback,
                       void *cookie);
+
+/*** Utility functions. */
+
+int ble_store_util_bonded_peers(ble_addr_t *out_peer_id_addrs,
+                                int *out_num_peers,
+                                int max_peers);
+int ble_store_util_delete_all(int type, const union ble_store_key *key);
+int ble_store_util_delete_peer(const ble_addr_t *peer_id_addr); 
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/include/host/ble_store.h
+++ b/net/nimble/host/include/host/ble_store.h
@@ -148,7 +148,7 @@ union ble_store_value {
  *                              BLE_HS_ENOENT if no matching object was found;
  *                              Other nonzero on error.
  */
-typedef int ble_store_read_fn(int obj_type, union ble_store_key *key,
+typedef int ble_store_read_fn(int obj_type, const union ble_store_key *key,
                               union ble_store_value *dst);
 
 /**
@@ -164,7 +164,7 @@ typedef int ble_store_read_fn(int obj_type, union ble_store_key *key,
  * @return                      0 if the object was successfully written;
  *                              Other nonzero on error.
  */
-typedef int ble_store_write_fn(int obj_type, union ble_store_value *val);
+typedef int ble_store_write_fn(int obj_type, const union ble_store_value *val);
 
 /**
  * Searches the store for the first object matching the specified criteria.  If
@@ -179,35 +179,35 @@ typedef int ble_store_write_fn(int obj_type, union ble_store_value *val);
  *                              BLE_HS_ENOENT if no matching object was found;
  *                              Other nonzero on error.
  */
-typedef int ble_store_delete_fn(int obj_type, union ble_store_key *key);
+typedef int ble_store_delete_fn(int obj_type, const union ble_store_key *key);
 
-int ble_store_read(int obj_type, union ble_store_key *key,
+int ble_store_read(int obj_type, const union ble_store_key *key,
                    union ble_store_value *val);
-int ble_store_write(int obj_type, union ble_store_value *val);
-int ble_store_delete(int obj_type, union ble_store_key *key);
+int ble_store_write(int obj_type, const union ble_store_value *val);
+int ble_store_delete(int obj_type, const union ble_store_key *key);
 
-int ble_store_read_our_sec(struct ble_store_key_sec *key_sec,
+int ble_store_read_our_sec(const struct ble_store_key_sec *key_sec,
                            struct ble_store_value_sec *value_sec);
-int ble_store_write_our_sec(struct ble_store_value_sec *value_sec);
-int ble_store_delete_our_sec(struct ble_store_key_sec *key_sec);
-int ble_store_read_peer_sec(struct ble_store_key_sec *key_sec,
+int ble_store_write_our_sec(const struct ble_store_value_sec *value_sec);
+int ble_store_delete_our_sec(const struct ble_store_key_sec *key_sec);
+int ble_store_read_peer_sec(const struct ble_store_key_sec *key_sec,
                             struct ble_store_value_sec *value_sec);
-int ble_store_write_peer_sec(struct ble_store_value_sec *value_sec);
-int ble_store_delete_peer_sec(struct ble_store_key_sec *key_sec);
+int ble_store_write_peer_sec(const struct ble_store_value_sec *value_sec);
+int ble_store_delete_peer_sec(const struct ble_store_key_sec *key_sec);
 
-int ble_store_read_cccd(struct ble_store_key_cccd *key,
+int ble_store_read_cccd(const struct ble_store_key_cccd *key,
                         struct ble_store_value_cccd *out_value);
-int ble_store_write_cccd(struct ble_store_value_cccd *value);
-int ble_store_delete_cccd(struct ble_store_key_cccd *key);
+int ble_store_write_cccd(const struct ble_store_value_cccd *value);
+int ble_store_delete_cccd(const struct ble_store_key_cccd *key);
 
 void ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
-                                  struct ble_store_value_sec *value);
+                                  const struct ble_store_value_sec *value);
 void ble_store_key_from_value_cccd(struct ble_store_key_cccd *out_key,
-                                   struct ble_store_value_cccd *value);
+                                   const struct ble_store_value_cccd *value);
 
 void ble_store_key_from_value(int obj_type,
                               union ble_store_key *out_key,
-                              union ble_store_value *value);
+                              const union ble_store_value *value);
 
 typedef int ble_store_iterator_fn(int obj_type,
                                   union ble_store_value *val,

--- a/net/nimble/host/include/host/ble_store.h
+++ b/net/nimble/host/include/host/ble_store.h
@@ -209,9 +209,10 @@ typedef int ble_store_iterator_fn(int obj_type,
                                   union ble_store_value *val,
                                   void *cookie);
 
-void ble_store_iterate(int obj_type,
-                       ble_store_iterator_fn *callback,
-                       void *cookie);
+int ble_store_iterate(int obj_type,
+                      ble_store_iterator_fn *callback,
+                      void *cookie);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/nimble/host/src/ble_hs_pvcy.c
+++ b/net/nimble/host/src/ble_hs_pvcy.c
@@ -66,7 +66,7 @@ ble_hs_pvcy_set_resolve_enabled(int enable)
 }
 
 int
-ble_hs_pvcy_remove_entry(uint8_t addr_type, uint8_t *addr)
+ble_hs_pvcy_remove_entry(uint8_t addr_type, const uint8_t *addr)
 {
     uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_RMV_FROM_RESOLV_LIST_LEN];
     int rc;
@@ -105,7 +105,8 @@ ble_hs_pvcy_clear_entries(void)
 }
 
 int
-ble_hs_pvcy_add_entry(uint8_t *addr, uint8_t addr_type, uint8_t *irk)
+ble_hs_pvcy_add_entry(const uint8_t *addr, uint8_t addr_type,
+                      const uint8_t *irk)
 {
     struct hci_add_dev_to_resolving_list add;
     uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_ADD_TO_RESOLV_LIST_LEN];

--- a/net/nimble/host/src/ble_hs_pvcy_priv.h
+++ b/net/nimble/host/src/ble_hs_pvcy_priv.h
@@ -28,8 +28,9 @@ extern "C" {
 
 int ble_hs_pvcy_set_our_irk(const uint8_t *irk);
 int ble_hs_pvcy_our_irk(const uint8_t **out_irk);
-int ble_hs_pvcy_remove_entry(uint8_t addr_type, uint8_t *addr);
-int ble_hs_pvcy_add_entry(uint8_t *addr, uint8_t addrtype, uint8_t *irk);
+int ble_hs_pvcy_remove_entry(uint8_t addr_type, const uint8_t *addr);
+int ble_hs_pvcy_add_entry(const uint8_t *addr, uint8_t addrtype,
+                          const uint8_t *irk);
 int ble_hs_pvcy_ensure_started(void);
 
 #ifdef __cplusplus

--- a/net/nimble/host/src/ble_store.c
+++ b/net/nimble/host/src/ble_store.c
@@ -236,6 +236,27 @@ ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
     out_key->idx = 0;
 }
 
+void
+ble_store_key_from_value(int obj_type,
+                         union ble_store_key *out_key,
+                         union ble_store_value *value)
+{
+    switch (obj_type) {
+    case BLE_STORE_OBJ_TYPE_OUR_SEC:
+    case BLE_STORE_OBJ_TYPE_PEER_SEC:
+        ble_store_key_from_value_sec(&out_key->sec, &value->sec);
+        break;
+
+    case BLE_STORE_OBJ_TYPE_CCCD:
+        ble_store_key_from_value_cccd(&out_key->cccd, &value->cccd);
+        break;
+
+    default:
+        BLE_HS_DBG_ASSERT(0);
+        break;
+    }
+}
+
 int
 ble_store_iterate(int obj_type,
                   ble_store_iterator_fn *callback,
@@ -258,6 +279,7 @@ ble_store_iterate(int obj_type,
         case BLE_STORE_OBJ_TYPE_CCCD:
             key.cccd.peer_addr = *BLE_ADDR_ANY;
             pidx = &key.cccd.idx;
+            break;
         default:
             BLE_HS_DBG_ASSERT(0);
             return BLE_HS_EINVAL;

--- a/net/nimble/host/src/ble_store.c
+++ b/net/nimble/host/src/ble_store.c
@@ -268,7 +268,11 @@ void ble_store_iterate(int obj_type,
             /* read error or no more entries */
             break;
         } else if (callback) {
-            callback(obj_type, &value, cookie);
+            rc = callback(obj_type, &value, cookie);
+            if (rc != 0) {
+                /* User function indicates to stop iterating. */
+                break;
+            }
         }
         idx++;
     }

--- a/net/nimble/host/src/ble_store.c
+++ b/net/nimble/host/src/ble_store.c
@@ -23,7 +23,7 @@
 #include "ble_hs_priv.h"
 
 int
-ble_store_read(int obj_type, union ble_store_key *key,
+ble_store_read(int obj_type, const union ble_store_key *key,
                union ble_store_value *val)
 {
     int rc;
@@ -38,7 +38,7 @@ ble_store_read(int obj_type, union ble_store_key *key,
 }
 
 int
-ble_store_write(int obj_type, union ble_store_value *val)
+ble_store_write(int obj_type, const union ble_store_value *val)
 {
     int rc;
 
@@ -52,7 +52,7 @@ ble_store_write(int obj_type, union ble_store_value *val)
 }
 
 int
-ble_store_delete(int obj_type, union ble_store_key *key)
+ble_store_delete(int obj_type, const union ble_store_key *key)
 {
     int rc;
 
@@ -66,7 +66,7 @@ ble_store_delete(int obj_type, union ble_store_key *key)
 }
 
 int
-ble_store_read_our_sec(struct ble_store_key_sec *key_sec,
+ble_store_read_our_sec(const struct ble_store_key_sec *key_sec,
                        struct ble_store_value_sec *value_sec)
 {
     union ble_store_value *store_value;
@@ -84,7 +84,8 @@ ble_store_read_our_sec(struct ble_store_key_sec *key_sec,
 }
 
 static int
-ble_store_persist_sec(int obj_type, struct ble_store_value_sec *value_sec)
+ble_store_persist_sec(int obj_type,
+                      const struct ble_store_value_sec *value_sec)
 {
     union ble_store_value *store_value;
     int rc;
@@ -101,7 +102,7 @@ ble_store_persist_sec(int obj_type, struct ble_store_value_sec *value_sec)
 }
 
 int
-ble_store_write_our_sec(struct ble_store_value_sec *value_sec)
+ble_store_write_our_sec(const struct ble_store_value_sec *value_sec)
 {
     int rc;
 
@@ -110,7 +111,7 @@ ble_store_write_our_sec(struct ble_store_value_sec *value_sec)
 }
 
 int
-ble_store_delete_our_sec(struct ble_store_key_sec *key_sec)
+ble_store_delete_our_sec(const struct ble_store_key_sec *key_sec)
 {
     union ble_store_key *store_key;
     int rc;
@@ -121,7 +122,7 @@ ble_store_delete_our_sec(struct ble_store_key_sec *key_sec)
 }
 
 int
-ble_store_delete_peer_sec(struct ble_store_key_sec *key_sec)
+ble_store_delete_peer_sec(const struct ble_store_key_sec *key_sec)
 {
     union ble_store_key *store_key;
     int rc;
@@ -132,7 +133,7 @@ ble_store_delete_peer_sec(struct ble_store_key_sec *key_sec)
 }
 
 int
-ble_store_read_peer_sec(struct ble_store_key_sec *key_sec,
+ble_store_read_peer_sec(const struct ble_store_key_sec *key_sec,
                         struct ble_store_value_sec *value_sec)
 {
     union ble_store_value *store_value;
@@ -154,7 +155,7 @@ ble_store_read_peer_sec(struct ble_store_key_sec *key_sec,
 }
 
 int
-ble_store_write_peer_sec(struct ble_store_value_sec *value_sec)
+ble_store_write_peer_sec(const struct ble_store_value_sec *value_sec)
 {
     int rc;
 
@@ -180,7 +181,7 @@ ble_store_write_peer_sec(struct ble_store_value_sec *value_sec)
 }
 
 int
-ble_store_read_cccd(struct ble_store_key_cccd *key,
+ble_store_read_cccd(const struct ble_store_key_cccd *key,
                     struct ble_store_value_cccd *out_value)
 {
     union ble_store_value *store_value;
@@ -194,7 +195,7 @@ ble_store_read_cccd(struct ble_store_key_cccd *key,
 }
 
 int
-ble_store_write_cccd(struct ble_store_value_cccd *value)
+ble_store_write_cccd(const struct ble_store_value_cccd *value)
 {
     union ble_store_value *store_value;
     int rc;
@@ -205,7 +206,7 @@ ble_store_write_cccd(struct ble_store_value_cccd *value)
 }
 
 int
-ble_store_delete_cccd(struct ble_store_key_cccd *key)
+ble_store_delete_cccd(const struct ble_store_key_cccd *key)
 {
     union ble_store_key *store_key;
     int rc;
@@ -217,7 +218,7 @@ ble_store_delete_cccd(struct ble_store_key_cccd *key)
 
 void
 ble_store_key_from_value_cccd(struct ble_store_key_cccd *out_key,
-                              struct ble_store_value_cccd *value)
+                              const struct ble_store_value_cccd *value)
 {
     out_key->peer_addr = value->peer_addr;
     out_key->chr_val_handle = value->chr_val_handle;
@@ -226,7 +227,7 @@ ble_store_key_from_value_cccd(struct ble_store_key_cccd *out_key,
 
 void
 ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
-                             struct ble_store_value_sec *value)
+                             const struct ble_store_value_sec *value)
 {
     out_key->peer_addr = value->peer_addr;
 
@@ -239,7 +240,7 @@ ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
 void
 ble_store_key_from_value(int obj_type,
                          union ble_store_key *out_key,
-                         union ble_store_value *value)
+                         const union ble_store_value *value)
 {
     switch (obj_type) {
     case BLE_STORE_OBJ_TYPE_OUR_SEC:

--- a/net/nimble/host/src/ble_store_util.c
+++ b/net/nimble/host/src/ble_store_util.c
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "host/ble_store.h"
+#include "ble_hs_priv.h"
+
+struct ble_store_util_peer_set {
+    ble_addr_t *peer_id_addrs;
+    int num_peers;
+    int max_peers;
+    int status;
+};
+
+static int
+ble_store_util_iter_unique_peer(int obj_type,
+                                union ble_store_value *val,
+                                void *arg)
+{
+    struct ble_store_util_peer_set *set;
+    int i;
+
+    BLE_HS_DBG_ASSERT(obj_type == BLE_STORE_OBJ_TYPE_OUR_SEC ||
+                      obj_type == BLE_STORE_OBJ_TYPE_PEER_SEC);
+
+    set = arg;
+
+    /* Do nothing if this peer is a duplicate. */
+    for (i = 0; i < set->num_peers; i++) {
+        if (ble_addr_cmp(set->peer_id_addrs + i, &val->sec.peer_addr) == 0) {
+            return 0;
+        }
+    }
+
+    if (set->num_peers >= set->max_peers) {
+        /* Overflow; abort the iterate procedure. */
+        set->status = BLE_HS_ENOMEM;
+        return 1;
+    }
+
+    set->peer_id_addrs[set->num_peers] = val->sec.peer_addr;
+    set->num_peers++;
+
+    return 0;
+}
+
+/**
+ * Retrieves the set of peer addresses for which a bond has been established.
+ *
+ * @param out_peer_id_addrs     On success, the set of bonded peer addresses
+ *                                  gets written here.
+ * @param out_num_peers         On success, the number of bonds gets written
+ *                                  here.
+ * @param max_peers             The capacity of the destination buffer.
+ *
+ * @return                      0 on success;
+ *                              BLE_HS_ENOMEM if the destination buffer is too
+ *                                  small;
+ *                              Other nonzero on error.
+ */
+int
+ble_store_util_bonded_peers(ble_addr_t *out_peer_id_addrs, int *out_num_peers,
+                            int max_peers)
+{
+    struct ble_store_util_peer_set set = {
+        .peer_id_addrs = out_peer_id_addrs,
+        .num_peers = 0,
+        .max_peers = max_peers,
+        .status = 0,
+    };
+    int rc;
+
+    rc = ble_store_iterate(BLE_STORE_OBJ_TYPE_OUR_SEC,
+                           ble_store_util_iter_unique_peer,
+                           &set);
+    if (rc != 0) {
+        return rc;
+    }
+    if (set.status != 0) {
+        return set.status;
+    }
+
+    *out_num_peers = set.num_peers;
+    return 0;
+}
+
+/**
+ * Deletes all entries from the store that are attached to the specified peer
+ * address.  This function deletes security entries and CCCD records.
+ *
+ * @param peer_id_addr          Entries with this peer address get deleted.
+ *
+ * @return                      0 on success;
+ *                              Other nonzero on error.
+ */
+int
+ble_store_util_delete_peer(const ble_addr_t *peer_id_addr)
+{
+    union ble_store_key key;
+    int rc;
+
+    memset(&key, 0, sizeof key);
+    key.sec.peer_addr = *peer_id_addr;
+
+    rc = ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_OUR_SEC, &key);
+    if (rc != 0) {
+        return rc;
+    }
+        
+    rc = ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_PEER_SEC, &key);
+    if (rc != 0) {
+        return rc;
+    }
+        
+    memset(&key, 0, sizeof key);
+    key.cccd.peer_addr = *peer_id_addr;
+
+    rc = ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_CCCD, &key);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}
+
+/**
+ * Deletes all entries from the store that match the specified key.
+ *
+ * @param type                  The type of store entry to delete.
+ * @param key                   Entries matching this key get deleted.
+ *
+ * @return                      0 on success;
+ *                              Other nonzero on error.
+ */
+int
+ble_store_util_delete_all(int type, const union ble_store_key *key)
+{
+    int rc;
+
+    do {
+        rc = ble_store_delete(type, key);
+    } while (rc == 0);
+
+    if (rc != BLE_HS_ENOENT) {
+        return rc;
+    }
+
+    return 0;
+}

--- a/net/nimble/host/store/ram/include/store/ram/ble_store_ram.h
+++ b/net/nimble/host/store/ram/include/store/ram/ble_store_ram.h
@@ -27,10 +27,10 @@ extern "C" {
 union ble_store_key;
 union ble_store_value;
 
-int ble_store_ram_read(int obj_type, union ble_store_key *key,
+int ble_store_ram_read(int obj_type, const union ble_store_key *key,
                        union ble_store_value *value);
-int ble_store_ram_write(int obj_type, union ble_store_value *val);
-int ble_store_ram_delete(int obj_type, union ble_store_key *key);
+int ble_store_ram_write(int obj_type, const union ble_store_value *val);
+int ble_store_ram_delete(int obj_type, const union ble_store_key *key);
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/store/ram/src/ble_store_ram.c
+++ b/net/nimble/host/store/ram/src/ble_store_ram.c
@@ -48,7 +48,7 @@ static int ble_store_ram_num_cccds;
  *****************************************************************************/
 
 static void
-ble_store_ram_print_value_sec(struct ble_store_value_sec *sec)
+ble_store_ram_print_value_sec(const struct ble_store_value_sec *sec)
 {
     if (sec->ltk_present) {
         BLE_HS_LOG(DEBUG, "ediv=%u rand=%llu authenticated=%d ltk=",
@@ -71,7 +71,7 @@ ble_store_ram_print_value_sec(struct ble_store_value_sec *sec)
 }
 
 static void
-ble_store_ram_print_key_sec(struct ble_store_key_sec *key_sec)
+ble_store_ram_print_key_sec(const struct ble_store_key_sec *key_sec)
 {
     if (ble_addr_cmp(&key_sec->peer_addr, BLE_ADDR_ANY)) {
         BLE_HS_LOG(DEBUG, "peer_addr_type=%d peer_addr=",
@@ -86,11 +86,11 @@ ble_store_ram_print_key_sec(struct ble_store_key_sec *key_sec)
 }
 
 static int
-ble_store_ram_find_sec(struct ble_store_key_sec *key_sec,
-                       struct ble_store_value_sec *value_secs,
+ble_store_ram_find_sec(const struct ble_store_key_sec *key_sec,
+                       const struct ble_store_value_sec *value_secs,
                        int num_value_secs)
 {
-    struct ble_store_value_sec *cur;
+    const struct ble_store_value_sec *cur;
     int skipped;
     int i;
 
@@ -127,7 +127,7 @@ ble_store_ram_find_sec(struct ble_store_key_sec *key_sec,
 }
 
 static int
-ble_store_ram_read_our_sec(struct ble_store_key_sec *key_sec,
+ble_store_ram_read_our_sec(const struct ble_store_key_sec *key_sec,
                            struct ble_store_value_sec *value_sec)
 {
     int idx;
@@ -143,7 +143,7 @@ ble_store_ram_read_our_sec(struct ble_store_key_sec *key_sec,
 }
 
 static int
-ble_store_ram_write_our_sec(struct ble_store_value_sec *value_sec)
+ble_store_ram_write_our_sec(const struct ble_store_value_sec *value_sec)
 {
     struct ble_store_key_sec key_sec;
     int idx;
@@ -191,7 +191,7 @@ ble_store_ram_delete_obj(void *values, int value_size, int idx,
 }
 
 static int
-ble_store_ram_delete_sec(struct ble_store_key_sec *key_sec,
+ble_store_ram_delete_sec(const struct ble_store_key_sec *key_sec,
                          struct ble_store_value_sec *value_secs,
                          int *num_value_secs)
 {
@@ -213,7 +213,7 @@ ble_store_ram_delete_sec(struct ble_store_key_sec *key_sec,
 }
 
 static int
-ble_store_ram_delete_our_sec(struct ble_store_key_sec *key_sec)
+ble_store_ram_delete_our_sec(const struct ble_store_key_sec *key_sec)
 {
     int rc;
 
@@ -227,7 +227,7 @@ ble_store_ram_delete_our_sec(struct ble_store_key_sec *key_sec)
 }
 
 static int
-ble_store_ram_delete_peer_sec(struct ble_store_key_sec *key_sec)
+ble_store_ram_delete_peer_sec(const struct ble_store_key_sec *key_sec)
 {
     int rc;
 
@@ -241,7 +241,7 @@ ble_store_ram_delete_peer_sec(struct ble_store_key_sec *key_sec)
 }
 
 static int
-ble_store_ram_read_peer_sec(struct ble_store_key_sec *key_sec,
+ble_store_ram_read_peer_sec(const struct ble_store_key_sec *key_sec,
                             struct ble_store_value_sec *value_sec)
 {
     int idx;
@@ -257,7 +257,7 @@ ble_store_ram_read_peer_sec(struct ble_store_key_sec *key_sec,
 }
 
 static int
-ble_store_ram_write_peer_sec(struct ble_store_value_sec *value_sec)
+ble_store_ram_write_peer_sec(const struct ble_store_value_sec *value_sec)
 {
     struct ble_store_key_sec key_sec;
     int idx;
@@ -288,7 +288,7 @@ ble_store_ram_write_peer_sec(struct ble_store_value_sec *value_sec)
  *****************************************************************************/
 
 static int
-ble_store_ram_find_cccd(struct ble_store_key_cccd *key)
+ble_store_ram_find_cccd(const struct ble_store_key_cccd *key)
 {
     struct ble_store_value_cccd *cccd;
     int skipped;
@@ -322,8 +322,8 @@ ble_store_ram_find_cccd(struct ble_store_key_cccd *key)
 }
 
 static int
-ble_store_ram_read_cccd(struct ble_store_key_cccd *key_cccd,
-                struct ble_store_value_cccd *value_cccd)
+ble_store_ram_read_cccd(const struct ble_store_key_cccd *key_cccd,
+                        struct ble_store_value_cccd *value_cccd)
 {
     int idx;
 
@@ -337,7 +337,7 @@ ble_store_ram_read_cccd(struct ble_store_key_cccd *key_cccd,
 }
 
 static int
-ble_store_ram_write_cccd(struct ble_store_value_cccd *value_cccd)
+ble_store_ram_write_cccd(const struct ble_store_value_cccd *value_cccd)
 {
     struct ble_store_key_cccd key_cccd;
     int idx;
@@ -369,7 +369,7 @@ ble_store_ram_write_cccd(struct ble_store_value_cccd *value_cccd)
  * @return                      0 if a key was found; else BLE_HS_ENOENT.
  */
 int
-ble_store_ram_read(int obj_type, union ble_store_key *key,
+ble_store_ram_read(int obj_type, const union ble_store_key *key,
                    union ble_store_value *value)
 {
     int rc;
@@ -413,7 +413,7 @@ ble_store_ram_read(int obj_type, union ble_store_key *key,
  *                                  full.
  */
 int
-ble_store_ram_write(int obj_type, union ble_store_value *val)
+ble_store_ram_write(int obj_type, const union ble_store_value *val)
 {
     int rc;
 
@@ -436,7 +436,7 @@ ble_store_ram_write(int obj_type, union ble_store_value *val)
 }
 
 int
-ble_store_ram_delete(int obj_type, union ble_store_key *key)
+ble_store_ram_delete(int obj_type, const union ble_store_key *key)
 {
     int rc;
 

--- a/net/nimble/host/store/ram/src/ble_store_ram.c
+++ b/net/nimble/host/store/ram/src/ble_store_ram.c
@@ -322,6 +322,28 @@ ble_store_ram_find_cccd(const struct ble_store_key_cccd *key)
 }
 
 static int
+ble_store_ram_delete_cccd(const struct ble_store_key_cccd *key_cccd)
+{
+    int idx;
+    int rc;
+
+    idx = ble_store_ram_find_cccd(key_cccd);
+    if (idx == -1) {
+        return BLE_HS_ENOENT;
+    }
+
+    rc = ble_store_ram_delete_obj(ble_store_ram_cccds,
+                                  sizeof *ble_store_ram_cccds,
+                                  idx,
+                                  &ble_store_ram_num_cccds);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}
+
+static int
 ble_store_ram_read_cccd(const struct ble_store_key_cccd *key_cccd,
                         struct ble_store_value_cccd *value_cccd)
 {
@@ -450,8 +472,8 @@ ble_store_ram_delete(int obj_type, const union ble_store_key *key)
         return rc;
 
     case BLE_STORE_OBJ_TYPE_CCCD:
-        /* XXX: There is no good reason not to support this. */
-        return BLE_HS_ENOTSUP;
+        rc = ble_store_ram_delete_cccd(&key->cccd);
+        return rc;
 
     default:
         return BLE_HS_ENOTSUP;

--- a/net/nimble/host/store/ram/src/ble_store_ram.c
+++ b/net/nimble/host/store/ram/src/ble_store_ram.c
@@ -27,21 +27,20 @@
 #include <string.h>
 
 #include "sysinit/sysinit.h"
+#include "syscfg/syscfg.h"
 #include "host/ble_hs.h"
 #include "store/ram/ble_store_ram.h"
 
-/* XXX: This should be configurable. */
-#define STORE_MAX_SLV_LTKS   4
-#define STORE_MAX_MST_LTKS   4
-#define STORE_MAX_CCCDS      16
-
-static struct ble_store_value_sec ble_store_ram_our_secs[STORE_MAX_SLV_LTKS];
+static struct ble_store_value_sec
+    ble_store_ram_our_secs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
 static int ble_store_ram_num_our_secs;
 
-static struct ble_store_value_sec ble_store_ram_peer_secs[STORE_MAX_MST_LTKS];
+static struct ble_store_value_sec
+    ble_store_ram_peer_secs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
 static int ble_store_ram_num_peer_secs;
 
-static struct ble_store_value_cccd ble_store_ram_cccds[STORE_MAX_CCCDS];
+static struct ble_store_value_cccd
+    ble_store_ram_cccds[MYNEWT_VAL(BLE_STORE_MAX_CCCDS)];
 static int ble_store_ram_num_cccds;
 
 /*****************************************************************************
@@ -156,7 +155,7 @@ ble_store_ram_write_our_sec(struct ble_store_value_sec *value_sec)
     idx = ble_store_ram_find_sec(&key_sec, ble_store_ram_our_secs,
                                  ble_store_ram_num_our_secs);
     if (idx == -1) {
-        if (ble_store_ram_num_our_secs >= STORE_MAX_SLV_LTKS) {
+        if (ble_store_ram_num_our_secs >= MYNEWT_VAL(BLE_STORE_MAX_BONDS)) {
             BLE_HS_LOG(DEBUG, "error persisting our sec; too many entries "
                               "(%d)\n", ble_store_ram_num_our_secs);
             return BLE_HS_ENOMEM;
@@ -270,7 +269,7 @@ ble_store_ram_write_peer_sec(struct ble_store_value_sec *value_sec)
     idx = ble_store_ram_find_sec(&key_sec, ble_store_ram_peer_secs,
                                  ble_store_ram_num_peer_secs);
     if (idx == -1) {
-        if (ble_store_ram_num_peer_secs >= STORE_MAX_MST_LTKS) {
+        if (ble_store_ram_num_peer_secs >= MYNEWT_VAL(BLE_STORE_MAX_BONDS)) {
             BLE_HS_LOG(DEBUG, "error persisting peer sec; too many entries "
                              "(%d)\n", ble_store_ram_num_peer_secs);
             return BLE_HS_ENOMEM;
@@ -346,7 +345,7 @@ ble_store_ram_write_cccd(struct ble_store_value_cccd *value_cccd)
     ble_store_key_from_value_cccd(&key_cccd, value_cccd);
     idx = ble_store_ram_find_cccd(&key_cccd);
     if (idx == -1) {
-        if (ble_store_ram_num_cccds >= STORE_MAX_SLV_LTKS) {
+        if (ble_store_ram_num_cccds >= MYNEWT_VAL(BLE_STORE_MAX_CCCDS)) {
             BLE_HS_LOG(DEBUG, "error persisting cccd; too many entries (%d)\n",
                        ble_store_ram_num_cccds);
             return BLE_HS_ENOMEM;

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -314,3 +314,14 @@ syscfg.defs:
         description: >
             Enables advertising of Eddystone beacons.
         value: 1
+
+    # Store settings.
+    BLE_STORE_MAX_BONDS:
+        description: >
+            Number of bonds to persist before recycling old ones.
+        value: 4
+    BLE_STORE_MAX_CCCDS:
+        description: >
+            Number of client characteristic configuration descriptors to
+            persist before recycling old ones.
+        value: 16

--- a/net/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/net/nimble/host/test/src/ble_gatts_notify_test.c
@@ -74,9 +74,9 @@ ble_gatts_notify_test_events[BLE_GATTS_NOTIFY_TEST_MAX_EVENTS];
 
 static int ble_gatts_notify_test_num_events;
 
-typedef int ble_store_write_fn(int obj_type, union ble_store_value *val);
+typedef int ble_store_write_fn(int obj_type, const union ble_store_value *val);
 
-typedef int ble_store_delete_fn(int obj_type, union ble_store_key *key);
+typedef int ble_store_delete_fn(int obj_type, const union ble_store_key *key);
 
 static int
 ble_gatts_notify_test_util_gap_event(struct ble_gap_event *event, void *arg)

--- a/net/nimble/host/test/src/ble_hs_test.c
+++ b/net/nimble/host/test/src/ble_hs_test.c
@@ -47,12 +47,13 @@ main(int argc, char **argv)
     ble_gatts_notify_test_all();
     ble_gatts_read_test_suite();
     ble_gatts_reg_test_all();
-    ble_hs_hci_test_all();
     ble_hs_adv_test_all();
     ble_hs_conn_test_all();
+    ble_hs_hci_test_all();
     ble_l2cap_test_all();
     ble_os_test_all();
     ble_sm_test_all();
+    ble_store_test_all();
     ble_uuid_test_all();
 
     return tu_any_failed;

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -2320,7 +2320,7 @@ ble_hs_test_util_num_peer_secs(void)
 }
 
 static int
-ble_hs_test_util_store_read(int obj_type, union ble_store_key *key,
+ble_hs_test_util_store_read(int obj_type, const union ble_store_key *key,
                             union ble_store_value *value)
 {
     int rc;
@@ -2335,7 +2335,7 @@ ble_hs_test_util_store_read(int obj_type, union ble_store_key *key,
 }
 
 static int
-ble_hs_test_util_store_write(int obj_type, union ble_store_value *value)
+ble_hs_test_util_store_write(int obj_type, const union ble_store_value *value)
 {
     int rc;
 
@@ -2348,7 +2348,7 @@ ble_hs_test_util_store_write(int obj_type, union ble_store_value *value)
 }
 
 static int
-ble_hs_test_util_store_delete(int obj_type, union ble_store_key *key)
+ble_hs_test_util_store_delete(int obj_type, const union ble_store_key *key)
 {
     int rc;
 

--- a/net/nimble/host/test/src/ble_store_test.c
+++ b/net/nimble/host/test/src/ble_store_test.c
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "testutil/testutil.h"
+#include "host/ble_hs_test.h"
+#include "ble_hs_test_util.h"
+
+static void
+ble_store_test_util_verify_peer_deleted(const ble_addr_t *addr)
+{
+    union ble_store_value value;
+    union ble_store_key key;
+    ble_addr_t addrs[64];
+    int num_addrs;
+    int rc;
+    int i;
+
+    memset(&key, 0, sizeof key);
+    key.sec.peer_addr = *addr;
+    rc = ble_store_read(BLE_STORE_OBJ_TYPE_OUR_SEC, &key, &value);
+    TEST_ASSERT(rc == BLE_HS_ENOENT);
+    rc = ble_store_read(BLE_STORE_OBJ_TYPE_PEER_SEC, &key, &value);
+    TEST_ASSERT(rc == BLE_HS_ENOENT);
+
+    memset(&key, 0, sizeof key);
+    key.cccd.peer_addr = *addr;
+    rc = ble_store_read(BLE_STORE_OBJ_TYPE_CCCD, &key, &value);
+    TEST_ASSERT(rc == BLE_HS_ENOENT);
+
+    rc = ble_store_util_bonded_peers(addrs, &num_addrs,
+                                     sizeof addrs / sizeof addrs[0]);
+    TEST_ASSERT_FATAL(rc == 0);
+    for (i = 0; i < num_addrs; i++) {
+        TEST_ASSERT(ble_addr_cmp(addr, addrs + i) != 0);
+    }
+}
+
+TEST_CASE(ble_store_test_peers)
+{
+    struct ble_store_value_sec secs[4] = {
+        {
+            .peer_addr = { BLE_ADDR_PUBLIC,     { 1, 2, 3, 4, 5, 6 } },
+            .ltk_present = 1,
+        },
+        {
+            /* Address value is a duplicate of above, but type differs. */
+            .peer_addr = { BLE_ADDR_RANDOM,     { 1, 2, 3, 4, 5, 6 } },
+            .ltk_present = 1,
+        },
+        {
+            .peer_addr = { BLE_ADDR_PUBLIC,     { 2, 3, 4, 5, 6, 7 } },
+            .ltk_present = 1,
+        },
+        {
+            .peer_addr = { BLE_ADDR_RANDOM,     { 3, 4, 5, 6, 7, 8 } },
+            .ltk_present = 1,
+        },
+    };
+    ble_addr_t peer_addrs[4];
+    int num_addrs;
+    int rc;
+    int i;
+
+    for (i = 0; i < sizeof secs / sizeof secs[0]; i++) {
+        rc = ble_store_write_our_sec(secs + i);
+        TEST_ASSERT_FATAL(rc == 0);
+        rc = ble_store_write_peer_sec(secs + i);
+        TEST_ASSERT_FATAL(rc == 0);
+    }
+
+    rc = ble_store_util_bonded_peers(peer_addrs, &num_addrs,
+                                     sizeof peer_addrs / sizeof peer_addrs[0]);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    TEST_ASSERT(num_addrs == sizeof secs / sizeof secs[0]);
+    for (i = 0; i < num_addrs; i++) {
+        TEST_ASSERT(ble_addr_cmp(&peer_addrs[i], &secs[i].peer_addr) == 0);
+    }
+}
+
+TEST_CASE(ble_store_test_delete_peer)
+{
+    struct ble_store_value_sec secs[2] = {
+        {
+            .peer_addr = { BLE_ADDR_PUBLIC,     { 1, 2, 3, 4, 5, 6 } },
+            .ltk_present = 1,
+        },
+        {
+            /* Address value is a duplicate of above, but type differs. */
+            .peer_addr = { BLE_ADDR_RANDOM,     { 1, 2, 3, 4, 5, 6 } },
+            .ltk_present = 1,
+        },
+    };
+    struct ble_store_value_cccd cccds[3] = {
+        /* First two belong to first peer. */
+        {
+            .peer_addr = secs[0].peer_addr,
+            .chr_val_handle = 5,
+        },
+        {
+            .peer_addr = secs[0].peer_addr,
+            .chr_val_handle = 8,
+        },
+
+        /* Last belongs to second peer. */
+        {
+            .peer_addr = secs[1].peer_addr,
+            .chr_val_handle = 5,
+        },
+    };
+
+    int rc;
+    int i;
+
+    for (i = 0; i < sizeof secs / sizeof secs[0]; i++) {
+        rc = ble_store_write_our_sec(secs + i);
+        TEST_ASSERT_FATAL(rc == 0);
+        rc = ble_store_write_peer_sec(secs + i);
+        TEST_ASSERT_FATAL(rc == 0);
+    }
+
+    for (i = 0; i < sizeof cccds / sizeof cccds[0]; i++) {
+        rc = ble_store_write_cccd(cccds + i);
+        TEST_ASSERT_FATAL(rc == 0);
+    }
+
+    /* Delete first peer. */
+    rc = ble_store_util_delete_peer(&secs[0].peer_addr);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Ensure all traces of first peer have been removed. */
+    ble_store_test_util_verify_peer_deleted(&secs[0].peer_addr);
+
+    /* Delete second peer. */
+    rc = ble_store_util_delete_peer(&secs[1].peer_addr);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Ensure all traces of first peer have been removed. */
+    ble_store_test_util_verify_peer_deleted(&secs[1].peer_addr);
+}
+
+TEST_SUITE(ble_store_suite)
+{
+    tu_suite_set_post_test_cb(ble_hs_test_util_post_test, NULL);
+
+    ble_store_test_peers();
+    ble_store_test_delete_peer();
+}
+
+int
+ble_store_test_all(void)
+{
+    ble_store_suite();
+
+    return tu_any_failed;
+}

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -235,7 +235,14 @@ typedef struct {
 
 static inline int ble_addr_cmp(const ble_addr_t *a, const ble_addr_t *b)
 {
-    return memcmp(a, b, sizeof(*a));
+    int type_diff;
+
+    type_diff = a->type - b->type;
+    if (type_diff != 0) {
+        return type_diff;
+    }
+
+    return memcmp(a->val, b->val, sizeof(a->val));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This pull request adds the following three functions to the host store
API:

```
/**
 * Deletes all entries from the store that match the specified key.
 *
 * @param type                  The type of store entry to delete.
 * @param key                   Entries matching this key get deleted.
 *
 * @return                      0 on success;
 *                              Other nonzero on error.
 */
int
ble_store_util_delete_all(int type, const union ble_store_key *key)
```
```
/**
 * Retrieves the set of peer addresses for which a bond has been
 * established.
 *
 * @param out_peer_id_addrs     On success, the set of bonded peer
 *                                  addresses gets written here.
 * @param out_num_peers         On success, the number of bonds gets
 *                                  written here.
 * @param max_peers             The capacity of the destination buffer.
 *
 * @return                      0 on success;
 *                              BLE_HS_ENOMEM if the destination buffer
 *                                  is too small;
 *                              Other nonzero on error.
 */
int
ble_store_util_bonded_peers(ble_addr_t *out_peer_id_addrs,
                            int *out_num_peers, int max_peers)
```
```
/**
 * Deletes all entries from the store that are attached to the specified
 * peer address.  This function deletes security entries and CCCD
 * records.
 *
 * @param peer_id_addr          Entries with this peer address get
 *                                  deleted.
 *
 * @return                      0 on success;
 *                              Other nonzero on error.
 */
int
ble_store_util_delete_peer(const ble_addr_t *peer_id_addr)
```
It also contains some miscellaneous fixes.
