### PR TITLE
Ensure Redbear Blend2 has i2c headers

### DIFF
--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -29,6 +29,7 @@
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
+#include "hal/hal_i2c.h"
 #include "hal/hal_watchdog.h"
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include "uart/uart.h"


### PR DESCRIPTION
This code at the end of the rb-blend2/src/hal_bsp.c files requires the hal_i2c.h headers.

```
#if MYNEWT_VAL(I2C_0)
    rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
    assert(rc == 0);
#endif
```