### PR TITLE
nimble/controller: Fix setting parameters for scanning

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -54,6 +54,15 @@ extern "C" {
 #define BLE_SCAN_RSP_DATA_MAX_LEN       (31)
 #define BLE_SCAN_MAX_PKT_LEN            (37)
 
+struct ble_ll_scan_params
+{
+    uint8_t scan_type;
+    uint8_t own_addr_type;
+    uint8_t scan_filt_policy;
+    uint16_t scan_itvl;
+    uint16_t scan_window;
+};
+
 /* Scanning state machine (used when initiating as well) */
 struct ble_ll_scan_sm
 {


### PR DESCRIPTION
Parameters set by HCI LE Set Scan Parameters should be stored and then
applied each time scan is enabled using HCI LE Set Scan Enable. This way
scan uses proper parameters as set by host.

Without this fix scan parameters in SM will be overwritten when
initiating new connection. Since also scan type is set to 'initiating'
in such case, no advertising reports will be sent to host until scan
parameters are set once more by the host.