### PR TITLE
Re-add 128-bit iotivity service UUID.

### DIFF
--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -117,15 +117,29 @@ bleprph_advertise(void)
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
 
-    fields.uuids16 = (ble_uuid16_t[]) {
-        BLE_UUID16_INIT(OC_GATT_SERVICE_UUID)
+    fields.uuids128 = (ble_uuid128_t []) {
+        BLE_UUID128_INIT(OC_GATT_SERVICE_UUID)
     };
-    fields.num_uuids16 = 1;
-    fields.uuids16_is_complete = 1;
+    fields.num_uuids128 = 1;
+    fields.uuids128_is_complete = 1;
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
         BLEPRPH_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        return;
+    }
+
+    /* Advertise the 16-bit CoAP-over-BLE service UUID in the scan response. */
+    memset(&fields, 0, sizeof fields);
+    fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(RUNTIME_COAP_SERVICE_UUID)
+    };
+    fields.num_uuids16 = 1;
+    fields.uuids16_is_complete = 1;
+
+    rc = ble_gap_adv_rsp_set_fields(&fields);
+    if (rc != 0) {
+        BLEPRPH_LOG(ERROR, "error setting scan response data; rc=%d\n", rc);
         return;
     }
 
@@ -364,7 +378,7 @@ main(void)
     ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;
 
     /* Set the default device name. */
-    rc = ble_svc_gap_device_name_set("pi");
+    rc = ble_svc_gap_device_name_set("c5");
     assert(rc == 0);
 
     /* Our light resource */

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -170,15 +170,29 @@ sensor_oic_advertise(void)
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
 
-    fields.uuids16 = (ble_uuid16_t[]) {
-        BLE_UUID16_INIT(OC_GATT_SERVICE_UUID)
+    fields.uuids128 = (ble_uuid128_t []) {
+        BLE_UUID128_INIT(OC_GATT_SERVICE_UUID)
     };
-    fields.num_uuids16 = 1;
-    fields.uuids16_is_complete = 1;
+    fields.num_uuids128 = 1;
+    fields.uuids128_is_complete = 1;
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
         BLEPRPH_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        return;
+    }
+
+    /* Advertise the 16-bit CoAP-over-BLE service UUID in the scan response. */
+    memset(&fields, 0, sizeof fields);
+    fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(RUNTIME_COAP_SERVICE_UUID)
+    };
+    fields.num_uuids16 = 1;
+    fields.uuids16_is_complete = 1;
+
+    rc = ble_gap_adv_rsp_set_fields(&fields);
+    if (rc != 0) {
+        BLEPRPH_LOG(ERROR, "error setting scan response data; rc=%d\n", rc);
         return;
     }
 

--- a/net/oic/include/oic/oc_gatt.h
+++ b/net/oic/include/oic/oc_gatt.h
@@ -26,7 +26,14 @@
 extern "C" {
 #endif
 
-#define OC_GATT_SERVICE_UUID    0x9923
+/* ADE3D529-C784-4F63-A987-EB69F70EE816 */
+#define OC_GATT_SERVICE_UUID  0x16, 0xe8, 0x0e, 0xf7, 0x69, 0xeb, 0x87, 0xa9, \
+                              0x63, 0x4f, 0x84, 0xc7, 0x29, 0xd5, 0xe3, 0xad
+
+/* XXX: This UUID, its name, and its location in this file are all
+ * tentative.
+ */
+#define RUNTIME_COAP_SERVICE_UUID    0x9923
 
 int oc_ble_coap_gatt_srv_init(void);
 void oc_ble_coap_conn_new(uint16_t conn_handle);

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -37,9 +37,13 @@
 /* OIC Transport Profile GATT */
 
 /* service UUID */
-/* 0x9923 */
-static const ble_uuid16_t oc_gatt_svc_uuid =
-    BLE_UUID16_INIT(OC_GATT_SERVICE_UUID);
+/* ADE3D529-C784-4F63-A987-EB69F70EE816 */
+static const ble_uuid128_t oc_gatt_svc_uuid =
+    BLE_UUID128_INIT(OC_GATT_SERVICE_UUID);
+
+/* 16-bit service UUID. */
+static const ble_uuid16_t runtime_coap_svc_uuid =
+    BLE_UUID16_INIT(RUNTIME_COAP_SERVICE_UUID);
 
 /* request characteristic UUID */
 /* AD7B334F-4637-4B86-90B6-9D787F03D218 */
@@ -86,9 +90,31 @@ static int oc_gatt_chr_access(uint16_t conn_handle, uint16_t attr_handle,
                    struct ble_gatt_access_ctxt *ctxt, void *arg);
 
 static const struct ble_gatt_svc_def gatt_svr_svcs[] = { {
-        /* Service: newtmgr */
+        /* Service: iotivity */
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
         .uuid = &oc_gatt_svc_uuid.u,
+        .characteristics = (struct ble_gatt_chr_def[]) {
+            {
+                /* Characteristic: Request */
+                .uuid = &oc_gatt_req_chr_uuid.u,
+                .access_cb = oc_gatt_chr_access,
+                .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_NO_RSP |
+                         BLE_GATT_CHR_F_NOTIFY,
+                .val_handle = &oc_ble_coap_req_handle,
+            },{
+                /* Characteristic: Response */
+                .uuid = &oc_gatt_rsp_chr_uuid.u,
+                .access_cb = oc_gatt_chr_access,
+                .flags = BLE_GATT_CHR_F_NOTIFY,
+                .val_handle = &oc_ble_coap_rsp_handle,
+            },{
+                0, /* No more characteristics in this service */
+            }
+        },
+
+        /* Service: CoAP-over-BLE */
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = &runtime_coap_svc_uuid.u,
         .characteristics = (struct ble_gatt_chr_def[]) {
             {
                 /* Characteristic: Request */


### PR DESCRIPTION
Earlier, we started using a 16-bit UUID (0x9923) instead of the 128-bit
UUID for this service.  The 128-bit UUID was actually the iotivity
service UUID which we want to support.  This commit adds the 128-bit
UUID back.