### PR TITLE
mn_socket: Unix domain socket support.

### DIFF
--- a/net/ip/mn_socket/include/mn_socket/mn_socket.h
+++ b/net/ip/mn_socket/include/mn_socket/mn_socket.h
@@ -140,6 +140,7 @@ struct mn_mreq {
 #define MN_MCAST_JOIN_GROUP             1
 #define MN_MCAST_LEAVE_GROUP            2
 #define MN_MCAST_IF                     3
+#define MN_REUSEADDR                    4
 
 /*
  * Socket calls.

--- a/net/ip/native_sockets/include/native_sockets/native_sock.h
+++ b/net/ip/native_sockets/include/native_sockets/native_sock.h
@@ -1,0 +1,15 @@
+#ifndef H_NATIVE_SOCKETS_
+#define H_NATIVE_SOCKETS_
+
+#include <sys/socket.h>
+
+#define MN_AF_LOCAL         255
+#define MN_PF_LOCAL         MN_AF_LOCAL
+
+struct mn_sockaddr_un {
+    uint8_t msun_len;
+    uint8_t msun_family;
+    char msun_path[104];
+};
+
+#endif


### PR DESCRIPTION
This adds unix domain socket support to the mn_socket / native_sockets packages.  This is needed for blehostd.