### PR TITLE
apps/btshell: add bletiny clone that uses new shell

### DIFF
--- a/apps/btshell/pkg.yml
+++ b/apps/btshell/pkg.yml
@@ -35,3 +35,4 @@ pkg.deps:
     - sys/stats/full
     - sys/console/full
     - sys/shell
+    - util/parse

--- a/apps/btshell/pkg.yml
+++ b/apps/btshell/pkg.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: apps/btshell
+pkg.type: app
+pkg.description: Shell application exposing the nimble GAP and GATT.
+pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - kernel/os
+    - net/nimble/controller
+    - net/nimble/host
+    - net/nimble/host/services/ans
+    - net/nimble/host/services/gap
+    - net/nimble/host/services/gatt
+    - net/nimble/host/store/ram
+    - net/nimble/transport/ram
+    - sys/log/full
+    - sys/stats/full
+    - sys/console/full
+    - sys/shell

--- a/apps/btshell/src/bletiny.h
+++ b/apps/btshell/src/bletiny.h
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLETINY_PRIV_
+#define H_BLETINY_PRIV_
+
+#include <inttypes.h>
+#include "nimble/ble.h"
+#include "nimble/nimble_opt.h"
+#include "log/log.h"
+#include "os/queue.h"
+
+#include "host/ble_gatt.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ble_gap_white_entry;
+struct ble_hs_adv_fields;
+struct ble_gap_upd_params;
+struct ble_gap_conn_params;
+struct hci_adv_params;
+struct ble_l2cap_sig_update_req;
+struct ble_l2cap_sig_update_params;
+union ble_store_value;
+union ble_store_key;
+struct ble_gap_adv_params;
+struct ble_gap_conn_desc;
+struct ble_gap_disc_params;
+
+struct bletiny_dsc {
+    SLIST_ENTRY(bletiny_dsc) next;
+    struct ble_gatt_dsc dsc;
+};
+SLIST_HEAD(bletiny_dsc_list, bletiny_dsc);
+
+struct bletiny_chr {
+    SLIST_ENTRY(bletiny_chr) next;
+    struct ble_gatt_chr chr;
+
+    struct bletiny_dsc_list dscs;
+};
+SLIST_HEAD(bletiny_chr_list, bletiny_chr);
+
+struct bletiny_svc {
+    SLIST_ENTRY(bletiny_svc) next;
+    struct ble_gatt_svc svc;
+
+    struct bletiny_chr_list chrs;
+};
+
+SLIST_HEAD(bletiny_svc_list, bletiny_svc);
+
+struct bletiny_l2cap_coc {
+    SLIST_ENTRY(bletiny_l2cap_coc) next;
+    struct ble_l2cap_chan *chan;
+};
+
+SLIST_HEAD(bletiny_l2cap_coc_list, bletiny_l2cap_coc);
+
+struct bletiny_conn {
+    uint16_t handle;
+    struct bletiny_svc_list svcs;
+    struct bletiny_l2cap_coc_list coc_list;
+};
+
+extern struct bletiny_conn bletiny_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
+extern int bletiny_num_conns;
+
+extern uint16_t nm_attr_val_handle;
+
+extern struct log bletiny_log;
+int nm_chr_access(uint16_t conn_handle, uint16_t attr_handle,
+                  uint8_t op, struct ble_gatt_access_ctxt *ctxt,
+                  void *arg);
+int nm_rx_rsp(uint8_t *attr_val, uint16_t attr_len);
+void nm_init(void);
+void bletiny_lock(void);
+void bletiny_unlock(void);
+int bletiny_exchange_mtu(uint16_t conn_handle);
+int bletiny_disc_svcs(uint16_t conn_handle);
+int bletiny_disc_svc_by_uuid(uint16_t conn_handle, const ble_uuid_t *uuid);
+int bletiny_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
+                           uint16_t end_handle);
+int bletiny_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
+                               uint16_t end_handle, const ble_uuid_t *uuid);
+int bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+                          uint16_t end_handle);
+int bletiny_disc_full(uint16_t conn_handle);
+int bletiny_find_inc_svcs(uint16_t conn_handle, uint16_t start_handle,
+                           uint16_t end_handle);
+int bletiny_read(uint16_t conn_handle, uint16_t attr_handle);
+int bletiny_read_long(uint16_t conn_handle, uint16_t attr_handle,
+                      uint16_t offset);
+int bletiny_read_by_uuid(uint16_t conn_handle, uint16_t start_handle,
+                          uint16_t end_handle, const ble_uuid_t *uuid);
+int bletiny_read_mult(uint16_t conn_handle, uint16_t *attr_handles,
+                       int num_attr_handles);
+int bletiny_write(uint16_t conn_handle, uint16_t attr_handle,
+                  struct os_mbuf *om);
+int bletiny_write_no_rsp(uint16_t conn_handle, uint16_t attr_handle,
+                         struct os_mbuf *om);
+int bletiny_write_long(uint16_t conn_handle, uint16_t attr_handle,
+                       uint16_t offset, struct os_mbuf *om);
+int bletiny_write_reliable(uint16_t conn_handle,
+                           struct ble_gatt_attr *attrs, int num_attrs);
+int bletiny_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
+                      int32_t duration_ms,
+                      const struct ble_gap_adv_params *params);
+int bletiny_adv_stop(void);
+int bletiny_conn_initiate(uint8_t own_addr_type, const ble_addr_t *peer_addr,
+                          int32_t duration_ms,
+                          struct ble_gap_conn_params *params);
+int bletiny_conn_cancel(void);
+int bletiny_term_conn(uint16_t conn_handle, uint8_t reason);
+int bletiny_wl_set(ble_addr_t *addrs, int addrs_count);
+int bletiny_scan(uint8_t own_addr_type, int32_t duration_ms,
+                 const struct ble_gap_disc_params *disc_params);
+int bletiny_scan_cancel(void);
+int bletiny_set_adv_data(struct ble_hs_adv_fields *adv_fields);
+int bletiny_update_conn(uint16_t conn_handle,
+                         struct ble_gap_upd_params *params);
+void bletiny_chrup(uint16_t attr_handle);
+int bletiny_datalen(uint16_t conn_handle, uint16_t tx_octets,
+                    uint16_t tx_time);
+int bletiny_l2cap_update(uint16_t conn_handle,
+                          struct ble_l2cap_sig_update_params *params);
+int bletiny_sec_start(uint16_t conn_handle);
+int bletiny_sec_pair(uint16_t conn_handle);
+int bletiny_sec_restart(uint16_t conn_handle, uint8_t *ltk, uint16_t ediv,
+                        uint64_t rand_val, int auth);
+int bletiny_tx_start(uint16_t handle, uint16_t len, uint16_t rate,
+                     uint16_t num);
+int bletiny_rssi(uint16_t conn_handle, int8_t *out_rssi);
+int bletiny_l2cap_create_srv(uint16_t psm);
+int bletiny_l2cap_connect(uint16_t conn, uint16_t psm);
+int bletiny_l2cap_disconnect(uint16_t conn, uint16_t idx);
+#define BLETINY_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
+#define BLETINY_LOG(lvl, ...) \
+    LOG_ ## lvl(&bletiny_log, BLETINY_LOG_MODULE, __VA_ARGS__)
+
+/** GATT server. */
+#define GATT_SVR_SVC_ALERT_UUID               0x1811
+#define GATT_SVR_CHR_SUP_NEW_ALERT_CAT_UUID   0x2A47
+#define GATT_SVR_CHR_NEW_ALERT                0x2A46
+#define GATT_SVR_CHR_SUP_UNR_ALERT_CAT_UUID   0x2A48
+#define GATT_SVR_CHR_UNR_ALERT_STAT_UUID      0x2A45
+#define GATT_SVR_CHR_ALERT_NOT_CTRL_PT        0x2A44
+
+void gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg);
+int gatt_svr_init(void);
+void gatt_svr_print_svcs(void);
+
+/** Misc. */
+void print_bytes(const uint8_t *bytes, int len);
+void print_mbuf(const struct os_mbuf *om);
+void print_addr(const void *addr);
+void print_uuid(const ble_uuid_t *uuid);
+int svc_is_empty(const struct bletiny_svc *svc);
+uint16_t chr_end_handle(const struct bletiny_svc *svc,
+                        const struct bletiny_chr *chr);
+int chr_is_empty(const struct bletiny_svc *svc, const struct bletiny_chr *chr);
+void print_conn_desc(const struct ble_gap_conn_desc *desc);
+void print_svc(struct bletiny_svc *svc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -44,116 +44,116 @@ struct ble_gap_adv_params;
 struct ble_gap_conn_desc;
 struct ble_gap_disc_params;
 
-struct bletiny_dsc {
-    SLIST_ENTRY(bletiny_dsc) next;
+struct btshell_dsc {
+    SLIST_ENTRY(btshell_dsc) next;
     struct ble_gatt_dsc dsc;
 };
-SLIST_HEAD(bletiny_dsc_list, bletiny_dsc);
+SLIST_HEAD(btshell_dsc_list, btshell_dsc);
 
-struct bletiny_chr {
-    SLIST_ENTRY(bletiny_chr) next;
+struct btshell_chr {
+    SLIST_ENTRY(btshell_chr) next;
     struct ble_gatt_chr chr;
 
-    struct bletiny_dsc_list dscs;
+    struct btshell_dsc_list dscs;
 };
-SLIST_HEAD(bletiny_chr_list, bletiny_chr);
+SLIST_HEAD(btshell_chr_list, btshell_chr);
 
-struct bletiny_svc {
-    SLIST_ENTRY(bletiny_svc) next;
+struct btshell_svc {
+    SLIST_ENTRY(btshell_svc) next;
     struct ble_gatt_svc svc;
 
-    struct bletiny_chr_list chrs;
+    struct btshell_chr_list chrs;
 };
 
-SLIST_HEAD(bletiny_svc_list, bletiny_svc);
+SLIST_HEAD(btshell_svc_list, btshell_svc);
 
-struct bletiny_l2cap_coc {
-    SLIST_ENTRY(bletiny_l2cap_coc) next;
+struct btshell_l2cap_coc {
+    SLIST_ENTRY(btshell_l2cap_coc) next;
     struct ble_l2cap_chan *chan;
 };
 
-SLIST_HEAD(bletiny_l2cap_coc_list, bletiny_l2cap_coc);
+SLIST_HEAD(btshell_l2cap_coc_list, btshell_l2cap_coc);
 
-struct bletiny_conn {
+struct btshell_conn {
     uint16_t handle;
-    struct bletiny_svc_list svcs;
-    struct bletiny_l2cap_coc_list coc_list;
+    struct btshell_svc_list svcs;
+    struct btshell_l2cap_coc_list coc_list;
 };
 
-extern struct bletiny_conn bletiny_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
-extern int bletiny_num_conns;
+extern struct btshell_conn btshell_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
+extern int btshell_num_conns;
 
 extern uint16_t nm_attr_val_handle;
 
-extern struct log bletiny_log;
+extern struct log btshell_log;
 int nm_chr_access(uint16_t conn_handle, uint16_t attr_handle,
                   uint8_t op, struct ble_gatt_access_ctxt *ctxt,
                   void *arg);
 int nm_rx_rsp(uint8_t *attr_val, uint16_t attr_len);
 void nm_init(void);
-void bletiny_lock(void);
-void bletiny_unlock(void);
-int bletiny_exchange_mtu(uint16_t conn_handle);
-int bletiny_disc_svcs(uint16_t conn_handle);
-int bletiny_disc_svc_by_uuid(uint16_t conn_handle, const ble_uuid_t *uuid);
-int bletiny_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
+void btshell_lock(void);
+void btshell_unlock(void);
+int btshell_exchange_mtu(uint16_t conn_handle);
+int btshell_disc_svcs(uint16_t conn_handle);
+int btshell_disc_svc_by_uuid(uint16_t conn_handle, const ble_uuid_t *uuid);
+int btshell_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
                            uint16_t end_handle);
-int bletiny_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
+int btshell_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
                                uint16_t end_handle, const ble_uuid_t *uuid);
-int bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+int btshell_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
                           uint16_t end_handle);
-int bletiny_disc_full(uint16_t conn_handle);
-int bletiny_find_inc_svcs(uint16_t conn_handle, uint16_t start_handle,
+int btshell_disc_full(uint16_t conn_handle);
+int btshell_find_inc_svcs(uint16_t conn_handle, uint16_t start_handle,
                            uint16_t end_handle);
-int bletiny_read(uint16_t conn_handle, uint16_t attr_handle);
-int bletiny_read_long(uint16_t conn_handle, uint16_t attr_handle,
+int btshell_read(uint16_t conn_handle, uint16_t attr_handle);
+int btshell_read_long(uint16_t conn_handle, uint16_t attr_handle,
                       uint16_t offset);
-int bletiny_read_by_uuid(uint16_t conn_handle, uint16_t start_handle,
+int btshell_read_by_uuid(uint16_t conn_handle, uint16_t start_handle,
                           uint16_t end_handle, const ble_uuid_t *uuid);
-int bletiny_read_mult(uint16_t conn_handle, uint16_t *attr_handles,
+int btshell_read_mult(uint16_t conn_handle, uint16_t *attr_handles,
                        int num_attr_handles);
-int bletiny_write(uint16_t conn_handle, uint16_t attr_handle,
+int btshell_write(uint16_t conn_handle, uint16_t attr_handle,
                   struct os_mbuf *om);
-int bletiny_write_no_rsp(uint16_t conn_handle, uint16_t attr_handle,
+int btshell_write_no_rsp(uint16_t conn_handle, uint16_t attr_handle,
                          struct os_mbuf *om);
-int bletiny_write_long(uint16_t conn_handle, uint16_t attr_handle,
+int btshell_write_long(uint16_t conn_handle, uint16_t attr_handle,
                        uint16_t offset, struct os_mbuf *om);
-int bletiny_write_reliable(uint16_t conn_handle,
+int btshell_write_reliable(uint16_t conn_handle,
                            struct ble_gatt_attr *attrs, int num_attrs);
-int bletiny_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
+int btshell_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
                       int32_t duration_ms,
                       const struct ble_gap_adv_params *params);
-int bletiny_adv_stop(void);
-int bletiny_conn_initiate(uint8_t own_addr_type, const ble_addr_t *peer_addr,
+int btshell_adv_stop(void);
+int btshell_conn_initiate(uint8_t own_addr_type, const ble_addr_t *peer_addr,
                           int32_t duration_ms,
                           struct ble_gap_conn_params *params);
-int bletiny_conn_cancel(void);
-int bletiny_term_conn(uint16_t conn_handle, uint8_t reason);
-int bletiny_wl_set(ble_addr_t *addrs, int addrs_count);
-int bletiny_scan(uint8_t own_addr_type, int32_t duration_ms,
+int btshell_conn_cancel(void);
+int btshell_term_conn(uint16_t conn_handle, uint8_t reason);
+int btshell_wl_set(ble_addr_t *addrs, int addrs_count);
+int btshell_scan(uint8_t own_addr_type, int32_t duration_ms,
                  const struct ble_gap_disc_params *disc_params);
-int bletiny_scan_cancel(void);
-int bletiny_set_adv_data(struct ble_hs_adv_fields *adv_fields);
-int bletiny_update_conn(uint16_t conn_handle,
+int btshell_scan_cancel(void);
+int btshell_set_adv_data(struct ble_hs_adv_fields *adv_fields);
+int btshell_update_conn(uint16_t conn_handle,
                          struct ble_gap_upd_params *params);
-void bletiny_chrup(uint16_t attr_handle);
-int bletiny_datalen(uint16_t conn_handle, uint16_t tx_octets,
+void btshell_chrup(uint16_t attr_handle);
+int btshell_datalen(uint16_t conn_handle, uint16_t tx_octets,
                     uint16_t tx_time);
-int bletiny_l2cap_update(uint16_t conn_handle,
+int btshell_l2cap_update(uint16_t conn_handle,
                           struct ble_l2cap_sig_update_params *params);
-int bletiny_sec_start(uint16_t conn_handle);
-int bletiny_sec_pair(uint16_t conn_handle);
-int bletiny_sec_restart(uint16_t conn_handle, uint8_t *ltk, uint16_t ediv,
+int btshell_sec_start(uint16_t conn_handle);
+int btshell_sec_pair(uint16_t conn_handle);
+int btshell_sec_restart(uint16_t conn_handle, uint8_t *ltk, uint16_t ediv,
                         uint64_t rand_val, int auth);
-int bletiny_tx_start(uint16_t handle, uint16_t len, uint16_t rate,
+int btshell_tx_start(uint16_t handle, uint16_t len, uint16_t rate,
                      uint16_t num);
-int bletiny_rssi(uint16_t conn_handle, int8_t *out_rssi);
-int bletiny_l2cap_create_srv(uint16_t psm);
-int bletiny_l2cap_connect(uint16_t conn, uint16_t psm);
-int bletiny_l2cap_disconnect(uint16_t conn, uint16_t idx);
+int btshell_rssi(uint16_t conn_handle, int8_t *out_rssi);
+int btshell_l2cap_create_srv(uint16_t psm);
+int btshell_l2cap_connect(uint16_t conn, uint16_t psm);
+int btshell_l2cap_disconnect(uint16_t conn, uint16_t idx);
 #define BLETINY_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
 #define BLETINY_LOG(lvl, ...) \
-    LOG_ ## lvl(&bletiny_log, BLETINY_LOG_MODULE, __VA_ARGS__)
+    LOG_ ## lvl(&btshell_log, BLETINY_LOG_MODULE, __VA_ARGS__)
 
 /** GATT server. */
 #define GATT_SVR_SVC_ALERT_UUID               0x1811
@@ -172,12 +172,12 @@ void print_bytes(const uint8_t *bytes, int len);
 void print_mbuf(const struct os_mbuf *om);
 void print_addr(const void *addr);
 void print_uuid(const ble_uuid_t *uuid);
-int svc_is_empty(const struct bletiny_svc *svc);
-uint16_t chr_end_handle(const struct bletiny_svc *svc,
-                        const struct bletiny_chr *chr);
-int chr_is_empty(const struct bletiny_svc *svc, const struct bletiny_chr *chr);
+int svc_is_empty(const struct btshell_svc *svc);
+uint16_t chr_end_handle(const struct btshell_svc *svc,
+                        const struct btshell_chr *chr);
+int chr_is_empty(const struct btshell_svc *svc, const struct btshell_chr *chr);
 void print_conn_desc(const struct ble_gap_conn_desc *desc);
-void print_svc(struct bletiny_svc *svc);
+void print_svc(struct btshell_svc *svc);
 
 #ifdef __cplusplus
 }

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -71,7 +71,7 @@ cmd_parse_conn_start_end(uint16_t *out_conn, uint16_t *out_start,
     return 0;
 }
 
-static struct kv_pair cmd_own_addr_types[] = {
+static const struct kv_pair cmd_own_addr_types[] = {
     { "public",     BLE_OWN_ADDR_PUBLIC },
     { "random",     BLE_OWN_ADDR_RANDOM },
     { "rpa_pub",    BLE_OWN_ADDR_RPA_PUBLIC_DEFAULT },
@@ -79,7 +79,7 @@ static struct kv_pair cmd_own_addr_types[] = {
     { NULL }
 };
 
-static struct kv_pair cmd_peer_addr_types[] = {
+static const struct kv_pair cmd_peer_addr_types[] = {
     { "public",     BLE_ADDR_PUBLIC },
     { "random",     BLE_ADDR_RANDOM },
     { "public_id",  BLE_ADDR_PUBLIC_ID },
@@ -87,7 +87,7 @@ static struct kv_pair cmd_peer_addr_types[] = {
     { NULL }
 };
 
-static struct kv_pair cmd_addr_type[] = {
+static const struct kv_pair cmd_addr_type[] = {
     { "public",     BLE_ADDR_PUBLIC },
     { "random",     BLE_ADDR_RANDOM },
     { NULL }
@@ -99,21 +99,21 @@ static struct kv_pair cmd_addr_type[] = {
  * $advertise                                                                *
  *****************************************************************************/
 
-static struct kv_pair cmd_adv_conn_modes[] = {
+static const struct kv_pair cmd_adv_conn_modes[] = {
     { "non", BLE_GAP_CONN_MODE_NON },
     { "und", BLE_GAP_CONN_MODE_UND },
     { "dir", BLE_GAP_CONN_MODE_DIR },
     { NULL }
 };
 
-static struct kv_pair cmd_adv_disc_modes[] = {
+static const struct kv_pair cmd_adv_disc_modes[] = {
     { "non", BLE_GAP_DISC_MODE_NON },
     { "ltd", BLE_GAP_DISC_MODE_LTD },
     { "gen", BLE_GAP_DISC_MODE_GEN },
     { NULL }
 };
 
-static struct kv_pair cmd_adv_filt_types[] = {
+static const struct kv_pair cmd_adv_filt_types[] = {
     { "none", BLE_HCI_ADV_FILT_NONE },
     { "scan", BLE_HCI_ADV_FILT_SCAN },
     { "conn", BLE_HCI_ADV_FILT_CONN },
@@ -455,7 +455,7 @@ static const struct shell_cmd_help disconnect_help = {
  * $scan                                                                     *
  *****************************************************************************/
 
-static struct kv_pair cmd_scan_filt_policies[] = {
+static const struct kv_pair cmd_scan_filt_policies[] = {
     { "no_wl", BLE_HCI_SCAN_FILT_NO_WL },
     { "use_wl", BLE_HCI_SCAN_FILT_USE_WL },
     { "no_wl_inita", BLE_HCI_SCAN_FILT_NO_WL_INITA },
@@ -568,7 +568,7 @@ static const struct shell_cmd_help scan_help = {
  * $set                                                                      *
  *****************************************************************************/
 
-static struct kv_pair cmd_set_addr_types[] = {
+static const struct kv_pair cmd_set_addr_types[] = {
     { "public",         BLE_ADDR_PUBLIC },
     { "random",         BLE_ADDR_RANDOM },
     { NULL }
@@ -1256,7 +1256,7 @@ static const struct shell_cmd_help conn_datalen_help = {
  * keystore                                                                  *
  *****************************************************************************/
 
-static struct kv_pair cmd_keystore_entry_type[] = {
+static const struct kv_pair cmd_keystore_entry_type[] = {
     { "msec",       BLE_STORE_OBJ_TYPE_PEER_SEC },
     { "ssec",       BLE_STORE_OBJ_TYPE_OUR_SEC },
     { "cccd",       BLE_STORE_OBJ_TYPE_CCCD },

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1,0 +1,2515 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "syscfg/syscfg.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <string.h>
+#include "bsp/bsp.h"
+
+#include "nimble/ble.h"
+#include "nimble/nimble_opt.h"
+#include "nimble/hci_common.h"
+#include "host/ble_gap.h"
+#include "host/ble_hs_adv.h"
+#include "host/ble_sm.h"
+#include "host/ble_eddystone.h"
+#include "host/ble_hs_id.h"
+#include "services/gatt/ble_svc_gatt.h"
+#include "../src/ble_hs_priv.h"
+
+#include "console/console.h"
+#include "shell/shell.h"
+
+#include "cmd.h"
+#include "bletiny.h"
+#include "cmd_gatt.h"
+#include "cmd_l2cap.h"
+
+#define BTSHELL_MODULE "btshell"
+
+
+int
+cmd_parse_conn_start_end(uint16_t *out_conn, uint16_t *out_start,
+                         uint16_t *out_end)
+{
+    int rc;
+
+    *out_conn = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        return rc;
+    }
+
+    *out_start = parse_arg_uint16("start", &rc);
+    if (rc != 0) {
+        return rc;
+    }
+
+    *out_end = parse_arg_uint16("end", &rc);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}
+
+static struct kv_pair cmd_own_addr_types[] = {
+    { "public",     BLE_OWN_ADDR_PUBLIC },
+    { "random",     BLE_OWN_ADDR_RANDOM },
+    { "rpa_pub",    BLE_OWN_ADDR_RPA_PUBLIC_DEFAULT },
+    { "rpa_rnd",    BLE_OWN_ADDR_RPA_RANDOM_DEFAULT },
+    { NULL }
+};
+
+static struct kv_pair cmd_peer_addr_types[] = {
+    { "public",     BLE_ADDR_PUBLIC },
+    { "random",     BLE_ADDR_RANDOM },
+    { "public_id",  BLE_ADDR_PUBLIC_ID },
+    { "random_id",  BLE_ADDR_RANDOM_ID },
+    { NULL }
+};
+
+static struct kv_pair cmd_addr_type[] = {
+    { "public",     BLE_ADDR_PUBLIC },
+    { "random",     BLE_ADDR_RANDOM },
+    { NULL }
+};
+
+
+
+/*****************************************************************************
+ * $advertise                                                                *
+ *****************************************************************************/
+
+static struct kv_pair cmd_adv_conn_modes[] = {
+    { "non", BLE_GAP_CONN_MODE_NON },
+    { "und", BLE_GAP_CONN_MODE_UND },
+    { "dir", BLE_GAP_CONN_MODE_DIR },
+    { NULL }
+};
+
+static struct kv_pair cmd_adv_disc_modes[] = {
+    { "non", BLE_GAP_DISC_MODE_NON },
+    { "ltd", BLE_GAP_DISC_MODE_LTD },
+    { "gen", BLE_GAP_DISC_MODE_GEN },
+    { NULL }
+};
+
+static struct kv_pair cmd_adv_filt_types[] = {
+    { "none", BLE_HCI_ADV_FILT_NONE },
+    { "scan", BLE_HCI_ADV_FILT_SCAN },
+    { "conn", BLE_HCI_ADV_FILT_CONN },
+    { "both", BLE_HCI_ADV_FILT_BOTH },
+    { NULL }
+};
+
+static int
+cmd_advertise(int argc, char **argv)
+{
+    struct ble_gap_adv_params params;
+    int32_t duration_ms;
+    ble_addr_t peer_addr;
+    ble_addr_t *peer_addr_param = &peer_addr;
+    uint8_t own_addr_type;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "stop") == 0) {
+        rc = bletiny_adv_stop();
+        if (rc != 0) {
+            console_printf("advertise stop fail: %d\n", rc);
+            return rc;
+        }
+
+        return 0;
+    }
+
+    params.conn_mode = parse_arg_kv_default("conn", cmd_adv_conn_modes,
+                                            BLE_GAP_CONN_MODE_UND, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    params.disc_mode = parse_arg_kv_default("discov", cmd_adv_disc_modes,
+                                            BLE_GAP_DISC_MODE_GEN, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'discov' parameter\n");
+        return rc;
+    }
+
+    peer_addr.type = parse_arg_kv_default(
+        "peer_addr_type", cmd_peer_addr_types, BLE_ADDR_PUBLIC, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'peer_addr_type' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_mac("peer_addr", peer_addr.val);
+    if (rc == ENOENT) {
+        peer_addr_param = NULL;
+    } else if (rc != 0) {
+        console_printf("invalid 'peer_addr' parameter\n");
+        return rc;
+    }
+
+    own_addr_type = parse_arg_kv_default(
+        "own_addr_type", cmd_own_addr_types, BLE_OWN_ADDR_PUBLIC, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'own_addr_type' parameter\n");
+        return rc;
+    }
+
+    params.channel_map = parse_arg_long_bounds_default("channel_map", 0, 0xff, 0,
+                                                       &rc);
+    if (rc != 0) {
+        console_printf("invalid 'channel_map' parameter\n");
+        return rc;
+    }
+
+    params.filter_policy = parse_arg_kv_default("filter", cmd_adv_filt_types,
+                                                BLE_HCI_ADV_FILT_NONE, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'filter' parameter\n");
+        return rc;
+    }
+
+    params.itvl_min = parse_arg_long_bounds_default("interval_min", 0, UINT16_MAX,
+                                                    0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval_min' parameter\n");
+        return rc;
+    }
+
+    params.itvl_max = parse_arg_long_bounds_default("interval_max", 0, UINT16_MAX,
+                                                    0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval_max' parameter\n");
+        return rc;
+    }
+
+    params.high_duty_cycle = parse_arg_long_bounds_default("high_duty", 0, 1, 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'high_duty' parameter\n");
+        return rc;
+    }
+
+    duration_ms = parse_arg_long_bounds_default("duration", 1, INT32_MAX,
+                                                BLE_HS_FOREVER, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'duration' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_adv_start(own_addr_type, peer_addr_param, duration_ms,
+                           &params);
+    if (rc != 0) {
+        console_printf("advertise fail: %d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param advertise_params[] = {
+    {"stop", "stop advertising procedure"},
+    {"conn", "connectable mode, usage: =[non|und|dir], default: und"},
+    {"discov", "discoverable mode, usage: =[non|ltd|gen], default: gen"},
+    {"peer_addr_type", "usage: =[public|random|public_id|random_id], default: public"},
+    {"peer_addr", "usage: =[XX:XX:XX:XX:XX:XX]"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {"channel_map", "usage: =[0x00-0xff], default: 0"},
+    {"filter", "usage: =[none|scan|conn|both], default: none"},
+    {"interval_min", "usage: =[0-UINT16_MAX], default: 0"},
+    {"interval_max", "usage: =[0-UINT16_MAX], default: 0"},
+    {"high_duty", "usage: =[0-1], default: 0"},
+    {"duration", "usage: =[1-INT32_MAX], default: INT32_MAX"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help advertise_help = {
+    .summary = "start/stop advertising with specific parameters",
+    .usage = NULL,
+    .params = advertise_params,
+};
+
+/*****************************************************************************
+ * $connect                                                                  *
+ *****************************************************************************/
+
+static int
+cmd_connect(int argc, char **argv)
+{
+    struct ble_gap_conn_params params;
+    int32_t duration_ms;
+    ble_addr_t peer_addr;
+    ble_addr_t *peer_addr_param = &peer_addr;
+    int own_addr_type;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "cancel") == 0) {
+        rc = bletiny_conn_cancel();
+        if (rc != 0) {
+            console_printf("connection cancel fail: %d\n", rc);
+            return rc;
+        }
+
+        return 0;
+    }
+
+    peer_addr.type = parse_arg_kv_default("peer_addr_type", cmd_peer_addr_types,
+                                          BLE_ADDR_PUBLIC, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'peer_addr_type' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_mac("peer_addr", peer_addr.val);
+    if (rc == ENOENT) {
+        /* Allow "addr" for backwards compatibility. */
+        rc = parse_arg_mac("addr", peer_addr.val);
+    }
+
+    if (rc == ENOENT) {
+        /* With no "peer_addr" specified we'll use white list */
+        peer_addr_param = NULL;
+    } else if (rc != 0) {
+        console_printf("invalid 'peer_addr' parameter\n");
+        return rc;
+    }
+
+    own_addr_type = parse_arg_kv_default("own_addr_type", cmd_own_addr_types,
+                                         BLE_OWN_ADDR_PUBLIC, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'own_addr_type' parameter\n");
+        return rc;
+    }
+
+    params.scan_itvl = parse_arg_uint16_dflt("scan_interval", 0x0010, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'scan_interval' parameter\n");
+        return rc;
+    }
+
+    params.scan_window = parse_arg_uint16_dflt("scan_window", 0x0010, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'scan_window' parameter\n");
+        return rc;
+    }
+
+    params.itvl_min = parse_arg_uint16_dflt(
+        "interval_min", BLE_GAP_INITIAL_CONN_ITVL_MIN, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval_min' parameter\n");
+        return rc;
+    }
+
+    params.itvl_max = parse_arg_uint16_dflt(
+        "interval_max", BLE_GAP_INITIAL_CONN_ITVL_MAX, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval_max' parameter\n");
+        return rc;
+    }
+
+    params.latency = parse_arg_uint16_dflt("latency", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'latency' parameter\n");
+        return rc;
+    }
+
+    params.supervision_timeout = parse_arg_uint16_dflt("timeout", 0x0100, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'timeout' parameter\n");
+        return rc;
+    }
+
+    params.min_ce_len = parse_arg_uint16_dflt("min_conn_event_len", 0x0010, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'min_conn_event_len' parameter\n");
+        return rc;
+    }
+
+    params.max_ce_len = parse_arg_uint16_dflt("max_conn_event_len", 0x0300, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'max_conn_event_len' parameter\n");
+        return rc;
+    }
+
+    duration_ms = parse_arg_long_bounds_default("duration", 1, INT32_MAX, 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'duration' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_conn_initiate(own_addr_type, peer_addr_param, duration_ms,
+                               &params);
+    if (rc != 0) {
+        console_printf("error connecting; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param connect_params[] = {
+    {"cancel", "cancel connection procedure"},
+    {"peer_addr_type", "usage: =[public|random|public_id|random_id], default: public"},
+    {"peer_addr", "usage: =[XX:XX:XX:XX:XX:XX]"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {"scan_interval", "usage: =[0-UINT16_MAX], default: 0x0010"},
+    {"scan_window", "usage: =[0-UINT16_MAX], default: 0x0010"},
+    {"interval_min", "usage: =[0-UINT16_MAX], default: 30"},
+    {"interval_max", "usage: =[0-UINT16_MAX], default: 50"},
+    {"latency", "usage: =[UINT16], default: 0"},
+    {"timeout", "usage: =[UINT16], default: 0x0100"},
+    {"min_conn_event_len", "usage: =[UINT16], default: 0x0010"},
+    {"max_conn_event_len", "usage: =[UINT16], default: 0x0300"},
+    {"duration", "usage: =[1-INT32_MAX], default: 0"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help connect_help = {
+    .summary = "start/stop connection procedure with specific parameters",
+    .usage = NULL,
+    .params = connect_params,
+};
+
+
+/*****************************************************************************
+ * $disconnect                                                               *
+ *****************************************************************************/
+
+static int
+cmd_disconnect(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    uint8_t reason;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    reason = parse_arg_uint8_dflt("reason", BLE_ERR_REM_USER_CONN_TERM, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'reason' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_term_conn(conn_handle, reason);
+    if (rc != 0) {
+        console_printf("error terminating connection; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param disconnect_params[] = {
+    {"conn", "connection handle parameter, usage: =<UINT16>"},
+    {"reason", "disconnection reason, usage: =[UINT8], default: 19 (remote user terminated connection)"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help disconnect_help = {
+    .summary = "disconnect command",
+    .usage = NULL,
+    .params = disconnect_params,
+};
+
+/*****************************************************************************
+ * $scan                                                                     *
+ *****************************************************************************/
+
+static struct kv_pair cmd_scan_filt_policies[] = {
+    { "no_wl", BLE_HCI_SCAN_FILT_NO_WL },
+    { "use_wl", BLE_HCI_SCAN_FILT_USE_WL },
+    { "no_wl_inita", BLE_HCI_SCAN_FILT_NO_WL_INITA },
+    { "use_wl_inita", BLE_HCI_SCAN_FILT_USE_WL_INITA },
+    { NULL }
+};
+
+static int
+cmd_scan(int argc, char **argv)
+{
+    struct ble_gap_disc_params params;
+    int32_t duration_ms;
+    uint8_t own_addr_type;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "cancel") == 0) {
+        rc = bletiny_scan_cancel();
+        if (rc != 0) {
+            console_printf("connection cancel fail: %d\n", rc);
+            return rc;
+        }
+        return 0;
+    }
+
+    duration_ms = parse_arg_long_bounds_default("duration", 1, INT32_MAX,
+                                                BLE_HS_FOREVER, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'duration' parameter\n");
+        return rc;
+    }
+
+    params.limited = parse_arg_bool_default("limited", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'limited' parameter\n");
+        return rc;
+    }
+
+    params.passive = parse_arg_bool_default("passive", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'passive' parameter\n");
+        return rc;
+    }
+
+    params.itvl = parse_arg_uint16_dflt("interval", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval' parameter\n");
+        return rc;
+    }
+
+    params.window = parse_arg_uint16_dflt("window", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'window' parameter\n");
+        return rc;
+    }
+
+    params.filter_policy = parse_arg_kv_default(
+        "filter", cmd_scan_filt_policies, BLE_HCI_SCAN_FILT_NO_WL, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'filter' parameter\n");
+        return rc;
+    }
+
+    params.filter_duplicates = parse_arg_bool_default("nodups", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'nodups' parameter\n");
+        return rc;
+    }
+
+    own_addr_type = parse_arg_kv_default("own_addr_type", cmd_own_addr_types,
+                                         BLE_OWN_ADDR_PUBLIC, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'own_addr_type' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_scan(own_addr_type, duration_ms, &params);
+    if (rc != 0) {
+        console_printf("error scanning; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param scan_params[] = {
+    {"cancel", "cancel scan procedure"},
+    {"duration", "usage: =[1-INT32_MAX], default: INT32_MAX"},
+    {"limited", "usage: =[0-1], default: 0"},
+    {"passive", "usage: =[0-1], default: 0"},
+    {"interval", "usage: =[0-UINT16_MAX], default: 0"},
+    {"window", "usage: =[0-UINT16_MAX], default: 0"},
+    {"filter", "usage: =[no_wl|use_wl|no_wl_inita|use_wl_inita], default: no_wl"},
+    {"nodups", "usage: =[0-UINT16_MAX], default: 0"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help scan_help = {
+    .summary = "start/stop scan procedure with specific parameters",
+    .usage = NULL,
+    .params = scan_params,
+};
+
+/*****************************************************************************
+ * $set                                                                      *
+ *****************************************************************************/
+
+static struct kv_pair cmd_set_addr_types[] = {
+    { "public",         BLE_ADDR_PUBLIC },
+    { "random",         BLE_ADDR_RANDOM },
+    { NULL }
+};
+
+static int
+cmd_set_addr(void)
+{
+    uint8_t addr[6];
+    int addr_type;
+    int rc;
+
+    addr_type = parse_arg_kv_default("addr_type", cmd_set_addr_types,
+                                     BLE_ADDR_PUBLIC, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'addr_type' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_mac("addr", addr);
+    if (rc != 0) {
+        console_printf("invalid 'addr' parameter\n");
+        return rc;
+    }
+
+    switch (addr_type) {
+    case BLE_ADDR_PUBLIC:
+        /* We shouldn't be writing to the controller's address (g_dev_addr).
+         * There is no standard way to set the local public address, so this is
+         * our only option at the moment.
+         */
+        memcpy(g_dev_addr, addr, 6);
+        ble_hs_id_set_pub(g_dev_addr);
+        break;
+
+    case BLE_ADDR_RANDOM:
+        rc = ble_hs_id_set_rnd(addr);
+        if (rc != 0) {
+            return rc;
+        }
+        break;
+
+    default:
+        return BLE_HS_EUNKNOWN;
+    }
+
+    return 0;
+}
+
+static int
+cmd_set(int argc, char **argv)
+{
+    uint16_t mtu;
+    uint8_t irk[16];
+    int good = 0;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = parse_arg_find_idx("addr");
+    if (rc != -1) {
+        rc = cmd_set_addr();
+        if (rc != 0) {
+            return rc;
+        }
+        good = 1;
+    }
+
+    mtu = parse_arg_uint16("mtu", &rc);
+    if (rc == 0) {
+        rc = ble_att_set_preferred_mtu(mtu);
+        if (rc == 0) {
+            good = 1;
+        }
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'mtu' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream_exact_length("irk", irk, 16);
+    if (rc == 0) {
+        good = 1;
+        ble_hs_pvcy_set_our_irk(irk);
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'irk' parameter\n");
+        return rc;
+    }
+
+    if (!good) {
+        console_printf("Error: no valid settings specified\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+static const struct shell_param set_params[] = {
+    {"addr", "set device address, usage: =[XX:XX:XX:XX:XX:XX]"},
+    {"addr_type", "set device address type, usage: =[public|random|public_id|random_id], default: public"},
+    {"mtu", "Maximum Transimssion Unit, usage: =[0-UINT16_MAX]"},
+    {"irk", "Identity Resolving Key, usage: =[XX:XX...], len=16 octets"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help set_help = {
+    .summary = "set device parameters",
+    .usage = NULL,
+    .params = set_params,
+};
+
+/*****************************************************************************
+ * $set-adv-data                                                             *
+ *****************************************************************************/
+
+#define CMD_ADV_DATA_MAX_UUIDS16                8
+#define CMD_ADV_DATA_MAX_UUIDS32                8
+#define CMD_ADV_DATA_MAX_UUIDS128               2
+#define CMD_ADV_DATA_MAX_PUBLIC_TGT_ADDRS       8
+#define CMD_ADV_DATA_SVC_DATA_UUID16_MAX_LEN    BLE_HS_ADV_MAX_FIELD_SZ
+#define CMD_ADV_DATA_SVC_DATA_UUID32_MAX_LEN    BLE_HS_ADV_MAX_FIELD_SZ
+#define CMD_ADV_DATA_SVC_DATA_UUID128_MAX_LEN   BLE_HS_ADV_MAX_FIELD_SZ
+#define CMD_ADV_DATA_URI_MAX_LEN                BLE_HS_ADV_MAX_FIELD_SZ
+#define CMD_ADV_DATA_MFG_DATA_MAX_LEN           BLE_HS_ADV_MAX_FIELD_SZ
+
+static int
+cmd_set_adv_data(int argc, char **argv)
+{
+    static bssnz_t ble_uuid16_t uuids16[CMD_ADV_DATA_MAX_UUIDS16];
+    static bssnz_t ble_uuid32_t uuids32[CMD_ADV_DATA_MAX_UUIDS32];
+    static bssnz_t ble_uuid128_t uuids128[CMD_ADV_DATA_MAX_UUIDS128];
+    static bssnz_t uint8_t
+        public_tgt_addrs[CMD_ADV_DATA_MAX_PUBLIC_TGT_ADDRS]
+                        [BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN];
+    static bssnz_t uint8_t slave_itvl_range[BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN];
+    static bssnz_t uint8_t
+        svc_data_uuid16[CMD_ADV_DATA_SVC_DATA_UUID16_MAX_LEN];
+    static bssnz_t uint8_t
+        svc_data_uuid32[CMD_ADV_DATA_SVC_DATA_UUID32_MAX_LEN];
+    static bssnz_t uint8_t
+        svc_data_uuid128[CMD_ADV_DATA_SVC_DATA_UUID128_MAX_LEN];
+    static bssnz_t uint8_t uri[CMD_ADV_DATA_URI_MAX_LEN];
+    static bssnz_t uint8_t mfg_data[CMD_ADV_DATA_MFG_DATA_MAX_LEN];
+    struct ble_hs_adv_fields adv_fields;
+    uint32_t uuid32;
+    uint16_t uuid16;
+    uint8_t uuid128[16];
+    uint8_t public_tgt_addr[BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN];
+    uint8_t eddystone_url_body_len;
+    uint8_t eddystone_url_suffix;
+    uint8_t eddystone_url_scheme;
+    char eddystone_url_body[BLE_EDDYSTONE_URL_MAX_LEN];
+    char *eddystone_url_full;
+    int svc_data_uuid16_len;
+    int svc_data_uuid32_len;
+    int svc_data_uuid128_len;
+    int uri_len;
+    int mfg_data_len;
+    int tmp;
+    int rc;
+
+    memset(&adv_fields, 0, sizeof adv_fields);
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    tmp = parse_arg_long_bounds("flags", 0, UINT8_MAX, &rc);
+    if (rc == 0) {
+        adv_fields.flags = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'flags' parameter\n");
+        return rc;
+    }
+
+    while (1) {
+        uuid16 = parse_arg_uint16("uuid16", &rc);
+        if (rc == 0) {
+            if (adv_fields.num_uuids16 >= CMD_ADV_DATA_MAX_UUIDS16) {
+                console_printf("invalid 'uuid16' parameter\n");
+                return EINVAL;
+            }
+            uuids16[adv_fields.num_uuids16] = (ble_uuid16_t) BLE_UUID16_INIT(uuid16);
+            adv_fields.num_uuids16++;
+        } else if (rc == ENOENT) {
+            break;
+        } else {
+            console_printf("invalid 'uuid16' parameter\n");
+            return rc;
+        }
+    }
+    if (adv_fields.num_uuids16 > 0) {
+        adv_fields.uuids16 = uuids16;
+    }
+
+    tmp = parse_arg_long("uuids16_is_complete", &rc);
+    if (rc == 0) {
+        adv_fields.uuids16_is_complete = !!tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'uuids16_is_complete' parameter\n");
+        return rc;
+    }
+
+    while (1) {
+        uuid32 = parse_arg_uint32("uuid32", &rc);
+        if (rc == 0) {
+            if (adv_fields.num_uuids32 >= CMD_ADV_DATA_MAX_UUIDS32) {
+                console_printf("invalid 'uuid32' parameter\n");
+                return EINVAL;
+            }
+            uuids32[adv_fields.num_uuids32] = (ble_uuid32_t) BLE_UUID32_INIT(uuid32);
+            adv_fields.num_uuids32++;
+        } else if (rc == ENOENT) {
+            break;
+        } else {
+            console_printf("invalid 'uuid32' parameter\n");
+            return rc;
+        }
+    }
+    if (adv_fields.num_uuids32 > 0) {
+        adv_fields.uuids32 = uuids32;
+    }
+
+    tmp = parse_arg_long("uuids32_is_complete", &rc);
+    if (rc == 0) {
+        adv_fields.uuids32_is_complete = !!tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'uuids32_is_complete' parameter\n");
+        return rc;
+    }
+
+    while (1) {
+        rc = parse_arg_byte_stream_exact_length("uuid128", uuid128, 16);
+        if (rc == 0) {
+            if (adv_fields.num_uuids128 >= CMD_ADV_DATA_MAX_UUIDS128) {
+                console_printf("invalid 'uuid128' parameter\n");
+                return EINVAL;
+            }
+            ble_uuid_init_from_buf((ble_uuid_any_t *) &uuids128[adv_fields.num_uuids128],
+                                   uuid128, 16);
+            adv_fields.num_uuids128++;
+        } else if (rc == ENOENT) {
+            break;
+        } else {
+            console_printf("invalid 'uuid128' parameter\n");
+            return rc;
+        }
+    }
+    if (adv_fields.num_uuids128 > 0) {
+        adv_fields.uuids128 = uuids128;
+    }
+
+    tmp = parse_arg_long("uuids128_is_complete", &rc);
+    if (rc == 0) {
+        adv_fields.uuids128_is_complete = !!tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'uuids128_is_complete' parameter\n");
+        return rc;
+    }
+
+    adv_fields.name = (uint8_t *)parse_arg_extract("name");
+    if (adv_fields.name != NULL) {
+        adv_fields.name_len = strlen((char *)adv_fields.name);
+    }
+
+    tmp = parse_arg_long_bounds("tx_power_level", INT8_MIN, INT8_MAX, &rc);
+    if (rc == 0) {
+        adv_fields.tx_pwr_lvl = tmp;
+        adv_fields.tx_pwr_lvl_is_present = 1;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'tx_power_level' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream_exact_length("slave_interval_range",
+                                            slave_itvl_range,
+                                            BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
+    if (rc == 0) {
+        adv_fields.slave_itvl_range = slave_itvl_range;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'slave_interval_range' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream("service_data_uuid16",
+                               CMD_ADV_DATA_SVC_DATA_UUID16_MAX_LEN,
+                               svc_data_uuid16, &svc_data_uuid16_len);
+    if (rc == 0) {
+        adv_fields.svc_data_uuid16 = svc_data_uuid16;
+        adv_fields.svc_data_uuid16_len = svc_data_uuid16_len;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'service_data_uuid16' parameter\n");
+        return rc;
+    }
+
+    while (1) {
+        rc = parse_arg_byte_stream_exact_length(
+            "public_target_address", public_tgt_addr,
+            BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN);
+        if (rc == 0) {
+            if (adv_fields.num_public_tgt_addrs >=
+                CMD_ADV_DATA_MAX_PUBLIC_TGT_ADDRS) {
+
+                console_printf("invalid 'public_target_address' parameter\n");
+                return EINVAL;
+            }
+            memcpy(public_tgt_addrs[adv_fields.num_public_tgt_addrs],
+                   public_tgt_addr, BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN);
+            adv_fields.num_public_tgt_addrs++;
+        } else if (rc == ENOENT) {
+            break;
+        } else {
+            console_printf("invalid 'public_target_address' parameter\n");
+            return rc;
+        }
+    }
+    if (adv_fields.num_public_tgt_addrs > 0) {
+        adv_fields.public_tgt_addr = (void *)public_tgt_addrs;
+    }
+
+    adv_fields.appearance = parse_arg_uint16("appearance", &rc);
+    if (rc == 0) {
+        adv_fields.appearance_is_present = 1;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'appearance' parameter\n");
+        return rc;
+    }
+
+    adv_fields.adv_itvl = parse_arg_uint16("advertising_interval", &rc);
+    if (rc == 0) {
+        adv_fields.adv_itvl_is_present = 1;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'advertising_interval' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream("service_data_uuid32",
+                               CMD_ADV_DATA_SVC_DATA_UUID32_MAX_LEN,
+                               svc_data_uuid32, &svc_data_uuid32_len);
+    if (rc == 0) {
+        adv_fields.svc_data_uuid32 = svc_data_uuid32;
+        adv_fields.svc_data_uuid32_len = svc_data_uuid32_len;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'service_data_uuid32' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream("service_data_uuid128",
+                               CMD_ADV_DATA_SVC_DATA_UUID128_MAX_LEN,
+                               svc_data_uuid128, &svc_data_uuid128_len);
+    if (rc == 0) {
+        adv_fields.svc_data_uuid128 = svc_data_uuid128;
+        adv_fields.svc_data_uuid128_len = svc_data_uuid128_len;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'service_data_uuid128' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream("uri", CMD_ADV_DATA_URI_MAX_LEN, uri, &uri_len);
+    if (rc == 0) {
+        adv_fields.uri = uri;
+        adv_fields.uri_len = uri_len;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'uri' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_byte_stream("mfg_data", CMD_ADV_DATA_MFG_DATA_MAX_LEN,
+                               mfg_data, &mfg_data_len);
+    if (rc == 0) {
+        adv_fields.mfg_data = mfg_data;
+        adv_fields.mfg_data_len = mfg_data_len;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'mfg_data' parameter\n");
+        return rc;
+    }
+
+    eddystone_url_full = parse_arg_extract("eddystone_url");
+    if (eddystone_url_full != NULL) {
+        rc = parse_eddystone_url(eddystone_url_full, &eddystone_url_scheme,
+                                 eddystone_url_body,
+                                 &eddystone_url_body_len,
+                                 &eddystone_url_suffix);
+        if (rc != 0) {
+            return rc;
+        }
+
+        rc = ble_eddystone_set_adv_data_url(&adv_fields, eddystone_url_scheme,
+                                            eddystone_url_body,
+                                            eddystone_url_body_len,
+                                            eddystone_url_suffix);
+    } else {
+        rc = bletiny_set_adv_data(&adv_fields);
+    }
+    if (rc != 0) {
+        console_printf("error setting advertisement data; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param set_adv_data_params[] = {
+    {"flags", "usage: =[0-UINT8_MAX]"},
+    {"uuid16", "usage: =[UINT16]"},
+    {"uuid16_is_complete", "usage: =[0-1]"},
+    {"uuid32", "usage: =[UINT32]"},
+    {"uuid32_is_complete", "usage: =[0-1]"},
+    {"uuid128", "usage: =[XX:XX...], len=16 octets"},
+    {"uuid128_is_complete", "usage: =[0-1]"},
+    {"tx_power_level", "usage: =[INT8_MIN-INT8_MAX]"},
+    {"slave_interval_range", "usage: =[XX:XX:XX:XX]"},
+    {"public_target_address", "usage: =[XX:XX:XX:XX:XX:XX]"},
+    {"appearance", "usage: =[UINT16]"},
+    {"name", "usage: =[string]"},
+    {"advertising_interval", "usage: =[UINT16]"},
+    {"service_data_uuid16", "usage: =[XX:XX...]"},
+    {"service_data_uuid32", "usage: =[XX:XX...]"},
+    {"service_data_uuid128", "usage: =[XX:XX...]"},
+    {"uri", "usage: =[XX:XX...]"},
+    {"mfg_data", "usage: =[XX:XX...]"},
+    {"eddystone_url", "usage: =[string]"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help set_adv_data_help = {
+    .summary = "set advertising data",
+    .usage = NULL,
+    .params = set_adv_data_params,
+};
+
+/*****************************************************************************
+ * $white-list                                                               *
+ *****************************************************************************/
+
+#define CMD_WL_MAX_SZ   8
+
+static int
+cmd_white_list(int argc, char **argv)
+{
+    static ble_addr_t addrs[CMD_WL_MAX_SZ];
+    int addrs_cnt;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    addrs_cnt = 0;
+    while (1) {
+        if (addrs_cnt >= CMD_WL_MAX_SZ) {
+            return EINVAL;
+        }
+
+        rc = parse_arg_mac("addr", addrs[addrs_cnt].val);
+        if (rc == ENOENT) {
+            break;
+        } else if (rc != 0) {
+            console_printf("invalid 'addr' parameter\n");
+            return rc;
+        }
+
+        addrs[addrs_cnt].type = parse_arg_kv("addr_type", cmd_addr_type, &rc);
+        if (rc != 0) {
+            console_printf("invalid 'addr' parameter\n");
+            return rc;
+        }
+
+        addrs_cnt++;
+    }
+
+    if (addrs_cnt == 0) {
+        return EINVAL;
+    }
+
+    bletiny_wl_set(addrs, addrs_cnt);
+
+    return 0;
+}
+
+static const struct shell_param white_list_params[] = {
+    {"addr", "white-list device addresses, usage: =[XX:XX:XX:XX:XX:XX]"},
+    {"addr_type", "white-list address types, usage: =[public|random]"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help white_list_help = {
+    .summary = "set white-list addresses",
+    .usage = NULL,
+    .params = white_list_params,
+};
+
+/*****************************************************************************
+ * $conn-rssi                                                                *
+ *****************************************************************************/
+
+static int
+cmd_conn_rssi(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    int8_t rssi;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_rssi(conn_handle, &rssi);
+    if (rc != 0) {
+        console_printf("error reading rssi; rc=%d\n", rc);
+        return rc;
+    }
+
+    console_printf("conn=%d rssi=%d\n", conn_handle, rssi);
+
+    return 0;
+}
+
+static const struct shell_param conn_rssi_params[] = {
+    {"conn", "connection handle parameter, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help conn_rssi_help = {
+    .summary = "check connection rssi",
+    .usage = NULL,
+    .params = conn_rssi_params,
+};
+
+/*****************************************************************************
+ * $conn-update-params                                                       *
+ *****************************************************************************/
+
+static int
+cmd_conn_update_params(int argc, char **argv)
+{
+    struct ble_gap_upd_params params;
+    uint16_t conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    params.itvl_min = parse_arg_uint16_dflt(
+        "itvl_min", BLE_GAP_INITIAL_CONN_ITVL_MIN, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'itvl_min' parameter\n");
+        return rc;
+    }
+
+    params.itvl_max = parse_arg_uint16_dflt(
+        "itvl_max", BLE_GAP_INITIAL_CONN_ITVL_MAX, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'itvl_max' parameter\n");
+        return rc;
+    }
+
+    params.latency = parse_arg_uint16_dflt("latency", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'latency' parameter\n");
+        return rc;
+    }
+
+    params.supervision_timeout = parse_arg_uint16_dflt("timeout", 0x0100, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'timeout' parameter\n");
+        return rc;
+    }
+
+    params.min_ce_len = parse_arg_uint16_dflt("min_ce_len", 0x0010, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'min_ce_len' parameter\n");
+        return rc;
+    }
+
+    params.max_ce_len = parse_arg_uint16_dflt("max_ce_len", 0x0300, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'max_ce_len' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_update_conn(conn_handle, &params);
+    if (rc != 0) {
+        console_printf("error updating connection; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param conn_update_params_params[] = {
+    {"conn", "conn_update_paramsion handle, usage: =<UINT16>"},
+    {"interval_min", "usage: =[0-UINT16_MAX], default: 30"},
+    {"interval_max", "usage: =[0-UINT16_MAX], default: 50"},
+    {"latency", "usage: =[UINT16], default: 0"},
+    {"timeout", "usage: =[UINT16], default: 0x0100"},
+    {"min_conn_event_len", "usage: =[UINT16], default: 0x0010"},
+    {"max_conn_event_len", "usage: =[UINT16], default: 0x0300"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help conn_update_params_help = {
+    .summary = "update connection parameters",
+    .usage = "conn_update_params usage",
+    .params = conn_update_params_params,
+};
+
+/*****************************************************************************
+ * $conn-datalen                                                             *
+ *****************************************************************************/
+
+static int
+cmd_conn_datalen(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    uint16_t tx_octets;
+    uint16_t tx_time;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    tx_octets = parse_arg_long("octets", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'octets' parameter\n");
+        return rc;
+    }
+
+    tx_time = parse_arg_long("time", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'time' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_datalen(conn_handle, tx_octets, tx_time);
+    if (rc != 0) {
+        console_printf("error setting data length; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param conn_datalen_params[] = {
+    {"conn", "conn_datalenion handle, usage: =<UINT16>"},
+    {"octets", "usage: =<UINT16>"},
+    {"time", "usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help conn_datalen_help = {
+    .summary = "set data length parameters for connection",
+    .usage = NULL,
+    .params = conn_datalen_params,
+};
+
+/*****************************************************************************
+ * keystore                                                                  *
+ *****************************************************************************/
+
+static struct kv_pair cmd_keystore_entry_type[] = {
+    { "msec",       BLE_STORE_OBJ_TYPE_PEER_SEC },
+    { "ssec",       BLE_STORE_OBJ_TYPE_OUR_SEC },
+    { "cccd",       BLE_STORE_OBJ_TYPE_CCCD },
+    { NULL }
+};
+
+static int
+cmd_keystore_parse_keydata(int argc, char **argv, union ble_store_key *out,
+                           int *obj_type)
+{
+    int rc;
+
+    memset(out, 0, sizeof(*out));
+    *obj_type = parse_arg_kv("type", cmd_keystore_entry_type, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'type' parameter\n");
+        return rc;
+    }
+
+    switch (*obj_type) {
+    case BLE_STORE_OBJ_TYPE_PEER_SEC:
+    case BLE_STORE_OBJ_TYPE_OUR_SEC:
+        out->sec.peer_addr.type = parse_arg_kv("addr_type", cmd_addr_type, &rc);
+        if (rc != 0) {
+            console_printf("invalid 'addr_type' parameter\n");
+            return rc;
+        }
+
+        rc = parse_arg_mac("addr", out->sec.peer_addr.val);
+        if (rc != 0) {
+            console_printf("invalid 'addr' parameter\n");
+            return rc;
+        }
+
+        out->sec.ediv = parse_arg_uint16("ediv", &rc);
+        if (rc != 0) {
+            console_printf("invalid 'ediv' parameter\n");
+            return rc;
+        }
+
+        out->sec.rand_num = parse_arg_uint64("rand", &rc);
+        if (rc != 0) {
+            console_printf("invalid 'rand' parameter\n");
+            return rc;
+        }
+        return 0;
+
+    default:
+        return EINVAL;
+    }
+}
+
+static int
+cmd_keystore_parse_valuedata(int argc, char **argv,
+                             int obj_type,
+                             union ble_store_key *key,
+                             union ble_store_value *out)
+{
+    int rc;
+    int valcnt = 0;
+    memset(out, 0, sizeof(*out));
+
+    switch (obj_type) {
+        case BLE_STORE_OBJ_TYPE_PEER_SEC:
+        case BLE_STORE_OBJ_TYPE_OUR_SEC:
+            rc = parse_arg_byte_stream_exact_length("ltk", out->sec.ltk, 16);
+            if (rc == 0) {
+                out->sec.ltk_present = 1;
+                swap_in_place(out->sec.ltk, 16);
+                valcnt++;
+            } else if (rc != ENOENT) {
+                console_printf("invalid 'ltk' parameter\n");
+                return rc;
+            }
+            rc = parse_arg_byte_stream_exact_length("irk", out->sec.irk, 16);
+            if (rc == 0) {
+                out->sec.irk_present = 1;
+                swap_in_place(out->sec.irk, 16);
+                valcnt++;
+            } else if (rc != ENOENT) {
+                console_printf("invalid 'irk' parameter\n");
+                return rc;
+            }
+            rc = parse_arg_byte_stream_exact_length("csrk", out->sec.csrk, 16);
+            if (rc == 0) {
+                out->sec.csrk_present = 1;
+                swap_in_place(out->sec.csrk, 16);
+                valcnt++;
+            } else if (rc != ENOENT) {
+                console_printf("invalid 'csrk' parameter\n");
+                return rc;
+            }
+            out->sec.peer_addr = key->sec.peer_addr;
+            out->sec.ediv = key->sec.ediv;
+            out->sec.rand_num = key->sec.rand_num;
+            break;
+    }
+
+    if (valcnt) {
+        return 0;
+    }
+    return -1;
+}
+
+/*****************************************************************************
+ * keystore-add                                                              *
+ *****************************************************************************/
+
+static int
+cmd_keystore_add(int argc, char **argv)
+{
+    union ble_store_key key;
+    union ble_store_value value;
+    int obj_type;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = cmd_keystore_parse_keydata(argc, argv, &key, &obj_type);
+
+    if (rc) {
+        return rc;
+    }
+
+    rc = cmd_keystore_parse_valuedata(argc, argv, obj_type, &key, &value);
+
+    if (rc) {
+        return rc;
+    }
+
+    switch(obj_type) {
+        case BLE_STORE_OBJ_TYPE_PEER_SEC:
+            rc = ble_store_write_peer_sec(&value.sec);
+            break;
+        case BLE_STORE_OBJ_TYPE_OUR_SEC:
+            rc = ble_store_write_our_sec(&value.sec);
+            break;
+        case BLE_STORE_OBJ_TYPE_CCCD:
+            rc = ble_store_write_cccd(&value.cccd);
+            break;
+        default:
+            rc = ble_store_write(obj_type, &value);
+    }
+    return rc;
+}
+
+static const struct shell_param keystore_add_params[] = {
+    {"type", "entry type, usage: =<msec|ssec|cccd>"},
+    {"addr_type", "usage: =<public|random>"},
+    {"addr", "usage: =<XX:XX:XX:XX:XX:XX>"},
+    {"ediv", "usage: =<UINT16>"},
+    {"rand", "usage: =<UINT64>"},
+    {"ltk", "usage: =<XX:XX:...>, len=16 octets"},
+    {"irk", "usage: =<XX:XX:...>, len=16 octets"},
+    {"csrk", "usage: =<XX:XX:...>, len=16 octets"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help keystore_add_help = {
+    .summary = "add data to keystore",
+    .usage = NULL,
+    .params = keystore_add_params,
+};
+
+/*****************************************************************************
+ * keystore-del                                                              *
+ *****************************************************************************/
+
+static int
+cmd_keystore_del(int argc, char **argv)
+{
+    union ble_store_key key;
+    int obj_type;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = cmd_keystore_parse_keydata(argc, argv, &key, &obj_type);
+
+    if (rc) {
+        return rc;
+    }
+    rc = ble_store_delete(obj_type, &key);
+    return rc;
+}
+
+static const struct shell_param keystore_del_params[] = {
+    {"type", "entry type, usage: =<msec|ssec|cccd>"},
+    {"addr_type", "usage: =<public|random>"},
+    {"addr", "usage: =<XX:XX:XX:XX:XX:XX>"},
+    {"ediv", "usage: =<UINT16>"},
+    {"rand", "usage: =<UINT64>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help keystore_del_help = {
+    .summary = "remove data from keystore",
+    .usage = NULL,
+    .params = keystore_del_params,
+};
+
+/*****************************************************************************
+ * keystore-show                                                             *
+ *****************************************************************************/
+
+static int
+cmd_keystore_iterator(int obj_type,
+                      union ble_store_value *val,
+                      void *cookie) {
+
+    switch (obj_type) {
+        case BLE_STORE_OBJ_TYPE_PEER_SEC:
+        case BLE_STORE_OBJ_TYPE_OUR_SEC:
+            console_printf("Key: ");
+            if (ble_addr_cmp(&val->sec.peer_addr, BLE_ADDR_ANY) == 0) {
+                console_printf("ediv=%u ", val->sec.ediv);
+                console_printf("ediv=%llu ", val->sec.rand_num);
+            } else {
+                console_printf("addr_type=%u ", val->sec.peer_addr.type);
+                print_addr(val->sec.peer_addr.val);
+            }
+            console_printf("\n");
+
+            if (val->sec.ltk_present) {
+                console_printf("    LTK: ");
+                print_bytes(val->sec.ltk, 16);
+                console_printf("\n");
+            }
+            if (val->sec.irk_present) {
+                console_printf("    IRK: ");
+                print_bytes(val->sec.irk, 16);
+                console_printf("\n");
+            }
+            if (val->sec.csrk_present) {
+                console_printf("    CSRK: ");
+                print_bytes(val->sec.csrk, 16);
+                console_printf("\n");
+            }
+            break;
+    }
+    return 0;
+}
+
+static int
+cmd_keystore_show(int argc, char **argv)
+{
+    int type;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    type = parse_arg_kv("type", cmd_keystore_entry_type, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'type' parameter\n");
+        return rc;
+    }
+
+    ble_store_iterate(type, &cmd_keystore_iterator, NULL);
+    return 0;
+}
+
+static const struct shell_param keystore_show_params[] = {
+    {"type", "entry type, usage: =<msec|ssec|cccd>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help keystore_show_help = {
+    .summary = "show data in keystore",
+    .usage = NULL,
+    .params = keystore_show_params,
+};
+
+#if NIMBLE_BLE_SM
+/*****************************************************************************
+ * $auth-passkey                                                             *
+ *****************************************************************************/
+
+static int
+cmd_auth_passkey(int argc, char **argv)
+{
+#if !NIMBLE_BLE_SM
+    return BLE_HS_ENOTSUP;
+#endif
+
+    uint16_t conn_handle;
+    struct ble_sm_io pk;
+    char *yesno;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    pk.action = parse_arg_uint16("action", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'action' parameter\n");
+        return rc;
+    }
+
+    switch (pk.action) {
+        case BLE_SM_IOACT_INPUT:
+        case BLE_SM_IOACT_DISP:
+           /* passkey is 6 digit number */
+           pk.passkey = parse_arg_long_bounds("key", 0, 999999, &rc);
+           if (rc != 0) {
+               console_printf("invalid 'key' parameter\n");
+               return rc;
+           }
+           break;
+
+        case BLE_SM_IOACT_OOB:
+            rc = parse_arg_byte_stream_exact_length("oob", pk.oob, 16);
+            if (rc != 0) {
+                console_printf("invalid 'oob' parameter\n");
+                return rc;
+            }
+            break;
+
+        case BLE_SM_IOACT_NUMCMP:
+            yesno = parse_arg_extract("yesno");
+            if (yesno == NULL) {
+                console_printf("invalid 'yesno' parameter\n");
+                return EINVAL;
+            }
+
+            switch (yesno[0]) {
+            case 'y':
+            case 'Y':
+                pk.numcmp_accept = 1;
+                break;
+            case 'n':
+            case 'N':
+                pk.numcmp_accept = 0;
+                break;
+
+            default:
+                console_printf("invalid 'yesno' parameter\n");
+                return EINVAL;
+            }
+            break;
+
+       default:
+         console_printf("invalid passkey action action=%d\n", pk.action);
+         return EINVAL;
+    }
+
+    rc = ble_sm_inject_io(conn_handle, &pk);
+    if (rc != 0) {
+        console_printf("error providing passkey; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param auth_passkey_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"action", "auth action type, usage: =<UINT16>"},
+    {"key", "usage: =[0-999999]"},
+    {"oob", "usage: =[XX:XX...], len=16 octets"},
+    {"yesno", "usage: =[string]"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help auth_passkey_help = {
+    .summary = "set authorization passkey options",
+    .usage = NULL,
+    .params = auth_passkey_params,
+};
+
+/*****************************************************************************
+ * $security-pair                                                            *
+ *****************************************************************************/
+
+static int
+cmd_security_pair(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_sec_pair(conn_handle);
+    if (rc != 0) {
+        console_printf("error initiating pairing; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param security_pair_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help security_pair_help = {
+    .summary = "start pairing procedure for connection",
+    .usage = NULL,
+    .params = security_pair_params,
+};
+
+/*****************************************************************************
+ * $security-start                                                           *
+ *****************************************************************************/
+
+static int
+cmd_security_start(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_sec_start(conn_handle);
+    if (rc != 0) {
+        console_printf("error starting security; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param security_start_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help security_start_help = {
+    .summary = "start security procedure for connection",
+    .usage = NULL,
+    .params = security_start_params,
+};
+
+/*****************************************************************************
+ * $security-encryption                                                      *
+ *****************************************************************************/
+
+static int
+cmd_security_encryption(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    uint16_t ediv;
+    uint64_t rand_val;
+    uint8_t ltk[16];
+    int rc;
+    int auth;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    ediv = parse_arg_uint16("ediv", &rc);
+    if (rc == ENOENT) {
+        rc = bletiny_sec_restart(conn_handle, NULL, 0, 0, 0);
+    } else {
+        rand_val = parse_arg_uint64("rand", &rc);
+        if (rc != 0) {
+            console_printf("invalid 'rand' parameter\n");
+            return rc;
+        }
+
+        auth = parse_arg_bool("auth", &rc);
+        if (rc != 0) {
+            console_printf("invalid 'auth' parameter\n");
+            return rc;
+        }
+
+        rc = parse_arg_byte_stream_exact_length("ltk", ltk, 16);
+        if (rc != 0) {
+            console_printf("invalid 'ltk' parameter\n");
+            return rc;
+        }
+
+        rc = bletiny_sec_restart(conn_handle, ltk, ediv, rand_val, auth);
+    }
+
+    if (rc != 0) {
+        console_printf("error initiating encryption; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+static const struct shell_param security_encryption_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"ediv", "usage: =[UINT16]"},
+    {"rand", "usage: =[UINT64]"},
+    {"auth", "usage: =[0-1]"},
+    {"ltk", "usage: =[XX:XX...], len=16 octets"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help security_encryption_help = {
+    .summary = "start encryption procedure for connection",
+    .usage = NULL,
+    .params = security_encryption_params,
+};
+
+/*****************************************************************************
+ * $security-set-data                                                        *
+ *****************************************************************************/
+
+static int
+cmd_security_set_data(int argc, char **argv)
+{
+    uint8_t tmp;
+    int good;
+    int rc;
+
+    good = 0;
+
+    tmp = parse_arg_bool("oob_flag", &rc);
+    if (rc == 0) {
+        ble_hs_cfg.sm_oob_data_flag = tmp;
+        good++;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'oob_flag' parameter\n");
+        return rc;
+    }
+
+    tmp = parse_arg_bool("mitm_flag", &rc);
+    if (rc == 0) {
+        good++;
+        ble_hs_cfg.sm_mitm = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'mitm_flag' parameter\n");
+        return rc;
+    }
+
+    tmp = parse_arg_uint8("io_capabilities", &rc);
+    if (rc == 0) {
+        good++;
+        ble_hs_cfg.sm_io_cap = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'io_capabilities' parameter\n");
+        return rc;
+    }
+
+    tmp = parse_arg_uint8("our_key_dist", &rc);
+    if (rc == 0) {
+        good++;
+        ble_hs_cfg.sm_our_key_dist = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'our_key_dist' parameter\n");
+        return rc;
+    }
+
+    tmp = parse_arg_uint8("their_key_dist", &rc);
+    if (rc == 0) {
+        good++;
+        ble_hs_cfg.sm_their_key_dist = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'their_key_dist' parameter\n");
+        return rc;
+    }
+
+    tmp = parse_arg_bool("bonding", &rc);
+    if (rc == 0) {
+        good++;
+        ble_hs_cfg.sm_bonding = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'bonding' parameter\n");
+        return rc;
+    }
+
+    tmp = parse_arg_bool("sc", &rc);
+    if (rc == 0) {
+        good++;
+        ble_hs_cfg.sm_sc = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'sc' parameter\n");
+        return rc;
+    }
+
+    if (!good) {
+        console_printf("Error: no valid settings specified\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+static const struct shell_param security_set_data_params[] = {
+    {"oob_flag", "usage: =[0-1]"},
+    {"mitm_flag", "usage: =[0-1]"},
+    {"io_capabilities", "usage: =[UINT8]"},
+    {"our_key_dist", "usage: =[UINT8]"},
+    {"their_key_dist", "usage: =[UINT8]"},
+    {"bonding", "usage: =[0-1]"},
+    {"sc", "usage: =[0-1]"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help security_set_data_help = {
+    .summary = "set security data",
+    .usage = NULL,
+    .params = security_set_data_params,
+};
+#endif
+
+/*****************************************************************************
+ * $test-tx                                                                  *
+ *                                                                           *
+ * Command to transmit 'num' packets of size 'len' at rate 'r' to
+ * handle 'h' Note that length must be <= 251. The rate is in msecs.
+ *
+ *****************************************************************************/
+
+static int
+cmd_test_tx(int argc, char **argv)
+{
+    int rc;
+    uint16_t rate;
+    uint16_t len;
+    uint16_t handle;
+    uint16_t num;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rate = parse_arg_uint16("rate", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'rate' parameter\n");
+        return rc;
+    }
+
+    len = parse_arg_uint16("length", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'length' parameter\n");
+        return rc;
+    }
+    if ((len > 251) || (len < 4)) {
+        console_printf("error: len must be between 4 and 251, inclusive");
+    }
+
+    num = parse_arg_uint16("num", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'num' parameter\n");
+        return rc;
+    }
+
+    handle = parse_arg_uint16("handle", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'handle' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_tx_start(handle, len, rate, num);
+    return rc;
+}
+
+static const struct shell_param test_tx_params[] = {
+    {"num", "number of packets, usage: =<UINT16>"},
+    {"length", "size of packet, usage: =<UINT16>"},
+    {"rate", "rate of tx, usage: =<UINT16>"},
+    {"handle", "handle to tx to, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help test_tx_help = {
+    .summary = "test packet transmission",
+    .usage = NULL,
+    .params = test_tx_params,
+};
+
+/*****************************************************************************
+ * $gatt-discover                                                            *
+ *****************************************************************************/
+
+static const struct shell_param gatt_discover_characteristic_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"uuid", "discover by uuid, usage: =[UUID]"},
+    {"start", "start handle, usage: =<UINT16>"},
+    {"end", "end handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_discover_characteristic_help = {
+    .summary = "perform characteristic discovery procedure",
+    .usage = NULL,
+    .params = gatt_discover_characteristic_params,
+};
+
+static const struct shell_param gatt_discover_descriptor_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"start", "start handle, usage: =<UINT16>"},
+    {"end", "end handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_discover_descriptor_help = {
+    .summary = "perform descriptor discovery procedure",
+    .usage = NULL,
+    .params = gatt_discover_descriptor_params,
+};
+
+static const struct shell_param gatt_discover_service_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"uuid", "discover by uuid, usage: =[UUID]"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_discover_service_help = {
+    .summary = "perform service discovery procedure",
+    .usage = NULL,
+    .params = gatt_discover_service_params,
+};
+
+static const struct shell_param gatt_discover_full_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_discover_full_help = {
+    .summary = "perform full discovery procedure",
+    .usage = NULL,
+    .params = gatt_discover_full_params,
+};
+
+/*****************************************************************************
+ * $gatt-exchange-mtu                                                        *
+ *****************************************************************************/
+
+static const struct shell_param gatt_exchange_mtu_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_exchange_mtu_help = {
+    .summary = "perform mtu exchange procedure",
+    .usage = NULL,
+    .params = gatt_exchange_mtu_params,
+};
+
+/*****************************************************************************
+ * $gatt-find-included-services                                              *
+ *****************************************************************************/
+
+static const struct shell_param gatt_find_included_services_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"start", "start handle, usage: =<UINT16>"},
+    {"end", "end handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_find_included_services_help = {
+    .summary = "perform find included services procedure",
+    .usage = NULL,
+    .params = gatt_find_included_services_params,
+};
+
+/*****************************************************************************
+ * $gatt-notify                                                                *
+ *****************************************************************************/
+
+static const struct shell_param gatt_notify_params[] = {
+    {"attr", "attribute handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_notify_help = {
+    .summary = "notify about attribute value changed",
+    .usage = NULL,
+    .params = gatt_notify_params,
+};
+
+/*****************************************************************************
+ * $gatt-read                                                                *
+ *****************************************************************************/
+
+static const struct shell_param gatt_read_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"long", "is read long, usage: =[0-1], default=0"},
+    {"attr", "attribute handle, usage: =<UINT16>"},
+    {"offset", "attribute handle, usage: =<UINT16>"},
+    {"uuid", "read by uuid, usage: =[UUID]"},
+    {"start", "start handle, usage: =<UINT16>"},
+    {"end", "end handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_read_help = {
+    .summary = "perform gatt read procedure",
+    .usage = NULL,
+    .params = gatt_read_params,
+};
+
+/*****************************************************************************
+ * $gatt-service-changed                                                     *
+ *****************************************************************************/
+
+static const struct shell_param gatt_service_changed_params[] = {
+    {"start", "start handle, usage: =<UINT16>"},
+    {"end", "end handle, usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_service_changed_help = {
+    .summary = "send service changed indication",
+    .usage = NULL,
+    .params = gatt_service_changed_params,
+};
+
+/*****************************************************************************
+ * $gatt-show                                                                *
+ *****************************************************************************/
+
+static const struct shell_param gatt_show_params[] = {
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_show_help = {
+    .summary = "show discovered gatt database",
+    .usage = NULL,
+    .params = gatt_show_params,
+};
+
+static const struct shell_cmd_help gatt_show_local_help = {
+    .summary = "show local gatt database",
+    .usage = NULL,
+    .params = gatt_show_params,
+};
+
+static const struct shell_cmd_help gatt_show_addr_help = {
+    .summary = "show device address",
+    .usage = NULL,
+    .params = gatt_show_params,
+};
+
+static const struct shell_cmd_help gatt_show_conn_help = {
+    .summary = "show connections information",
+    .usage = NULL,
+    .params = gatt_show_params,
+};
+
+static const struct shell_cmd_help gatt_show_coc_help = {
+    .summary = "show coc information",
+    .usage = NULL,
+    .params = gatt_show_params,
+};
+
+/*****************************************************************************
+ * $gatt-write                                                                *
+ *****************************************************************************/
+
+static const struct shell_param gatt_write_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"no_rsp", "write without response, usage: =[0-1], default=0"},
+    {"long", "is write long, usage: =[0-1], default=0"},
+    {"attr", "attribute handle, usage: =<UINT16>"},
+    {"offset", "attribute handle, usage: =<UINT16>"},
+    {"value", "usage: =<octets>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help gatt_write_help = {
+    .summary = "perform gatt write procedure",
+    .usage = NULL,
+    .params = gatt_write_params,
+};
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM)
+/*****************************************************************************
+ * $l2cap-update                                                             *
+ *****************************************************************************/
+
+static const struct shell_param l2cap_update_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"interval_min", "usage: =[0-UINT16_MAX], default: 30"},
+    {"interval_max", "usage: =[0-UINT16_MAX], default: 50"},
+    {"latency", "usage: =[UINT16], default: 0"},
+    {"timeout", "usage: =[UINT16], default: 0x0100"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help l2cap_update_help = {
+    .summary = "update l2cap parameters for connection",
+    .usage = NULL,
+    .params = l2cap_update_params,
+};
+
+/*****************************************************************************
+ * $l2cap-create-server                                                      *
+ *****************************************************************************/
+
+static const struct shell_param l2cap_create_server_params[] = {
+    {"psm", "usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help l2cap_create_server_help = {
+    .summary = "create l2cap server",
+    .usage = NULL,
+    .params = l2cap_create_server_params,
+};
+
+/*****************************************************************************
+ * $l2cap-connect                                                            *
+ *****************************************************************************/
+
+static const struct shell_param l2cap_connect_params[] = {
+    {"conn", "connection handle, usage: =<UINT16>"},
+    {"psm", "usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help l2cap_connect_help = {
+    .summary = "perform l2cap connect procedure",
+    .usage = NULL,
+    .params = l2cap_connect_params,
+};
+
+/*****************************************************************************
+ * $l2cap-disconnect                                                         *
+ *****************************************************************************/
+
+static const struct shell_param l2cap_disconnect_params[] = {
+    {"conn", "disconnection handle, usage: =<UINT16>"},
+    {"idx", "usage: =<UINT16>"},
+    {NULL, NULL}
+};
+
+static const struct shell_cmd_help l2cap_disconnect_help = {
+    .summary = "perform l2cap disconnect procedure",
+    .usage = "use show-coc to get the parameters",
+    .params = l2cap_disconnect_params,
+};
+
+#endif
+
+static const struct shell_cmd btshell_commands[] = {
+    {
+        .sc_cmd = "advertise",
+        .sc_cmd_func = cmd_advertise,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &advertise_help,
+#endif
+    },
+    {
+        .sc_cmd = "connect",
+        .sc_cmd_func = cmd_connect,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &connect_help,
+#endif
+    },
+    {
+        .sc_cmd = "disconnect",
+        .sc_cmd_func = cmd_disconnect,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &disconnect_help,
+#endif
+    },
+    {
+        .sc_cmd = "scan",
+        .sc_cmd_func = cmd_scan,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &scan_help,
+#endif
+    },
+    {
+        .sc_cmd = "set",
+        .sc_cmd_func = cmd_set,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &set_help,
+#endif
+    },
+    {
+        .sc_cmd = "set-adv-data",
+        .sc_cmd_func = cmd_set_adv_data,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &set_adv_data_help,
+#endif
+    },
+    {
+        .sc_cmd = "white-list",
+        .sc_cmd_func = cmd_white_list,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &white_list_help,
+#endif
+    },
+    {
+        .sc_cmd = "conn-rssi",
+        .sc_cmd_func = cmd_conn_rssi,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &conn_rssi_help,
+#endif
+    },
+    {
+        .sc_cmd = "conn-update-params",
+        .sc_cmd_func = cmd_conn_update_params,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &conn_update_params_help,
+#endif
+    },
+    {
+        .sc_cmd = "conn-datalen",
+        .sc_cmd_func = cmd_conn_datalen,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &conn_datalen_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-discover-characteristic",
+        .sc_cmd_func = cmd_gatt_discover_characteristic,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_discover_characteristic_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-discover-descriptor",
+        .sc_cmd_func = cmd_gatt_discover_descriptor,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_discover_descriptor_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-discover-service",
+        .sc_cmd_func = cmd_gatt_discover_service,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_discover_service_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-discover-full",
+        .sc_cmd_func = cmd_gatt_discover_full,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_discover_full_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-find-included-services",
+        .sc_cmd_func = cmd_gatt_find_included_services,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_find_included_services_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-exchange-mtu",
+        .sc_cmd_func = cmd_gatt_exchange_mtu,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_exchange_mtu_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-read",
+        .sc_cmd_func = cmd_gatt_read,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_read_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-notify",
+        .sc_cmd_func = cmd_gatt_notify,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_notify_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-service-changed",
+        .sc_cmd_func = cmd_gatt_service_changed,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_service_changed_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-show",
+        .sc_cmd_func = cmd_gatt_show,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_show_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-show-local",
+        .sc_cmd_func = cmd_gatt_show_local,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_show_local_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-show-addr",
+        .sc_cmd_func = cmd_gatt_show_addr,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_show_addr_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-show-conn",
+        .sc_cmd_func = cmd_gatt_show_conn,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_show_conn_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-show-coc",
+        .sc_cmd_func = cmd_gatt_show_coc,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_show_coc_help,
+#endif
+    },
+    {
+        .sc_cmd = "gatt-write",
+        .sc_cmd_func = cmd_gatt_write,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &gatt_write_help,
+#endif
+    },
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM)
+    {
+        .sc_cmd = "l2cap-update",
+        .sc_cmd_func = cmd_l2cap_update,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &l2cap_update_help,
+#endif
+    },
+    {
+        .sc_cmd = "l2cap-create-server",
+        .sc_cmd_func = cmd_l2cap_create_server,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &l2cap_create_server_help,
+#endif
+    },
+    {
+        .sc_cmd = "l2cap-connect",
+        .sc_cmd_func = cmd_l2cap_connect,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &l2cap_connect_help,
+#endif
+    },
+    {
+        .sc_cmd = "l2cap-disconnect",
+        .sc_cmd_func = cmd_l2cap_disconnect,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &l2cap_disconnect_help,
+#endif
+    },
+#endif
+    {
+        .sc_cmd = "keystore-add",
+        .sc_cmd_func = cmd_keystore_add,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &keystore_add_help,
+#endif
+    },
+    {
+        .sc_cmd = "keystore-del",
+        .sc_cmd_func = cmd_keystore_del,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &keystore_del_help,
+#endif
+    },
+    {
+        .sc_cmd = "keystore-show",
+        .sc_cmd_func = cmd_keystore_show,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &keystore_show_help,
+#endif
+    },
+#if NIMBLE_BLE_SM
+    {
+        .sc_cmd = "auth-passkey",
+        .sc_cmd_func = cmd_auth_passkey,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &auth_passkey_help,
+#endif
+    },
+    {
+        .sc_cmd = "security-pair",
+        .sc_cmd_func = cmd_security_pair,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &security_pair_help,
+#endif
+    },
+    {
+        .sc_cmd = "security-start",
+        .sc_cmd_func = cmd_security_start,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &security_start_help,
+#endif
+    },
+    {
+        .sc_cmd = "security-encryption",
+        .sc_cmd_func = cmd_security_encryption,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &security_encryption_help,
+#endif
+    },
+    {
+        .sc_cmd = "security-set-data",
+        .sc_cmd_func = cmd_security_set_data,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &security_set_data_help,
+#endif
+    },
+#endif
+    {
+        .sc_cmd = "test-tx",
+        .sc_cmd_func = cmd_test_tx,
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+        .help = &test_tx_help,
+#endif
+    },
+    { NULL, NULL, NULL },
+};
+
+
+void
+cmd_init(void)
+{
+    shell_register(BTSHELL_MODULE, btshell_commands);
+    shell_register_default_module(BTSHELL_MODULE);
+}

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -41,7 +41,7 @@
 #include "shell/shell.h"
 
 #include "cmd.h"
-#include "bletiny.h"
+#include "btshell.h"
 #include "cmd_gatt.h"
 #include "cmd_l2cap.h"
 
@@ -138,7 +138,7 @@ cmd_advertise(int argc, char **argv)
     }
 
     if (argc > 1 && strcmp(argv[1], "stop") == 0) {
-        rc = bletiny_adv_stop();
+        rc = btshell_adv_stop();
         if (rc != 0) {
             console_printf("advertise stop fail: %d\n", rc);
             return rc;
@@ -224,7 +224,7 @@ cmd_advertise(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_adv_start(own_addr_type, peer_addr_param, duration_ms,
+    rc = btshell_adv_start(own_addr_type, peer_addr_param, duration_ms,
                            &params);
     if (rc != 0) {
         console_printf("advertise fail: %d\n", rc);
@@ -276,7 +276,7 @@ cmd_connect(int argc, char **argv)
     }
 
     if (argc > 1 && strcmp(argv[1], "cancel") == 0) {
-        rc = bletiny_conn_cancel();
+        rc = btshell_conn_cancel();
         if (rc != 0) {
             console_printf("connection cancel fail: %d\n", rc);
             return rc;
@@ -369,7 +369,7 @@ cmd_connect(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_conn_initiate(own_addr_type, peer_addr_param, duration_ms,
+    rc = btshell_conn_initiate(own_addr_type, peer_addr_param, duration_ms,
                                &params);
     if (rc != 0) {
         console_printf("error connecting; rc=%d\n", rc);
@@ -431,7 +431,7 @@ cmd_disconnect(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_term_conn(conn_handle, reason);
+    rc = btshell_term_conn(conn_handle, reason);
     if (rc != 0) {
         console_printf("error terminating connection; rc=%d\n", rc);
         return rc;
@@ -478,7 +478,7 @@ cmd_scan(int argc, char **argv)
     }
 
     if (argc > 1 && strcmp(argv[1], "cancel") == 0) {
-        rc = bletiny_scan_cancel();
+        rc = btshell_scan_cancel();
         if (rc != 0) {
             console_printf("connection cancel fail: %d\n", rc);
             return rc;
@@ -537,7 +537,7 @@ cmd_scan(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_scan(own_addr_type, duration_ms, &params);
+    rc = btshell_scan(own_addr_type, duration_ms, &params);
     if (rc != 0) {
         console_printf("error scanning; rc=%d\n", rc);
         return rc;
@@ -965,7 +965,7 @@ cmd_set_adv_data(int argc, char **argv)
                                             eddystone_url_body_len,
                                             eddystone_url_suffix);
     } else {
-        rc = bletiny_set_adv_data(&adv_fields);
+        rc = btshell_set_adv_data(&adv_fields);
     }
     if (rc != 0) {
         console_printf("error setting advertisement data; rc=%d\n", rc);
@@ -1049,7 +1049,7 @@ cmd_white_list(int argc, char **argv)
         return EINVAL;
     }
 
-    bletiny_wl_set(addrs, addrs_cnt);
+    btshell_wl_set(addrs, addrs_cnt);
 
     return 0;
 }
@@ -1088,7 +1088,7 @@ cmd_conn_rssi(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_rssi(conn_handle, &rssi);
+    rc = btshell_rssi(conn_handle, &rssi);
     if (rc != 0) {
         console_printf("error reading rssi; rc=%d\n", rc);
         return rc;
@@ -1170,7 +1170,7 @@ cmd_conn_update_params(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_update_conn(conn_handle, &params);
+    rc = btshell_update_conn(conn_handle, &params);
     if (rc != 0) {
         console_printf("error updating connection; rc=%d\n", rc);
         return rc;
@@ -1231,7 +1231,7 @@ cmd_conn_datalen(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_datalen(conn_handle, tx_octets, tx_time);
+    rc = btshell_datalen(conn_handle, tx_octets, tx_time);
     if (rc != 0) {
         console_printf("error setting data length; rc=%d\n", rc);
         return rc;
@@ -1665,7 +1665,7 @@ cmd_security_pair(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_sec_pair(conn_handle);
+    rc = btshell_sec_pair(conn_handle);
     if (rc != 0) {
         console_printf("error initiating pairing; rc=%d\n", rc);
         return rc;
@@ -1706,7 +1706,7 @@ cmd_security_start(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_sec_start(conn_handle);
+    rc = btshell_sec_start(conn_handle);
     if (rc != 0) {
         console_printf("error starting security; rc=%d\n", rc);
         return rc;
@@ -1753,7 +1753,7 @@ cmd_security_encryption(int argc, char **argv)
 
     ediv = parse_arg_uint16("ediv", &rc);
     if (rc == ENOENT) {
-        rc = bletiny_sec_restart(conn_handle, NULL, 0, 0, 0);
+        rc = btshell_sec_restart(conn_handle, NULL, 0, 0, 0);
     } else {
         rand_val = parse_arg_uint64("rand", &rc);
         if (rc != 0) {
@@ -1773,7 +1773,7 @@ cmd_security_encryption(int argc, char **argv)
             return rc;
         }
 
-        rc = bletiny_sec_restart(conn_handle, ltk, ediv, rand_val, auth);
+        rc = btshell_sec_restart(conn_handle, ltk, ediv, rand_val, auth);
     }
 
     if (rc != 0) {
@@ -1950,7 +1950,7 @@ cmd_test_tx(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_tx_start(handle, len, rate, num);
+    rc = btshell_tx_start(handle, len, rate, num);
     return rc;
 }
 

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -36,6 +36,7 @@
 #include "services/gatt/ble_svc_gatt.h"
 #include "../src/ble_hs_priv.h"
 
+#include "parse/parse.h"
 #include "console/console.h"
 #include "shell/shell.h"
 
@@ -651,7 +652,7 @@ cmd_set(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream_exact_length("irk", irk, 16);
+    rc = parse_byte_stream_exact_length("irk", irk, 16);
     if (rc == 0) {
         good = 1;
         ble_hs_pvcy_set_our_irk(irk);
@@ -804,7 +805,7 @@ cmd_set_adv_data(int argc, char **argv)
     }
 
     while (1) {
-        rc = parse_arg_byte_stream_exact_length("uuid128", uuid128, 16);
+        rc = parse_byte_stream_exact_length("uuid128", uuid128, 16);
         if (rc == 0) {
             if (adv_fields.num_uuids128 >= CMD_ADV_DATA_MAX_UUIDS128) {
                 console_printf("invalid 'uuid128' parameter\n");
@@ -846,9 +847,9 @@ cmd_set_adv_data(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream_exact_length("slave_interval_range",
-                                            slave_itvl_range,
-                                            BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
+    rc = parse_byte_stream_exact_length("slave_interval_range",
+                                        slave_itvl_range,
+                                        BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
     if (rc == 0) {
         adv_fields.slave_itvl_range = slave_itvl_range;
     } else if (rc != ENOENT) {
@@ -856,9 +857,9 @@ cmd_set_adv_data(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream("service_data_uuid16",
-                               CMD_ADV_DATA_SVC_DATA_UUID16_MAX_LEN,
-                               svc_data_uuid16, &svc_data_uuid16_len);
+    rc = parse_byte_stream("service_data_uuid16",
+                           CMD_ADV_DATA_SVC_DATA_UUID16_MAX_LEN,
+                           svc_data_uuid16, &svc_data_uuid16_len);
     if (rc == 0) {
         adv_fields.svc_data_uuid16 = svc_data_uuid16;
         adv_fields.svc_data_uuid16_len = svc_data_uuid16_len;
@@ -868,7 +869,7 @@ cmd_set_adv_data(int argc, char **argv)
     }
 
     while (1) {
-        rc = parse_arg_byte_stream_exact_length(
+        rc = parse_byte_stream_exact_length(
             "public_target_address", public_tgt_addr,
             BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN);
         if (rc == 0) {
@@ -908,9 +909,9 @@ cmd_set_adv_data(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream("service_data_uuid32",
-                               CMD_ADV_DATA_SVC_DATA_UUID32_MAX_LEN,
-                               svc_data_uuid32, &svc_data_uuid32_len);
+    rc = parse_byte_stream("service_data_uuid32",
+                           CMD_ADV_DATA_SVC_DATA_UUID32_MAX_LEN,
+                           svc_data_uuid32, &svc_data_uuid32_len);
     if (rc == 0) {
         adv_fields.svc_data_uuid32 = svc_data_uuid32;
         adv_fields.svc_data_uuid32_len = svc_data_uuid32_len;
@@ -919,9 +920,9 @@ cmd_set_adv_data(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream("service_data_uuid128",
-                               CMD_ADV_DATA_SVC_DATA_UUID128_MAX_LEN,
-                               svc_data_uuid128, &svc_data_uuid128_len);
+    rc = parse_byte_stream("service_data_uuid128",
+                           CMD_ADV_DATA_SVC_DATA_UUID128_MAX_LEN,
+                           svc_data_uuid128, &svc_data_uuid128_len);
     if (rc == 0) {
         adv_fields.svc_data_uuid128 = svc_data_uuid128;
         adv_fields.svc_data_uuid128_len = svc_data_uuid128_len;
@@ -930,7 +931,7 @@ cmd_set_adv_data(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream("uri", CMD_ADV_DATA_URI_MAX_LEN, uri, &uri_len);
+    rc = parse_byte_stream("uri", CMD_ADV_DATA_URI_MAX_LEN, uri, &uri_len);
     if (rc == 0) {
         adv_fields.uri = uri;
         adv_fields.uri_len = uri_len;
@@ -939,8 +940,8 @@ cmd_set_adv_data(int argc, char **argv)
         return rc;
     }
 
-    rc = parse_arg_byte_stream("mfg_data", CMD_ADV_DATA_MFG_DATA_MAX_LEN,
-                               mfg_data, &mfg_data_len);
+    rc = parse_byte_stream("mfg_data", CMD_ADV_DATA_MFG_DATA_MAX_LEN,
+                           mfg_data, &mfg_data_len);
     if (rc == 0) {
         adv_fields.mfg_data = mfg_data;
         adv_fields.mfg_data_len = mfg_data_len;
@@ -1322,7 +1323,7 @@ cmd_keystore_parse_valuedata(int argc, char **argv,
     switch (obj_type) {
         case BLE_STORE_OBJ_TYPE_PEER_SEC:
         case BLE_STORE_OBJ_TYPE_OUR_SEC:
-            rc = parse_arg_byte_stream_exact_length("ltk", out->sec.ltk, 16);
+            rc = parse_byte_stream_exact_length("ltk", out->sec.ltk, 16);
             if (rc == 0) {
                 out->sec.ltk_present = 1;
                 swap_in_place(out->sec.ltk, 16);
@@ -1331,7 +1332,7 @@ cmd_keystore_parse_valuedata(int argc, char **argv,
                 console_printf("invalid 'ltk' parameter\n");
                 return rc;
             }
-            rc = parse_arg_byte_stream_exact_length("irk", out->sec.irk, 16);
+            rc = parse_byte_stream_exact_length("irk", out->sec.irk, 16);
             if (rc == 0) {
                 out->sec.irk_present = 1;
                 swap_in_place(out->sec.irk, 16);
@@ -1340,7 +1341,7 @@ cmd_keystore_parse_valuedata(int argc, char **argv,
                 console_printf("invalid 'irk' parameter\n");
                 return rc;
             }
-            rc = parse_arg_byte_stream_exact_length("csrk", out->sec.csrk, 16);
+            rc = parse_byte_stream_exact_length("csrk", out->sec.csrk, 16);
             if (rc == 0) {
                 out->sec.csrk_present = 1;
                 swap_in_place(out->sec.csrk, 16);
@@ -1584,7 +1585,7 @@ cmd_auth_passkey(int argc, char **argv)
            break;
 
         case BLE_SM_IOACT_OOB:
-            rc = parse_arg_byte_stream_exact_length("oob", pk.oob, 16);
+            rc = parse_byte_stream_exact_length("oob", pk.oob, 16);
             if (rc != 0) {
                 console_printf("invalid 'oob' parameter\n");
                 return rc;
@@ -1766,7 +1767,7 @@ cmd_security_encryption(int argc, char **argv)
             return rc;
         }
 
-        rc = parse_arg_byte_stream_exact_length("ltk", ltk, 16);
+        rc = parse_byte_stream_exact_length("ltk", ltk, 16);
         if (rc != 0) {
             console_printf("invalid 'ltk' parameter\n");
             return rc;

--- a/apps/btshell/src/cmd.h
+++ b/apps/btshell/src/cmd.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CMD_H
+#define CMD_H
+
+#include <inttypes.h>
+#include "host/ble_uuid.h"
+
+typedef int cmd_fn(int argc, char **argv);
+struct cmd_entry {
+    char *name;
+    cmd_fn *cb;
+};
+
+struct kv_pair {
+    char *key;
+    int val;
+};
+
+const struct cmd_entry *parse_cmd_find(const struct cmd_entry *cmds,
+                                       char *name);
+struct kv_pair *parse_kv_find(struct kv_pair *kvs, char *name);
+int parse_arg_find_idx(const char *key);
+char *parse_arg_extract(const char *key);
+long parse_arg_long_bounds(char *name, long min, long max, int *out_status);
+long parse_arg_long_bounds_default(char *name, long min, long max,
+                                   long dflt, int *out_status);
+uint64_t parse_arg_uint64_bounds(char *name, uint64_t min,
+                                 uint64_t max, int *out_status);
+long parse_arg_long(char *name, int *staus);
+uint8_t parse_arg_bool(char *name, int *status);
+uint8_t parse_arg_bool_default(char *name, uint8_t dflt, int *out_status);
+uint8_t parse_arg_uint8(char *name, int *status);
+uint8_t parse_arg_uint8_dflt(char *name, uint8_t dflt, int *out_status);
+uint16_t parse_arg_uint16(char *name, int *status);
+uint16_t parse_arg_uint16_dflt(char *name, uint16_t dflt, int *out_status);
+uint32_t parse_arg_uint32(char *name, int *out_status);
+uint32_t parse_arg_uint32_dflt(char *name, uint32_t dflt, int *out_status);
+uint64_t parse_arg_uint64(char *name, int *out_status);
+int parse_arg_kv(char *name, struct kv_pair *kvs, int *out_status);
+int parse_arg_kv_default(char *name, struct kv_pair *kvs, int def_val,
+                         int *out_status);
+int parse_arg_byte_stream(char *name, int max_len, uint8_t *dst, int *out_len);
+int parse_arg_byte_stream_exact_length(char *name, uint8_t *dst, int len);
+int parse_arg_mac(char *name, uint8_t *dst);
+int parse_arg_uuid(char *name, ble_uuid_any_t *uuid);
+int parse_err_too_few_args(char *cmd_name);
+int parse_arg_all(int argc, char **argv);
+int parse_eddystone_url(char *full_url, uint8_t *out_scheme, char *out_body,
+                        uint8_t *out_body_len, uint8_t *out_suffix);
+int cmd_parse_conn_start_end(uint16_t *out_conn, uint16_t *out_start,
+                             uint16_t *out_end);
+
+void cmd_init(void);
+
+#endif

--- a/apps/btshell/src/cmd.h
+++ b/apps/btshell/src/cmd.h
@@ -36,7 +36,7 @@ struct kv_pair {
 
 const struct cmd_entry *parse_cmd_find(const struct cmd_entry *cmds,
                                        char *name);
-struct kv_pair *parse_kv_find(struct kv_pair *kvs, char *name);
+const struct kv_pair *parse_kv_find(const struct kv_pair *kvs, char *name);
 int parse_arg_find_idx(const char *key);
 char *parse_arg_extract(const char *key);
 long parse_arg_long_bounds(char *name, long min, long max, int *out_status);
@@ -54,8 +54,8 @@ uint16_t parse_arg_uint16_dflt(char *name, uint16_t dflt, int *out_status);
 uint32_t parse_arg_uint32(char *name, int *out_status);
 uint32_t parse_arg_uint32_dflt(char *name, uint32_t dflt, int *out_status);
 uint64_t parse_arg_uint64(char *name, int *out_status);
-int parse_arg_kv(char *name, struct kv_pair *kvs, int *out_status);
-int parse_arg_kv_default(char *name, struct kv_pair *kvs, int def_val,
+int parse_arg_kv(char *name, const struct kv_pair *kvs, int *out_status);
+int parse_arg_kv_default(char *name, const struct kv_pair *kvs, int def_val,
                          int *out_status);
 int parse_arg_byte_stream(char *name, int max_len, uint8_t *dst, int *out_len);
 int parse_arg_byte_stream_exact_length(char *name, uint8_t *dst, int len);

--- a/apps/btshell/src/cmd.h
+++ b/apps/btshell/src/cmd.h
@@ -23,19 +23,11 @@
 #include <inttypes.h>
 #include "host/ble_uuid.h"
 
-typedef int cmd_fn(int argc, char **argv);
-struct cmd_entry {
-    char *name;
-    cmd_fn *cb;
-};
-
 struct kv_pair {
     char *key;
     int val;
 };
 
-const struct cmd_entry *parse_cmd_find(const struct cmd_entry *cmds,
-                                       char *name);
 const struct kv_pair *parse_kv_find(const struct kv_pair *kvs, char *name);
 int parse_arg_find_idx(const char *key);
 char *parse_arg_extract(const char *key);
@@ -61,7 +53,6 @@ int parse_arg_byte_stream(char *name, int max_len, uint8_t *dst, int *out_len);
 int parse_arg_byte_stream_exact_length(char *name, uint8_t *dst, int len);
 int parse_arg_mac(char *name, uint8_t *dst);
 int parse_arg_uuid(char *name, ble_uuid_any_t *uuid);
-int parse_err_too_few_args(char *cmd_name);
 int parse_arg_all(int argc, char **argv);
 int parse_eddystone_url(char *full_url, uint8_t *out_scheme, char *out_body,
                         uint8_t *out_body_len, uint8_t *out_suffix);

--- a/apps/btshell/src/cmd.h
+++ b/apps/btshell/src/cmd.h
@@ -49,8 +49,6 @@ uint64_t parse_arg_uint64(char *name, int *out_status);
 int parse_arg_kv(char *name, const struct kv_pair *kvs, int *out_status);
 int parse_arg_kv_default(char *name, const struct kv_pair *kvs, int def_val,
                          int *out_status);
-int parse_arg_byte_stream(char *name, int max_len, uint8_t *dst, int *out_len);
-int parse_arg_byte_stream_exact_length(char *name, uint8_t *dst, int len);
 int parse_arg_mac(char *name, uint8_t *dst);
 int parse_arg_uuid(char *name, ble_uuid_any_t *uuid);
 int parse_arg_all(int argc, char **argv);

--- a/apps/btshell/src/cmd_gatt.c
+++ b/apps/btshell/src/cmd_gatt.c
@@ -25,6 +25,7 @@
 #include "host/ble_gap.h"
 #include "services/gatt/ble_svc_gatt.h"
 #include "console/console.h"
+#include "parse/parse.h"
 #include "bletiny.h"
 #include "cmd.h"
 #include "cmd_gatt.h"
@@ -561,8 +562,8 @@ cmd_gatt_write(int argc, char **argv)
             goto done;
         }
 
-        rc = parse_arg_byte_stream("value", sizeof cmd_buf - total_attr_len,
-                                   cmd_buf + total_attr_len, &attr_len);
+        rc = parse_byte_stream("value", sizeof cmd_buf - total_attr_len,
+                               cmd_buf + total_attr_len, &attr_len);
         if (rc == ENOENT) {
             break;
         } else if (rc != 0) {

--- a/apps/btshell/src/cmd_gatt.c
+++ b/apps/btshell/src/cmd_gatt.c
@@ -1,0 +1,632 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <errno.h>
+
+#include "bsp/bsp.h"
+#include "host/ble_hs_mbuf.h"
+#include "host/ble_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
+#include "console/console.h"
+#include "bletiny.h"
+#include "cmd.h"
+#include "cmd_gatt.h"
+
+#define CMD_BUF_SZ      256
+static bssnz_t uint8_t cmd_buf[CMD_BUF_SZ];
+
+/*****************************************************************************
+ * $gatt-discover                                                            *
+ *****************************************************************************/
+
+int
+cmd_gatt_discover_characteristic(int argc, char **argv)
+{
+    uint16_t start_handle;
+    uint16_t conn_handle;
+    uint16_t end_handle;
+    ble_uuid_any_t uuid;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = cmd_parse_conn_start_end(&conn_handle, &start_handle, &end_handle);
+    if (rc != 0) {
+        console_printf("invalid 'conn start end' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_uuid("uuid", &uuid);
+    if (rc == 0) {
+        rc = bletiny_disc_chrs_by_uuid(conn_handle, start_handle, end_handle,
+                                       &uuid.u);
+    } else if (rc == ENOENT) {
+        rc = bletiny_disc_all_chrs(conn_handle, start_handle, end_handle);
+    } else  {
+        console_printf("invalid 'uuid' parameter\n");
+        return rc;
+    }
+    if (rc != 0) {
+        console_printf("error discovering characteristics; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+int
+cmd_gatt_discover_descriptor(int argc, char **argv)
+{
+    uint16_t start_handle;
+    uint16_t conn_handle;
+    uint16_t end_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = cmd_parse_conn_start_end(&conn_handle, &start_handle, &end_handle);
+    if (rc != 0) {
+        console_printf("invalid 'conn start end' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_disc_all_dscs(conn_handle, start_handle, end_handle);
+    if (rc != 0) {
+        console_printf("error discovering descriptors; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+int
+cmd_gatt_discover_service(int argc, char **argv)
+{
+    ble_uuid_any_t uuid;
+    int conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    rc = parse_arg_uuid("uuid", &uuid);
+    if (rc == 0) {
+        rc = bletiny_disc_svc_by_uuid(conn_handle, &uuid.u);
+    } else if (rc == ENOENT) {
+        rc = bletiny_disc_svcs(conn_handle);
+    } else  {
+        console_printf("invalid 'uuid' parameter\n");
+        return rc;
+    }
+
+    if (rc != 0) {
+        console_printf("error discovering services; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+int
+cmd_gatt_discover_full(int argc, char **argv)
+{
+    int conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_disc_full(conn_handle);
+    if (rc != 0) {
+        console_printf("error discovering all; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $gatt-exchange-mtu                                                        *
+ *****************************************************************************/
+
+int
+cmd_gatt_exchange_mtu(int argc, char **argv)
+{
+    uint16_t conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_exchange_mtu(conn_handle);
+    if (rc != 0) {
+        console_printf("error exchanging mtu; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $gatt-notify                                                              *
+ *****************************************************************************/
+
+int
+cmd_gatt_notify(int argc, char **argv)
+{
+    uint16_t attr_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    attr_handle = parse_arg_long("attr", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'attr' parameter\n");
+        return rc;
+    }
+
+    bletiny_chrup(attr_handle);
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $gatt-read                                                                *
+ *****************************************************************************/
+
+#define CMD_READ_MAX_ATTRS  8
+
+int
+cmd_gatt_read(int argc, char **argv)
+{
+    static uint16_t attr_handles[CMD_READ_MAX_ATTRS];
+    uint16_t conn_handle;
+    uint16_t start;
+    uint16_t end;
+    uint16_t offset;
+    ble_uuid_any_t uuid;
+    uint8_t num_attr_handles;
+    int is_uuid;
+    int is_long;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    is_long = parse_arg_long("long", &rc);
+    if (rc == ENOENT) {
+        is_long = 0;
+    } else if (rc != 0) {
+        console_printf("invalid 'long' parameter\n");
+        return rc;
+    }
+
+    for (num_attr_handles = 0;
+         num_attr_handles < CMD_READ_MAX_ATTRS;
+         num_attr_handles++) {
+
+        attr_handles[num_attr_handles] = parse_arg_uint16("attr", &rc);
+        if (rc == ENOENT) {
+            break;
+        } else if (rc != 0) {
+            console_printf("invalid 'attr' parameter\n");
+            return rc;
+        }
+    }
+
+    rc = parse_arg_uuid("uuid", &uuid);
+    if (rc == ENOENT) {
+        is_uuid = 0;
+    } else if (rc == 0) {
+        is_uuid = 1;
+    } else {
+        console_printf("invalid 'uuid' parameter\n");
+        return rc;
+    }
+
+    start = parse_arg_uint16("start", &rc);
+    if (rc == ENOENT) {
+        start = 0;
+    } else if (rc != 0) {
+        console_printf("invalid 'start' parameter\n");
+        return rc;
+    }
+
+    end = parse_arg_uint16("end", &rc);
+    if (rc == ENOENT) {
+        end = 0;
+    } else if (rc != 0) {
+        console_printf("invalid 'end' parameter\n");
+        return rc;
+    }
+
+    offset = parse_arg_uint16("offset", &rc);
+    if (rc == ENOENT) {
+        offset = 0;
+    } else if (rc != 0) {
+        console_printf("invalid 'offset' parameter\n");
+        return rc;
+    }
+
+    if (num_attr_handles == 1) {
+        if (is_long) {
+            rc = bletiny_read_long(conn_handle, attr_handles[0], offset);
+        } else {
+            rc = bletiny_read(conn_handle, attr_handles[0]);
+        }
+    } else if (num_attr_handles > 1) {
+        rc = bletiny_read_mult(conn_handle, attr_handles, num_attr_handles);
+    } else if (is_uuid) {
+        if (start == 0 || end == 0) {
+            rc = EINVAL;
+        } else {
+            rc = bletiny_read_by_uuid(conn_handle, start, end, &uuid.u);
+        }
+    } else {
+        rc = EINVAL;
+    }
+
+    if (rc != 0) {
+        console_printf("error reading characteristic; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+
+/*****************************************************************************
+ * $gatt-service-changed                                                     *
+ *****************************************************************************/
+
+int
+cmd_gatt_service_changed(int argc, char **argv)
+{
+    uint16_t start;
+    uint16_t end;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    start = parse_arg_uint16("start", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'start' parameter\n");
+        return rc;
+    }
+
+    end = parse_arg_uint16("end", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'end' parameter\n");
+        return rc;
+    }
+
+    ble_svc_gatt_changed(start, end);
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $gatt-find-included-services                                              *
+ *****************************************************************************/
+
+int
+cmd_gatt_find_included_services(int argc, char **argv)
+{
+    uint16_t start_handle;
+    uint16_t conn_handle;
+    uint16_t end_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = cmd_parse_conn_start_end(&conn_handle, &start_handle, &end_handle);
+    if (rc != 0) {
+        console_printf("invalid 'conn start end' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_find_inc_svcs(conn_handle, start_handle, end_handle);
+    if (rc != 0) {
+        console_printf("error finding included services; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $gatt-show                                                                *
+ *****************************************************************************/
+
+int
+cmd_gatt_show(int argc, char **argv)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_svc *svc;
+    int i;
+
+    for (i = 0; i < bletiny_num_conns; i++) {
+        conn = bletiny_conns + i;
+
+        console_printf("CONNECTION: handle=%d\n", conn->handle);
+
+        SLIST_FOREACH(svc, &conn->svcs, next) {
+            print_svc(svc);
+        }
+    }
+
+    return 0;
+}
+
+int
+cmd_gatt_show_local(int argc, char **argv)
+{
+    gatt_svr_print_svcs();
+    return 0;
+}
+
+int
+cmd_gatt_show_addr(int argc, char **argv)
+{
+    uint8_t id_addr[6];
+    int rc;
+
+    console_printf("public_id_addr=");
+    rc = ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, id_addr, NULL);
+    if (rc == 0) {
+        print_addr(id_addr);
+    } else {
+        console_printf("none");
+    }
+
+    console_printf(" random_id_addr=");
+    rc = ble_hs_id_copy_addr(BLE_ADDR_RANDOM, id_addr, NULL);
+    if (rc == 0) {
+        print_addr(id_addr);
+    } else {
+        console_printf("none");
+    }
+    console_printf("\n");
+
+    return 0;
+}
+
+int
+cmd_gatt_show_conn(int argc, char **argv)
+{
+    struct ble_gap_conn_desc conn_desc;
+    struct bletiny_conn *conn;
+    int rc;
+    int i;
+
+    for (i = 0; i < bletiny_num_conns; i++) {
+        conn = bletiny_conns + i;
+
+        rc = ble_gap_conn_find(conn->handle, &conn_desc);
+        if (rc == 0) {
+            print_conn_desc(&conn_desc);
+        }
+    }
+
+    return 0;
+}
+
+int
+cmd_gatt_show_coc(int argc, char **argv)
+{
+    struct bletiny_conn *conn = NULL;
+    struct bletiny_l2cap_coc *coc;
+    int i, j;
+
+    for (i = 0; i < bletiny_num_conns; i++) {
+        conn = bletiny_conns + i;
+        if (!conn) {
+            break;
+        }
+
+        if (SLIST_EMPTY(&conn->coc_list)) {
+            continue;
+        }
+
+        console_printf("conn_handle: 0x%04x\n", conn->handle);
+        j = 0;
+        SLIST_FOREACH(coc, &conn->coc_list, next) {
+            console_printf("    idx: %i, chan pointer = 0x%08lx\n", j++,
+                           (uint32_t)coc->chan);
+        }
+    }
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $gatt-write                                                               *
+ *****************************************************************************/
+
+int
+cmd_gatt_write(int argc, char **argv)
+{
+    struct ble_gatt_attr attrs[MYNEWT_VAL(BLE_GATT_WRITE_MAX_ATTRS)] = { { 0 } };
+    uint16_t attr_handle;
+    uint16_t conn_handle;
+    uint16_t offset;
+    int total_attr_len;
+    int num_attrs;
+    int attr_len;
+    int is_long;
+    int no_rsp;
+    int rc;
+    int i;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    no_rsp = parse_arg_long("no_rsp", &rc);
+    if (rc == ENOENT) {
+        no_rsp = 0;
+    } else if (rc != 0) {
+        console_printf("invalid 'no_rsp' parameter\n");
+        return rc;
+    }
+
+    is_long = parse_arg_long("long", &rc);
+    if (rc == ENOENT) {
+        is_long = 0;
+    } else if (rc != 0) {
+        console_printf("invalid 'long' parameter\n");
+        return rc;
+    }
+
+    total_attr_len = 0;
+    num_attrs = 0;
+    while (1) {
+        attr_handle = parse_arg_long("attr", &rc);
+        if (rc == ENOENT) {
+            break;
+        } else if (rc != 0) {
+            rc = -rc;
+            console_printf("invalid 'attr' parameter\n");
+            goto done;
+        }
+
+        rc = parse_arg_byte_stream("value", sizeof cmd_buf - total_attr_len,
+                                   cmd_buf + total_attr_len, &attr_len);
+        if (rc == ENOENT) {
+            break;
+        } else if (rc != 0) {
+            console_printf("invalid 'value' parameter\n");
+            goto done;
+        }
+
+        offset = parse_arg_uint16("offset", &rc);
+        if (rc == ENOENT) {
+            offset = 0;
+        } else if (rc != 0) {
+            console_printf("invalid 'offset' parameter\n");
+            return rc;
+        }
+
+        if (num_attrs >= sizeof attrs / sizeof attrs[0]) {
+            rc = -EINVAL;
+            goto done;
+        }
+
+        attrs[num_attrs].handle = attr_handle;
+        attrs[num_attrs].offset = offset;
+        attrs[num_attrs].om = ble_hs_mbuf_from_flat(cmd_buf + total_attr_len,
+                                                    attr_len);
+        if (attrs[num_attrs].om == NULL) {
+            goto done;
+        }
+
+        total_attr_len += attr_len;
+        num_attrs++;
+    }
+
+    if (no_rsp) {
+        if (num_attrs != 1) {
+            rc = -EINVAL;
+            goto done;
+        }
+        rc = bletiny_write_no_rsp(conn_handle, attrs[0].handle, attrs[0].om);
+        attrs[0].om = NULL;
+    } else if (is_long) {
+        if (num_attrs != 1) {
+            rc = -EINVAL;
+            goto done;
+        }
+        rc = bletiny_write_long(conn_handle, attrs[0].handle,
+                                attrs[0].offset, attrs[0].om);
+        attrs[0].om = NULL;
+    } else if (num_attrs > 1) {
+        rc = bletiny_write_reliable(conn_handle, attrs, num_attrs);
+    } else if (num_attrs == 1) {
+        rc = bletiny_write(conn_handle, attrs[0].handle, attrs[0].om);
+        attrs[0].om = NULL;
+    } else {
+        rc = -EINVAL;
+    }
+
+done:
+    for (i = 0; i < sizeof attrs / sizeof attrs[0]; i++) {
+        os_mbuf_free_chain(attrs[i].om);
+    }
+
+    if (rc != 0) {
+        console_printf("error writing characteristic; rc=%d\n", rc);
+    }
+
+    return rc;
+}

--- a/apps/btshell/src/cmd_gatt.c
+++ b/apps/btshell/src/cmd_gatt.c
@@ -26,7 +26,7 @@
 #include "services/gatt/ble_svc_gatt.h"
 #include "console/console.h"
 #include "parse/parse.h"
-#include "bletiny.h"
+#include "btshell.h"
 #include "cmd.h"
 #include "cmd_gatt.h"
 
@@ -59,10 +59,10 @@ cmd_gatt_discover_characteristic(int argc, char **argv)
 
     rc = parse_arg_uuid("uuid", &uuid);
     if (rc == 0) {
-        rc = bletiny_disc_chrs_by_uuid(conn_handle, start_handle, end_handle,
+        rc = btshell_disc_chrs_by_uuid(conn_handle, start_handle, end_handle,
                                        &uuid.u);
     } else if (rc == ENOENT) {
-        rc = bletiny_disc_all_chrs(conn_handle, start_handle, end_handle);
+        rc = btshell_disc_all_chrs(conn_handle, start_handle, end_handle);
     } else  {
         console_printf("invalid 'uuid' parameter\n");
         return rc;
@@ -94,7 +94,7 @@ cmd_gatt_discover_descriptor(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_disc_all_dscs(conn_handle, start_handle, end_handle);
+    rc = btshell_disc_all_dscs(conn_handle, start_handle, end_handle);
     if (rc != 0) {
         console_printf("error discovering descriptors; rc=%d\n", rc);
         return rc;
@@ -123,9 +123,9 @@ cmd_gatt_discover_service(int argc, char **argv)
 
     rc = parse_arg_uuid("uuid", &uuid);
     if (rc == 0) {
-        rc = bletiny_disc_svc_by_uuid(conn_handle, &uuid.u);
+        rc = btshell_disc_svc_by_uuid(conn_handle, &uuid.u);
     } else if (rc == ENOENT) {
-        rc = bletiny_disc_svcs(conn_handle);
+        rc = btshell_disc_svcs(conn_handle);
     } else  {
         console_printf("invalid 'uuid' parameter\n");
         return rc;
@@ -156,7 +156,7 @@ cmd_gatt_discover_full(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_disc_full(conn_handle);
+    rc = btshell_disc_full(conn_handle);
     if (rc != 0) {
         console_printf("error discovering all; rc=%d\n", rc);
         return rc;
@@ -186,7 +186,7 @@ cmd_gatt_exchange_mtu(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_exchange_mtu(conn_handle);
+    rc = btshell_exchange_mtu(conn_handle);
     if (rc != 0) {
         console_printf("error exchanging mtu; rc=%d\n", rc);
         return rc;
@@ -216,7 +216,7 @@ cmd_gatt_notify(int argc, char **argv)
         return rc;
     }
 
-    bletiny_chrup(attr_handle);
+    btshell_chrup(attr_handle);
 
     return 0;
 }
@@ -309,17 +309,17 @@ cmd_gatt_read(int argc, char **argv)
 
     if (num_attr_handles == 1) {
         if (is_long) {
-            rc = bletiny_read_long(conn_handle, attr_handles[0], offset);
+            rc = btshell_read_long(conn_handle, attr_handles[0], offset);
         } else {
-            rc = bletiny_read(conn_handle, attr_handles[0]);
+            rc = btshell_read(conn_handle, attr_handles[0]);
         }
     } else if (num_attr_handles > 1) {
-        rc = bletiny_read_mult(conn_handle, attr_handles, num_attr_handles);
+        rc = btshell_read_mult(conn_handle, attr_handles, num_attr_handles);
     } else if (is_uuid) {
         if (start == 0 || end == 0) {
             rc = EINVAL;
         } else {
-            rc = bletiny_read_by_uuid(conn_handle, start, end, &uuid.u);
+            rc = btshell_read_by_uuid(conn_handle, start, end, &uuid.u);
         }
     } else {
         rc = EINVAL;
@@ -390,7 +390,7 @@ cmd_gatt_find_included_services(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_find_inc_svcs(conn_handle, start_handle, end_handle);
+    rc = btshell_find_inc_svcs(conn_handle, start_handle, end_handle);
     if (rc != 0) {
         console_printf("error finding included services; rc=%d\n", rc);
         return rc;
@@ -406,12 +406,12 @@ cmd_gatt_find_included_services(int argc, char **argv)
 int
 cmd_gatt_show(int argc, char **argv)
 {
-    struct bletiny_conn *conn;
-    struct bletiny_svc *svc;
+    struct btshell_conn *conn;
+    struct btshell_svc *svc;
     int i;
 
-    for (i = 0; i < bletiny_num_conns; i++) {
-        conn = bletiny_conns + i;
+    for (i = 0; i < btshell_num_conns; i++) {
+        conn = btshell_conns + i;
 
         console_printf("CONNECTION: handle=%d\n", conn->handle);
 
@@ -460,12 +460,12 @@ int
 cmd_gatt_show_conn(int argc, char **argv)
 {
     struct ble_gap_conn_desc conn_desc;
-    struct bletiny_conn *conn;
+    struct btshell_conn *conn;
     int rc;
     int i;
 
-    for (i = 0; i < bletiny_num_conns; i++) {
-        conn = bletiny_conns + i;
+    for (i = 0; i < btshell_num_conns; i++) {
+        conn = btshell_conns + i;
 
         rc = ble_gap_conn_find(conn->handle, &conn_desc);
         if (rc == 0) {
@@ -479,12 +479,12 @@ cmd_gatt_show_conn(int argc, char **argv)
 int
 cmd_gatt_show_coc(int argc, char **argv)
 {
-    struct bletiny_conn *conn = NULL;
-    struct bletiny_l2cap_coc *coc;
+    struct btshell_conn *conn = NULL;
+    struct btshell_l2cap_coc *coc;
     int i, j;
 
-    for (i = 0; i < bletiny_num_conns; i++) {
-        conn = bletiny_conns + i;
+    for (i = 0; i < btshell_num_conns; i++) {
+        conn = btshell_conns + i;
         if (!conn) {
             break;
         }
@@ -601,20 +601,20 @@ cmd_gatt_write(int argc, char **argv)
             rc = -EINVAL;
             goto done;
         }
-        rc = bletiny_write_no_rsp(conn_handle, attrs[0].handle, attrs[0].om);
+        rc = btshell_write_no_rsp(conn_handle, attrs[0].handle, attrs[0].om);
         attrs[0].om = NULL;
     } else if (is_long) {
         if (num_attrs != 1) {
             rc = -EINVAL;
             goto done;
         }
-        rc = bletiny_write_long(conn_handle, attrs[0].handle,
+        rc = btshell_write_long(conn_handle, attrs[0].handle,
                                 attrs[0].offset, attrs[0].om);
         attrs[0].om = NULL;
     } else if (num_attrs > 1) {
-        rc = bletiny_write_reliable(conn_handle, attrs, num_attrs);
+        rc = btshell_write_reliable(conn_handle, attrs, num_attrs);
     } else if (num_attrs == 1) {
-        rc = bletiny_write(conn_handle, attrs[0].handle, attrs[0].om);
+        rc = btshell_write(conn_handle, attrs[0].handle, attrs[0].om);
         attrs[0].om = NULL;
     } else {
         rc = -EINVAL;

--- a/apps/btshell/src/cmd_gatt.h
+++ b/apps/btshell/src/cmd_gatt.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CMD_GATT_H
+#define CMD_GATT_H
+
+#include "cmd.h"
+
+int cmd_gatt_discover_characteristic(int argc, char **argv);
+int cmd_gatt_discover_descriptor(int argc, char **argv);
+int cmd_gatt_discover_service(int argc, char **argv);
+int cmd_gatt_discover_full(int argc, char **argv);
+int cmd_gatt_find_included_services(int argc, char **argv);
+int cmd_gatt_exchange_mtu(int argc, char **argv);
+int cmd_gatt_notify(int argc, char **argv);
+int cmd_gatt_read(int argc, char **argv);
+int cmd_gatt_service_changed(int argc, char **argv);
+int cmd_gatt_show(int argc, char **argv);
+int cmd_gatt_show_local(int argc, char **argv);
+int cmd_gatt_show_addr(int argc, char **argv);
+int cmd_gatt_show_conn(int argc, char **argv);
+int cmd_gatt_show_coc(int argc, char **argv);
+int cmd_gatt_write(int argc, char **argv);
+
+#endif

--- a/apps/btshell/src/cmd_l2cap.c
+++ b/apps/btshell/src/cmd_l2cap.c
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <errno.h>
+
+#include "host/ble_gap.h"
+#include "host/ble_l2cap.h"
+#include "console/console.h"
+#include "bletiny.h"
+#include "cmd.h"
+#include "cmd_l2cap.h"
+
+
+/*****************************************************************************
+ * $l2cap-update                                                             *
+ *****************************************************************************/
+
+int
+cmd_l2cap_update(int argc, char **argv)
+{
+    struct ble_l2cap_sig_update_params params;
+    uint16_t conn_handle;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn_handle = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+        return rc;
+    }
+
+    params.itvl_min = parse_arg_uint16_dflt(
+        "itvl_min", BLE_GAP_INITIAL_CONN_ITVL_MIN, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval_min' parameter\n");
+        return rc;
+    }
+
+    params.itvl_max = parse_arg_uint16_dflt(
+        "itvl_max", BLE_GAP_INITIAL_CONN_ITVL_MAX, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'interval_max' parameter\n");
+        return rc;
+    }
+
+    params.slave_latency = parse_arg_uint16_dflt("latency", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'latency' parameter\n");
+        return rc;
+    }
+
+    params.timeout_multiplier = parse_arg_uint16_dflt("timeout", 0x0100, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'timeout' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_l2cap_update(conn_handle, &params);
+    if (rc != 0) {
+        console_printf("error txing l2cap update; rc=%d\n", rc);
+        return rc;
+    }
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $l2cap-create-server                                                      *
+ *****************************************************************************/
+
+int
+cmd_l2cap_create_server(int argc, char **argv)
+{
+    uint16_t psm = 0;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    psm = parse_arg_uint16("psm", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'psm' parameter\n");
+        return rc;
+    }
+
+    rc = bletiny_l2cap_create_srv(psm);
+    if (rc) {
+        console_printf("Server create error: 0x%02x", rc);
+    }
+
+    return 0;
+}
+
+/*****************************************************************************
+ * $l2cap-connect                                                            *
+ *****************************************************************************/
+
+int
+cmd_l2cap_connect(int argc, char **argv)
+{
+    uint16_t conn = 0;
+    uint16_t psm = 0;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+    }
+
+    psm = parse_arg_uint16("psm", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'psm' parameter\n");
+        return rc;
+    }
+
+    return bletiny_l2cap_connect(conn, psm);
+}
+
+/*****************************************************************************
+ * $l2cap-disconnect                                                         *
+ *****************************************************************************/
+
+int
+cmd_l2cap_disconnect(int argc, char **argv)
+{
+    uint16_t conn;
+    uint16_t idx;
+    int rc;
+
+    rc = parse_arg_all(argc - 1, argv + 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    conn = parse_arg_uint16("conn", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'conn' parameter\n");
+    }
+
+    idx = parse_arg_uint16("idx", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'idx' parameter\n");
+        return 0;
+    }
+
+    return bletiny_l2cap_disconnect(conn, idx);
+}

--- a/apps/btshell/src/cmd_l2cap.c
+++ b/apps/btshell/src/cmd_l2cap.c
@@ -23,7 +23,7 @@
 #include "host/ble_gap.h"
 #include "host/ble_l2cap.h"
 #include "console/console.h"
-#include "bletiny.h"
+#include "btshell.h"
 #include "cmd.h"
 #include "cmd_l2cap.h"
 
@@ -76,7 +76,7 @@ cmd_l2cap_update(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_l2cap_update(conn_handle, &params);
+    rc = btshell_l2cap_update(conn_handle, &params);
     if (rc != 0) {
         console_printf("error txing l2cap update; rc=%d\n", rc);
         return rc;
@@ -106,7 +106,7 @@ cmd_l2cap_create_server(int argc, char **argv)
         return rc;
     }
 
-    rc = bletiny_l2cap_create_srv(psm);
+    rc = btshell_l2cap_create_srv(psm);
     if (rc) {
         console_printf("Server create error: 0x%02x", rc);
     }
@@ -141,7 +141,7 @@ cmd_l2cap_connect(int argc, char **argv)
         return rc;
     }
 
-    return bletiny_l2cap_connect(conn, psm);
+    return btshell_l2cap_connect(conn, psm);
 }
 
 /*****************************************************************************
@@ -171,5 +171,5 @@ cmd_l2cap_disconnect(int argc, char **argv)
         return 0;
     }
 
-    return bletiny_l2cap_disconnect(conn, idx);
+    return btshell_l2cap_disconnect(conn, idx);
 }

--- a/apps/btshell/src/cmd_l2cap.h
+++ b/apps/btshell/src/cmd_l2cap.h
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CMD_L2CAP_H
+#define CMD_L2CAP_H
+
+#include "cmd.h"
+
+int cmd_l2cap_update(int argc, char **argv);
+int cmd_l2cap_create_server(int argc, char **argv);
+int cmd_l2cap_connect(int argc, char **argv);
+int cmd_l2cap_disconnect(int argc, char **argv);
+
+#endif

--- a/apps/btshell/src/gatt_svr.c
+++ b/apps/btshell/src/gatt_svr.c
@@ -1,0 +1,604 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include "bsp/bsp.h"
+#include "console/console.h"
+#include "host/ble_hs.h"
+#include "host/ble_uuid.h"
+#include "host/ble_gatt.h"
+#include "bletiny.h"
+
+/* 0000xxxx-8c26-476f-89a7-a108033a69c7 */
+#define PTS_UUID_DECLARE(uuid16)                                \
+    ((const ble_uuid_t *) (&(ble_uuid128_t) BLE_UUID128_INIT(   \
+        0xc7, 0x69, 0x3a, 0x03, 0x08, 0xa1, 0xa7, 0x89,         \
+        0x6f, 0x47, 0x26, 0x8c, uuid16, uuid16 >> 8, 0x00, 0x00 \
+    )))
+
+#define  PTS_SVC                         0x0001
+#define  PTS_CHR_READ                    0x0002
+#define  PTS_CHR_WRITE                   0x0003
+#define  PTS_CHR_RELIABLE_WRITE          0x0004
+#define  PTS_CHR_WRITE_NO_RSP            0x0005
+#define  PTS_CHR_READ_WRITE              0x0006
+#define  PTS_CHR_READ_WRITE_ENC          0x0007
+#define  PTS_CHR_READ_WRITE_AUTHEN       0x0008
+#define  PTS_DSC_READ                    0x0009
+#define  PTS_DSC_WRITE                   0x000a
+#define  PTS_DSC_READ_WRITE              0x000b
+#define  PTS_DSC_READ_WRITE_ENC          0x000c
+#define  PTS_DSC_READ_WRITE_AUTHEN       0x000d
+
+#define  PTS_LONG_SVC                    0x0011
+#define  PTS_LONG_CHR_READ               0x0012
+#define  PTS_LONG_CHR_WRITE              0x0013
+#define  PTS_LONG_CHR_RELIABLE_WRITE     0x0014
+#define  PTS_LONG_CHR_READ_WRITE         0x0015
+#define  PTS_LONG_CHR_READ_WRITE_ALT     0x0016
+#define  PTS_LONG_CHR_READ_WRITE_ENC     0x0017
+#define  PTS_LONG_CHR_READ_WRITE_AUTHEN  0x0018
+#define  PTS_LONG_DSC_READ               0x0019
+#define  PTS_LONG_DSC_WRITE              0x001a
+#define  PTS_LONG_DSC_READ_WRITE         0x001b
+#define  PTS_LONG_DSC_READ_WRITE_ENC     0x001c
+#define  PTS_LONG_DSC_READ_WRITE_AUTHEN  0x001d
+
+/**
+ * The vendor specific security test service consists of two characteristics:
+ *     o random-number-generator: generates a random 32-bit number each time
+ *       it is read.  This characteristic can only be read over an encrypted
+ *       connection.
+ *     o static-value: a single-byte characteristic that can always be read,
+ *       but can only be written over an encrypted connection.
+ */
+
+/* 59462f12-9543-9999-12c8-58b459a2712d */
+static const ble_uuid128_t gatt_svr_svc_sec_test_uuid =
+    BLE_UUID128_INIT(0x2d, 0x71, 0xa2, 0x59, 0xb4, 0x58, 0xc8, 0x12,
+                     0x99, 0x99, 0x43, 0x95, 0x12, 0x2f, 0x46, 0x59);
+
+/* 5c3a659e-897e-45e1-b016-007107c96df6 */
+static const ble_uuid128_t gatt_svr_chr_sec_test_rand_uuid =
+    BLE_UUID128_INIT(0xf6, 0x6d, 0xc9, 0x07, 0x71, 0x00, 0x16, 0xb0,
+                     0xe1, 0x45, 0x7e, 0x89, 0x9e, 0x65, 0x3a, 0x5c);
+
+/* 5c3a659e-897e-45e1-b016-007107c96df7 */
+static const ble_uuid128_t gatt_svr_chr_sec_test_static_uuid =
+    BLE_UUID128_INIT(0xf7, 0x6d, 0xc9, 0x07, 0x71, 0x00, 0x16, 0xb0,
+                     0xe1, 0x45, 0x7e, 0x89, 0x9e, 0x65, 0x3a, 0x5c);
+
+/* 5c3a659e-897e-45e1-b016-007107c96df8 */
+static const ble_uuid128_t gatt_svr_chr_sec_test_static_auth_uuid =
+    BLE_UUID128_INIT(0xf8, 0x6d, 0xc9, 0x07, 0x71, 0x00, 0x16, 0xb0,
+                     0xe1, 0x45, 0x7e, 0x89, 0x9e, 0x65, 0x3a, 0x5c);
+
+static uint8_t gatt_svr_sec_test_static_val;
+
+static uint8_t gatt_svr_pts_static_val;
+static uint8_t gatt_svr_pts_static_long_val[30];
+static uint8_t gatt_svr_pts_static_long_val_alt[30];
+
+static int
+gatt_svr_chr_access_sec_test(uint16_t conn_handle, uint16_t attr_handle,
+                             struct ble_gatt_access_ctxt *ctxt,
+                             void *arg);
+
+static int
+gatt_svr_access_test(uint16_t conn_handle, uint16_t attr_handle,
+                     struct ble_gatt_access_ctxt *ctxt,
+                     void *arg);
+
+static int
+gatt_svr_long_access_test(uint16_t conn_handle, uint16_t attr_handle,
+                                  struct ble_gatt_access_ctxt *ctxt,
+                                  void *arg);
+
+static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
+    {
+        /*** Service: PTS test. */
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = PTS_UUID_DECLARE(PTS_SVC),
+        .characteristics = (struct ble_gatt_chr_def[]) { {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_READ),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_READ,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_WRITE),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_RELIABLE_WRITE),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_RELIABLE_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_WRITE_NO_RSP),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE_NO_RSP,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_ENC),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC |
+                BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_ENC,
+                .min_key_size = 16,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_AUTHEN),
+                .access_cb = gatt_svr_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_AUTHEN |
+                BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_AUTHEN,
+
+                .descriptors = (struct ble_gatt_dsc_def[]){ {
+                        .uuid = PTS_UUID_DECLARE(PTS_DSC_READ),
+                        .access_cb = gatt_svr_access_test,
+                        .att_flags = BLE_ATT_F_READ,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_DSC_WRITE),
+                        .access_cb = gatt_svr_access_test,
+                        .att_flags = BLE_ATT_F_WRITE,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_DSC_READ_WRITE),
+                        .access_cb = gatt_svr_access_test,
+                        .att_flags = BLE_ATT_F_READ | BLE_ATT_F_WRITE,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_DSC_READ_WRITE_ENC),
+                        .access_cb = gatt_svr_access_test,
+                        .att_flags = BLE_ATT_F_READ | BLE_ATT_F_READ_ENC |
+                        BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_ENC,
+                        .min_key_size = 16,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_DSC_READ_WRITE_AUTHEN),
+                        .access_cb = gatt_svr_access_test,
+                        .att_flags = BLE_ATT_F_READ | BLE_ATT_F_READ_AUTHEN |
+                        BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_AUTHEN,
+                    }, {
+                        0, /* No more descriptors in this characteristic. */
+                    } }
+            }, {
+                0, /* No more characteristics in this service. */
+            } },
+    },
+
+    {
+        /*** Service: PTS long test. */
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = PTS_UUID_DECLARE(PTS_LONG_SVC),
+        .characteristics = (struct ble_gatt_chr_def[]) { {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_READ),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_READ,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_WRITE),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_RELIABLE_WRITE),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_RELIABLE_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_READ_WRITE),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_READ_WRITE_ALT),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_READ_WRITE_ENC),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC |
+                BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_ENC,
+                .min_key_size = 16,
+            }, {
+                .uuid = PTS_UUID_DECLARE(PTS_LONG_CHR_READ_WRITE_AUTHEN),
+                .access_cb = gatt_svr_long_access_test,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_AUTHEN |
+                BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_AUTHEN,
+
+                .descriptors = (struct ble_gatt_dsc_def[]){ {
+                        .uuid = PTS_UUID_DECLARE(PTS_LONG_DSC_READ),
+                        .access_cb = gatt_svr_long_access_test,
+                        .att_flags = BLE_ATT_F_READ,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_LONG_DSC_WRITE),
+                        .access_cb = gatt_svr_long_access_test,
+                        .att_flags = BLE_ATT_F_WRITE,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_LONG_DSC_READ_WRITE),
+                        .access_cb = gatt_svr_long_access_test,
+                        .att_flags = BLE_ATT_F_READ | BLE_ATT_F_WRITE,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_LONG_DSC_READ_WRITE_ENC),
+                        .access_cb = gatt_svr_long_access_test,
+                        .att_flags = BLE_ATT_F_READ | BLE_ATT_F_READ_ENC |
+                        BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_ENC,
+                        .min_key_size = 16,
+                    }, {
+                        .uuid = PTS_UUID_DECLARE(PTS_LONG_DSC_READ_WRITE_AUTHEN),
+                        .access_cb = gatt_svr_long_access_test,
+                        .att_flags = BLE_ATT_F_READ | BLE_ATT_F_READ_AUTHEN |
+                        BLE_ATT_F_WRITE | BLE_ATT_F_WRITE_AUTHEN,
+                    }, {
+                        0, /* No more descriptors in this characteristic. */
+                    } }
+            }, {
+                0, /* No more characteristics in this service. */
+            } },
+    },
+
+    {
+        /*** Service: Security test. */
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = &gatt_svr_svc_sec_test_uuid.u,
+        .characteristics = (struct ble_gatt_chr_def[]) { {
+            /*** Characteristic: Random number generator. */
+            .uuid = &gatt_svr_chr_sec_test_rand_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
+            .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC,
+        }, {
+            /*** Characteristic: Static value. */
+            .uuid = &gatt_svr_chr_sec_test_static_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
+            .flags = BLE_GATT_CHR_F_READ |
+                     BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_ENC,
+        }, {
+            /*** Characteristic: Static value. */
+            .uuid = &gatt_svr_chr_sec_test_static_auth_uuid.u,
+            .access_cb = gatt_svr_chr_access_sec_test,
+            .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_AUTHEN,
+        }, {
+            0, /* No more characteristics in this service. */
+        } },
+    },
+
+    {
+        0, /* No more services. */
+    },
+};
+
+static int
+gatt_svr_chr_write(struct os_mbuf *om, uint16_t min_len, uint16_t max_len,
+                   void *dst, uint16_t *len)
+{
+    uint16_t om_len;
+    int rc;
+
+    om_len = OS_MBUF_PKTLEN(om);
+    if (om_len < min_len || om_len > max_len) {
+        return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+    }
+
+    rc = ble_hs_mbuf_to_flat(om, dst, max_len, len);
+    if (rc != 0) {
+        return BLE_ATT_ERR_UNLIKELY;
+    }
+
+    return 0;
+}
+
+static int
+gatt_svr_chr_access_sec_test(uint16_t conn_handle, uint16_t attr_handle,
+                             struct ble_gatt_access_ctxt *ctxt,
+                             void *arg)
+{
+    const ble_uuid_t *uuid;
+    int rand_num;
+    int rc;
+
+    uuid = ctxt->chr->uuid;
+
+    /* Determine which characteristic is being accessed by examining its
+     * 128-bit UUID.
+     */
+
+    if (ble_uuid_cmp(uuid, &gatt_svr_chr_sec_test_rand_uuid.u) == 0) {
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
+
+        /* Respond with a 32-bit random number. */
+        rand_num = rand();
+        rc = os_mbuf_append(ctxt->om, &rand_num, sizeof rand_num);
+        return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+    }
+
+    if (ble_uuid_cmp(uuid, &gatt_svr_chr_sec_test_static_uuid.u) == 0 ||
+        ble_uuid_cmp(uuid, &gatt_svr_chr_sec_test_static_auth_uuid.u) == 0) {
+        switch (ctxt->op) {
+        case BLE_GATT_ACCESS_OP_READ_CHR:
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_sec_test_static_val,
+                                sizeof gatt_svr_sec_test_static_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+
+        case BLE_GATT_ACCESS_OP_WRITE_CHR:
+            rc = gatt_svr_chr_write(ctxt->om,
+                                    sizeof gatt_svr_sec_test_static_val,
+                                    sizeof gatt_svr_sec_test_static_val,
+                                    &gatt_svr_sec_test_static_val, NULL);
+            return rc;
+
+        default:
+            assert(0);
+            return BLE_ATT_ERR_UNLIKELY;
+        }
+    }
+
+    /* Unknown characteristic; the nimble stack should not have called this
+     * function.
+     */
+    assert(0);
+    return BLE_ATT_ERR_UNLIKELY;
+}
+
+/* This method is used for PTS testing only, to extract 16 bit value
+ * from 128 bit vendor specific UUID.
+ */
+static uint16_t
+extract_uuid16_from_pts_uuid128(const ble_uuid_t *uuid)
+{
+    const uint8_t *u8ptr;
+    uint16_t uuid16;
+
+    u8ptr = BLE_UUID128(uuid)->value;
+    uuid16 = u8ptr[12];
+    uuid16 |= (uint16_t)u8ptr[13] << 8;
+    return uuid16;
+}
+
+static int
+gatt_svr_access_test(uint16_t conn_handle, uint16_t attr_handle,
+                     struct ble_gatt_access_ctxt *ctxt,
+                     void *arg)
+{
+    uint16_t uuid16;
+    int rc;
+
+    uuid16 = extract_uuid16_from_pts_uuid128(ctxt->chr->uuid);
+    assert(uuid16 != 0);
+
+    switch (uuid16) {
+    case PTS_CHR_READ:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
+        rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_val,
+                            sizeof gatt_svr_pts_static_val);
+        return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+
+    case PTS_CHR_WRITE:
+    case PTS_CHR_RELIABLE_WRITE:
+    case PTS_CHR_WRITE_NO_RSP:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_val,
+                                    &gatt_svr_pts_static_val, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_val,
+                                sizeof gatt_svr_pts_static_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    case PTS_CHR_READ_WRITE:
+    case PTS_CHR_READ_WRITE_ENC:
+    case PTS_CHR_READ_WRITE_AUTHEN:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_val,
+                                    &gatt_svr_pts_static_val, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_val,
+                                sizeof gatt_svr_pts_static_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    case PTS_DSC_READ:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_DSC);
+        rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_val,
+                            sizeof gatt_svr_pts_static_val);
+        return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+
+    case PTS_DSC_WRITE:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_WRITE_DSC);
+        rc = gatt_svr_chr_write(ctxt->om,0,
+                                sizeof gatt_svr_pts_static_val,
+                                &gatt_svr_pts_static_val, NULL);
+        return rc;
+
+    case PTS_DSC_READ_WRITE:
+    case PTS_DSC_READ_WRITE_ENC:
+    case PTS_DSC_READ_WRITE_AUTHEN:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_DSC) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_val,
+                                    &gatt_svr_pts_static_val, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_DSC) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_val,
+                                sizeof gatt_svr_pts_static_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    default:
+        assert(0);
+        return BLE_ATT_ERR_UNLIKELY;
+    }
+}
+
+static int
+gatt_svr_long_access_test(uint16_t conn_handle, uint16_t attr_handle,
+                          struct ble_gatt_access_ctxt *ctxt,
+                          void *arg)
+{
+    uint16_t uuid16;
+    int rc;
+
+    uuid16 = extract_uuid16_from_pts_uuid128(ctxt->chr->uuid);
+    assert(uuid16 != 0);
+
+    switch (uuid16) {
+    case PTS_LONG_CHR_READ:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
+        rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_long_val,
+                            sizeof gatt_svr_pts_static_long_val);
+        return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+
+    case PTS_LONG_CHR_WRITE:
+    case PTS_LONG_CHR_RELIABLE_WRITE:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR);
+        rc = gatt_svr_chr_write(ctxt->om,0,
+                                sizeof gatt_svr_pts_static_long_val,
+                                &gatt_svr_pts_static_long_val, NULL);
+        return rc;
+
+    case PTS_LONG_CHR_READ_WRITE:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_long_val,
+                                    &gatt_svr_pts_static_long_val, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_long_val,
+                                sizeof gatt_svr_pts_static_long_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    case PTS_LONG_CHR_READ_WRITE_ALT:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_long_val_alt,
+                                    &gatt_svr_pts_static_long_val_alt, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_long_val_alt,
+                                sizeof gatt_svr_pts_static_long_val_alt);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    case PTS_LONG_CHR_READ_WRITE_ENC:
+    case PTS_LONG_CHR_READ_WRITE_AUTHEN:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_long_val,
+                                    &gatt_svr_pts_static_long_val, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_long_val,
+                                sizeof gatt_svr_pts_static_long_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    case PTS_LONG_DSC_READ:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_READ_DSC);
+        rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_long_val,
+                            sizeof gatt_svr_pts_static_long_val);
+        return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+
+    case PTS_LONG_DSC_WRITE:
+        assert(ctxt->op == BLE_GATT_ACCESS_OP_WRITE_DSC);
+        rc = gatt_svr_chr_write(ctxt->om,0,
+                                sizeof gatt_svr_pts_static_long_val,
+                                &gatt_svr_pts_static_long_val, NULL);
+        return rc;
+
+    case PTS_LONG_DSC_READ_WRITE:
+    case PTS_LONG_DSC_READ_WRITE_ENC:
+    case PTS_LONG_DSC_READ_WRITE_AUTHEN:
+        if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_DSC) {
+            rc = gatt_svr_chr_write(ctxt->om,0,
+                                    sizeof gatt_svr_pts_static_long_val,
+                                    &gatt_svr_pts_static_long_val, NULL);
+            return rc;
+        } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_DSC) {
+            rc = os_mbuf_append(ctxt->om, &gatt_svr_pts_static_long_val,
+                                sizeof gatt_svr_pts_static_long_val);
+            return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+        }
+
+    default:
+        assert(0);
+        return BLE_ATT_ERR_UNLIKELY;
+    }
+}
+
+void
+gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
+{
+    char buf[BLE_UUID_STR_LEN];
+
+    switch (ctxt->op) {
+    case BLE_GATT_REGISTER_OP_SVC:
+        BLETINY_LOG(DEBUG, "registered service %s with handle=%d\n",
+                    ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
+                    ctxt->svc.handle);
+        break;
+
+    case BLE_GATT_REGISTER_OP_CHR:
+        BLETINY_LOG(DEBUG, "registering characteristic %s with "
+                           "def_handle=%d val_handle=%d\n",
+                    ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
+                    ctxt->chr.def_handle,
+                    ctxt->chr.val_handle);
+        break;
+
+    case BLE_GATT_REGISTER_OP_DSC:
+        BLETINY_LOG(DEBUG, "registering descriptor %s with handle=%d\n",
+                    ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
+                    ctxt->dsc.handle);
+        break;
+
+    default:
+        assert(0);
+        break;
+    }
+}
+
+int
+gatt_svr_register(void)
+{
+    int rc;
+
+    rc = ble_gatts_register_svcs(gatt_svr_svcs, gatt_svr_register_cb, NULL);
+    return rc;
+}
+
+void
+gatt_svr_print_svcs(void)
+{
+    ble_gatts_show_local();
+}
+
+int
+gatt_svr_init(void)
+{
+    int rc;
+
+    rc = ble_gatts_count_cfg(gatt_svr_svcs);
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = ble_gatts_add_svcs(gatt_svr_svcs);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}

--- a/apps/btshell/src/gatt_svr.c
+++ b/apps/btshell/src/gatt_svr.c
@@ -24,7 +24,7 @@
 #include "host/ble_hs.h"
 #include "host/ble_uuid.h"
 #include "host/ble_gatt.h"
-#include "bletiny.h"
+#include "btshell.h"
 
 /* 0000xxxx-8c26-476f-89a7-a108033a69c7 */
 #define PTS_UUID_DECLARE(uuid16)                                \

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -1,0 +1,1850 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include "syscfg/syscfg.h"
+#include "sysinit/sysinit.h"
+#include "bsp/bsp.h"
+#include "log/log.h"
+#include "stats/stats.h"
+#include "os/os.h"
+#include "bsp/bsp.h"
+#include "hal/hal_gpio.h"
+#include "console/console.h"
+#include "bletiny.h"
+#include "cmd.h"
+
+/* BLE */
+#include "nimble/ble.h"
+#include "nimble/nimble_opt.h"
+#include "nimble/ble_hci_trans.h"
+#include "controller/ble_ll.h"
+#include "host/ble_hs.h"
+#include "host/ble_hs_adv.h"
+#include "host/ble_uuid.h"
+#include "host/ble_att.h"
+#include "host/ble_gap.h"
+#include "host/ble_gatt.h"
+#include "host/ble_store.h"
+#include "host/ble_sm.h"
+
+/* RAM HCI transport. */
+#include "transport/ram/ble_hci_ram.h"
+
+/* Mandatory services. */
+#include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
+
+/* XXX: An app should not include private headers from a library.  The bletiny
+ * app uses some of nimble's internal details for logging.
+ */
+#include "../src/ble_hs_conn_priv.h"
+#include "../src/ble_hs_atomic_priv.h"
+#include "../src/ble_hs_hci_priv.h"
+
+#if MYNEWT_VAL(BLE_ROLE_CENTRAL)
+#define BLETINY_MAX_SVCS               32
+#define BLETINY_MAX_CHRS               64
+#define BLETINY_MAX_DSCS               64
+#else
+#define BLETINY_MAX_SVCS               1
+#define BLETINY_MAX_CHRS               1
+#define BLETINY_MAX_DSCS               1
+#endif
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM)
+#define BLETINY_COC_MTU               (256)
+#endif
+
+struct log bletiny_log;
+
+bssnz_t struct bletiny_conn bletiny_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
+int bletiny_num_conns;
+
+static void *bletiny_svc_mem;
+static struct os_mempool bletiny_svc_pool;
+
+static void *bletiny_chr_mem;
+static struct os_mempool bletiny_chr_pool;
+
+static void *bletiny_dsc_mem;
+static struct os_mempool bletiny_dsc_pool;
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM)
+static void *bletiny_coc_conn_mem;
+static struct os_mempool bletiny_coc_conn_pool;
+
+static void *bletiny_sdu_coc_mem;
+static struct os_mempool bletiny_sdu_coc_pool;
+#endif
+
+static struct os_callout bletiny_tx_timer;
+struct bletiny_tx_data_s
+{
+    uint16_t tx_num;
+    uint16_t tx_rate;
+    uint16_t tx_handle;
+    uint16_t tx_len;
+};
+static struct bletiny_tx_data_s bletiny_tx_data;
+int bletiny_full_disc_prev_chr_val;
+
+#define XSTR(s) STR(s)
+#ifndef STR
+#define STR(s) #s
+#endif
+
+
+#ifdef DEVICE_NAME
+#define BLETINY_AUTO_DEVICE_NAME    XSTR(DEVICE_NAME)
+#else
+#define BLETINY_AUTO_DEVICE_NAME    ""
+#endif
+
+static void
+bletiny_print_error(char *msg, uint16_t conn_handle,
+                    const struct ble_gatt_error *error)
+{
+    if (msg == NULL) {
+        msg = "ERROR";
+    }
+
+    console_printf("%s: conn_handle=%d status=%d att_handle=%d\n",
+                   msg, conn_handle, error->status, error->att_handle);
+}
+
+static void
+bletiny_print_adv_fields(const struct ble_hs_adv_fields *fields)
+{
+    uint8_t *u8p;
+    int i;
+
+    if (fields->flags != 0) {
+        console_printf("    flags=0x%02x:\n", fields->flags);
+
+        if (!(fields->flags & BLE_HS_ADV_F_DISC_LTD) &&
+                !(fields->flags & BLE_HS_ADV_F_DISC_GEN)) {
+                console_printf("        Non-discoverable mode\n");
+        }
+
+        if (fields->flags & BLE_HS_ADV_F_DISC_LTD) {
+                console_printf("        Limited discoverable mode\n");
+        }
+
+        if (fields->flags & BLE_HS_ADV_F_DISC_GEN) {
+                console_printf("        General discoverable mode\n");
+        }
+
+        if (fields->flags & BLE_HS_ADV_F_BREDR_UNSUP) {
+                console_printf("        BR/EDR not supported\n");
+        }
+    }
+
+    if (fields->uuids16 != NULL) {
+        console_printf("    uuids16(%scomplete)=",
+                       fields->uuids16_is_complete ? "" : "in");
+        for (i = 0; i < fields->num_uuids16; i++) {
+            print_uuid(&fields->uuids16[i].u);
+            console_printf(" ");
+        }
+        console_printf("\n");
+    }
+
+    if (fields->uuids32 != NULL) {
+        console_printf("    uuids32(%scomplete)=",
+                       fields->uuids32_is_complete ? "" : "in");
+        for (i = 0; i < fields->num_uuids32; i++) {
+            print_uuid(&fields->uuids32[i].u);
+            console_printf(" ");
+        }
+        console_printf("\n");
+    }
+
+    if (fields->uuids128 != NULL) {
+        console_printf("    uuids128(%scomplete)=",
+                       fields->uuids128_is_complete ? "" : "in");
+        for (i = 0; i < fields->num_uuids128; i++) {
+            print_uuid(&fields->uuids128[i].u);
+            console_printf(" ");
+        }
+        console_printf("\n");
+    }
+
+    if (fields->name != NULL) {
+        console_printf("    name(%scomplete)=",
+                       fields->name_is_complete ? "" : "in");
+        console_write((char *)fields->name, fields->name_len);
+        console_printf("\n");
+    }
+
+    if (fields->tx_pwr_lvl_is_present) {
+        console_printf("    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
+    }
+
+    if (fields->slave_itvl_range != NULL) {
+        console_printf("    slave_itvl_range=");
+        print_bytes(fields->slave_itvl_range,
+                            BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
+        console_printf("\n");
+    }
+
+    if (fields->svc_data_uuid16 != NULL) {
+        console_printf("    svc_data_uuid16=");
+        print_bytes(fields->svc_data_uuid16,
+                            fields->svc_data_uuid16_len);
+        console_printf("\n");
+    }
+
+    if (fields->public_tgt_addr != NULL) {
+        console_printf("    public_tgt_addr=");
+        u8p = fields->public_tgt_addr;
+        for (i = 0; i < fields->num_public_tgt_addrs; i++) {
+            print_addr(u8p);
+            u8p += BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN;
+        }
+        console_printf("\n");
+    }
+
+    if (fields->appearance_is_present) {
+        console_printf("    appearance=0x%04x\n", fields->appearance);
+    }
+
+    if (fields->adv_itvl_is_present) {
+        console_printf("    adv_itvl=0x%04x\n", fields->adv_itvl);
+    }
+
+    if (fields->svc_data_uuid32 != NULL) {
+        console_printf("    svc_data_uuid32=");
+        print_bytes(fields->svc_data_uuid32,
+                             fields->svc_data_uuid32_len);
+        console_printf("\n");
+    }
+
+    if (fields->svc_data_uuid128 != NULL) {
+        console_printf("    svc_data_uuid128=");
+        print_bytes(fields->svc_data_uuid128,
+                            fields->svc_data_uuid128_len);
+        console_printf("\n");
+    }
+
+    if (fields->uri != NULL) {
+        console_printf("    uri=");
+        print_bytes(fields->uri, fields->uri_len);
+        console_printf("\n");
+    }
+
+    if (fields->mfg_data != NULL) {
+        console_printf("    mfg_data=");
+        print_bytes(fields->mfg_data, fields->mfg_data_len);
+        console_printf("\n");
+    }
+}
+
+static int
+bletiny_conn_find_idx(uint16_t handle)
+{
+    int i;
+
+    for (i = 0; i < bletiny_num_conns; i++) {
+        if (bletiny_conns[i].handle == handle) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static struct bletiny_conn *
+bletiny_conn_find(uint16_t handle)
+{
+    int idx;
+
+    idx = bletiny_conn_find_idx(handle);
+    if (idx == -1) {
+        return NULL;
+    } else {
+        return bletiny_conns + idx;
+    }
+}
+
+static struct bletiny_svc *
+bletiny_svc_find_prev(struct bletiny_conn *conn, uint16_t svc_start_handle)
+{
+    struct bletiny_svc *prev;
+    struct bletiny_svc *svc;
+
+    prev = NULL;
+    SLIST_FOREACH(svc, &conn->svcs, next) {
+        if (svc->svc.start_handle >= svc_start_handle) {
+            break;
+        }
+
+        prev = svc;
+    }
+
+    return prev;
+}
+
+static struct bletiny_svc *
+bletiny_svc_find(struct bletiny_conn *conn, uint16_t svc_start_handle,
+                 struct bletiny_svc **out_prev)
+{
+    struct bletiny_svc *prev;
+    struct bletiny_svc *svc;
+
+    prev = bletiny_svc_find_prev(conn, svc_start_handle);
+    if (prev == NULL) {
+        svc = SLIST_FIRST(&conn->svcs);
+    } else {
+        svc = SLIST_NEXT(prev, next);
+    }
+
+    if (svc != NULL && svc->svc.start_handle != svc_start_handle) {
+        svc = NULL;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+    return svc;
+}
+
+static struct bletiny_svc *
+bletiny_svc_find_range(struct bletiny_conn *conn, uint16_t attr_handle)
+{
+    struct bletiny_svc *svc;
+
+    SLIST_FOREACH(svc, &conn->svcs, next) {
+        if (svc->svc.start_handle <= attr_handle &&
+            svc->svc.end_handle >= attr_handle) {
+
+            return svc;
+        }
+    }
+
+    return NULL;
+}
+
+static void
+bletiny_chr_delete(struct bletiny_chr *chr)
+{
+    struct bletiny_dsc *dsc;
+
+    while ((dsc = SLIST_FIRST(&chr->dscs)) != NULL) {
+        SLIST_REMOVE_HEAD(&chr->dscs, next);
+        os_memblock_put(&bletiny_dsc_pool, dsc);
+    }
+
+    os_memblock_put(&bletiny_chr_pool, chr);
+}
+
+static void
+bletiny_svc_delete(struct bletiny_svc *svc)
+{
+    struct bletiny_chr *chr;
+
+    while ((chr = SLIST_FIRST(&svc->chrs)) != NULL) {
+        SLIST_REMOVE_HEAD(&svc->chrs, next);
+        bletiny_chr_delete(chr);
+    }
+
+    os_memblock_put(&bletiny_svc_pool, svc);
+}
+
+static struct bletiny_svc *
+bletiny_svc_add(uint16_t conn_handle, const struct ble_gatt_svc *gatt_svc)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_svc *prev;
+    struct bletiny_svc *svc;
+
+    conn = bletiny_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLETINY_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                           "HANDLE=%d\n",
+                    conn_handle);
+        return NULL;
+    }
+
+    svc = bletiny_svc_find(conn, gatt_svc->start_handle, &prev);
+    if (svc != NULL) {
+        /* Service already discovered. */
+        return svc;
+    }
+
+    svc = os_memblock_get(&bletiny_svc_pool);
+    if (svc == NULL) {
+        BLETINY_LOG(DEBUG, "OOM WHILE DISCOVERING SERVICE\n");
+        return NULL;
+    }
+    memset(svc, 0, sizeof *svc);
+
+    svc->svc = *gatt_svc;
+    SLIST_INIT(&svc->chrs);
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&conn->svcs, svc, next);
+    } else {
+        SLIST_INSERT_AFTER(prev, svc, next);
+    }
+
+    return svc;
+}
+
+static struct bletiny_chr *
+bletiny_chr_find_prev(const struct bletiny_svc *svc, uint16_t chr_val_handle)
+{
+    struct bletiny_chr *prev;
+    struct bletiny_chr *chr;
+
+    prev = NULL;
+    SLIST_FOREACH(chr, &svc->chrs, next) {
+        if (chr->chr.val_handle >= chr_val_handle) {
+            break;
+        }
+
+        prev = chr;
+    }
+
+    return prev;
+}
+
+static struct bletiny_chr *
+bletiny_chr_find(const struct bletiny_svc *svc, uint16_t chr_val_handle,
+                 struct bletiny_chr **out_prev)
+{
+    struct bletiny_chr *prev;
+    struct bletiny_chr *chr;
+
+    prev = bletiny_chr_find_prev(svc, chr_val_handle);
+    if (prev == NULL) {
+        chr = SLIST_FIRST(&svc->chrs);
+    } else {
+        chr = SLIST_NEXT(prev, next);
+    }
+
+    if (chr != NULL && chr->chr.val_handle != chr_val_handle) {
+        chr = NULL;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+    return chr;
+}
+
+static struct bletiny_chr *
+bletiny_chr_add(uint16_t conn_handle,  uint16_t svc_start_handle,
+                const struct ble_gatt_chr *gatt_chr)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_chr *prev;
+    struct bletiny_chr *chr;
+    struct bletiny_svc *svc;
+
+    conn = bletiny_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLETINY_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                           "HANDLE=%d\n",
+                    conn_handle);
+        return NULL;
+    }
+
+    svc = bletiny_svc_find(conn, svc_start_handle, NULL);
+    if (svc == NULL) {
+        BLETINY_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED CHR; HANDLE=%d\n",
+                    conn_handle);
+        return NULL;
+    }
+
+    chr = bletiny_chr_find(svc, gatt_chr->val_handle, &prev);
+    if (chr != NULL) {
+        /* Characteristic already discovered. */
+        return chr;
+    }
+
+    chr = os_memblock_get(&bletiny_chr_pool);
+    if (chr == NULL) {
+        BLETINY_LOG(DEBUG, "OOM WHILE DISCOVERING CHARACTERISTIC\n");
+        return NULL;
+    }
+    memset(chr, 0, sizeof *chr);
+
+    chr->chr = *gatt_chr;
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&svc->chrs, chr, next);
+    } else {
+        SLIST_NEXT(prev, next) = chr;
+    }
+
+    return chr;
+}
+
+static struct bletiny_dsc *
+bletiny_dsc_find_prev(const struct bletiny_chr *chr, uint16_t dsc_handle)
+{
+    struct bletiny_dsc *prev;
+    struct bletiny_dsc *dsc;
+
+    prev = NULL;
+    SLIST_FOREACH(dsc, &chr->dscs, next) {
+        if (dsc->dsc.handle >= dsc_handle) {
+            break;
+        }
+
+        prev = dsc;
+    }
+
+    return prev;
+}
+
+static struct bletiny_dsc *
+bletiny_dsc_find(const struct bletiny_chr *chr, uint16_t dsc_handle,
+                 struct bletiny_dsc **out_prev)
+{
+    struct bletiny_dsc *prev;
+    struct bletiny_dsc *dsc;
+
+    prev = bletiny_dsc_find_prev(chr, dsc_handle);
+    if (prev == NULL) {
+        dsc = SLIST_FIRST(&chr->dscs);
+    } else {
+        dsc = SLIST_NEXT(prev, next);
+    }
+
+    if (dsc != NULL && dsc->dsc.handle != dsc_handle) {
+        dsc = NULL;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+    return dsc;
+}
+
+static struct bletiny_dsc *
+bletiny_dsc_add(uint16_t conn_handle, uint16_t chr_val_handle,
+                const struct ble_gatt_dsc *gatt_dsc)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_dsc *prev;
+    struct bletiny_dsc *dsc;
+    struct bletiny_svc *svc;
+    struct bletiny_chr *chr;
+
+    conn = bletiny_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLETINY_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+                           "HANDLE=%d\n",
+                    conn_handle);
+        return NULL;
+    }
+
+    svc = bletiny_svc_find_range(conn, chr_val_handle);
+    if (svc == NULL) {
+        BLETINY_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
+                    conn_handle);
+        return NULL;
+    }
+
+    chr = bletiny_chr_find(svc, chr_val_handle, NULL);
+    if (chr == NULL) {
+        BLETINY_LOG(DEBUG, "CAN'T FIND CHARACTERISTIC FOR DISCOVERED DSC; "
+                           "HANDLE=%d\n",
+                    conn_handle);
+        return NULL;
+    }
+
+    dsc = bletiny_dsc_find(chr, gatt_dsc->handle, &prev);
+    if (dsc != NULL) {
+        /* Descriptor already discovered. */
+        return dsc;
+    }
+
+    dsc = os_memblock_get(&bletiny_dsc_pool);
+    if (dsc == NULL) {
+        console_printf("OOM WHILE DISCOVERING DESCRIPTOR\n");
+        return NULL;
+    }
+    memset(dsc, 0, sizeof *dsc);
+
+    dsc->dsc = *gatt_dsc;
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&chr->dscs, dsc, next);
+    } else {
+        SLIST_NEXT(prev, next) = dsc;
+    }
+
+    return dsc;
+}
+
+static struct bletiny_conn *
+bletiny_conn_add(struct ble_gap_conn_desc *desc)
+{
+    struct bletiny_conn *conn;
+
+    assert(bletiny_num_conns < MYNEWT_VAL(BLE_MAX_CONNECTIONS));
+
+    conn = bletiny_conns + bletiny_num_conns;
+    bletiny_num_conns++;
+
+    conn->handle = desc->conn_handle;
+    SLIST_INIT(&conn->svcs);
+    SLIST_INIT(&conn->coc_list);
+
+    return conn;
+}
+
+static void
+bletiny_conn_delete_idx(int idx)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_svc *svc;
+
+    assert(idx >= 0 && idx < bletiny_num_conns);
+
+    conn = bletiny_conns + idx;
+    while ((svc = SLIST_FIRST(&conn->svcs)) != NULL) {
+        SLIST_REMOVE_HEAD(&conn->svcs, next);
+        bletiny_svc_delete(svc);
+    }
+
+    /* This '#if' is not strictly necessary.  It is here to prevent a spurious
+     * warning from being reported.
+     */
+#if MYNEWT_VAL(BLE_MAX_CONNECTIONS) > 1
+    int i;
+    for (i = idx + 1; i < bletiny_num_conns; i++) {
+        bletiny_conns[i - 1] = bletiny_conns[i];
+    }
+#endif
+
+    bletiny_num_conns--;
+}
+
+static int
+bletiny_on_mtu(uint16_t conn_handle, const struct ble_gatt_error *error,
+               uint16_t mtu, void *arg)
+{
+    switch (error->status) {
+    case 0:
+        console_printf("mtu exchange complete: conn_handle=%d mtu=%d\n",
+                       conn_handle, mtu);
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static void
+bletiny_full_disc_complete(int rc)
+{
+    console_printf("full discovery complete; rc=%d\n", rc);
+    bletiny_full_disc_prev_chr_val = 0;
+}
+
+static void
+bletiny_disc_full_dscs(uint16_t conn_handle)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_chr *chr;
+    struct bletiny_svc *svc;
+    int rc;
+
+    conn = bletiny_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLETINY_LOG(DEBUG, "Failed to discover descriptors for conn=%d; "
+                           "not connected\n", conn_handle);
+        bletiny_full_disc_complete(BLE_HS_ENOTCONN);
+        return;
+    }
+
+    SLIST_FOREACH(svc, &conn->svcs, next) {
+        SLIST_FOREACH(chr, &svc->chrs, next) {
+            if (!chr_is_empty(svc, chr) &&
+                SLIST_EMPTY(&chr->dscs) &&
+                bletiny_full_disc_prev_chr_val <= chr->chr.def_handle) {
+
+                rc = bletiny_disc_all_dscs(conn_handle,
+                                           chr->chr.val_handle,
+                                           chr_end_handle(svc, chr));
+                if (rc != 0) {
+                    bletiny_full_disc_complete(rc);
+                }
+
+                bletiny_full_disc_prev_chr_val = chr->chr.val_handle;
+                return;
+            }
+        }
+    }
+
+    /* All descriptors discovered. */
+    bletiny_full_disc_complete(0);
+}
+
+static void
+bletiny_disc_full_chrs(uint16_t conn_handle)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_svc *svc;
+    int rc;
+
+    conn = bletiny_conn_find(conn_handle);
+    if (conn == NULL) {
+        BLETINY_LOG(DEBUG, "Failed to discover characteristics for conn=%d; "
+                           "not connected\n", conn_handle);
+        bletiny_full_disc_complete(BLE_HS_ENOTCONN);
+        return;
+    }
+
+    SLIST_FOREACH(svc, &conn->svcs, next) {
+        if (!svc_is_empty(svc) && SLIST_EMPTY(&svc->chrs)) {
+            rc = bletiny_disc_all_chrs(conn_handle, svc->svc.start_handle,
+                                       svc->svc.end_handle);
+            if (rc != 0) {
+                bletiny_full_disc_complete(rc);
+            }
+            return;
+        }
+    }
+
+    /* All characteristics discovered. */
+    bletiny_disc_full_dscs(conn_handle);
+}
+
+static int
+bletiny_on_disc_s(uint16_t conn_handle, const struct ble_gatt_error *error,
+                  const struct ble_gatt_svc *service, void *arg)
+{
+    switch (error->status) {
+    case 0:
+        bletiny_svc_add(conn_handle, service);
+        break;
+
+    case BLE_HS_EDONE:
+        console_printf("service discovery successful\n");
+        if (bletiny_full_disc_prev_chr_val > 0) {
+            bletiny_disc_full_chrs(conn_handle);
+        }
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static int
+bletiny_on_disc_c(uint16_t conn_handle, const struct ble_gatt_error *error,
+                  const struct ble_gatt_chr *chr, void *arg)
+{
+    intptr_t svc_start_handle;
+
+    svc_start_handle = (intptr_t)arg;
+
+    switch (error->status) {
+    case 0:
+        bletiny_chr_add(conn_handle, svc_start_handle, chr);
+        break;
+
+    case BLE_HS_EDONE:
+        console_printf("characteristic discovery successful\n");
+        if (bletiny_full_disc_prev_chr_val > 0) {
+            bletiny_disc_full_chrs(conn_handle);
+        }
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static int
+bletiny_on_disc_d(uint16_t conn_handle, const struct ble_gatt_error *error,
+                  uint16_t chr_val_handle, const struct ble_gatt_dsc *dsc,
+                  void *arg)
+{
+    switch (error->status) {
+    case 0:
+        bletiny_dsc_add(conn_handle, chr_val_handle, dsc);
+        break;
+
+    case BLE_HS_EDONE:
+        console_printf("descriptor discovery successful\n");
+        if (bletiny_full_disc_prev_chr_val > 0) {
+            bletiny_disc_full_dscs(conn_handle);
+        }
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static int
+bletiny_on_read(uint16_t conn_handle, const struct ble_gatt_error *error,
+                struct ble_gatt_attr *attr, void *arg)
+{
+    switch (error->status) {
+    case 0:
+        console_printf("characteristic read; conn_handle=%d "
+                       "attr_handle=%d len=%d value=", conn_handle,
+                       attr->handle, OS_MBUF_PKTLEN(attr->om));
+        print_mbuf(attr->om);
+        console_printf("\n");
+        break;
+
+    case BLE_HS_EDONE:
+        console_printf("characteristic read complete\n");
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static int
+bletiny_on_write(uint16_t conn_handle, const struct ble_gatt_error *error,
+                 struct ble_gatt_attr *attr, void *arg)
+{
+    switch (error->status) {
+    case 0:
+        console_printf("characteristic write complete; conn_handle=%d "
+                       "attr_handle=%d\n", conn_handle, attr->handle);
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static int
+bletiny_on_write_reliable(uint16_t conn_handle,
+                          const struct ble_gatt_error *error,
+                          struct ble_gatt_attr *attrs, uint8_t num_attrs,
+                          void *arg)
+{
+    int i;
+
+    switch (error->status) {
+    case 0:
+        console_printf("characteristic write reliable complete; "
+                       "conn_handle=%d", conn_handle);
+
+        for (i = 0; i < num_attrs; i++) {
+            console_printf(" attr_handle=%d len=%d value=", attrs[i].handle,
+                           OS_MBUF_PKTLEN(attrs[i].om));
+            print_mbuf(attrs[i].om);
+        }
+        console_printf("\n");
+        break;
+
+    default:
+        bletiny_print_error(NULL, conn_handle, error);
+        break;
+    }
+
+    return 0;
+}
+
+static int
+bletiny_gap_event(struct ble_gap_event *event, void *arg)
+{
+    struct ble_gap_conn_desc desc;
+    struct ble_hs_adv_fields fields;
+    int conn_idx;
+    int rc;
+
+    switch (event->type) {
+    case BLE_GAP_EVENT_CONNECT:
+        console_printf("connection %s; status=%d ",
+                       event->connect.status == 0 ? "established" : "failed",
+                       event->connect.status);
+
+        if (event->connect.status == 0) {
+            rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+            assert(rc == 0);
+            print_conn_desc(&desc);
+            bletiny_conn_add(&desc);
+        }
+        return 0;
+
+    case BLE_GAP_EVENT_DISCONNECT:
+        console_printf("disconnect; reason=%d ", event->disconnect.reason);
+        print_conn_desc(&event->disconnect.conn);
+
+        conn_idx = bletiny_conn_find_idx(event->disconnect.conn.conn_handle);
+        if (conn_idx != -1) {
+            bletiny_conn_delete_idx(conn_idx);
+        }
+        return 0;
+
+    case BLE_GAP_EVENT_DISC:
+        console_printf("received advertisement; event_type=%d rssi=%d "
+                       "addr_type=%d addr=", event->disc.event_type,
+                       event->disc.rssi, event->disc.addr.type);
+        print_addr(event->disc.addr.val);
+
+        /*
+         * There is no adv data to print in case of connectable
+         * directed advertising
+         */
+        if (event->disc.event_type == BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD ||
+                event->disc.event_type == BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD) {
+                console_printf("\nConnectable directed advertising event\n");
+                return 0;
+        }
+
+        console_printf(" length_data=%d data=",
+                               event->disc.length_data);
+        print_bytes(event->disc.data, event->disc.length_data);
+        console_printf(" fields:\n");
+        ble_hs_adv_parse_fields(&fields, event->disc.data,
+                                event->disc.length_data);
+        bletiny_print_adv_fields(&fields);
+        console_printf("\n");
+        return 0;
+
+    case BLE_GAP_EVENT_DISC_COMPLETE:
+        console_printf("scanning finished\n");
+        return 0;
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        console_printf("advertising complete.\n");
+        return 0;
+
+    case BLE_GAP_EVENT_CONN_CANCEL:
+        console_printf("connection procedure cancelled.\n");
+        return 0;
+
+    case BLE_GAP_EVENT_CONN_UPDATE:
+        console_printf("connection updated; status=%d ",
+                       event->conn_update.status);
+        rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
+        assert(rc == 0);
+        print_conn_desc(&desc);
+        return 0;
+
+    case BLE_GAP_EVENT_CONN_UPDATE_REQ:
+        console_printf("connection update request\n");
+        *event->conn_update_req.self_params =
+            *event->conn_update_req.peer_params;
+        return 0;
+
+    case BLE_GAP_EVENT_PASSKEY_ACTION:
+        console_printf("passkey action event; action=%d",
+                       event->passkey.params.action);
+        if (event->passkey.params.action == BLE_SM_IOACT_NUMCMP) {
+            console_printf(" numcmp=%lu",
+                           (unsigned long)event->passkey.params.numcmp);
+        }
+        console_printf("\n");
+        return 0;
+
+    case BLE_GAP_EVENT_ENC_CHANGE:
+        console_printf("encryption change event; status=%d ",
+                       event->enc_change.status);
+        rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
+        assert(rc == 0);
+        print_conn_desc(&desc);
+        return 0;
+
+    case BLE_GAP_EVENT_NOTIFY_RX:
+        console_printf("notification rx event; attr_handle=%d indication=%d "
+                       "len=%d data=",
+                       event->notify_rx.attr_handle,
+                       event->notify_rx.indication,
+                       OS_MBUF_PKTLEN(event->notify_rx.om));
+
+        print_mbuf(event->notify_rx.om);
+        console_printf("\n");
+        return 0;
+
+    case BLE_GAP_EVENT_NOTIFY_TX:
+        console_printf("notification tx event; status=%d attr_handle=%d "
+                       "indication=%d\n",
+                       event->notify_tx.status,
+                       event->notify_tx.attr_handle,
+                       event->notify_tx.indication);
+        return 0;
+
+    case BLE_GAP_EVENT_SUBSCRIBE:
+        console_printf("subscribe event; conn_handle=%d attr_handle=%d "
+                       "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
+                       event->subscribe.conn_handle,
+                       event->subscribe.attr_handle,
+                       event->subscribe.reason,
+                       event->subscribe.prev_notify,
+                       event->subscribe.cur_notify,
+                       event->subscribe.prev_indicate,
+                       event->subscribe.cur_indicate);
+        return 0;
+
+    case BLE_GAP_EVENT_MTU:
+        console_printf("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+                       event->mtu.conn_handle,
+                       event->mtu.channel_id,
+                       event->mtu.value);
+        return 0;
+
+    case BLE_GAP_EVENT_IDENTITY_RESOLVED:
+        console_printf("identity resolved ");
+        rc = ble_gap_conn_find(event->identity_resolved.conn_handle, &desc);
+        assert(rc == 0);
+        print_conn_desc(&desc);
+        return 0;
+
+    default:
+        return 0;
+    }
+}
+
+static void
+bletiny_on_l2cap_update(uint16_t conn_handle, int status, void *arg)
+{
+    console_printf("l2cap update complete; conn_handle=%d status=%d\n",
+                   conn_handle, status);
+}
+
+static void
+bletiny_tx_timer_cb(struct os_event *ev)
+{
+    int i;
+    uint8_t len;
+    int32_t timeout;
+    uint8_t *dptr;
+    struct os_mbuf *om;
+
+    if ((bletiny_tx_data.tx_num == 0) || (bletiny_tx_data.tx_len == 0)) {
+        return;
+    }
+
+    len = bletiny_tx_data.tx_len;
+
+    om = NULL;
+    if (os_msys_num_free() >= 4) {
+        om = os_msys_get_pkthdr(len + 4, sizeof(struct ble_mbuf_hdr));
+    }
+
+    if (om) {
+        /* Put the HCI header in the mbuf */
+        om->om_len = len + 4;
+        put_le16(om->om_data, bletiny_tx_data.tx_handle);
+        put_le16(om->om_data + 2, len);
+        dptr = om->om_data + 4;
+
+        /*
+         * NOTE: first byte gets 0xff so not confused with l2cap channel.
+         * The rest of the data gets filled with incrementing pattern starting
+         * from 0.
+         */
+        put_le16(dptr, len - 4);
+        dptr[2] = 0xff;
+        dptr[3] = 0xff;
+        dptr += 4;
+        len -= 4;
+
+        for (i = 0; i < len; ++i) {
+            *dptr = i;
+            ++dptr;
+        }
+
+        /* Set packet header length */
+        OS_MBUF_PKTHDR(om)->omp_len = om->om_len;
+        ble_hci_trans_hs_acl_tx(om);
+
+        --bletiny_tx_data.tx_num;
+    }
+
+    if (bletiny_tx_data.tx_num) {
+        timeout = (int32_t)bletiny_tx_data.tx_rate;
+        timeout = (timeout * OS_TICKS_PER_SEC) / 1000;
+        os_callout_reset(&bletiny_tx_timer, timeout);
+    }
+}
+
+int
+bletiny_exchange_mtu(uint16_t conn_handle)
+{
+    int rc;
+
+    rc = ble_gattc_exchange_mtu(conn_handle, bletiny_on_mtu, NULL);
+    return rc;
+}
+
+int
+bletiny_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
+                      uint16_t end_handle)
+{
+    intptr_t svc_start_handle;
+    int rc;
+
+    svc_start_handle = start_handle;
+    rc = ble_gattc_disc_all_chrs(conn_handle, start_handle, end_handle,
+                                 bletiny_on_disc_c, (void *)svc_start_handle);
+    return rc;
+}
+
+int
+bletiny_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
+                           uint16_t end_handle, const ble_uuid_t *uuid)
+{
+    intptr_t svc_start_handle;
+    int rc;
+
+    svc_start_handle = start_handle;
+    rc = ble_gattc_disc_chrs_by_uuid(conn_handle, start_handle, end_handle,
+                                     uuid, bletiny_on_disc_c,
+                                     (void *)svc_start_handle);
+    return rc;
+}
+
+int
+bletiny_disc_svcs(uint16_t conn_handle)
+{
+    int rc;
+
+    rc = ble_gattc_disc_all_svcs(conn_handle, bletiny_on_disc_s, NULL);
+    return rc;
+}
+
+int
+bletiny_disc_svc_by_uuid(uint16_t conn_handle, const ble_uuid_t *uuid)
+{
+    int rc;
+
+    rc = ble_gattc_disc_svc_by_uuid(conn_handle, uuid,
+                                    bletiny_on_disc_s, NULL);
+    return rc;
+}
+
+int
+bletiny_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,
+                      uint16_t end_handle)
+{
+    int rc;
+
+    rc = ble_gattc_disc_all_dscs(conn_handle, start_handle, end_handle,
+                                 bletiny_on_disc_d, NULL);
+    return rc;
+}
+
+int
+bletiny_disc_full(uint16_t conn_handle)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_svc *svc;
+
+    /* Undiscover everything first. */
+    conn = bletiny_conn_find(conn_handle);
+    if (conn == NULL) {
+        return BLE_HS_ENOTCONN;
+    }
+
+    while ((svc = SLIST_FIRST(&conn->svcs)) != NULL) {
+        SLIST_REMOVE_HEAD(&conn->svcs, next);
+        bletiny_svc_delete(svc);
+    }
+
+    bletiny_full_disc_prev_chr_val = 1;
+    bletiny_disc_svcs(conn_handle);
+
+    return 0;
+}
+
+int
+bletiny_find_inc_svcs(uint16_t conn_handle, uint16_t start_handle,
+                       uint16_t end_handle)
+{
+    int rc;
+
+    rc = ble_gattc_find_inc_svcs(conn_handle, start_handle, end_handle,
+                                 bletiny_on_disc_s, NULL);
+    return rc;
+}
+
+int
+bletiny_read(uint16_t conn_handle, uint16_t attr_handle)
+{
+    struct os_mbuf *om;
+    int rc;
+
+    if (conn_handle == BLE_HS_CONN_HANDLE_NONE) {
+        rc = ble_att_svr_read_local(attr_handle, &om);
+        if (rc == 0) {
+            console_printf("read local; attr_handle=%d len=%d value=",
+                           attr_handle, OS_MBUF_PKTLEN(om));
+            print_mbuf(om);
+            console_printf("\n");
+
+            os_mbuf_free_chain(om);
+        }
+    } else {
+        rc = ble_gattc_read(conn_handle, attr_handle, bletiny_on_read, NULL);
+    }
+    return rc;
+}
+
+int
+bletiny_read_long(uint16_t conn_handle, uint16_t attr_handle, uint16_t offset)
+{
+    int rc;
+
+    rc = ble_gattc_read_long(conn_handle, attr_handle, offset,
+                             bletiny_on_read, NULL);
+    return rc;
+}
+
+int
+bletiny_read_by_uuid(uint16_t conn_handle, uint16_t start_handle,
+                      uint16_t end_handle, const ble_uuid_t *uuid)
+{
+    int rc;
+
+    rc = ble_gattc_read_by_uuid(conn_handle, start_handle, end_handle, uuid,
+                                bletiny_on_read, NULL);
+    return rc;
+}
+
+int
+bletiny_read_mult(uint16_t conn_handle, uint16_t *attr_handles,
+                   int num_attr_handles)
+{
+    int rc;
+
+    rc = ble_gattc_read_mult(conn_handle, attr_handles, num_attr_handles,
+                             bletiny_on_read, NULL);
+    return rc;
+}
+
+int
+bletiny_write(uint16_t conn_handle, uint16_t attr_handle, struct os_mbuf *om)
+{
+    int rc;
+
+    if (conn_handle == BLE_HS_CONN_HANDLE_NONE) {
+        rc = ble_att_svr_write_local(attr_handle, om);
+    } else {
+        rc = ble_gattc_write(conn_handle, attr_handle, om,
+                             bletiny_on_write, NULL);
+    }
+
+    return rc;
+}
+
+int
+bletiny_write_no_rsp(uint16_t conn_handle, uint16_t attr_handle,
+                     struct os_mbuf *om)
+{
+    int rc;
+
+    rc = ble_gattc_write_no_rsp(conn_handle, attr_handle, om);
+
+    return rc;
+}
+
+int
+bletiny_write_long(uint16_t conn_handle, uint16_t attr_handle,
+                   uint16_t offset, struct os_mbuf *om)
+{
+    int rc;
+
+    rc = ble_gattc_write_long(conn_handle, attr_handle, offset,
+                              om, bletiny_on_write, NULL);
+    return rc;
+}
+
+int
+bletiny_write_reliable(uint16_t conn_handle,
+                       struct ble_gatt_attr *attrs,
+                       int num_attrs)
+{
+    int rc;
+
+    rc = ble_gattc_write_reliable(conn_handle, attrs, num_attrs,
+                                  bletiny_on_write_reliable, NULL);
+    return rc;
+}
+
+int
+bletiny_adv_stop(void)
+{
+    int rc;
+
+    rc = ble_gap_adv_stop();
+    return rc;
+}
+
+int
+bletiny_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
+                  int32_t duration_ms, const struct ble_gap_adv_params *params)
+{
+    int rc;
+
+    rc = ble_gap_adv_start(own_addr_type, direct_addr, duration_ms, params,
+                           bletiny_gap_event, NULL);
+    return rc;
+}
+
+int
+bletiny_conn_initiate(uint8_t own_addr_type, const ble_addr_t *peer_addr,
+                      int32_t duration_ms, struct ble_gap_conn_params *params)
+{
+    int rc;
+
+    rc = ble_gap_connect(own_addr_type, peer_addr, duration_ms, params,
+                         bletiny_gap_event, NULL);
+
+    return rc;
+}
+
+int
+bletiny_conn_cancel(void)
+{
+    int rc;
+
+    rc = ble_gap_conn_cancel();
+    return rc;
+}
+
+int
+bletiny_term_conn(uint16_t conn_handle, uint8_t reason)
+{
+    int rc;
+
+    rc = ble_gap_terminate(conn_handle, reason);
+    return rc;
+}
+
+int
+bletiny_wl_set(ble_addr_t *addrs, int addrs_count)
+{
+    int rc;
+
+    rc = ble_gap_wl_set(addrs, addrs_count);
+    return rc;
+}
+
+int
+bletiny_scan(uint8_t own_addr_type, int32_t duration_ms,
+             const struct ble_gap_disc_params *disc_params)
+{
+    int rc;
+
+    rc = ble_gap_disc(own_addr_type, duration_ms, disc_params,
+                      bletiny_gap_event, NULL);
+    return rc;
+}
+
+int
+bletiny_scan_cancel(void)
+{
+    int rc;
+
+    rc = ble_gap_disc_cancel();
+    return rc;
+}
+
+int
+bletiny_set_adv_data(struct ble_hs_adv_fields *adv_fields)
+{
+    int rc;
+
+    rc = ble_gap_adv_set_fields(adv_fields);
+    return rc;
+}
+
+int
+bletiny_update_conn(uint16_t conn_handle, struct ble_gap_upd_params *params)
+{
+    int rc;
+
+    rc = ble_gap_update_params(conn_handle, params);
+    return rc;
+}
+
+void
+bletiny_chrup(uint16_t attr_handle)
+{
+    ble_gatts_chr_updated(attr_handle);
+}
+
+int
+bletiny_datalen(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time)
+{
+    int rc;
+
+    rc = ble_hs_hci_util_set_data_len(conn_handle, tx_octets, tx_time);
+    return rc;
+}
+
+int
+bletiny_l2cap_update(uint16_t conn_handle,
+                     struct ble_l2cap_sig_update_params *params)
+{
+    int rc;
+
+    rc = ble_l2cap_sig_update(conn_handle, params, bletiny_on_l2cap_update,
+                              NULL);
+    return rc;
+}
+
+int
+bletiny_sec_pair(uint16_t conn_handle)
+{
+#if !NIMBLE_BLE_SM
+    return BLE_HS_ENOTSUP;
+#endif
+
+    int rc;
+
+    rc = ble_gap_pair_initiate(conn_handle);
+    return rc;
+}
+
+int
+bletiny_sec_start(uint16_t conn_handle)
+{
+#if !NIMBLE_BLE_SM
+    return BLE_HS_ENOTSUP;
+#endif
+
+    int rc;
+
+    rc = ble_gap_security_initiate(conn_handle);
+    return rc;
+}
+
+int
+bletiny_sec_restart(uint16_t conn_handle,
+                    uint8_t *ltk,
+                    uint16_t ediv,
+                    uint64_t rand_val,
+                    int auth)
+{
+#if !NIMBLE_BLE_SM
+    return BLE_HS_ENOTSUP;
+#endif
+
+    struct ble_store_value_sec value_sec;
+    struct ble_store_key_sec key_sec;
+    struct ble_gap_conn_desc desc;
+    ble_hs_conn_flags_t conn_flags;
+    int rc;
+
+    if (ltk == NULL) {
+        /* The user is requesting a store lookup. */
+        rc = ble_gap_conn_find(conn_handle, &desc);
+        if (rc != 0) {
+            return rc;
+        }
+
+        memset(&key_sec, 0, sizeof key_sec);
+        key_sec.peer_addr = desc.peer_id_addr;
+
+        rc = ble_hs_atomic_conn_flags(conn_handle, &conn_flags);
+        if (rc != 0) {
+            return rc;
+        }
+        if (conn_flags & BLE_HS_CONN_F_MASTER) {
+            rc = ble_store_read_peer_sec(&key_sec, &value_sec);
+        } else {
+            rc = ble_store_read_our_sec(&key_sec, &value_sec);
+        }
+        if (rc != 0) {
+            return rc;
+        }
+
+        ltk = value_sec.ltk;
+        ediv = value_sec.ediv;
+        rand_val = value_sec.rand_num;
+        auth = value_sec.authenticated;
+    }
+
+    rc = ble_gap_encryption_initiate(conn_handle, ltk, ediv, rand_val, auth);
+    return rc;
+}
+
+/**
+ * Called to start transmitting 'num' packets at rate 'rate' of size 'size'
+ * to connection handle 'handle'
+ *
+ * @param handle
+ * @param len
+ * @param rate
+ * @param num
+ *
+ * @return int
+ */
+int
+bletiny_tx_start(uint16_t handle, uint16_t len, uint16_t rate, uint16_t num)
+{
+    /* Cannot be currently in a session */
+    if (num == 0) {
+        return 0;
+    }
+
+    /* Do not allow start if already in progress */
+    if (bletiny_tx_data.tx_num != 0) {
+        return -1;
+    }
+
+    /* XXX: for now, must have contiguous mbuf space */
+    if ((len + 4) > MYNEWT_VAL_MSYS_1_BLOCK_SIZE) {
+        return -2;
+    }
+
+    bletiny_tx_data.tx_num = num;
+    bletiny_tx_data.tx_rate = rate;
+    bletiny_tx_data.tx_len = len;
+    bletiny_tx_data.tx_handle = handle;
+
+    os_callout_reset(&bletiny_tx_timer, 0);
+
+    return 0;
+}
+
+int
+bletiny_rssi(uint16_t conn_handle, int8_t *out_rssi)
+{
+    int rc;
+
+    rc = ble_gap_conn_rssi(conn_handle, out_rssi);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}
+
+static void
+bletiny_on_reset(int reason)
+{
+    console_printf("Error: Resetting state; reason=%d\n", reason);
+}
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+
+static int
+bletiny_l2cap_coc_add(uint16_t conn_handle, struct ble_l2cap_chan *chan)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_l2cap_coc *coc;
+    struct bletiny_l2cap_coc *prev, *cur;
+
+    conn = bletiny_conn_find(conn_handle);
+    assert(conn != NULL);
+
+    coc = os_memblock_get(&bletiny_coc_conn_pool);
+    if (!coc) {
+        return ENOMEM;
+    }
+
+    coc->chan = chan;
+
+    prev = NULL;
+    SLIST_FOREACH(cur, &conn->coc_list, next) {
+        prev = cur;
+    }
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&conn->coc_list, coc, next);
+    } else {
+        SLIST_INSERT_AFTER(prev, coc, next);
+    }
+
+    return 0;
+}
+
+static void
+bletiny_l2cap_coc_remove(uint16_t conn_handle, struct ble_l2cap_chan *chan)
+{
+    struct bletiny_conn *conn;
+    struct bletiny_l2cap_coc *coc;
+    struct bletiny_l2cap_coc *cur;
+
+    conn = bletiny_conn_find(conn_handle);
+    assert(conn != NULL);
+
+    coc = NULL;
+    SLIST_FOREACH(cur, &conn->coc_list, next) {
+        if (cur->chan == chan) {
+            coc = cur;
+            break;
+        }
+    }
+
+    if (!coc) {
+        return;
+    }
+
+    SLIST_REMOVE(&conn->coc_list, coc, bletiny_l2cap_coc, next);
+    os_memblock_put(&bletiny_coc_conn_pool, coc);
+}
+
+static void
+bletiny_l2cap_coc_recv(struct ble_l2cap_chan *chan, struct os_mbuf *sdu)
+{
+    console_printf("LE CoC SDU received, chan: 0x%08lx\n", (uint32_t) chan);
+}
+
+static int
+bletiny_l2cap_coc_accept(uint16_t conn_handle, uint16_t peer_mtu,
+                           struct ble_l2cap_chan *chan)
+{
+    struct os_mbuf *sdu_rx;
+
+    sdu_rx = os_memblock_get(&bletiny_sdu_coc_pool);
+    if (!sdu_rx) {
+            return BLE_HS_ENOMEM;
+    }
+
+    ble_l2cap_recv_ready(chan, sdu_rx);
+
+    return 0;
+}
+
+static int
+bletiny_l2cap_event(struct ble_l2cap_event *event, void *arg)
+{
+    switch(event->type) {
+        case BLE_L2CAP_EVENT_COC_CONNECTED:
+            if (event->connect.status) {
+                console_printf("LE COC error: %d\n", event->connect.status);
+                return 0;
+            }
+
+            console_printf("LE COC connected, conn: %d, chan: 0x%08lx\n",
+                           event->connect.conn_handle,
+                           (uint32_t) event->connect.chan);
+
+            bletiny_l2cap_coc_add(event->connect.conn_handle,
+                                  event->connect.chan);
+
+            return 0;
+        case BLE_L2CAP_EVENT_COC_DISCONNECTED:
+            console_printf("LE CoC disconnected, chan: 0x%08lx\n",
+                           (uint32_t) event->disconnect.chan);
+
+            bletiny_l2cap_coc_remove(event->disconnect.conn_handle,
+                                     event->disconnect.chan);
+            return 0;
+        case BLE_L2CAP_EVENT_COC_ACCEPT:
+            return bletiny_l2cap_coc_accept(event->accept.conn_handle,
+                                            event->accept.peer_sdu_size,
+                                            event->accept.chan);
+
+        case BLE_L2CAP_EVENT_COC_DATA_RECEIVED:
+            bletiny_l2cap_coc_recv(event->receive.chan, event->receive.sdu_rx);
+            return 0;
+        default:
+            return 0;
+    }
+}
+#endif
+
+int
+bletiny_l2cap_create_srv(uint16_t psm)
+{
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) == 0
+    console_printf("BLE L2CAP LE COC not supported.");
+    console_printf(" Configure nimble host to enable it\n");
+    return 0;
+#else
+
+    return ble_l2cap_create_server(psm, BLETINY_COC_MTU, bletiny_l2cap_event,
+                                                                       NULL);
+#endif
+}
+
+int
+bletiny_l2cap_connect(uint16_t conn_handle, uint16_t psm)
+{
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) == 0
+    console_printf("BLE L2CAP LE COC not supported.");
+    console_printf(" Configure nimble host to enable it\n");
+    return 0;
+#else
+
+    struct os_mbuf *sdu_rx;
+
+    sdu_rx = os_memblock_get(&bletiny_sdu_coc_pool);
+    assert(sdu_rx != NULL);
+
+    return ble_l2cap_connect(conn_handle, psm, BLETINY_COC_MTU, sdu_rx,
+                             bletiny_l2cap_event, NULL);
+#endif
+}
+
+int
+bletiny_l2cap_disconnect(uint16_t conn_handle, uint16_t idx)
+{
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) == 0
+    console_printf("BLE L2CAP LE COC not supported.");
+    console_printf(" Configure nimble host to enable it\n");
+    return 0;
+#else
+
+    struct bletiny_conn *conn;
+    struct bletiny_l2cap_coc *coc;
+    int i;
+
+    conn = bletiny_conn_find(conn_handle);
+    assert(conn != NULL);
+
+    i = 0;
+    SLIST_FOREACH(coc, &conn->coc_list, next) {
+        if (i == idx) {
+                break;
+        }
+        i++;
+    }
+    assert(coc != NULL);
+
+    ble_l2cap_disconnect(coc->chan);
+
+    return 0;
+#endif
+}
+
+/**
+ * main
+ *
+ * The main task for the project. This function initializes the packages,
+ * then starts serving events from default event queue.
+ *
+ * @return int NOTE: this function should never return!
+ */
+int
+main(void)
+{
+    int rc;
+
+    /* Initialize OS */
+    sysinit();
+
+    /* Allocate some application specific memory pools. */
+    bletiny_svc_mem = malloc(
+        OS_MEMPOOL_BYTES(BLETINY_MAX_SVCS, sizeof (struct bletiny_svc)));
+    assert(bletiny_svc_mem != NULL);
+
+    rc = os_mempool_init(&bletiny_svc_pool, BLETINY_MAX_SVCS,
+                         sizeof (struct bletiny_svc), bletiny_svc_mem,
+                         "bletiny_svc_pool");
+    assert(rc == 0);
+
+    bletiny_chr_mem = malloc(
+        OS_MEMPOOL_BYTES(BLETINY_MAX_CHRS, sizeof (struct bletiny_chr)));
+    assert(bletiny_chr_mem != NULL);
+
+    rc = os_mempool_init(&bletiny_chr_pool, BLETINY_MAX_CHRS,
+                         sizeof (struct bletiny_chr), bletiny_chr_mem,
+                         "bletiny_chr_pool");
+    assert(rc == 0);
+
+    bletiny_dsc_mem = malloc(
+        OS_MEMPOOL_BYTES(BLETINY_MAX_DSCS, sizeof (struct bletiny_dsc)));
+    assert(bletiny_dsc_mem != NULL);
+
+    rc = os_mempool_init(&bletiny_dsc_pool, BLETINY_MAX_DSCS,
+                         sizeof (struct bletiny_dsc), bletiny_dsc_mem,
+                         "bletiny_dsc_pool");
+    assert(rc == 0);
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+    /* For testing we want to support all the available channels */
+    bletiny_sdu_coc_mem = malloc(
+        OS_MEMPOOL_BYTES(BLETINY_COC_MTU * MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                         sizeof (struct os_mbuf)));
+    assert(bletiny_sdu_coc_mem != NULL);
+
+    rc = os_mempool_init(&bletiny_sdu_coc_pool,
+                         BLETINY_COC_MTU * MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                         sizeof (struct os_mbuf), bletiny_sdu_coc_mem,
+                         "bletiny_coc_sdu_pool");
+    assert(rc == 0);
+
+    bletiny_coc_conn_mem = malloc(
+        OS_MEMPOOL_BYTES(MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                         sizeof (struct bletiny_l2cap_coc)));
+    assert(bletiny_coc_conn_mem != NULL);
+
+    rc = os_mempool_init(&bletiny_coc_conn_pool,
+                         MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM),
+                         sizeof (struct bletiny_l2cap_coc), bletiny_coc_conn_mem,
+                         "bletiny_coc_conn_pool");
+    assert(rc == 0);
+#endif
+
+    /* Initialize the logging system. */
+    log_register("bletiny", &bletiny_log, &log_console_handler, NULL,
+                 LOG_SYSLEVEL);
+
+    /* Initialize the NimBLE host configuration. */
+    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
+                 LOG_SYSLEVEL);
+    ble_hs_cfg.reset_cb = bletiny_on_reset;
+    ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;
+
+    rc = gatt_svr_init();
+    assert(rc == 0);
+
+    cmd_init();
+
+    /* Set the default device name. */
+    rc = ble_svc_gap_device_name_set("nimble-bletiny");
+    assert(rc == 0);
+
+    /* Create a callout (timer).  This callout is used by the "tx" bletiny
+     * command to repeatedly send packets of sequential data bytes.
+     */
+    os_callout_init(&bletiny_tx_timer, os_eventq_dflt_get(),
+                    bletiny_tx_timer_cb, NULL);
+
+    while (1) {
+        os_eventq_run(os_eventq_dflt_get());
+    }
+    /* os start should never return. If it does, this should be an error */
+    assert(0);
+
+    return 0;
+}

--- a/apps/btshell/src/misc.c
+++ b/apps/btshell/src/misc.c
@@ -21,7 +21,7 @@
 #include "host/ble_uuid.h"
 #include "host/ble_gap.h"
 
-#include "bletiny.h"
+#include "btshell.h"
 
 /**
  * Utility function to log an array of bytes.
@@ -74,15 +74,15 @@ print_uuid(const ble_uuid_t *uuid)
 }
 
 int
-svc_is_empty(const struct bletiny_svc *svc)
+svc_is_empty(const struct btshell_svc *svc)
 {
     return svc->svc.end_handle < svc->svc.start_handle;
 }
 
 uint16_t
-chr_end_handle(const struct bletiny_svc *svc, const struct bletiny_chr *chr)
+chr_end_handle(const struct btshell_svc *svc, const struct btshell_chr *chr)
 {
-    const struct bletiny_chr *next_chr;
+    const struct btshell_chr *next_chr;
 
     next_chr = SLIST_NEXT(chr, next);
     if (next_chr != NULL) {
@@ -93,7 +93,7 @@ chr_end_handle(const struct bletiny_svc *svc, const struct bletiny_chr *chr)
 }
 
 int
-chr_is_empty(const struct bletiny_svc *svc, const struct bletiny_chr *chr)
+chr_is_empty(const struct btshell_svc *svc, const struct btshell_chr *chr)
 {
     return chr_end_handle(svc, chr) <= chr->chr.val_handle;
 }
@@ -123,7 +123,7 @@ print_conn_desc(const struct ble_gap_conn_desc *desc)
 }
 
 static void
-print_dsc(struct bletiny_dsc *dsc)
+print_dsc(struct btshell_dsc *dsc)
 {
     console_printf("            dsc_handle=%d uuid=", dsc->dsc.handle);
     print_uuid(&dsc->dsc.uuid.u);
@@ -131,9 +131,9 @@ print_dsc(struct bletiny_dsc *dsc)
 }
 
 static void
-print_chr(struct bletiny_chr *chr)
+print_chr(struct btshell_chr *chr)
 {
-    struct bletiny_dsc *dsc;
+    struct btshell_dsc *dsc;
 
     console_printf("        def_handle=%d val_handle=%d properties=0x%02x "
                    "uuid=", chr->chr.def_handle, chr->chr.val_handle,
@@ -147,9 +147,9 @@ print_chr(struct bletiny_chr *chr)
 }
 
 void
-print_svc(struct bletiny_svc *svc)
+print_svc(struct btshell_svc *svc)
 {
-    struct bletiny_chr *chr;
+    struct btshell_chr *chr;
 
     console_printf("    start=%d end=%d uuid=", svc->svc.start_handle,
                    svc->svc.end_handle);

--- a/apps/btshell/src/misc.c
+++ b/apps/btshell/src/misc.c
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "console/console.h"
+#include "host/ble_uuid.h"
+#include "host/ble_gap.h"
+
+#include "bletiny.h"
+
+/**
+ * Utility function to log an array of bytes.
+ */
+void
+print_bytes(const uint8_t *bytes, int len)
+{
+    int i;
+
+    for (i = 0; i < len; i++) {
+        console_printf("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+    }
+}
+
+void
+print_mbuf(const struct os_mbuf *om)
+{
+    int colon;
+
+    colon = 0;
+    while (om != NULL) {
+        if (colon) {
+            console_printf(":");
+        } else {
+            colon = 1;
+        }
+        print_bytes(om->om_data, om->om_len);
+        om = SLIST_NEXT(om, om_next);
+    }
+}
+
+void
+print_addr(const void *addr)
+{
+    const uint8_t *u8p;
+
+    u8p = addr;
+    console_printf("%02x:%02x:%02x:%02x:%02x:%02x",
+                   u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
+}
+
+void
+print_uuid(const ble_uuid_t *uuid)
+{
+    char buf[BLE_UUID_STR_LEN];
+
+    ble_uuid_to_str(uuid, buf);
+
+    console_printf(buf);
+}
+
+int
+svc_is_empty(const struct bletiny_svc *svc)
+{
+    return svc->svc.end_handle < svc->svc.start_handle;
+}
+
+uint16_t
+chr_end_handle(const struct bletiny_svc *svc, const struct bletiny_chr *chr)
+{
+    const struct bletiny_chr *next_chr;
+
+    next_chr = SLIST_NEXT(chr, next);
+    if (next_chr != NULL) {
+        return next_chr->chr.def_handle - 1;
+    } else {
+        return svc->svc.end_handle;
+    }
+}
+
+int
+chr_is_empty(const struct bletiny_svc *svc, const struct bletiny_chr *chr)
+{
+    return chr_end_handle(svc, chr) <= chr->chr.val_handle;
+}
+
+void
+print_conn_desc(const struct ble_gap_conn_desc *desc)
+{
+    console_printf("handle=%d our_ota_addr_type=%d our_ota_addr=",
+                   desc->conn_handle, desc->our_ota_addr.type);
+    print_addr(desc->our_ota_addr.val);
+    console_printf(" our_id_addr_type=%d our_id_addr=",
+                   desc->our_id_addr.type);
+    print_addr(desc->our_id_addr.val);
+    console_printf(" peer_ota_addr_type=%d peer_ota_addr=",
+                   desc->peer_ota_addr.type);
+    print_addr(desc->peer_ota_addr.val);
+    console_printf(" peer_id_addr_type=%d peer_id_addr=",
+                   desc->peer_id_addr.type);
+    print_addr(desc->peer_id_addr.val);
+    console_printf(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+                   "encrypted=%d authenticated=%d bonded=%d\n",
+                   desc->conn_itvl, desc->conn_latency,
+                   desc->supervision_timeout,
+                   desc->sec_state.encrypted,
+                   desc->sec_state.authenticated,
+                   desc->sec_state.bonded);
+}
+
+static void
+print_dsc(struct bletiny_dsc *dsc)
+{
+    console_printf("            dsc_handle=%d uuid=", dsc->dsc.handle);
+    print_uuid(&dsc->dsc.uuid.u);
+    console_printf("\n");
+}
+
+static void
+print_chr(struct bletiny_chr *chr)
+{
+    struct bletiny_dsc *dsc;
+
+    console_printf("        def_handle=%d val_handle=%d properties=0x%02x "
+                   "uuid=", chr->chr.def_handle, chr->chr.val_handle,
+                   chr->chr.properties);
+    print_uuid(&chr->chr.uuid.u);
+    console_printf("\n");
+
+    SLIST_FOREACH(dsc, &chr->dscs, next) {
+        print_dsc(dsc);
+    }
+}
+
+void
+print_svc(struct bletiny_svc *svc)
+{
+    struct bletiny_chr *chr;
+
+    console_printf("    start=%d end=%d uuid=", svc->svc.start_handle,
+                   svc->svc.end_handle);
+    print_uuid(&svc->svc.uuid.u);
+    console_printf("\n");
+
+    SLIST_FOREACH(chr, &svc->chrs, next) {
+        print_chr(chr);
+    }
+}

--- a/apps/btshell/src/parse.c
+++ b/apps/btshell/src/parse.c
@@ -1,0 +1,611 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <assert.h>
+#include "console/console.h"
+#include "host/ble_hs.h"
+#include "host/ble_uuid.h"
+#include "host/ble_eddystone.h"
+#include "cmd.h"
+#include "bletiny.h"
+
+#define CMD_MAX_ARGS        16
+
+static char *cmd_args[CMD_MAX_ARGS][2];
+static int cmd_num_args;
+
+int
+parse_err_too_few_args(char *cmd_name)
+{
+    console_printf("Error: too few arguments for command \"%s\"\n",
+                   cmd_name);
+    return -1;
+}
+
+const struct cmd_entry *
+parse_cmd_find(const struct cmd_entry *cmds, char *name)
+{
+    const struct cmd_entry *cmd;
+    int i;
+
+    for (i = 0; cmds[i].name != NULL; i++) {
+        cmd = cmds + i;
+        if (strcmp(name, cmd->name) == 0) {
+            return cmd;
+        }
+    }
+
+    return NULL;
+}
+
+struct kv_pair *
+parse_kv_find(struct kv_pair *kvs, char *name)
+{
+    struct kv_pair *kv;
+    int i;
+
+    for (i = 0; kvs[i].key != NULL; i++) {
+        kv = kvs + i;
+        if (strcmp(name, kv->key) == 0) {
+            return kv;
+        }
+    }
+
+    return NULL;
+}
+
+int
+parse_arg_find_idx(const char *key)
+{
+    int i;
+
+    for (i = 0; i < cmd_num_args; i++) {
+        if (strcmp(cmd_args[i][0], key) == 0) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+char *
+parse_arg_peek(const char *key)
+{
+    int i;
+
+    for (i = 0; i < cmd_num_args; i++) {
+        if (strcmp(cmd_args[i][0], key) == 0) {
+            return cmd_args[i][1];
+        }
+    }
+
+    return NULL;
+}
+
+char *
+parse_arg_extract(const char *key)
+{
+    int i;
+
+    for (i = 0; i < cmd_num_args; i++) {
+        if (strcmp(cmd_args[i][0], key) == 0) {
+            /* Erase parameter. */
+            cmd_args[i][0][0] = '\0';
+
+            return cmd_args[i][1];
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * Determines which number base to use when parsing the specified numeric
+ * string.  This just avoids base '0' so that numbers don't get interpreted as
+ * octal.
+ */
+static int
+parse_arg_long_base(char *sval)
+{
+    if (sval[0] == '0' && sval[1] == 'x') {
+        return 0;
+    } else {
+        return 10;
+    }
+}
+
+long
+parse_long_bounds(char *sval, long min, long max, int *out_status)
+{
+    char *endptr;
+    long lval;
+
+    lval = strtol(sval, &endptr, parse_arg_long_base(sval));
+    if (sval[0] != '\0' && *endptr == '\0' &&
+        lval >= min && lval <= max) {
+
+        *out_status = 0;
+        return lval;
+    }
+
+    *out_status = EINVAL;
+    return 0;
+}
+
+long
+parse_arg_long_bounds_peek(char *name, long min, long max, int *out_status)
+{
+    char *sval;
+
+    sval = parse_arg_peek(name);
+    if (sval == NULL) {
+        *out_status = ENOENT;
+        return 0;
+    }
+    return parse_long_bounds(sval, min, max, out_status);
+}
+
+long
+parse_arg_long_bounds(char *name, long min, long max, int *out_status)
+{
+    char *sval;
+
+    sval = parse_arg_extract(name);
+    if (sval == NULL) {
+        *out_status = ENOENT;
+        return 0;
+    }
+    return parse_long_bounds(sval, min, max, out_status);
+}
+
+long
+parse_arg_long_bounds_default(char *name, long min, long max,
+                              long dflt, int *out_status)
+{
+    long val;
+    int rc;
+
+    val = parse_arg_long_bounds(name, min, max, &rc);
+    if (rc == ENOENT) {
+        rc = 0;
+        val = dflt;
+    }
+
+    *out_status = rc;
+
+    return val;
+}
+
+uint64_t
+parse_arg_uint64_bounds(char *name, uint64_t min, uint64_t max, int *out_status)
+{
+    char *endptr;
+    char *sval;
+    uint64_t lval;
+
+    sval = parse_arg_extract(name);
+    if (sval == NULL) {
+        *out_status = ENOENT;
+        return 0;
+    }
+
+    lval = strtoull(sval, &endptr, parse_arg_long_base(sval));
+    if (sval[0] != '\0' && *endptr == '\0' &&
+        lval >= min && lval <= max) {
+
+        *out_status = 0;
+        return lval;
+    }
+
+    *out_status = EINVAL;
+    return 0;
+}
+
+long
+parse_arg_long(char *name, int *out_status)
+{
+    return parse_arg_long_bounds(name, LONG_MIN, LONG_MAX, out_status);
+}
+
+uint8_t
+parse_arg_bool(char *name, int *out_status)
+{
+    return parse_arg_long_bounds(name, 0, 1, out_status);
+}
+
+uint8_t
+parse_arg_bool_default(char *name, uint8_t dflt, int *out_status)
+{
+    return parse_arg_long_bounds_default(name, 0, 1, dflt, out_status);
+}
+
+uint8_t
+parse_arg_uint8(char *name, int *out_status)
+{
+    return parse_arg_long_bounds(name, 0, UINT8_MAX, out_status);
+}
+
+uint16_t
+parse_arg_uint16(char *name, int *out_status)
+{
+    return parse_arg_long_bounds(name, 0, UINT16_MAX, out_status);
+}
+
+uint16_t
+parse_arg_uint16_peek(char *name, int *out_status)
+{
+    return parse_arg_long_bounds_peek(name, 0, UINT16_MAX, out_status);
+}
+
+uint32_t
+parse_arg_uint32(char *name, int *out_status)
+{
+    return parse_arg_uint64_bounds(name, 0, UINT32_MAX, out_status);
+}
+
+uint64_t
+parse_arg_uint64(char *name, int *out_status)
+{
+    return parse_arg_uint64_bounds(name, 0, UINT64_MAX, out_status);
+}
+
+uint8_t
+parse_arg_uint8_dflt(char *name, uint8_t dflt, int *out_status)
+{
+    uint8_t val;
+    int rc;
+
+    val = parse_arg_uint8(name, &rc);
+    if (rc == ENOENT) {
+        val = dflt;
+        rc = 0;
+    }
+
+    *out_status = rc;
+    return val;
+}
+
+uint16_t
+parse_arg_uint16_dflt(char *name, uint16_t dflt, int *out_status)
+{
+    uint16_t val;
+    int rc;
+
+    val = parse_arg_uint16(name, &rc);
+    if (rc == ENOENT) {
+        val = dflt;
+        rc = 0;
+    }
+
+    *out_status = rc;
+    return val;
+}
+
+uint32_t
+parse_arg_uint32_dflt(char *name, uint32_t dflt, int *out_status)
+{
+    uint32_t val;
+    int rc;
+
+    val = parse_arg_uint32(name, &rc);
+    if (rc == ENOENT) {
+        val = dflt;
+        rc = 0;
+    }
+
+    *out_status = rc;
+    return val;
+}
+
+int
+parse_arg_kv(char *name, struct kv_pair *kvs, int *out_status)
+{
+    struct kv_pair *kv;
+    char *sval;
+
+    sval = parse_arg_extract(name);
+    if (sval == NULL) {
+        *out_status = ENOENT;
+        return -1;
+    }
+
+    kv = parse_kv_find(kvs, sval);
+    if (kv == NULL) {
+        *out_status = EINVAL;
+        return -1;
+    }
+
+    *out_status = 0;
+    return kv->val;
+}
+
+int
+parse_arg_kv_default(char *name, struct kv_pair *kvs, int def_val,
+                     int *out_status)
+{
+    int val;
+    int rc;
+
+    val = parse_arg_kv(name, kvs, &rc);
+    if (rc == ENOENT) {
+        rc = 0;
+        val = def_val;
+    }
+
+    *out_status = rc;
+
+    return val;
+}
+
+
+static int
+parse_arg_byte_stream_delim(char *sval, char *delims, int max_len,
+                            uint8_t *dst, int *out_len)
+{
+    unsigned long ul;
+    char *endptr;
+    char *token;
+    int i;
+
+    i = 0;
+    for (token = strtok(sval, delims);
+         token != NULL;
+         token = strtok(NULL, delims)) {
+
+        if (i >= max_len) {
+            return EINVAL;
+        }
+
+        ul = strtoul(token, &endptr, 16);
+        if (sval[0] == '\0' || *endptr != '\0' || ul > UINT8_MAX) {
+            return -1;
+        }
+
+        dst[i] = ul;
+        i++;
+    }
+
+    *out_len = i;
+
+    return 0;
+}
+
+int
+parse_arg_byte_stream(char *name, int max_len, uint8_t *dst, int *out_len)
+{
+    char *sval;
+
+    sval = parse_arg_extract(name);
+    if (sval == NULL) {
+        return ENOENT;
+    }
+
+    return parse_arg_byte_stream_delim(sval, ":-", max_len, dst, out_len);
+}
+
+int
+parse_arg_byte_stream_exact_length(char *name, uint8_t *dst, int len)
+{
+    int actual_len;
+    int rc;
+
+    rc = parse_arg_byte_stream(name, len, dst, &actual_len);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (actual_len != len) {
+        return EINVAL;
+    }
+
+    return 0;
+}
+
+static void
+parse_reverse_bytes(uint8_t *bytes, int len)
+{
+    uint8_t tmp;
+    int i;
+
+    for (i = 0; i < len / 2; i++) {
+        tmp = bytes[i];
+        bytes[i] = bytes[len - i - 1];
+        bytes[len - i - 1] = tmp;
+    }
+}
+
+int
+parse_arg_mac(char *name, uint8_t *dst)
+{
+    int rc;
+
+    rc = parse_arg_byte_stream_exact_length(name, dst, 6);
+    if (rc != 0) {
+        return rc;
+    }
+
+    parse_reverse_bytes(dst, 6);
+
+    return 0;
+}
+
+int
+parse_arg_uuid(char *str, ble_uuid_any_t *uuid)
+{
+    uint16_t uuid16;
+    uint8_t val[16];
+    int len;
+    int rc;
+
+    uuid16 = parse_arg_uint16_peek(str, &rc);
+    switch (rc) {
+    case ENOENT:
+        parse_arg_extract(str);
+        return ENOENT;
+
+    case 0:
+        len = 2;
+        val[0] = uuid16;
+        val[1] = uuid16 >> 8;
+        parse_arg_extract(str);
+        break;
+
+    default:
+        len = 16;
+        rc = parse_arg_byte_stream_exact_length(str, val, 16);
+        if (rc != 0) {
+            return EINVAL;
+        }
+        parse_reverse_bytes(val, 16);
+        break;
+    }
+
+    rc = ble_uuid_init_from_buf(uuid, val, len);
+    if (rc != 0) {
+        return EINVAL;
+    } else {
+        return 0;
+    }
+}
+
+int
+parse_arg_all(int argc, char **argv)
+{
+    char *key;
+    char *val;
+    int i;
+
+    cmd_num_args = 0;
+
+    for (i = 0; i < argc; i++) {
+        key = strtok(argv[i], "=");
+        val = strtok(NULL, "=");
+
+        if (key != NULL && val != NULL) {
+            if (strlen(key) == 0) {
+                console_printf("Error: invalid argument: %s\n", argv[i]);
+                return -1;
+            }
+
+            if (cmd_num_args >= CMD_MAX_ARGS) {
+                console_printf("Error: too many arguments");
+                return -1;
+            }
+
+            cmd_args[cmd_num_args][0] = key;
+            cmd_args[cmd_num_args][1] = val;
+            cmd_num_args++;
+        }
+    }
+
+    return 0;
+}
+
+int
+parse_eddystone_url(char *full_url, uint8_t *out_scheme, char *out_body,
+                    uint8_t *out_body_len, uint8_t *out_suffix)
+{
+    static const struct {
+        char *s;
+        uint8_t scheme;
+    } schemes[] = {
+        { "http://www.", BLE_EDDYSTONE_URL_SCHEME_HTTP_WWW },
+        { "https://www.", BLE_EDDYSTONE_URL_SCHEME_HTTPS_WWW },
+        { "http://", BLE_EDDYSTONE_URL_SCHEME_HTTP },
+        { "https://", BLE_EDDYSTONE_URL_SCHEME_HTTPS },
+    };
+
+    static const struct {
+        char *s;
+        uint8_t code;
+    } suffixes[] = {
+        { ".com/", BLE_EDDYSTONE_URL_SUFFIX_COM_SLASH },
+        { ".org/", BLE_EDDYSTONE_URL_SUFFIX_ORG_SLASH },
+        { ".edu/", BLE_EDDYSTONE_URL_SUFFIX_EDU_SLASH },
+        { ".net/", BLE_EDDYSTONE_URL_SUFFIX_NET_SLASH },
+        { ".info/", BLE_EDDYSTONE_URL_SUFFIX_INFO_SLASH },
+        { ".biz/", BLE_EDDYSTONE_URL_SUFFIX_BIZ_SLASH },
+        { ".gov/", BLE_EDDYSTONE_URL_SUFFIX_GOV_SLASH },
+        { ".com", BLE_EDDYSTONE_URL_SUFFIX_COM },
+        { ".org", BLE_EDDYSTONE_URL_SUFFIX_ORG },
+        { ".edu", BLE_EDDYSTONE_URL_SUFFIX_EDU },
+        { ".net", BLE_EDDYSTONE_URL_SUFFIX_NET },
+        { ".info", BLE_EDDYSTONE_URL_SUFFIX_INFO },
+        { ".biz", BLE_EDDYSTONE_URL_SUFFIX_BIZ },
+        { ".gov", BLE_EDDYSTONE_URL_SUFFIX_GOV },
+    };
+
+    char *prefix;
+    char *suffix;
+    int full_url_len;
+    int prefix_len;
+    int suffix_len;
+    int suffix_idx;
+    int rc;
+    int i;
+
+    full_url_len = strlen(full_url);
+
+    rc = BLE_HS_EINVAL;
+    for (i = 0; i < sizeof schemes / sizeof schemes[0]; i++) {
+        prefix = schemes[i].s;
+        prefix_len = strlen(schemes[i].s);
+
+        if (full_url_len >= prefix_len &&
+            memcmp(full_url, prefix, prefix_len) == 0) {
+
+            *out_scheme = i;
+            rc = 0;
+            break;
+        }
+    }
+    if (rc != 0) {
+        return rc;
+    }
+
+    rc = BLE_HS_EINVAL;
+    for (i = 0; i < sizeof suffixes / sizeof suffixes[0]; i++) {
+        suffix = suffixes[i].s;
+        suffix_len = strlen(suffixes[i].s);
+
+        suffix_idx = full_url_len - suffix_len;
+        if (suffix_idx >= prefix_len &&
+            memcmp(full_url + suffix_idx, suffix, suffix_len) == 0) {
+
+            *out_suffix = i;
+            rc = 0;
+            break;
+        }
+    }
+    if (rc != 0) {
+        *out_suffix = BLE_EDDYSTONE_URL_SUFFIX_NONE;
+        *out_body_len = full_url_len - prefix_len;
+    } else {
+        *out_body_len = full_url_len - prefix_len - suffix_len;
+    }
+
+    memcpy(out_body, full_url + prefix_len, *out_body_len);
+
+    return 0;
+}

--- a/apps/btshell/src/parse.c
+++ b/apps/btshell/src/parse.c
@@ -59,22 +59,6 @@ parse_cmd_find(const struct cmd_entry *cmds, char *name)
     return NULL;
 }
 
-struct kv_pair *
-parse_kv_find(struct kv_pair *kvs, char *name)
-{
-    struct kv_pair *kv;
-    int i;
-
-    for (i = 0; kvs[i].key != NULL; i++) {
-        kv = kvs + i;
-        if (strcmp(name, kv->key) == 0) {
-            return kv;
-        }
-    }
-
-    return NULL;
-}
-
 int
 parse_arg_find_idx(const char *key)
 {
@@ -318,10 +302,26 @@ parse_arg_uint32_dflt(char *name, uint32_t dflt, int *out_status)
     return val;
 }
 
-int
-parse_arg_kv(char *name, struct kv_pair *kvs, int *out_status)
+const struct kv_pair *
+parse_kv_find(const struct kv_pair *kvs, char *name)
 {
-    struct kv_pair *kv;
+    const struct kv_pair *kv;
+    int i;
+
+    for (i = 0; kvs[i].key != NULL; i++) {
+        kv = kvs + i;
+        if (strcmp(name, kv->key) == 0) {
+            return kv;
+        }
+    }
+
+    return NULL;
+}
+
+int
+parse_arg_kv(char *name, const struct kv_pair *kvs, int *out_status)
+{
+    const struct kv_pair *kv;
     char *sval;
 
     sval = parse_arg_extract(name);
@@ -341,7 +341,7 @@ parse_arg_kv(char *name, struct kv_pair *kvs, int *out_status)
 }
 
 int
-parse_arg_kv_default(char *name, struct kv_pair *kvs, int def_val,
+parse_arg_kv_default(char *name, const struct kv_pair *kvs, int def_val,
                      int *out_status)
 {
     int val;

--- a/apps/btshell/src/parse.c
+++ b/apps/btshell/src/parse.c
@@ -36,30 +36,6 @@ static char *cmd_args[CMD_MAX_ARGS][2];
 static int cmd_num_args;
 
 int
-parse_err_too_few_args(char *cmd_name)
-{
-    console_printf("Error: too few arguments for command \"%s\"\n",
-                   cmd_name);
-    return -1;
-}
-
-const struct cmd_entry *
-parse_cmd_find(const struct cmd_entry *cmds, char *name)
-{
-    const struct cmd_entry *cmd;
-    int i;
-
-    for (i = 0; cmds[i].name != NULL; i++) {
-        cmd = cmds + i;
-        if (strcmp(name, cmd->name) == 0) {
-            return cmd;
-        }
-    }
-
-    return NULL;
-}
-
-int
 parse_arg_find_idx(const char *key)
 {
     int i;

--- a/apps/btshell/src/parse.c
+++ b/apps/btshell/src/parse.c
@@ -29,7 +29,7 @@
 #include "host/ble_eddystone.h"
 #include "parse/parse.h"
 #include "cmd.h"
-#include "bletiny.h"
+#include "btshell.h"
 
 #define CMD_MAX_ARGS        16
 

--- a/apps/btshell/syscfg.yml
+++ b/apps/btshell/syscfg.yml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: apps/btshell
+
+syscfg.vals:
+    # Enable the shell task.
+    SHELL_TASK: 1
+
+    # Set log level to info (disable debug logging).
+    LOG_LEVEL: 1
+
+    # Disable security manager (pairing and bonding).
+    BLE_SM_LEGACY: 0
+    BLE_SM_SC: 0
+
+    # Disable eddystone beacons.
+    BLE_EDDYSTONE: 0
+
+    # Default task settings
+    OS_MAIN_STACK_SIZE: 512

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -459,6 +459,12 @@ int ble_gatts_find_chr(const ble_uuid_t *svc_uuid, const ble_uuid_t *chr_uuid,
 int ble_gatts_find_dsc(const ble_uuid_t *svc_uuid, const ble_uuid_t *chr_uuid,
                        const ble_uuid_t *dsc_uuid, uint16_t *out_dsc_handle);
 
+typedef void (*ble_gatt_svc_foreach_fn)(const struct ble_gatt_svc_def *svc,
+                                        uint16_t handle,
+                                        uint16_t end_group_handle);
+void ble_gatts_lcl_svc_foreach(ble_gatt_svc_foreach_fn cb);
+void ble_gatts_show_local(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -2080,6 +2080,18 @@ ble_gatts_count_cfg(const struct ble_gatt_svc_def *defs)
     return 0;
 }
 
+void
+ble_gatts_lcl_svc_foreach(ble_gatt_svc_foreach_fn cb)
+{
+    int i;
+
+    for (i = 0; i < ble_gatts_num_svc_entries; i++) {
+        cb(ble_gatts_svc_entries[i].svc,
+           ble_gatts_svc_entries[i].handle,
+           ble_gatts_svc_entries[i].end_group_handle);
+    }
+}
+
 int
 ble_gatts_init(void)
 {

--- a/net/nimble/host/src/ble_gatts_lcl.c
+++ b/net/nimble/host/src/ble_gatts_lcl.c
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include "host/ble_uuid.h"
+#include "console/console.h"
+#include "nimble/ble.h"
+#include "ble_hs_priv.h"
+
+
+static const char * const ble_gatt_chr_f_names[] = {
+    "BROADCAST",
+    "READ",
+    "WRITE_NO_RSP",
+    "WRITE",
+    "NOTIFY",
+    "INDICATE",
+    "AUTH_SIGN_WRITE",
+    "RELIABLE_WRITE",
+    "AUX_WRITE",
+    "READ_ENC",
+    "READ_AUTHEN",
+    "READ_AUTHOR",
+    "WRITE_ENC",
+    "WRITE_AUTHEN",
+    "WRITE_AUTHOR",
+    NULL
+};
+
+static const char * const ble_gatt_dsc_f_names[] = {
+    "READ",
+    "WRITE",
+    "READ_ENC",
+    "READ_AUTHEN",
+    "READ_AUTHOR",
+    "WRITE_ENC",
+    "WRITE_AUTHEN",
+    "WRITE_AUTHOR",
+    NULL
+};
+
+#define BLE_CHR_FLAGS_STR_LEN 180
+
+static char *
+ble_gatts_flags_to_str(uint16_t flags, char *buf,
+                       const char * const *names)
+{
+    int bit;
+    bool non_empty = false;
+    size_t length = 0;
+
+    buf[0] = '\0';
+    strcpy(buf, "[");
+    length += 1;
+    for (bit = 0; names[bit]; ++bit) {
+        if (flags & (1 << bit)) {
+            length += strlen(names[bit]);
+            if (length + 1 >= BLE_CHR_FLAGS_STR_LEN) {
+                return buf;
+            }
+            if (non_empty) {
+                strcat(buf, "|");
+                length += 1;
+            }
+            strcat(buf, names[bit]);
+            non_empty = true;
+        }
+    }
+    strcat(buf, "]");
+    return buf;
+}
+
+
+#define STRINGIFY(X) #X
+#define FIELD_NAME_LEN STRINGIFY(12)
+#define FIELD_INDENT STRINGIFY(2)
+
+static void
+ble_gatt_show_local_chr(const struct ble_gatt_svc_def *svc,
+                        uint16_t handle, char *uuid_buf, char *flags_buf)
+{
+    const struct ble_gatt_chr_def *chr;
+    const struct ble_gatt_dsc_def *dsc;
+
+    for (chr = svc->characteristics; chr && chr->uuid; ++chr) {
+        console_printf("characteristic\n");
+        console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                       "%s\n", " ", "uuid",
+                       ble_uuid_to_str(chr->uuid, uuid_buf));
+        console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                       "%d\n", " ", "def_handle", handle);
+        console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                       "%d\n", " ", "val_handle", handle+1);
+        console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                       "%d\n", " ", "min_key_size", chr->min_key_size);
+        console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                       "%s\n", " ", "flags",
+                       ble_gatts_flags_to_str(chr->flags,
+                       flags_buf, ble_gatt_chr_f_names));
+        handle += 2;
+        for (dsc = chr->descriptors; dsc && dsc->uuid; ++dsc) {
+            console_printf("descriptor\n");
+            console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                           "%s\n", " ", "uuid",
+                           ble_uuid_to_str(dsc->uuid, uuid_buf));
+            console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                           "%d\n", " ", "handle", handle);
+            console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                           "%d\n", " ", "min_key_size", dsc->min_key_size);
+            console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                           "%s\n", " ", "flags",
+                           ble_gatts_flags_to_str(dsc->att_flags,
+                           flags_buf, ble_gatt_dsc_f_names));
+            handle++;
+        }
+    }
+}
+
+static void
+ble_gatt_show_local_svc(const struct ble_gatt_svc_def *svc,
+                        uint16_t handle, uint16_t end_group_handle)
+{
+    char uuid_buf[BLE_UUID_STR_LEN];
+    char flags_buf[BLE_CHR_FLAGS_STR_LEN];
+
+    console_printf("%s service\n",
+                   svc->type == BLE_GATT_SVC_TYPE_PRIMARY ?
+                           "primary" : "secondary");
+    console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                   "%s\n", " ", "uuid",
+                   ble_uuid_to_str(svc->uuid, uuid_buf));
+    console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                   "%d\n", " ", "handle",
+                   handle);
+    console_printf("%" FIELD_INDENT "s %" FIELD_NAME_LEN "s "
+                   "%d\n", " ", "end_handle",
+                   end_group_handle);
+    ble_gatt_show_local_chr(svc, handle+1,
+                            uuid_buf, flags_buf);
+}
+
+void
+ble_gatts_show_local(void)
+{
+    ble_gatts_lcl_svc_foreach(ble_gatt_show_local_svc);
+}
+


### PR DESCRIPTION
Features improved command naming and tab completion functionality.
In the future it could replace bletiny. Later some commands
implementations could me placed inside respective packages and added
to shell as separate modules, e.g. l2cap, gatt, gap, etc.