### PR TITLE
Coded PHY support

### DIFF
--- a/hw/drivers/nimble/nrf51/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf51/src/ble_phy.c
@@ -387,11 +387,11 @@ ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
          * is captured in CC[2]. I just made up the 16 usecs I add here.
          */
         end_time = NRF_TIMER0->CC[2] + BLE_LL_IFS +
-            ble_phy_pdu_start_off(BLE_PHY_1M) + 16;
+            ble_phy_mode_pdu_start_off(BLE_PHY_MODE_1M) + 16;
     } else {
         /* CC[0] is set to when RXEN occurs. */
         end_time = NRF_TIMER0->CC[0] + XCVR_RX_START_DELAY_USECS + wfr_usecs +
-            ble_phy_pdu_start_off(BLE_PHY_1M) + BLE_LL_JITTER_USECS;
+            ble_phy_mode_pdu_start_off(BLE_PHY_MODE_1M) + BLE_LL_JITTER_USECS;
     }
 
     /* wfr_secs is the time from rxen until timeout */
@@ -565,10 +565,10 @@ ble_phy_tx_end_isr(void)
 #if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
         ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_TXRX, 0);
 #else
-        wfr_time = (BLE_LL_IFS + ble_phy_pdu_start_off(BLE_PHY_1M) +
+        wfr_time = (BLE_LL_IFS + ble_phy_mode_pdu_start_off(BLE_PHY_1M) +
                     (2 * BLE_LL_JITTER_USECS)) -
-                    ble_phy_pdu_start_off(BLE_PHY_1M);
-        wfr_time += ble_phy_pdu_dur(txlen, BLE_PHY_1M);
+                    ble_phy_mode_pdu_start_off(BLE_PHY_1M);
+        wfr_time += ble_phy_mode_pdu_dur(txlen, BLE_PHY_1M);
         wfr_time = os_cputime_usecs_to_ticks(wfr_time);
         ble_ll_wfr_enable(txstart + wfr_time);
 #endif
@@ -702,7 +702,7 @@ ble_phy_rx_start_isr(void)
      *
      * XXX: possibly use other routine with remainder!
      */
-    usecs = NRF_TIMER0->CC[1] - ble_phy_pdu_start_off(BLE_PHY_1M);
+    usecs = NRF_TIMER0->CC[1] - ble_phy_mode_pdu_start_off(BLE_PHY_MODE_1M);
     ticks = os_cputime_usecs_to_ticks(usecs);
     ble_hdr->rem_usecs = usecs - os_cputime_ticks_to_usecs(ticks);
     if (ble_hdr->rem_usecs == 31) {
@@ -712,7 +712,7 @@ ble_phy_rx_start_isr(void)
     ble_hdr->beg_cputime = g_ble_phy_data.phy_start_cputime + ticks;
 #else
     ble_hdr->beg_cputime = NRF_TIMER0->CC[1] -
-        os_cputime_usecs_to_ticks(ble_phy_pdu_start_off(BLE_PHY_1M));
+        os_cputime_usecs_to_ticks(ble_phy_mode_pdu_start_off(BLE_PHY_MODE_1M));
 #endif
 
     /* Wait to get 1st byte of frame */

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -985,7 +985,7 @@ ble_phy_init(void)
     NRF_RADIO->PREFIX0 = (BLE_ACCESS_ADDR_ADV >> 24) & 0xFF;
 
     /* Configure the CRC registers */
-    NRF_RADIO->CRCCNF = RADIO_CRCCNF_SKIPADDR_Msk | RADIO_CRCCNF_LEN_Three;
+    NRF_RADIO->CRCCNF = (RADIO_CRCCNF_SKIPADDR_Skip << RADIO_CRCCNF_SKIPADDR_Pos) | RADIO_CRCCNF_LEN_Three;
 
     /* Configure BLE poly */
     NRF_RADIO->CRCPOLY = 0x0100065B;

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -988,7 +988,7 @@ ble_phy_init(void)
     NRF_RADIO->CRCCNF = (RADIO_CRCCNF_SKIPADDR_Skip << RADIO_CRCCNF_SKIPADDR_Pos) | RADIO_CRCCNF_LEN_Three;
 
     /* Configure BLE poly */
-    NRF_RADIO->CRCPOLY = 0x0100065B;
+    NRF_RADIO->CRCPOLY = 0x0000065B;
 
     /* Configure IFS */
     NRF_RADIO->TIFS = BLE_LL_IFS;

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -50,9 +50,10 @@ extern uint32_t g_nrf_irk_list[];
  * zero bit S1 field. The preamble is 8 bits long.
  */
 #define NRF_LFLEN_BITS          (8)
-#define NRF_S0_LEN              (1)
-#define NRF_CI_LEN              (2)
-#define NRF_TERM_LEN            (3)
+#define NRF_S0LEN               (1)
+#define NRF_S1LEN_BITS          (0)
+#define NRF_CILEN_BITS          (2)
+#define NRF_TERMLEN_BITS        (3)
 
 /* Maximum length of frames */
 #define NRF_MAXLEN              (255)
@@ -253,7 +254,8 @@ ble_phy_mode_set(int cur_phy_mode, int txtorx_phy_mode)
 {
     if (cur_phy_mode == BLE_PHY_MODE_1M) {
         NRF_RADIO->MODE = RADIO_MODE_MODE_Ble_1Mbit;
-        NRF_RADIO->PCNF0 = g_ble_phy_data.phy_pcnf0;    /* Default is 8 bits */
+        NRF_RADIO->PCNF0 = g_ble_phy_data.phy_pcnf0 |
+            (RADIO_PCNF0_PLEN_8bit << RADIO_PCNF0_PLEN_Pos);
     } else if (cur_phy_mode == BLE_PHY_MODE_2M) {
         NRF_RADIO->MODE = RADIO_MODE_MODE_Ble_2Mbit;
         NRF_RADIO->PCNF0 = g_ble_phy_data.phy_pcnf0 |
@@ -262,14 +264,14 @@ ble_phy_mode_set(int cur_phy_mode, int txtorx_phy_mode)
         NRF_RADIO->MODE = RADIO_MODE_MODE_Ble_LR125Kbit;
         NRF_RADIO->PCNF0 = g_ble_phy_data.phy_pcnf0 |
             (RADIO_PCNF0_PLEN_LongRange << RADIO_PCNF0_PLEN_Pos) |
-            (NRF_CI_LEN << RADIO_PCNF0_CILEN_Pos) |
-            (NRF_TERM_LEN << RADIO_PCNF0_TERMLEN_Pos);
+            (NRF_CILEN_BITS << RADIO_PCNF0_CILEN_Pos) |
+            (NRF_TERMLEN_BITS << RADIO_PCNF0_TERMLEN_Pos);
     } else if (cur_phy_mode == BLE_PHY_MODE_CODED_500KBPS) {
         NRF_RADIO->MODE = RADIO_MODE_MODE_Ble_LR500Kbit;
         NRF_RADIO->PCNF0 = g_ble_phy_data.phy_pcnf0 |
             (RADIO_PCNF0_PLEN_LongRange << RADIO_PCNF0_PLEN_Pos) |
-            (NRF_CI_LEN << RADIO_PCNF0_CILEN_Pos) |
-            (NRF_TERM_LEN << RADIO_PCNF0_TERMLEN_Pos);
+            (NRF_CILEN_BITS << RADIO_PCNF0_CILEN_Pos) |
+            (NRF_TERMLEN_BITS << RADIO_PCNF0_TERMLEN_Pos);
     } else {
         assert(0);
     }
@@ -968,8 +970,8 @@ ble_phy_init(void)
     NRF_RADIO->MODE = RADIO_MODE_MODE_Ble_1Mbit;
     g_ble_phy_data.phy_pcnf0 = (NRF_LFLEN_BITS << RADIO_PCNF0_LFLEN_Pos)    |
                                RADIO_PCNF0_S1INCL_Msk                       |
-                               (NRF_S0_LEN << RADIO_PCNF0_S0LEN_Pos)        |
-                               (RADIO_PCNF0_PLEN_8bit << RADIO_PCNF0_PLEN_Pos);
+                               (NRF_S0LEN << RADIO_PCNF0_S0LEN_Pos)        |
+                               (NRF_S1LEN_BITS << RADIO_PCNF0_S1LEN_Pos);
     NRF_RADIO->PCNF0 = g_ble_phy_data.phy_pcnf0;
 
     /* XXX: should maxlen be 251 for encryption? */

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -494,6 +494,14 @@ ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
          */
         end_time = NRF_TIMER0->CC[2] + BLE_LL_IFS +
             ble_phy_mode_pdu_start_off(phy) + BLE_LL_JITTER_USECS;
+
+        /*
+         * FIXME!
+         * on Coded PHY the time calculated above seems to be too short - adding
+         * extra 32us "solves" the problem (extra 16us, i.e. doubling the jitter
+         * is not enough). Need to figure out what is wrong here.
+         */
+        end_time += 32;
     } else {
         /* CC[0] is set to when RXEN occurs. NOTE: the extra 16 usecs is
            jitter */

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -151,10 +151,10 @@ struct ble_ll_conn_phy_data
     uint32_t cur_rx_phy: 2;
     uint32_t new_tx_phy: 2;
     uint32_t new_rx_phy: 2;
-    uint32_t host_pref_tx_phys: 3;
-    uint32_t host_pref_rx_phys: 3;
-    uint32_t req_pref_tx_phys: 3;
-    uint32_t req_pref_rx_phys: 3;
+    uint32_t host_pref_tx_phys_mask: 3;
+    uint32_t host_pref_rx_phys_mask: 3;
+    uint32_t req_pref_tx_phys_mask: 3;
+    uint32_t req_pref_rx_phys_mask: 3;
     uint32_t phy_options: 2;
 }  __attribute__((packed));
 

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -20,6 +20,8 @@
 #ifndef H_BLE_PHY_
 #define H_BLE_PHY_
 
+#include "nimble/hci_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -187,25 +189,33 @@ void ble_phy_resolv_list_disable(void);
  * was done in order to save code when translating between the HCI phy value
  * and the phy API.
  */
-#define BLE_PHY_CODED_125KBPS   (0)
-#define BLE_PHY_1M              (1)
-#define BLE_PHY_2M              (2)
-#define BLE_PHY_CODED_500KBPS   (3)
+#define BLE_PHY_MODE_1M             (1)
+#define BLE_PHY_MODE_2M             (2)
+#define BLE_PHY_MODE_CODED_125KBPS  (0)
+#define BLE_PHY_MODE_CODED_500KBPS  (3)
+
+/* PHY numbers (compatible with HCI) */
+#define BLE_PHY_1M                  (BLE_HCI_LE_PHY_1M)
+#define BLE_PHY_2M                  (BLE_HCI_LE_PHY_2M)
+#define BLE_PHY_CODED               (BLE_HCI_LE_PHY_CODED)
+
+/* PHY bitmasks (compatible with HCI) */
+#define BLE_PHY_MASK_1M             (BLE_HCI_LE_PHY_1M_PREF_MASK)
+#define BLE_PHY_MASK_2M             (BLE_HCI_LE_PHY_2M_PREF_MASK)
+#define BLE_PHY_MASK_CODED          (BLE_HCI_LE_PHY_CODED_PREF_MASK)
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
-uint32_t ble_phy_pdu_dur(uint8_t len, int phy);
-uint32_t ble_phy_pdu_start_off(int phy);
-void ble_phy_set_mode(int cur_phy, int txtorx_phy);
+uint32_t ble_phy_mode_pdu_dur(uint8_t len, int phy);
+uint32_t ble_phy_mode_pdu_start_off(int phy);
+void ble_phy_mode_set(int cur_phy, int txtorx_phy);
 #else
-#define ble_phy_pdu_dur(len, phy)   \
+#define ble_phy_mode_pdu_dur(len, phy)      \
     (((len) + BLE_LL_PDU_HDR_LEN + BLE_LL_ACC_ADDR_LEN + BLE_LL_PREAMBLE_LEN \
       + BLE_LL_CRC_LEN) << 3)
 
-#define ble_phy_pdu_start_off(phy)      (40)
+#define ble_phy_mode_pdu_start_off(phy)     (40)
 
 #endif
-
-
 
 #ifdef __cplusplus
 }

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -1352,7 +1352,7 @@ ble_ll_init(void)
     features |= BLE_LL_FEAT_LE_2M_PHY;
 #endif
 
-#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2) == 1)
+#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY) == 1)
     features |= BLE_LL_FEAT_LE_CODED_PHY;
 #endif
 

--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -485,7 +485,7 @@ ble_ll_adv_tx_start_cb(struct ble_ll_sched_item *sch)
     ble_ll_adv_pdu_make(advsm, adv_pdu);
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_set_mode(BLE_PHY_1M, BLE_PHY_1M);
+    ble_phy_mode_set(BLE_PHY_MODE_1M, BLE_PHY_MODE_1M);
 #endif
 
     /* Transmit advertisement */
@@ -527,7 +527,7 @@ ble_ll_adv_set_sched(struct ble_ll_adv_sm *advsm)
     sch->sched_type = BLE_LL_SCHED_TYPE_ADV;
 
     /* Set end time to maximum time this schedule item may take */
-    max_usecs = ble_phy_pdu_dur(advsm->adv_pdu_len, BLE_PHY_1M);
+    max_usecs = ble_phy_mode_pdu_dur(advsm->adv_pdu_len, BLE_PHY_MODE_1M);
     switch (advsm->adv_type) {
     case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD:
     case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD:

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -229,7 +229,9 @@ static inline int ble_ll_conn_phy_to_phy_mode(int phy, int phy_options)
     phy_mode = phy;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
-        /* XXX: TODO convert to coded phy mode if new phy is coded */
+    if (phy == BLE_PHY_CODED && phy_options == BLE_HCI_LE_PHY_CODED_S8_PREF) {
+        phy_mode = BLE_PHY_MODE_CODED_125KBPS;
+    }
 #endif
 
     return phy_mode;

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -216,6 +216,25 @@ STATS_NAME_START(ble_ll_conn_stats)
     STATS_NAME(ble_ll_conn_stats, mic_failures)
 STATS_NAME_END(ble_ll_conn_stats)
 
+static inline int ble_ll_conn_phy_to_phy_mode(int phy, int phy_options)
+{
+    int phy_mode;
+
+    /*
+     * Mode values are set in a way that 1M, 2M and Coded(S=2) are equivalent
+     * to 1M, 2M and Coded in HCI. The only conversion is needed for Coded(S=8)
+     * which uses non-HCI value.
+     */
+
+    phy_mode = phy;
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
+        /* XXX: TODO convert to coded phy mode if new phy is coded */
+#endif
+
+    return phy_mode;
+}
+
 static void ble_ll_conn_event_end(struct os_event *ev);
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
@@ -238,14 +257,14 @@ ble_ll_conn_chk_phy_upd_start(struct ble_ll_conn_sm *csm)
     int rc;
 
     /* If no host preferences or  */
-    if (((csm->phy_data.host_pref_tx_phys == 0) &&
-         (csm->phy_data.host_pref_rx_phys == 0)) ||
-        ((csm->phy_data.host_pref_tx_phys & CONN_CUR_TX_PHY_MASK(csm)) &&
-         (csm->phy_data.host_pref_rx_phys & CONN_CUR_RX_PHY_MASK(csm)))) {
+    if (((csm->phy_data.host_pref_tx_phys_mask == 0) &&
+         (csm->phy_data.host_pref_rx_phys_mask == 0)) ||
+        ((csm->phy_data.host_pref_tx_phys_mask & CONN_CUR_TX_PHY_MASK(csm)) &&
+         (csm->phy_data.host_pref_rx_phys_mask & CONN_CUR_RX_PHY_MASK(csm)))) {
         rc = -1;
     } else {
-        csm->phy_data.req_pref_tx_phys = csm->phy_data.host_pref_tx_phys;
-        csm->phy_data.req_pref_rx_phys = csm->phy_data.host_pref_rx_phys;
+        csm->phy_data.req_pref_tx_phys_mask = csm->phy_data.host_pref_tx_phys_mask;
+        csm->phy_data.req_pref_rx_phys_mask = csm->phy_data.host_pref_rx_phys_mask;
         ble_ll_ctrl_proc_start(csm, BLE_LL_CTRL_PROC_PHY_UPDATE);
         rc = 0;
     }
@@ -1117,8 +1136,8 @@ ble_ll_conn_tx_data_pdu(struct ble_ll_conn_sm *connsm)
          * received a frame and we are replying to it.
          */
         ticks = (BLE_LL_IFS * 3) + connsm->eff_max_rx_time +
-                ble_phy_pdu_dur(next_txlen, connsm->phy_data.tx_phy_mode) +
-                ble_phy_pdu_dur(cur_txlen, connsm->phy_data.tx_phy_mode);
+                ble_phy_mode_pdu_dur(next_txlen, connsm->phy_data.tx_phy_mode) +
+                ble_phy_mode_pdu_dur(cur_txlen, connsm->phy_data.tx_phy_mode);
 
         if (connsm->conn_role == BLE_LL_CONN_ROLE_MASTER) {
             ticks += (BLE_LL_IFS + connsm->eff_max_rx_time);
@@ -1267,7 +1286,7 @@ conn_tx_pdu:
 #endif
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_set_mode(connsm->phy_data.tx_phy_mode,connsm->phy_data.rx_phy_mode);
+    ble_phy_mode_set(connsm->phy_data.tx_phy_mode,connsm->phy_data.rx_phy_mode);
 #endif
 
     /* Set transmit end callback */
@@ -1388,7 +1407,7 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
 #endif
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_set_mode(connsm->phy_data.rx_phy_mode,connsm->phy_data.rx_phy_mode);
+    ble_phy_mode_set(connsm->phy_data.rx_phy_mode,connsm->phy_data.rx_phy_mode);
 #endif
 
 #if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
@@ -1442,7 +1461,7 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
              * to be sure we do not bail out early.
              */
             usecs = connsm->slave_cur_tx_win_usecs + BLE_LL_IFS +
-                ble_phy_pdu_start_off(connsm->phy_data.rx_phy_mode) +
+                ble_phy_mode_pdu_start_off(connsm->phy_data.rx_phy_mode) +
                 (BLE_LL_JITTER_USECS * 2) + connsm->slave_cur_window_widening;
             wfr_time = connsm->anchor_point + os_cputime_usecs_to_ticks(usecs);
             ble_ll_wfr_enable(wfr_time);
@@ -1515,10 +1534,10 @@ ble_ll_conn_can_send_next_pdu(struct ble_ll_conn_sm *connsm, uint32_t begtime,
             if (rem_bytes > connsm->eff_max_tx_octets) {
                 rem_bytes = connsm->eff_max_tx_octets;
             }
-            usecs = ble_phy_pdu_dur(rem_bytes, connsm->phy_data.tx_phy_mode);
+            usecs = ble_phy_mode_pdu_dur(rem_bytes, connsm->phy_data.tx_phy_mode);
         } else {
             /* We will send empty pdu (just a LL header) */
-            usecs = ble_phy_pdu_dur(0, connsm->phy_data.tx_phy_mode);
+            usecs = ble_phy_mode_pdu_dur(0, connsm->phy_data.tx_phy_mode);
         }
         usecs += (BLE_LL_IFS * 2) + connsm->eff_max_rx_time;
 
@@ -1699,14 +1718,14 @@ ble_ll_conn_sm_new(struct ble_ll_conn_sm *connsm)
 
     /* XXX: TODO set these based on PHY that started connection */
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    connsm->phy_data.cur_tx_phy = BLE_HCI_LE_PHY_1M;
-    connsm->phy_data.cur_rx_phy = BLE_HCI_LE_PHY_1M;
-    connsm->phy_data.tx_phy_mode = BLE_PHY_1M;
-    connsm->phy_data.rx_phy_mode = BLE_PHY_1M;
-    connsm->phy_data.req_pref_tx_phys = 0;
-    connsm->phy_data.req_pref_rx_phys = 0;
-    connsm->phy_data.host_pref_tx_phys = g_ble_ll_data.ll_pref_tx_phys;
-    connsm->phy_data.host_pref_rx_phys = g_ble_ll_data.ll_pref_rx_phys;
+    connsm->phy_data.cur_tx_phy = BLE_PHY_1M;
+    connsm->phy_data.cur_rx_phy = BLE_PHY_1M;
+    connsm->phy_data.tx_phy_mode = BLE_PHY_MODE_1M;
+    connsm->phy_data.rx_phy_mode = BLE_PHY_MODE_1M;
+    connsm->phy_data.req_pref_tx_phys_mask = 0;
+    connsm->phy_data.req_pref_rx_phys_mask = 0;
+    connsm->phy_data.host_pref_tx_phys_mask = g_ble_ll_data.ll_pref_tx_phys;
+    connsm->phy_data.host_pref_rx_phys_mask = g_ble_ll_data.ll_pref_rx_phys;
     connsm->phy_data.phy_options = 0;
 #endif
 
@@ -2066,16 +2085,17 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
         /* Set cur phy to new phy */
         if (connsm->phy_data.new_tx_phy) {
             connsm->phy_data.cur_tx_phy = connsm->phy_data.new_tx_phy;
+            connsm->phy_data.tx_phy_mode =
+                                ble_ll_conn_phy_to_phy_mode(connsm->phy_data.cur_tx_phy,
+                                                   connsm->phy_data.phy_options);
         }
-        connsm->phy_data.tx_phy_mode = connsm->phy_data.cur_tx_phy;
+
         if (connsm->phy_data.new_rx_phy) {
             connsm->phy_data.cur_rx_phy = connsm->phy_data.new_rx_phy;
+            connsm->phy_data.rx_phy_mode =
+                                ble_ll_conn_phy_to_phy_mode(connsm->phy_data.cur_rx_phy,
+                                                   connsm->phy_data.phy_options);
         }
-        connsm->phy_data.rx_phy_mode = connsm->phy_data.cur_rx_phy;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
-        /* XXX: TODO convert to coded phy mode if new phy is coded */
-#endif
 
         /* Clear flags and set flag to send event at next instant */
         CONN_F_PHY_UPDATE_SCHED(connsm) = 0;
@@ -2194,7 +2214,7 @@ ble_ll_conn_created(struct ble_ll_conn_sm *connsm, struct ble_mbuf_hdr *rxhdr)
 
         usecs = rxhdr->rem_usecs + 1250 +
             (connsm->tx_win_off * BLE_LL_CONN_TX_WIN_USECS) +
-            ble_phy_pdu_dur(BLE_CONNECT_REQ_LEN, BLE_PHY_1M);
+            ble_phy_mode_pdu_dur(BLE_CONNECT_REQ_LEN, BLE_PHY_MODE_1M);
 
         /* Anchor point is cputime. */
         endtime = os_cputime_usecs_to_ticks(usecs);
@@ -2214,7 +2234,7 @@ ble_ll_conn_created(struct ble_ll_conn_sm *connsm, struct ble_mbuf_hdr *rxhdr)
 #else
         connsm->last_anchor_point = rxhdr->beg_cputime;
         endtime = rxhdr->beg_cputime +
-            os_cputime_usecs_to_ticks(ble_phy_pdu_dur(BLE_CONNECT_REQ_LEN,
+            os_cputime_usecs_to_ticks(ble_phy_mode_pdu_dur(BLE_CONNECT_REQ_LEN,
                                                       BLE_PHY_1M));
         connsm->slave_cur_tx_win_usecs =
             connsm->tx_win_size * BLE_LL_CONN_TX_WIN_USECS;
@@ -3153,10 +3173,10 @@ ble_ll_conn_rx_isr_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr)
 #if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     endtime = rxhdr->beg_cputime;
     add_usecs = rxhdr->rem_usecs +
-        ble_phy_pdu_dur(rx_pyld_len, connsm->phy_data.rx_phy_mode);
+        ble_phy_mode_pdu_dur(rx_pyld_len, connsm->phy_data.rx_phy_mode);
 #else
     endtime = rxhdr->beg_cputime +
-        os_cputime_usecs_to_ticks(ble_phy_pdu_dur(rx_pyld_len,
+        os_cputime_usecs_to_ticks(ble_phy_mode_pdu_dur(rx_pyld_len,
                                                   connsm->phy_data.rx_phy_mode));
 
     add_usecs = 0;
@@ -3684,17 +3704,17 @@ ble_ll_conn_module_reset(void)
     maxbytes = min(MYNEWT_VAL(BLE_LL_SUPP_MAX_RX_BYTES), max_phy_pyld);
     conn_params->supp_max_rx_octets = maxbytes;
     conn_params->supp_max_rx_time =
-        ble_phy_pdu_dur(maxbytes + BLE_LL_DATA_MIC_LEN, BLE_PHY_1M);
+        ble_phy_mode_pdu_dur(maxbytes + BLE_LL_DATA_MIC_LEN, BLE_PHY_MODE_1M);
 
     maxbytes = min(MYNEWT_VAL(BLE_LL_SUPP_MAX_TX_BYTES), max_phy_pyld);
     conn_params->supp_max_tx_octets = maxbytes;
     conn_params->supp_max_tx_time =
-        ble_phy_pdu_dur(maxbytes + BLE_LL_DATA_MIC_LEN, BLE_PHY_1M);
+        ble_phy_mode_pdu_dur(maxbytes + BLE_LL_DATA_MIC_LEN, BLE_PHY_MODE_1M);
 
     maxbytes = min(MYNEWT_VAL(BLE_LL_CONN_INIT_MAX_TX_BYTES), max_phy_pyld);
     conn_params->conn_init_max_tx_octets = maxbytes;
     conn_params->conn_init_max_tx_time =
-        ble_phy_pdu_dur(maxbytes + BLE_LL_DATA_MIC_LEN, BLE_PHY_1M);
+        ble_phy_mode_pdu_dur(maxbytes + BLE_LL_DATA_MIC_LEN, BLE_PHY_MODE_1M);
 
     conn_params->sugg_tx_octets = BLE_LL_CONN_SUPP_BYTES_MIN;
     conn_params->sugg_tx_time = BLE_LL_CONN_SUPP_TIME_MIN;

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -1233,7 +1233,7 @@ int
 ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf)
 {
     int rc;
-    uint8_t phy_options;
+    uint16_t phy_options;
     uint8_t tx_phys;
     uint8_t rx_phys;
     uint16_t handle;
@@ -1253,11 +1253,11 @@ ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf)
         return BLE_ERR_CMD_DISALLOWED;
     }
 
-    phy_options = cmdbuf[5];
+    phy_options = get_le16(cmdbuf + 5);
     if (phy_options > BLE_HCI_LE_PHY_CODED_S8_PREF) {
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
-    connsm->phy_data.phy_options = phy_options;
+    connsm->phy_data.phy_options = phy_options & 0x03;
 
     /* Check valid parameters */
     rc = ble_ll_hci_chk_phy_masks(cmdbuf + 2, &tx_phys, &rx_phys);

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -1265,8 +1265,8 @@ ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf)
         goto phy_cmd_param_err;
     }
 
-    connsm->phy_data.host_pref_tx_phys = tx_phys,
-    connsm->phy_data.host_pref_rx_phys = rx_phys;
+    connsm->phy_data.host_pref_tx_phys_mask = tx_phys,
+    connsm->phy_data.host_pref_rx_phys_mask = rx_phys;
 
     /*
      * The host preferences override the default phy preferences. Currently,

--- a/net/nimble/controller/src/ble_ll_ctrl.c
+++ b/net/nimble/controller/src/ble_ll_ctrl.c
@@ -625,13 +625,13 @@ ble_ll_ctrl_phy_update_ind_make(struct ble_ll_conn_sm *connsm, uint8_t *dptr,
         connsm->phy_instant = instant;
         CONN_F_PHY_UPDATE_SCHED(connsm) = 1;
 
-        /* Convert m_to_s and s_to_m to masks */
-        m_to_s = 1 << (m_to_s - 1);
-        s_to_m = 1 << (s_to_m - 1);
-
         /* Set new phys to use when instant occurs */
         connsm->phy_data.new_tx_phy = m_to_s;
         connsm->phy_data.new_rx_phy = s_to_m;
+
+        /* Convert m_to_s and s_to_m to masks */
+        m_to_s = 1 << (m_to_s - 1);
+        s_to_m = 1 << (s_to_m - 1);
     }
 
     ctrdata[0] = m_to_s;

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -596,7 +596,7 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm, uint8_t chan)
 #endif
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_set_mode(BLE_PHY_1M, BLE_PHY_1M);
+    ble_phy_mode_set(BLE_PHY_MODE_1M, BLE_PHY_MODE_1M);
 #endif
 
 #if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -365,7 +365,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     itvl_t = connsm->conn_itvl_ticks;
 #else
     adv_rxend = ble_hdr->beg_cputime +
-        os_cputime_usecs_to_ticks(ble_phy_pdu_dur(pyld_len, BLE_PHY_1M));
+        os_cputime_usecs_to_ticks(ble_phy_mode_pdu_dur(pyld_len, BLE_PHY_MODE_1M));
     /*
      * The earliest start time is 1.25 msecs from the end of the connect
      * request transmission. Note that adv_rxend is the end of the received
@@ -376,7 +376,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     dur = os_cputime_usecs_to_ticks(req_slots * BLE_LL_SCHED_USECS_PER_SLOT);
     earliest_start = adv_rxend +
         os_cputime_usecs_to_ticks(BLE_LL_IFS +
-                                  ble_phy_pdu_dur(BLE_CONNECT_REQ_LEN, BLE_PHY_1M) +
+                                  ble_phy_mode_pdu_dur(BLE_CONNECT_REQ_LEN, BLE_PHY_MODE_1M) +
                                   BLE_LL_CONN_INITIAL_OFFSET +
                                   MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) * BLE_LL_CONN_TX_OFF_USECS);
     earliest_end = earliest_start + dur;


### PR DESCRIPTION
This adds basic support for Coded PHY, i.e. connection can be switched to Coded PHY and should work as long as data can fit in Coded PHY timings since constraints for Coded PHY are not enforced yet.