### PR TITLE
Wi-Fire: Add SPI support (master mode only)

### DIFF
--- a/hw/bsp/pic32mz2048_wi-fire/include/bsp/bsp.h
+++ b/hw/bsp/pic32mz2048_wi-fire/include/bsp/bsp.h
@@ -51,6 +51,9 @@ extern uint8_t _ccram_start;
 #define UART_CNT 6
 #define CONSOLE_UART "uart3"
 
+/* SPI */
+#define SPI_CNT         (6)
+
 #define NFFS_AREA_MAX    (8)
 
 #ifdef __cplusplus

--- a/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
@@ -29,6 +29,11 @@
 #include <uart_hal/uart_hal.h>
 #endif
 
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || \
+    MYNEWT_VAL(SPI_2_MASTER) || MYNEWT_VAL(SPI_3_MASTER) || \
+    MYNEWT_VAL(SPI_4_MASTER) || MYNEWT_VAL(SPI_5_MASTER)
+#include "hal/hal_spi.h"
+#endif
 #include <bsp/bsp.h>
 
 #include <xc.h>
@@ -69,6 +74,48 @@ static const struct mips_uart_cfg uart4_cfg = {
 
 #if MYNEWT_VAL(UART_5)
 static struct uart_dev os_bsp_uart5;
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER)
+/*
+ * SPI 1 (J9 connector)
+ *   MOSI -> RF0
+ *   MISO -> RD11
+ *   SCK  -> RG6
+ */
+static const struct mips_spi_cfg spi1_cfg = {
+    .mosi = MCU_GPIO_PORTF(0),
+    .miso = MCU_GPIO_PORTD(11),
+    .sck = MCU_GPIO_PORTG(6)
+};
+#endif
+
+#if MYNEWT_VAL(SPI_2_MASTER)
+/*
+ * SPI 2 (microSD card)
+ *   MOSI -> RB10
+ *   MISO -> RC4
+ *   SCK  -> RB14
+ */
+static const struct mips_spi_cfg spi2_cfg = {
+    .mosi = MCU_GPIO_PORTB(10),
+    .miso = MCU_GPIO_PORTC(4),
+    .sck = MCU_GPIO_PORTB(14)
+};
+#endif
+
+#if MYNEWT_VAL(SPI_3_MASTER)
+/*
+ * SPI 3 (MRF24WG0MA)
+ *   MOSI -> RF5
+ *   MISO -> RG0
+ *   SCK  -> RD10
+ */
+static const struct mips_spi_cfg spi3_cfg = {
+    .mosi = MCU_GPIO_PORTF(5),
+    .miso = MCU_GPIO_PORTG(0),
+    .sck = MCU_GPIO_PORTD(10)
+};
 #endif
 
 const struct hal_flash *
@@ -115,6 +162,36 @@ hal_bsp_init(void)
     #if MYNEWT_VAL(UART_5)
         rc = os_dev_create((struct os_dev *) &os_bsp_uart5, "uart5",
             OS_DEV_INIT_PRIMARY, 0, uart_hal_init, 0);
+        assert(rc == 0);
+    #endif
+
+    #if MYNEWT_VAL(SPI_0_MASTER)
+        rc = hal_spi_init(0, NULL, HAL_SPI_TYPE_MASTER);
+        assert(rc == 0);
+    #endif
+
+    #if MYNEWT_VAL(SPI_1_MASTER)
+        rc = hal_spi_init(1, &spi1_cfg, HAL_SPI_TYPE_MASTER);
+        assert(rc == 0);
+    #endif
+
+    #if MYNEWT_VAL(SPI_2_MASTER)
+        rc = hal_spi_init(2, &spi2_cfg, HAL_SPI_TYPE_MASTER);
+        assert(rc == 0);
+    #endif
+
+    #if MYNEWT_VAL(SPI_3_MASTER)
+        rc = hal_spi_init(3, &spi3_cfg, HAL_SPI_TYPE_MASTER);
+        assert(rc == 0);
+    #endif
+
+    #if MYNEWT_VAL(SPI_4_MASTER)
+        rc = hal_spi_init(4, NULL, HAL_SPI_TYPE_MASTER);
+        assert(rc == 0);
+    #endif
+
+    #if MYNEWT_VAL(SPI_5_MASTER)
+        rc = hal_spi_init(5, NULL, HAL_SPI_TYPE_MASTER);
         assert(rc == 0);
     #endif
 

