### PR TITLE
MYNEWT-760  Switch testbench app over to CoAP (from plain NMP)

### DIFF
--- a/apps/testbench/pkg.yml
+++ b/apps/testbench/pkg.yml
@@ -30,8 +30,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/kernel/os/test"
     - "@apache-mynewt-core/mgmt/imgmgr"
-    - "@apache-mynewt-core/mgmt/newtmgr"
-    - "@apache-mynewt-core/mgmt/newtmgr/transport/nmgr_shell"
+    - "@apache-mynewt-core/mgmt/oicmgr"
     - "@apache-mynewt-core/sys/config"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/flash_map"
@@ -44,7 +43,6 @@ pkg.deps:
     - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.TESTBENCH_BLE:
-    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
     - "@apache-mynewt-core/net/nimble/controller"
     - "@apache-mynewt-core/net/nimble/host"
     - "@apache-mynewt-core/net/nimble/host/services/gap"

--- a/apps/testbench/src/tbb.c
+++ b/apps/testbench/src/tbb.c
@@ -42,6 +42,8 @@
 #include "host/ble_hs.h"
 #include "services/gap/ble_svc_gap.h"
 
+#include "oic/oc_gatt.h"
+
 #include "tbb.h"
 
 static int tbb_gap_event(struct ble_gap_event *event, void *arg);
@@ -133,6 +135,12 @@ tbb_advertise(void)
     fields.name = (uint8_t *)name;
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
+
+    fields.uuids128 = (ble_uuid128_t[]) {
+        BLE_UUID128_INIT(OC_GATT_SERVICE_UUID)
+    };
+    fields.num_uuids128 = 1;
+    fields.uuids128_is_complete = 1;
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {

--- a/apps/testbench/src/testbench.c
+++ b/apps/testbench/src/testbench.c
@@ -36,7 +36,6 @@
 #if MYNEWT_VAL(SPLIT_LOADER)
 #include "split/split.h"
 #endif
-#include <newtmgr/newtmgr.h>
 #include <bootutil/image.h>
 #include <bootutil/bootutil.h>
 #include <imgmgr/imgmgr.h>
@@ -47,6 +46,8 @@
 #include <os/os_time.h>
 #include <id/id.h>
 #include <os/os_eventq.h>
+#include <oic/oc_api.h>
+#include <oic/oc_gatt.h>
 
 #include "testutil/testutil.h"
 
@@ -369,6 +370,14 @@ TEST_SUITE_DECL(testbench_mutex);
 TEST_SUITE_DECL(testbench_sem);
 TEST_SUITE_DECL(testbench_json);
 
+static void
+omgr_app_init(void)
+{ }
+
+static const oc_handler_t omgr_oc_handler = {
+    .init = omgr_app_init,
+};
+
 /*
  * main()
  * Keep this app simple, just run the tests and then report success or failure.
@@ -390,6 +399,11 @@ main(int argc, char **argv)
 #if MYNEWT_VAL(TESTBENCH_BLE)
     tbb_init();
 #endif
+
+    /* Initialize the OIC  */
+    log_register("oic", &oc_log, &log_console_handler, NULL, LOG_SYSLEVEL);
+    oc_main_init((oc_handler_t *)&omgr_oc_handler);
+    oc_ble_coap_gatt_srv_init();
 
     conf_load();
 

--- a/apps/testbench/src/testbench.h
+++ b/apps/testbench/src/testbench.h
@@ -39,7 +39,6 @@
 #if MYNEWT_VAL(SPLIT_LOADER)
 #include "split/split.h"
 #endif
-#include <newtmgr/newtmgr.h>
 #include <bootutil/image.h>
 #include <bootutil/bootutil.h>
 #include <imgmgr/imgmgr.h>

--- a/apps/testbench/syscfg.yml
+++ b/apps/testbench/syscfg.yml
@@ -62,3 +62,11 @@ syscfg.vals:
 
     # Default task settings
     OS_MAIN_STACK_SIZE: 768
+
+    # OC server, with serial transport.
+    OC_SERVER: 1
+    OC_TRANSPORT_SERIAL: 1
+
+    # Optionally add OC BLE transport.
+syscfg.vals.TESTBENCH_BLE:
+    OC_TRANSPORT_GATT: 1


### PR DESCRIPTION
Currently, the testbench app uses plain newtmgr.  This PR modifies the app so that newtmgr messages are sent via CoAP instead.