### PR TITLE
cleanup - double include nrf52_bitfields.h

### DIFF
--- a/hw/drivers/nimble/nrf52/src/ble_hw.c
+++ b/hw/drivers/nimble/nrf52/src/ble_hw.c
@@ -29,8 +29,6 @@
 #include "controller/ble_hw.h"
 #include "bsp/cmsis_nvic.h"
 
-#include "nrf52_bitfields.h"
-
 /* Total number of resolving list elements */
 #define BLE_HW_RESOLV_LIST_SIZE     (16)
 


### PR DESCRIPTION
removed duplicated #include "nrf52_bitfields.h"