### PR TITLE
nimble/host: fix find by address when addr is NULL

### DIFF
--- a/net/nimble/host/src/ble_hs_conn.c
+++ b/net/nimble/host/src/ble_hs_conn.c
@@ -293,6 +293,10 @@ ble_hs_conn_find_by_addr(const ble_addr_t *addr)
 
     BLE_HS_DBG_ASSERT(ble_hs_locked_by_cur_task());
 
+    if (!addr) {
+        return NULL;
+    }
+
     SLIST_FOREACH(conn, &ble_hs_conns, bhc_next) {
         if (ble_addr_cmp(&conn->bhc_peer_addr, addr) == 0) {
             return conn;


### PR DESCRIPTION
Addr is NULL when sending le connection request using whitelist.
Error occurs on bsp/native when trying to do ble_addr_cmp
with NULL addr. There is segmentation fault when reading from NULL.