### PR TITLE
Wrap RTT console buffer if full

### DIFF
--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -40,13 +40,13 @@ console_out(int character)
     char c = (char)character;
 
     if ('\n' == c) {
-        SEGGER_RTT_WriteNoLock(0, &CR, 1);
+        SEGGER_RTT_WriteWithOverwriteNoLock(0, &CR, 1);
         console_is_midline = 0;
     } else {
         console_is_midline = 1;
     }
 
-    SEGGER_RTT_WriteNoLock(0, &c, 1);
+    SEGGER_RTT_WriteWithOverwriteNoLock(0, &c, 1);
 
     return character;
 }

--- a/sys/console/minimal/src/rtt_console.c
+++ b/sys/console/minimal/src/rtt_console.c
@@ -40,13 +40,13 @@ console_out(int character)
     char c = (char)character;
 
     if ('\n' == c) {
-        SEGGER_RTT_WriteNoLock(0, &CR, 1);
+        SEGGER_RTT_WriteWithOverwriteNoLock(0, &CR, 1);
         console_is_midline = 0;
     } else {
         console_is_midline = 1;
     }
 
-    SEGGER_RTT_WriteNoLock(0, &c, 1);
+    SEGGER_RTT_WriteWithOverwriteNoLock(0, &c, 1);
 
     return character;
 }


### PR DESCRIPTION
This ensures the RTT memory buffer always has the last 1kb of logs, as opposed to the first 1kb of logs. This is a lot more useful when dumping memory, for example. 