### PR TITLE
nimble/l2cap: Fix double free when calling ble_l2cap_discard_rx

### DIFF
--- a/net/nimble/host/src/ble_hs_hci_evt.c
+++ b/net/nimble/host/src/ble_hs_hci_evt.c
@@ -659,7 +659,7 @@ ble_hs_hci_evt_acl_process(struct os_mbuf *om)
         /* Final fragment received. */
         BLE_HS_DBG_ASSERT(rx_cb != NULL);
         rc = rx_cb(conn->bhc_rx_chan);
-        ble_l2cap_forget_rx(conn, conn->bhc_rx_chan);
+        ble_l2cap_remove_rx(conn, conn->bhc_rx_chan);
         break;
 
     case BLE_HS_EAGAIN:

--- a/net/nimble/host/src/ble_l2cap_priv.h
+++ b/net/nimble/host/src/ble_l2cap_priv.h
@@ -114,7 +114,8 @@ int ble_l2cap_rx(struct ble_hs_conn *conn,
 int ble_l2cap_tx(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan,
                  struct os_mbuf *txom);
 
-void ble_l2cap_forget_rx(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan);
+void ble_l2cap_remove_rx(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan);
+
 int ble_l2cap_init(void);
 
 #ifdef __cplusplus

--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -2353,7 +2353,7 @@ ble_sm_rx(struct ble_l2cap_chan *chan)
     ble_sm_rx_fn *rx_cb;
     uint8_t op;
     uint16_t conn_handle;
-    struct os_mbuf *om;
+    struct os_mbuf **om;
     int rc;
 
     STATS_INC(ble_l2cap_stats, sm_rx);
@@ -2363,22 +2363,22 @@ ble_sm_rx(struct ble_l2cap_chan *chan)
         return BLE_HS_ENOTCONN;
     }
 
-    om = chan->rx_buf;
-    BLE_HS_DBG_ASSERT(om != NULL);
+    om = &chan->rx_buf;
+    BLE_HS_DBG_ASSERT(*om != NULL);
 
-    rc = os_mbuf_copydata(om, 0, 1, &op);
+    rc = os_mbuf_copydata(*om, 0, 1, &op);
     if (rc != 0) {
         return BLE_HS_EBADDATA;
     }
 
     /* Strip L2CAP SM header from the front of the mbuf. */
-    os_mbuf_adj(om, 1);
+    os_mbuf_adj(*om, 1);
 
     rx_cb = ble_sm_dispatch_get(op);
     if (rx_cb != NULL) {
         memset(&res, 0, sizeof res);
 
-        rx_cb(conn_handle, &om, &res);
+        rx_cb(conn_handle, om, &res);
         ble_sm_process_result(conn_handle, &res);
         rc = res.app_status;
     } else {

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -953,7 +953,7 @@ ble_hs_test_util_l2cap_rx(uint16_t conn_handle,
     } else if (rc == 0) {
         TEST_ASSERT_FATAL(rx_cb != NULL);
         rc = rx_cb(conn->bhc_rx_chan);
-        ble_l2cap_forget_rx(conn, conn->bhc_rx_chan);
+        ble_l2cap_remove_rx(conn, conn->bhc_rx_chan);
     } else if (rc == BLE_HS_EAGAIN) {
         /* More fragments on the way. */
         rc = 0;


### PR DESCRIPTION
Couple of fixes after Simon review.