### PR TITLE
hw: mcu: pic32mz2048efg100: Reduce number of UART TX interrupts

### DIFF
--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_uart.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_uart.c
@@ -181,15 +181,20 @@ uart_receive_ready(int port)
 static void
 uart_transmit_ready(int port)
 {
-    int c = uarts[port].u_tx_func(uarts[port].u_func_arg);
-    if (c < 0) {
-        uart_disable_tx_int(port);
+    int c;
 
-        /* call tx done cb */
-        if (uarts[port].u_tx_done) {
-            uarts[port].u_tx_done(uarts[port].u_func_arg);
+    while(!(UxSTA(port) & _U1STA_UTXBF_MASK)) {
+        c = uarts[port].u_tx_func(uarts[port].u_func_arg);
+        if (c < 0) {
+            uart_disable_tx_int(port);
+
+            /* call tx done cb */
+            if (uarts[port].u_tx_done) {
+                uarts[port].u_tx_done(uarts[port].u_func_arg);
+            }
+            break;
         }
-    } else {
+
         UxTXREG(port) = (uint32_t)c & 0xff;
     }
 }


### PR DESCRIPTION
The UART TXIF flag is set when there is some space in the TX FIFO.
In the current implementation, only one byte is sent every time
the interrupt is handled.
This change modifies the behaviour of the UART TX interrupt
handler by sending as many bytes as possible until no more bytes
are available or the TX FIFO is full.

Signed-off-by: Francois Berder <fberder@outlook.fr>