### PR TITLE
Indicate custom

### DIFF
--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -188,6 +188,8 @@ int ble_gattc_write_reliable(uint16_t conn_handle,
 int ble_gattc_notify_custom(uint16_t conn_handle, uint16_t att_handle,
                             struct os_mbuf *om);
 int ble_gattc_notify(uint16_t conn_handle, uint16_t chr_val_handle);
+int ble_gattc_indicate_custom(uint16_t conn_handle, uint16_t chr_val_handle,
+                              struct os_mbuf *txom);
 int ble_gattc_indicate(uint16_t conn_handle, uint16_t chr_val_handle);
 
 int ble_gattc_init(void);

--- a/net/nimble/host/src/ble_gattc.c
+++ b/net/nimble/host/src/ble_gattc.c
@@ -4563,11 +4563,13 @@ ble_gatts_indicate_fail_notconn(uint16_t conn_handle)
  * @param chr_val_handle        The value attribute handle of the
  *                                  characteristic to include in the outgoing
  *                                  indication.
+ * @param txom                  The data to include in the indication.
  *
  * @return                      0 on success; nonzero on failure.
  */
 int
-ble_gattc_indicate(uint16_t conn_handle, uint16_t chr_val_handle)
+ble_gattc_indicate_custom(uint16_t conn_handle, uint16_t chr_val_handle,
+                          struct os_mbuf *txom)
 {
 #if !MYNEWT_VAL(BLE_GATT_INDICATE)
     return BLE_HS_ENOTSUP;
@@ -4575,12 +4577,9 @@ ble_gattc_indicate(uint16_t conn_handle, uint16_t chr_val_handle)
 
     struct ble_gattc_proc *proc;
     struct ble_hs_conn *conn;
-    struct os_mbuf *om;
     int rc;
 
     STATS_INC(ble_gattc_stats, indicate);
-
-    om = NULL;
 
     proc = ble_gattc_proc_alloc();
     if (proc == NULL) {
@@ -4594,23 +4593,28 @@ ble_gattc_indicate(uint16_t conn_handle, uint16_t chr_val_handle)
 
     ble_gattc_log_indicate(chr_val_handle);
 
-    om = ble_hs_mbuf_att_pkt();
-    if (om == NULL) {
-        rc = BLE_HS_ENOMEM;
-        goto done;
+    if (txom == NULL) {
+        /* No custom attribute data; read the value from the specified
+         * attribute.
+         */
+        txom = ble_hs_mbuf_att_pkt();
+        if (txom == NULL) {
+            rc = BLE_HS_ENOMEM;
+            goto done;
+        }
+
+        rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE, chr_val_handle,
+                                     0, txom, NULL);
+        if (rc != 0) {
+            /* Fatal error; application disallowed attribute read. */
+            BLE_HS_DBG_ASSERT(0);
+            rc = BLE_HS_EAPP;
+            goto done;
+        }
     }
 
-    rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE, chr_val_handle, 0,
-                                 om, NULL);
-    if (rc != 0) {
-        /* Fatal error; application disallowed attribute read. */
-        BLE_HS_DBG_ASSERT(0);
-        rc = BLE_HS_EAPP;
-        goto done;
-    }
-
-    rc = ble_att_clt_tx_indicate(conn_handle, chr_val_handle, om);
-    om = NULL;
+    rc = ble_att_clt_tx_indicate(conn_handle, chr_val_handle, txom);
+    txom = NULL;
     if (rc != 0) {
         goto done;
     }
@@ -4623,7 +4627,6 @@ ble_gattc_indicate(uint16_t conn_handle, uint16_t chr_val_handle)
     }
     ble_hs_unlock();
 
-
 done:
     if (rc != 0) {
         STATS_INC(ble_gattc_stats, indicate_fail);
@@ -4633,8 +4636,26 @@ done:
     ble_gap_notify_tx_event(rc, conn_handle, chr_val_handle, 1);
 
     ble_gattc_process_status(proc, rc);
-    os_mbuf_free_chain(om);
+    os_mbuf_free_chain(txom);
     return rc;
+}
+
+/**
+ * Sends a characteristic indication.  The content of the message is read from
+ * the specified characteristic.
+ *
+ * @param conn_handle           The connection over which to execute the
+ *                                  procedure.
+ * @param chr_val_handle        The value attribute handle of the
+ *                                  characteristic to include in the outgoing
+ *                                  indication.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+int
+ble_gattc_indicate(uint16_t conn_handle, uint16_t chr_val_handle)
+{
+    return ble_gattc_indicate_custom(conn_handle, chr_val_handle, NULL);
 }
 
 /*****************************************************************************

--- a/net/nimble/host/src/ble_hs_hci.c
+++ b/net/nimble/host/src/ble_hs_hci.c
@@ -369,7 +369,7 @@ ble_hs_hci_max_acl_payload_sz(void)
 static struct os_mbuf *
 ble_hs_hci_frag_alloc(uint16_t frag_size, void *arg)
 {
-    return ble_hs_mbuf_acm_pkt();
+    return ble_hs_mbuf_acl_pkt();
 }
 
 static struct os_mbuf *

--- a/net/nimble/host/src/ble_hs_mbuf.c
+++ b/net/nimble/host/src/ble_hs_mbuf.c
@@ -58,13 +58,13 @@ ble_hs_mbuf_bare_pkt(void)
 }
 
 /**
- * Allocates an mbuf suitable for an HCI ACM data packet.
+ * Allocates an mbuf suitable for an HCI ACL data packet.
  *
  * @return                  An empty mbuf on success; null on memory
  *                              exhaustion.
  */
 struct os_mbuf *
-ble_hs_mbuf_acm_pkt(void)
+ble_hs_mbuf_acl_pkt(void)
 {
     return ble_hs_mbuf_gen_pkt(BLE_HCI_DATA_HDR_SZ);
 }
@@ -72,7 +72,7 @@ ble_hs_mbuf_acm_pkt(void)
 /**
  * Allocates an mbuf suitable for an L2CAP data packet.  The resulting packet
  * has sufficient leading space for:
- *     o ACM data header
+ *     o ACL data header
  *     o L2CAP B-frame header
  *
  * @return                  An empty mbuf on success; null on memory
@@ -87,7 +87,7 @@ ble_hs_mbuf_l2cap_pkt(void)
 /**
  * Allocates an mbuf suitable for an ATT command packet.  The resulting packet
  * has sufficient leading space for:
- *     o ACM data header
+ *     o ACL data header
  *     o L2CAP B-frame header
  *     o Largest ATT command base (prepare write request / response).
  *

--- a/net/nimble/host/src/ble_hs_mbuf_priv.h
+++ b/net/nimble/host/src/ble_hs_mbuf_priv.h
@@ -27,7 +27,7 @@ extern "C" {
 struct os_mbuf;
 
 struct os_mbuf *ble_hs_mbuf_bare_pkt(void);
-struct os_mbuf *ble_hs_mbuf_acm_pkt(void);
+struct os_mbuf *ble_hs_mbuf_acl_pkt(void);
 struct os_mbuf *ble_hs_mbuf_l2cap_pkt(void);
 int ble_hs_mbuf_pullup_base(struct os_mbuf **om, int base_len);
 

--- a/net/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/net/nimble/host/test/src/ble_gatts_notify_test.c
@@ -436,7 +436,7 @@ ble_gatts_notify_test_misc_rx_indicate_rsp(uint16_t conn_handle,
 static void
 ble_gatts_notify_test_misc_verify_tx_n(uint16_t conn_handle,
                                        uint16_t attr_handle,
-                                       uint8_t *attr_data, int attr_len)
+                                       const uint8_t *attr_data, int attr_len)
 {
     struct ble_att_notify_req req;
     struct os_mbuf *om;
@@ -578,8 +578,11 @@ ble_gatts_notify_test_restore_bonding(uint16_t conn_handle,
 
 TEST_CASE(ble_gatts_notify_test_n)
 {
+    static const uint8_t fourbytes[] = { 1, 2, 3, 4 };
+    struct os_mbuf *om;
     uint16_t conn_handle;
     uint16_t flags;
+    int rc;
 
     ble_gatts_notify_test_misc_init(&conn_handle, 0,
                                     BLE_GATTS_CLT_CFG_F_NOTIFY,
@@ -592,6 +595,21 @@ TEST_CASE(ble_gatts_notify_test_n)
     flags = ble_gatts_notify_test_misc_read_notify(
         conn_handle, ble_gatts_notify_test_chr_2_def_handle);
     TEST_ASSERT(flags == BLE_GATTS_CLT_CFG_F_NOTIFY);
+
+    /* Verify custom notification data. */
+    om = ble_hs_mbuf_from_flat(fourbytes, sizeof fourbytes);
+    TEST_ASSERT_FATAL(om != NULL);
+
+    rc = ble_gattc_notify_custom(conn_handle,
+                                 ble_gatts_notify_test_chr_1_def_handle + 1,
+                                 om);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    ble_gatts_notify_test_misc_verify_tx_n(
+        conn_handle,
+        ble_gatts_notify_test_chr_1_def_handle + 1,
+        fourbytes,
+        sizeof fourbytes);
 
     /* Update characteristic 1's value. */
     ble_gatts_notify_test_chr_1_len = 1;

--- a/net/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/net/nimble/host/test/src/ble_gatts_notify_test.c
@@ -461,7 +461,7 @@ ble_gatts_notify_test_misc_verify_tx_n(uint16_t conn_handle,
 static void
 ble_gatts_notify_test_misc_verify_tx_i(uint16_t conn_handle,
                                        uint16_t attr_handle,
-                                       uint8_t *attr_data, int attr_len)
+                                       const uint8_t *attr_data, int attr_len)
 {
     struct ble_att_indicate_req req;
     struct os_mbuf *om;
@@ -673,12 +673,35 @@ TEST_CASE(ble_gatts_notify_test_n)
 
 TEST_CASE(ble_gatts_notify_test_i)
 {
+    static const uint8_t fourbytes[] = { 1, 2, 3, 4 };
+    struct os_mbuf *om;
     uint16_t conn_handle;
     uint16_t flags;
+    int rc;
 
     ble_gatts_notify_test_misc_init(&conn_handle, 0,
                                     BLE_GATTS_CLT_CFG_F_INDICATE,
                                     BLE_GATTS_CLT_CFG_F_INDICATE);
+
+    /* Verify custom indication data. */
+    om = ble_hs_mbuf_from_flat(fourbytes, sizeof fourbytes);
+    TEST_ASSERT_FATAL(om != NULL);
+
+    rc = ble_gattc_indicate_custom(conn_handle,
+                                   ble_gatts_notify_test_chr_1_def_handle + 1,
+                                   om);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    ble_gatts_notify_test_misc_verify_tx_i(
+        conn_handle,
+        ble_gatts_notify_test_chr_1_def_handle + 1,
+        fourbytes,
+        sizeof fourbytes);
+
+    /* Receive the confirmation for the indication. */
+    ble_gatts_notify_test_misc_rx_indicate_rsp(
+        conn_handle,
+        ble_gatts_notify_test_chr_1_def_handle + 1);
 
     /* Update characteristic 1's value. */
     ble_gatts_notify_test_chr_1_len = 1;


### PR DESCRIPTION
This feature is described in https://issues.apache.org/jira/browse/MYNEWT-550.

In addition, I noticed two issues in the code:
* Custom notifications don't generate a GAP event to the application.  Only non-custom notifications do.
* In a few places, "ACL" was misspelled as "ACM".