### PR TITLE
MYNEWT-742 Initialize OIC automatically.

### DIFF
--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -32,6 +32,7 @@
 #include <oic/oc_api.h>
 #include <oic/oc_gatt.h>
 #include <oic/oc_log.h>
+#include <oic/oc_mynewt.h>
 #include <cborattr/cborattr.h>
 
 /* BLE */
@@ -323,10 +324,6 @@ omgr_app_init(void)
 
 }
 
-static const oc_handler_t omgr_oc_handler = {
-    .init = omgr_app_init,
-};
-
 /**
  * main
  *
@@ -356,8 +353,7 @@ main(void)
 
     /* Initialize the OIC  */
     log_register("oic", &oc_log, &log_console_handler, NULL, LOG_SYSLEVEL);
-    oc_main_init((oc_handler_t *)&omgr_oc_handler);
-    oc_ble_coap_gatt_srv_init();
+    oc_cfg.main_handler.init = omgr_app_init;
 
     ble_hs_cfg.reset_cb = bleprph_on_reset;
     ble_hs_cfg.sync_cb = bleprph_on_sync;

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -50,12 +50,9 @@
 #if MYNEWT_VAL(SENSOR_OIC)
 #include <oic/oc_api.h>
 #include <oic/oc_gatt.h>
+#include <oic/oc_mynewt.h>
 
 extern int oc_stack_errno;
-
-static const oc_handler_t sensor_oic_handler = {
-    .init = sensor_oic_init,
-};
 
 #endif
 
@@ -593,7 +590,7 @@ sensor_ble_oic_server_init(void)
     /* Set initial BLE device address. */
     memcpy(g_dev_addr, (uint8_t[6]){0x0a, 0xfa, 0xcf, 0xac, 0xfa, 0xc0}, 6);
 
-    oc_ble_coap_gatt_srv_init();
+    oc_cfg.main_handler.init = sensor_oic_init;
 
     ble_hs_cfg.reset_cb = sensor_oic_on_reset;
     ble_hs_cfg.sync_cb = sensor_oic_on_sync;
@@ -602,9 +599,6 @@ sensor_ble_oic_server_init(void)
     /* Set the default device name. */
     rc = ble_svc_gap_device_name_set("pi");
     assert(rc == 0);
-
-    rc = oc_main_init((oc_handler_t *)&sensor_oic_handler);
-    assert(!rc);
 
     oc_init_platform("MyNewt", NULL, NULL);
     oc_add_device("/oic/d", "oic.d.pi", "pi", "1.0", "1.0", NULL,

--- a/mgmt/oicmgr/pkg.yml
+++ b/mgmt/oicmgr/pkg.yml
@@ -33,4 +33,5 @@ pkg.apis:
     - newtmgr
 
 pkg.init:
-    oicmgr_init: 500
+    # This must get initialized after net/oic.
+    oicmgr_init: 510

--- a/net/oic/include/oic/oc_mynewt.h
+++ b/net/oic/include/oic/oc_mynewt.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_OC_MYNEWT_
+#define H_OC_MYNEWT_
+
+#include "oic/oc_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct oc_cfg {
+    oc_handler_t main_handler;
+};
+extern struct oc_cfg oc_cfg;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/net/oic/src/api/oc_main.c
+++ b/net/oic/src/api/oc_main.c
@@ -43,7 +43,9 @@ oc_main_init(oc_handler_t *handler)
     oc_ri_init();
 
 #ifdef OC_SECURITY
-    handler->get_credentials();
+    if (handler->get_credentials) {
+        handler->get_credentials();
+    }
 
     oc_sec_load_pstat();
     oc_sec_load_doxm();
@@ -56,7 +58,10 @@ oc_main_init(oc_handler_t *handler)
     if (ret < 0) {
         goto err;
     }
-    handler->init();
+
+    if (handler->init) {
+        handler->init();
+    }
 
 #ifdef OC_SERVER
     if (handler->register_resources) {
@@ -77,7 +82,9 @@ oc_main_init(oc_handler_t *handler)
     OC_LOG_INFO("oci: Initialized\n");
 
 #ifdef OC_CLIENT
-    handler->requests_entry();
+    if (handler->requests_entry) {
+        handler->requests_entry();
+    }
 #endif
 
     initialized = true;


### PR DESCRIPTION
Prior to this commit, the OIC library requires some manual
initiliazation.  E.g.,

    static const oc_handler_t omgr_oc_handler = {
        .init = omgr_app_init,
    };

    int
    main(int argc, char **argv)
    {
        /* ... */
        oc_main_init((oc_handler_t *)&omgr_oc_handler);
        oc_ble_coap_gatt_srv_init();
    }

Now, the library gets initialized automatically.  The application can
optionally configure the library in main() by writing to the global
oc_cfg object.  E.g.,

    oc_cfg.main_handler.init = omgr_app_init;