--- a/hw/bsp/pic32mz2048_wi-fire/syscfg.yml
+++ b/hw/bsp/pic32mz2048_wi-fire/syscfg.yml
@@ -47,3 +47,15 @@ syscfg.defs:
     UART_5:
         description: 'TBD'
         value:  1
+
+    SPI_1_MASTER:
+        description: 'SPI on J9 connector'
+        value:  1
+
+    SPI_2_MASTER:
+        description: 'SPI connected to microSD card'
+        value:  1
+
+    SPI_3_MASTER:
+        description: 'SPI connected to MRF24WG0MA'
+        value:  1

--- a/hw/mcu/microchip/pic32mz2048efg100/include/mcu/mips_hal.h
+++ b/hw/mcu/microchip/pic32mz2048efg100/include/mcu/mips_hal.h
@@ -32,6 +32,13 @@ struct mips_uart_cfg {
     uint8_t rx;
 };
 
+/* I/O pins for SPI, SS pin is not handled by the driver */
+struct mips_spi_cfg {
+    uint8_t mosi;
+    uint8_t miso;
+    uint8_t sck;
+};
+
 /* Helper functions to enable/disable interrupts. */
 #define __HAL_DISABLE_INTERRUPTS(__os_sr) do {__os_sr = __builtin_get_isr_state(); \
         __builtin_disable_interrupts();} while(0)

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_spi.c
@@ -1,0 +1,624 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdbool.h>
+#include "bsp/bsp.h"
+#include "hal/hal_gpio.h"
+#include "hal/hal_spi.h"
+#include "mcu/mcu.h"
+#include "mcu/mips_hal.h"
+#include "mcu/p32mz2048efg100.h"
+#include "mcu/pps.h"
+#include "syscfg/syscfg.h"
+
+#define SPIxCON(P)          (base_address[P][0x0 / 0x4])
+#define SPIxCONCLR(P)       (base_address[P][0x4 / 0x4])
+#define SPIxCONSET(P)       (base_address[P][0x8 / 0x4])
+#define SPIxSTAT(P)         (base_address[P][0x10 / 0x4])
+#define SPIxSTATCLR(P)      (base_address[P][0x14 / 0x4])
+#define SPIxBUF(P)          (base_address[P][0x20 / 0x4])
+#define SPIxBRG(P)          (base_address[P][0x30 / 0x4])
+#define SPIxCON2(P)         (base_address[P][0x40 / 0x4])
+
+static volatile uint32_t * base_address[SPI_CNT] = {
+    (volatile uint32_t *)_SPI1_BASE_ADDRESS,
+    (volatile uint32_t *)_SPI2_BASE_ADDRESS,
+    (volatile uint32_t *)_SPI3_BASE_ADDRESS,
+    (volatile uint32_t *)_SPI4_BASE_ADDRESS,
+    (volatile uint32_t *)_SPI5_BASE_ADDRESS,
+    (volatile uint32_t *)_SPI6_BASE_ADDRESS
+};
+
+struct hal_spi {
+    bool                      slave;
+    uint8_t                   *txbuf;
+    uint8_t                   *rxbuf;
+    int                       len;
+    int                       txcnt;
+    int                       rxcnt;
+    hal_spi_txrx_cb           callback;
+    void                      *arg;
+    const struct mips_spi_cfg *pins;
+    uint32_t                  con;
+    uint32_t                  brg;
+};
+
+static struct hal_spi spis[SPI_CNT];
+
+static void
+hal_spi_power_up(int spi_num)
+{
+    uint32_t mask = 0;
+
+    switch (spi_num) {
+        case 0:
+            mask = _PMD5_SPI1MD_MASK;
+            break;
+        case 1:
+            mask = _PMD5_SPI2MD_MASK;
+            break;
+        case 2:
+            mask = _PMD5_SPI3MD_MASK;
+            break;
+        case 3:
+            mask = _PMD5_SPI4MD_MASK;
+            break;
+        case 4:
+            mask = _PMD5_SPI5MD_MASK;
+            break;
+        case 5:
+            mask = _PMD5_SPI6MD_MASK;
+            break;
+    }
+
+    if (!(PMD5 & mask))
+        return;
+
+    PMD5CLR = mask;
+
+    /* It appeared that powering down the SPI module also clears SPIxBRG and SPIxCON */
+    SPIxBRG(spi_num) = spis[spi_num].brg;
+    SPIxCON(spi_num) = spis[spi_num].con;
+}
+
+static void
+hal_spi_power_down(int spi_num)
+{
+    /* It appeared that powering down the SPI module also clears SPIxBRG and SPIxCON */
+    spis[spi_num].brg = SPIxBRG(spi_num);
+    spis[spi_num].con = SPIxCON(spi_num);
+
+    switch (spi_num) {
+        case 0:
+            PMD5SET = _PMD5_SPI1MD_MASK;
+            break;
+        case 1:
+            PMD5SET = _PMD5_SPI2MD_MASK;
+            break;
+        case 2:
+            PMD5SET = _PMD5_SPI3MD_MASK;
+            break;
+        case 3:
+            PMD5SET = _PMD5_SPI4MD_MASK;
+            break;
+        case 4:
+            PMD5SET = _PMD5_SPI5MD_MASK;
+            break;
+        case 5:
+            PMD5SET = _PMD5_SPI6MD_MASK;
+            break;
+    }
+}
+
+static int
+hal_spi_config_master(int spi_num, struct hal_spi_settings *psettings)
+{
+    uint32_t pbclk;
+
+    /*
+     * Make sure that the SPI module is not powered down.
+     * If the module is powered down, one cannot write to registers.
+     */
+    hal_spi_power_up(spi_num);
+
+    SPIxCON(spi_num) = 0;
+    SPIxCON2(spi_num) = 0;
+
+    /* Clear RX FIFO */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SPITBE_MASK)) {
+        volatile int rdata = SPIxBUF(spi_num);
+        (void)rdata;
+    }
+
+    /* The SPI module only supports MSB first */
+    if (psettings->data_order == HAL_SPI_LSB_FIRST) {
+        return -1;
+    }
+
+    /* Only 8-bit word size is supported */
+    if (psettings->word_size != HAL_SPI_WORD_SIZE_8BIT) {
+        return -1;
+    }
+
+    switch (psettings->data_mode) {
+        case HAL_SPI_MODE0:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            break;
+        case HAL_SPI_MODE1:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKE_MASK;
+            break;
+        case HAL_SPI_MODE2:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKE_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK;
+            break;
+        case HAL_SPI_MODE3:
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            break;
+        default:
+            return -1;
+    }
+
+    /*
+     * From equation 23-1 of Section 23 of PIC32 FRM:
+     *
+     *                 Fpb2
+     * Fsck =  -------------------
+     *          (2 * SPIxBRG) + 1
+     */
+    pbclk = MYNEWT_VAL(CLOCK_FREQ) / ((PB2DIV & _PB2DIV_PBDIV_MASK) + 1);
+    SPIxBRG(spi_num) =
+        (pbclk - psettings->baudrate) / (2 * psettings->baudrate);
+
+    SPIxSTATCLR(spi_num) = _SPI1STAT_SPIROV_MASK;
+    SPIxCONSET(spi_num) = _SPI1CON_ENHBUF_MASK | _SPI1CON_MSTEN_MASK;
+
+    return 0;
+}
+
+static int
+hal_spi_config_pins(int spi_num, uint8_t mode)
+{
+    int ret = 0;
+
+    if (hal_gpio_init_out(spis[spi_num].pins->mosi, 0) ||
+        hal_gpio_init_out(spis[spi_num].pins->sck, 1) ||
+        hal_gpio_init_in(spis[spi_num].pins->miso, HAL_GPIO_PULL_NONE)) {
+        return -1;
+    }
+
+    /*
+     * To avoid any glitches when turning off and on module, the SCK pin must
+     * be set to the correct value depending on the mode.
+     */
+    switch (mode) {
+        case HAL_SPI_MODE0:
+        case HAL_SPI_MODE1:
+            hal_gpio_write(spis[spi_num].pins->sck, 0);
+            break;
+        case HAL_SPI_MODE2:
+        case HAL_SPI_MODE3:
+            hal_gpio_write(spis[spi_num].pins->sck, 1);
+            break;
+    }
+
+    switch (spi_num) {
+        case 0:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO1_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI1_IN_FUNC);
+            break;
+        case 1:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO2_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI2_IN_FUNC);
+            break;
+        case 2:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO3_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI3_IN_FUNC);
+            break;
+        case 3:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO4_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI4_IN_FUNC);
+            break;
+        case 4:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO5_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI5_IN_FUNC);
+            break;
+        case 5:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO6_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI6_IN_FUNC);
+            break;
+    }
+
+    return ret;
+}
+
+static void
+hal_spi_enable_int(int spi_num)
+{
+    switch (spi_num) {
+        case 0:
+            IFS3CLR = _IFS3_SPI1TXIF_MASK;
+            IEC3SET = _IEC3_SPI1TXIE_MASK;
+            break;
+        case 1:
+            IFS4CLR = _IFS4_SPI2TXIF_MASK;
+            IEC4SET = _IEC4_SPI2TXIE_MASK;
+            break;
+        case 2:
+            IFS4CLR = _IFS4_SPI3TXIF_MASK;
+            IEC4SET = _IEC4_SPI3TXIE_MASK;
+            break;
+        case 3:
+            IFS5CLR = _IFS5_SPI4TXIF_MASK;
+            IEC5SET = _IEC5_SPI4TXIE_MASK;
+            break;
+        case 4:
+            IFS5CLR = _IFS5_SPI5TXIF_MASK;
+            IEC5SET = _IEC5_SPI5TXIE_MASK;
+            break;
+        case 5:
+            IFS5CLR = _IFS5_SPI6TX_MASK;
+            IEC5SET = _IEC5_SPI6TXIE_MASK;
+            break;
+    }
+}
+
+static void
+hal_spi_disable_int(int spi_num)
+{
+    switch (spi_num) {
+        case 0:
+            IFS3CLR = _IFS3_SPI1TXIF_MASK;
+            IEC3CLR = _IEC3_SPI1TXIE_MASK;
+            break;
+        case 1:
+            IFS4CLR = _IFS4_SPI2TXIF_MASK;
+            IEC4CLR = _IEC4_SPI2TXIE_MASK;
+            break;
+        case 2:
+            IFS4CLR = _IFS4_SPI3TXIF_MASK;
+            IEC4CLR = _IEC4_SPI3TXIE_MASK;
+            break;
+        case 3:
+            IFS5CLR = _IFS5_SPI4TXIF_MASK;
+            IEC5CLR = _IEC5_SPI4TXIE_MASK;
+            break;
+        case 4:
+            IFS5CLR = _IFS5_SPI5TXIF_MASK;
+            IEC5CLR = _IEC5_SPI5TXIE_MASK;
+            break;
+        case 5:
+            IFS5CLR = _IFS5_SPI6TX_MASK;
+            IEC5CLR = _IEC5_SPI6TXIE_MASK;
+            break;
+    }
+}
+
+static void
+hal_spi_handle_isr(int spi_num)
+{
+    /* Read everything in RX FIFO */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SPIRBE_MASK)) {
+        volatile uint32_t rxdata = SPIxBUF(spi_num);
+        if (spis[spi_num].rxbuf && spis[spi_num].rxcnt) {
+            *spis[spi_num].rxbuf++ = rxdata;
+            --spis[spi_num].rxcnt;
+        }
+    }
+
+    if (spis[spi_num].txcnt == 0 && spis[spi_num].rxcnt == 0) {
+        spis[spi_num].txbuf = NULL;
+        spis[spi_num].rxbuf = NULL;
+
+        if (spis[spi_num].callback) {
+            spis[spi_num].callback(spis[spi_num].arg, spis[spi_num].len);
+        }
+        hal_spi_disable_int(spi_num);
+    }
+
+
+    /* Fill TX FIFO */
+    while (spis[spi_num].txcnt &&
+           !(SPIxSTAT(spi_num) & _SPI1STAT_SPITBF_MASK)) {
+        SPIxBUF(spi_num) = *spis[spi_num].txbuf++;
+        --spis[spi_num].txcnt;
+    }
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI1_TX_VECTOR)))
+hal_spi1_isr(void)
+{
+    hal_spi_handle_isr(0);
+    IFS3CLR = _IFS3_SPI1TXIF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI2_TX_VECTOR)))
+hal_spi2_isr(void)
+{
+    hal_spi_handle_isr(1);
+    IFS4CLR = _IFS4_SPI2TXIF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI3_TX_VECTOR)))
+hal_spi3_isr(void)
+{
+    hal_spi_handle_isr(2);
+    IFS4CLR = _IFS4_SPI3TXIF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI4_TX_VECTOR)))
+hal_spi4_isr(void)
+{
+    hal_spi_handle_isr(3);
+    IFS5CLR = _IFS5_SPI4TXIF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI5_TX_VECTOR)))
+hal_spi5_isr(void)
+{
+    hal_spi_handle_isr(4);
+    IFS5CLR = _IFS5_SPI5TXIF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI6_TX_VECTOR)))
+hal_spi6_isr(void)
+{
+    hal_spi_handle_isr(5);
+    IFS5CLR = _IFS5_SPI6TX_MASK;
+}
+
+int
+hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
+{
+    if (spi_type != HAL_SPI_TYPE_MASTER &&
+        spi_type != HAL_SPI_TYPE_SLAVE) {
+        return -1;
+    }
+
+    spis[spi_num].slave = spi_type;
+    spis[spi_num].pins = cfg;
+
+    return 0;
+}
+
+int
+hal_spi_config(int spi_num, struct hal_spi_settings *psettings)
+{
+    /* Slave mode not supported */
+    if (spis[spi_num].slave) {
+        return -1;
+    }
+
+    /* Configure pins */
+    if (spis[spi_num].pins) {
+        if (hal_spi_config_pins(spi_num, psettings->data_mode)) {
+            return -1;
+        }
+    }
+
+    return hal_spi_config_master(spi_num, psettings);
+}
+
+int
+hal_spi_set_txrx_cb(int spi_num, hal_spi_txrx_cb txrx_cb, void *arg)
+{
+    if (SPIxCON(spi_num) & _SPI1CON_ON_MASK) {
+        return -1;
+    }
+
+    spis[spi_num].callback = txrx_cb;
+    spis[spi_num].arg = arg;
+    return 0;
+}
+
+int
+hal_spi_enable(int spi_num)
+{
+    hal_spi_power_up(spi_num);
+    SPIxCONSET(spi_num) = _SPI1CON_ON_MASK;
+
+    return 0;
+}
+
+int
+hal_spi_disable(int spi_num)
+{
+    /*
+     * Disabling SPI clears the FIFO, so this makes sure that everything was
+     * sent before disabling the module.
+     */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SPITBE_MASK)) {
+    }
+
+    SPIxCONCLR(spi_num) = _SPI1CON_ON_MASK;
+    hal_spi_power_down(spi_num);
+
+    return 0;
+}
+
+uint16_t
+hal_spi_tx_val(int spi_num, uint16_t val)
+{
+    if (spis[spi_num].slave) {
+        return 0xFFFF;
+    }
+
+    /* Wait until there is some space in TX FIFO */
+    while (SPIxSTAT(spi_num) & _SPI1STAT_SPITBF_MASK) {
+    }
+
+    SPIxBUF(spi_num) = val;
+
+    /* Wait until RX FIFO is not empty */
+    while (SPIxSTAT(spi_num) & _SPI1STAT_SPIRBE_MASK) {
+    }
+
+    return SPIxBUF(spi_num);
+}
+
+int
+hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int cnt)
+{
+    uint8_t *tx = (uint8_t *)txbuf;
+    uint8_t *rx = (uint8_t *)rxbuf;
+
+    /* Slave mode not supported */
+    if (spis[spi_num].slave) {
+        return -1;
+    }
+
+    while (cnt--) {
+        uint8_t rdata;
+        if (tx) {
+            /* Wait until there is some space in TX FIFO */
+            while (SPIxSTAT(spi_num) & _SPI1STAT_SPITBF_MASK) {
+            }
+
+            SPIxBUF(spi_num) = *tx++;
+        }
+
+        /* Always read RX FIFO to avoid overrun */
+        rdata = SPIxBUF(spi_num);
+
+        if (rx) {
+            /* Wait until RX FIFO is not empty */
+            while (SPIxSTAT(spi_num) & _SPI1STAT_SPIRBE_MASK) {
+            }
+
+            *rx++ = rdata;
+        }
+    }
+
+    return 0;
+}
+
+int
+hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int cnt)
+{
+    uint32_t ctx;
+
+    /* Slave mode not supported */
+    if (spis[spi_num].slave) {
+        return -1;
+    }
+
+    if (txbuf == NULL) {
+        return -1;
+    }
+
+    /* Check if a transfer is pending */
+    if (spis[spi_num].rxbuf != NULL || spis[spi_num].txbuf != NULL) {
+        return -1;
+    }
+
+    spis[spi_num].txbuf = txbuf;
+    spis[spi_num].rxbuf = rxbuf;
+    spis[spi_num].txcnt = cnt;
+    spis[spi_num].rxcnt = cnt;
+    spis[spi_num].len = cnt;
+
+    /* Configure SPIxTXIF to trigger when TX FIFO is empty */
+    SPIxCONCLR(spi_num) = _SPI1CON_STXISEL_MASK;
+    SPIxCONSET(spi_num) = 0b01 << _SPI1CON_STXISEL_POSITION;
+
+    /* Set interrupt priority */
+    switch (spi_num) {
+        case 0:
+            IPC27CLR = _IPC27_SPI1TXIS_MASK | _IPC27_SPI1TXIP_MASK;
+            IPC27SET = 2 << _IPC27_SPI1TXIP_POSITION;
+            break;
+        case 1:
+            IPC36CLR = _IPC36_SPI2TXIS_MASK | _IPC36_SPI2TXIP_MASK;
+            IPC36SET = 2 << _IPC36_SPI2TXIP_POSITION;
+            break;
+        case 2:
+            IPC39CLR = _IPC39_SPI3TXIS_MASK | _IPC39_SPI3TXIP_MASK;
+            IPC39SET = 2 << _IPC39_SPI3TXIP_POSITION;
+            break;
+        case 3:
+            IPC41CLR = _IPC41_SPI4TXIS_MASK | _IPC41_SPI4TXIP_MASK;
+            IPC41SET = 2 << _IPC41_SPI4TXIP_POSITION;
+            break;
+        case 4:
+            IPC44CLR = _IPC44_SPI5TXIS_MASK | _IPC44_SPI5TXIP_MASK;
+            IPC44SET = 2 << _IPC44_SPI5TXIP_POSITION;
+            break;
+        case 5:
+            IPC46CLR = _IPC46_SPI6TXIS_MASK | _IPC46_SPI6TXIP_MASK;
+            IPC46SET = 2 << _IPC46_SPI6TXIP_POSITION;
+            break;
+    }
+
+    /* Enable interrupt */
+    hal_spi_enable_int(spi_num);
+
+    return 0;
+}
+
+int
+hal_spi_slave_set_def_tx_val(int spi_num, uint16_t val)
+{
+    /* Slave mode not supported */
+    return -1;
+}
+
+int
+hal_spi_abort(int spi_num)
+{
+    /* Cannot abort transfer if spi is not enabled */
+    if (!(SPIxCON(spi_num) & _SPI1CON_ON_MASK)) {
+        return -1;
+    }
+
+    hal_spi_disable_int(spi_num);
+    spis[spi_num].txbuf = NULL;
+    spis[spi_num].rxbuf = NULL;
+    spis[spi_num].txcnt = 0;
+    spis[spi_num].rxcnt = 0;
+    spis[spi_num].len = 0;
+
+    /* Make sure that we finished transmitting current byte before turning off module */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SRMT_MASK)) {
+    }
+
+    /* Clear TX and RX FIFO by turning off and on module */
+    SPIxCONCLR(spi_num) = _SPI1CON_ON_MASK;
+    asm volatile ("nop");
+    SPIxCONSET(spi_num) = _SPI1CON_ON_MASK;
+
+    return 0;
+}


### PR DESCRIPTION
This pull request implements SPI driver for PCI32MZ2048EFG100 present on the Wi-Fire board. The driver only supports master mode, blocking and non-blocking calls.

Three SPI bus are initialized at boot:
  - **SPI 1**, pins available on J9 connector
  - **SPI 2**, connected to microSD card slot
  - **SPI 3**, connected to wifi module

I could not attach probes to SPI 2 and SPI 3 lines, so I checked the driver only with SPI 1.