### PR TITLE
MYNEWT-681 rb-nano2 remove flash write protection in download scripts 

### DIFF
--- a/hw/bsp/rb-nano2/rb-nano2_download.sh
+++ b/hw/bsp/rb-nano2/rb-nano2_download.sh
@@ -37,6 +37,14 @@ if [ "$MFG_IMAGE" ]; then
     FLASH_OFFSET=0
 fi
 
+# We write the config registers for BPROT so that NVMC write
+# protection gets disabled for all blocks of the flash
+# We also write the DISABLEINDEBUG register so that, write
+# protection gets disabled in debug register by default
+CFG_POST_INIT="mww 0x40000600 0;mww 0x40000604 0;mww 0x40000608 1;\
+               mww 0x40000610 0;mww 0x40000614 0;
+              "
+
 common_file_to_load
 openocd_load
 openocd_reset_run

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -101,15 +101,16 @@ openocd_debug () {
         if [ ! -z "$RESET" ]; then
             echo "mon reset halt" >> $GDB_CMD_FILE
         fi
-  echo "$EXTRA_GDB_CMDS" >> $GDB_CMD_FILE
 
-	if [ $WINDOWS -eq 1 ]; then
-	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
+        echo "$EXTRA_GDB_CMDS" >> $GDB_CMD_FILE
+
+        if [ $WINDOWS -eq 1 ]; then
+            FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
             $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
-	else
+        else
             arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE
-	fi
+        fi
     else
         # No GDB, wait for openocd to exit
         openocd $CFG -f $OCD_CMD_FILE -c init -c halt

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -102,7 +102,6 @@ openocd_debug () {
             echo "mon reset halt" >> $GDB_CMD_FILE
         fi
   echo "$EXTRA_GDB_CMDS" >> $GDB_CMD_FILE
-  echo "FILENAME" $FILE_NAME >>out
 
 	if [ $WINDOWS -eq 1 ]; then
 	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -101,7 +101,9 @@ openocd_debug () {
         if [ ! -z "$RESET" ]; then
             echo "mon reset halt" >> $GDB_CMD_FILE
         fi
-	echo "FILENAME" $FILE_NAME >>out
+  echo "$EXTRA_GDB_CMDS" >> $GDB_CMD_FILE
+  echo "FILENAME" $FILE_NAME >>out
+
 	if [ $WINDOWS -eq 1 ]; then
 	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
             $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"


### PR DESCRIPTION
- removing write protection in download script by setting the write
  protection bits in the BPROT config registers. Also, setting the
  DISABLEINDEBUG register.