### PR TITLE
MYNEWT-774 Serial errors in newtmgr messages

### DIFF
--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -33,8 +33,10 @@ syscfg.defs:
         description: 'Max number of modules'
         value: 3
     SHELL_MAX_CMD_QUEUED:
-        description: 'Max number of command lines queued'
-        value: 1
+        description: >
+            Max number of command lines queued.  A value >= 2 is required if
+            the shell is acting as a newtmgr transport.
+        value: 2
     SHELL_COMPAT:
         description: 'Enable compatibility module'
         value: 1


### PR DESCRIPTION
Using the nmgr_shell transport (newtmgr over shell), some incoming commands get dropped.  The problem seems to be caused by an exhaustion of shell events.  By default, the shell only allocates a single event.

The sequence looks like this:
    1. Client sends newtmgr command to device.
    2. Console passes newtmgr command to shell.
    3. Shell allocates the only event and fills it with the data.
    4. Shell processes event, hands data to newtmgr code.
    5. Newtmgr processes command and sends response.
    6. Client sees response and sends follow-up command.
    7. Console passes newtmgr command to shell.
    8. Shell has no events left; drops incoming command.
    9. Initial event gets freed.

By changing the default event count from 1 to 2, we ensure there is always a spare event available.  Since we will never send the second response before freeing the first event, two events is sufficient.