### PR TITLE
boot: Tickle watchdog during image swap and verify

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -24,6 +24,7 @@
 
 #include "syscfg/syscfg.h"
 #include "hal/hal_flash.h"
+#include "hal/hal_watchdog.h"
 #include "flash_map/flash_map.h"
 #include "bootutil/image.h"
 #include "bootutil/sign_key.h"
@@ -66,6 +67,9 @@ bootutil_img_hash(struct image_header *hdr, const struct flash_area *fap,
      */
     size = hdr->ih_img_size + hdr->ih_hdr_size;
     for (off = 0; off < size; off += blk_sz) {
+        /* Pet the watchdog, in case it is still enabled after a soft reset. */
+        hal_watchdog_tickle();
+
         blk_sz = size - off;
         if (blk_sz > tmp_buf_sz) {
             blk_sz = tmp_buf_sz;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -30,6 +30,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include <hal/hal_flash.h>
+#include <hal/hal_watchdog.h>
 #include <os/os_malloc.h>
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
@@ -867,6 +868,9 @@ boot_copy_image(struct boot_status *bs)
     swap_idx = 0;
     last_sector_idx = boot_data.imgs[0].num_sectors - 1;
     while (last_sector_idx >= 0) {
+        /* Pet the watchdog, in case it is still enabled after a soft reset. */
+        hal_watchdog_tickle();
+
         sz = boot_copy_sz(last_sector_idx, &first_sector_idx);
         if (swap_idx >= bs->idx) {
             boot_swap_sectors(first_sector_idx, sz, bs);


### PR DESCRIPTION
Watchdog timer that was enabled by the app is still running after a soft reset, but without a scheduler the bootloader invariably trips it whenever it has to swap or verify images. The bootloader actually does an incredible job recovering; the only shreds of evidence are longer boot time and a reset reason value of `WATCHDOG` saved in `NRF_POWER->RESETREAS` of the nRF51; which is possibly why this has gone unnoticed.

This is somewhat related to https://issues.apache.org/jira/browse/MYNEWT-618.