### PR TITLE
Add .cmd files for debug and download scripts for Windows.

### DIFF
--- a/hw/bsp/nina-b1/bsp.yml
+++ b/hw/bsp/nina-b1/bsp.yml
@@ -28,6 +28,8 @@ bsp.linkerscript.BOOT_LOADER.OVERWRITE:
 bsp.part2linkerscript: "hw/bsp/nina-b1/split-nrf52dk.ld"
 bsp.downloadscript: "hw/bsp/nina-b1/nrf52dk_download.sh"
 bsp.debugscript: "hw/bsp/nina-b1/nrf52dk_debug.sh"
+bsp.downloadscript.WINDOWS_OVERWRITE: "hw/bsp/nina-b1/nrf52dk_download.cmd"
+bsp.debugscript.WINDOWS.OVERWRITE: "hw/bsp/nina-b1/nrf52dk_debug.cmd"
 
 bsp.flash_map:
     areas:

--- a/hw/bsp/nina-b1/nrf52dk_debug.cmd
+++ b/hw/bsp/nina-b1/nrf52dk_debug.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/nina-b1/nrf52dk_download.cmd
+++ b/hw/bsp/nina-b1/nrf52dk_download.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/stm32f767-nucleo/bsp.yml
+++ b/hw/bsp/stm32f767-nucleo/bsp.yml
@@ -27,6 +27,8 @@ bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/mcu/stm/stm32f7xx/stm32f767.ld"
 bsp.downloadscript: "hw/bsp/stm32f767-nucleo/nucleo767_download.sh"
 bsp.debugscript: "hw/bsp/stm32f767-nucleo/nucleo767_debug.sh"
+bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/stm32f767-nucleo/nucleo767_download.cmd"
+bsp.debugscript.WINDOWS.OVERWRITE: "hw/bsp/stm32f767-nucleo/nucleo767_debug.cmd"
 
 bsp.flash_map:
     areas:

--- a/hw/bsp/stm32f767-nucleo/nucleo767_debug.cmd
+++ b/hw/bsp/stm32f767-nucleo/nucleo767_debug.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/stm32f767-nucleo/nucleo767_download.cmd
+++ b/hw/bsp/stm32f767-nucleo/nucleo767_download.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"


### PR DESCRIPTION
They are added for the following boards:
1) stm32f767-nucleo (tested)
2) nina-b1 (not tested - I don't have the board and also we do not have a tutorial that uses it). 

Note: The following boards do not have debug.sh and download.sh  so I did not add .cmd files for them:
1. ci40
2. pic32mx470_6lp_clicker 
3. pic32mz2048_wi-fire