### PR TITLE
make uart1 on rb-blend2 bitbanged

### DIFF
--- a/hw/bsp/rb-blend2/pkg.yml
+++ b/hw/bsp/rb-blend2/pkg.yml
@@ -82,7 +82,6 @@ pkg.cflags:
     - '-DTWIS0_ENABLED=1'
     - '-DTWIS1_ENABLED=0'
     - '-DUART0_ENABLED=1'
-    - '-DUART1_ENABLED=1'
     - '-DWDT_ENABLED=1'
 
 pkg.cflags.HARDFLOAT:
@@ -99,4 +98,4 @@ pkg.deps.UART_0:
     - hw/drivers/uart/uart_hal
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - hw/drivers/uart/uart_bitbang

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -30,9 +30,14 @@
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
-#if MYNEWT_VAL(UART_0)
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include "uart/uart.h"
+#endif
+#if MYNEWT_VAL(UART_0)
 #include "uart_hal/uart_hal.h"
+#endif
+#if MYNEWT_VAL(UART_1)
+#include "uart_bitbang/uart_bitbang.h"
 #endif
 #include "os/os_dev.h"
 
@@ -47,10 +52,11 @@ static const struct nrf52_uart_cfg os_bsp_uart0_cfg = {
 #endif
 
 #if MYNEWT_VAL(UART_1)
-static struct uart_dev os_bsp_uart1;
-static const struct nrf52_uart_cfg os_bsp_uart1_cfg = {
-    .suc_pin_tx = MYNEWT_VAL(UART_1_PIN_TX),
-    .suc_pin_rx = MYNEWT_VAL(UART_1_PIN_RX),
+static struct uart_dev os_bsp_bitbang_uart1;
+static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
+    .ubc_txpin = MYNEWT_VAL(UART_1_PIN_TX),
+    .ubc_rxpin = MYNEWT_VAL(UART_1_PIN_RX),
+    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
 };
 #endif
 
@@ -185,8 +191,8 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(UART_1)
-    rc = os_dev_create((struct os_dev *) &os_bsp_uart1, "uart1",
-      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *)&os_bsp_uart1_cfg);
+    rc = os_dev_create((struct os_dev *) &os_bsp_bitbang_uart1, "uart1",
+      OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init, (void *)&os_bsp_uart1_cfg);
     assert(rc == 0);
 #endif
 

--- a/hw/bsp/rb-blend2/syscfg.yml
+++ b/hw/bsp/rb-blend2/syscfg.yml
@@ -45,8 +45,8 @@ syscfg.defs:
         value: 5
 
     UART_1:
-        description: 'Whether to enable UART1'
-        value: 1
+        description: 'Whether to enable bitbanger UART1'
+        value: 0
     UART_1_PIN_TX:
         description: 'TX pin for UART1'
         value: 12


### PR DESCRIPTION
I noticed that both uart0 and uart1 were configured as hardware UARTs on the blend v2.
This PR fixes that and makes uart1 bitbanged (same as the other nrf52832 based boards).