### PR TITLE
MYNEWT-777 SensorAPI: Use util/parse pkg instead of using   sensor_shell_stol()

### DIFF
--- a/hw/drivers/sensors/bme280/pkg.yml
+++ b/hw/drivers/sensors/bme280/pkg.yml
@@ -30,3 +30,6 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
+
+pkg.deps.BME280_CLI:
+    - "@apache-mynewt-core/util/parse"

--- a/hw/drivers/sensors/bme280/src/bme280_shell.c
+++ b/hw/drivers/sensors/bme280/src/bme280_shell.c
@@ -42,23 +42,6 @@ static struct sensor_itf g_sensor_itf = {
 };
 
 static int
-bme280_shell_stol(char *param_val, long min, long max, long *output)
-{
-    char *endptr;
-    long lval;
-
-    lval = strtol(param_val, &endptr, 10); /* Base 10 */
-    if (param_val != '\0' && *endptr == '\0' &&
-        lval >= min && lval <= max) {
-            *output = lval;
-    } else {
-        return EINVAL;
-    }
-
-    return 0;
-}
-
-static int
 bme280_shell_err_too_many_args(char *cmd_name)
 {
     console_printf("Error: too many arguments for command \"%s\"\n",
@@ -130,7 +113,7 @@ bme280_shell_cmd_read(int argc, char **argv)
     int32_t press;
     int32_t humid;
     uint16_t samples = 1;
-    long val;
+    uint16_t val;
     int rc;
 
     if (argc > 3) {
@@ -139,10 +122,11 @@ bme280_shell_cmd_read(int argc, char **argv)
 
     /* Check if more than one sample requested */
     if (argc == 3) {
-        if (bme280_shell_stol(argv[2], 1, UINT16_MAX, &val)) {
+        val = parse_ll_bounds(argv[2], 1, UINT16_MAX, &rc);
+        if (rc) {
             return bme280_shell_err_invalid_arg(argv[2]);
         }
-        samples = (uint16_t)val;
+        samples = val;
     }
 
     while(samples--) {
@@ -175,7 +159,7 @@ bme280_shell_cmd_read(int argc, char **argv)
 static int
 bme280_shell_cmd_oversample(int argc, char **argv)
 {
-    long val;
+    uint8_t val;
     int rc;
     uint8_t oversample;
     uint32_t type;
@@ -186,7 +170,8 @@ bme280_shell_cmd_oversample(int argc, char **argv)
 
     /* Display the oversample */
     if (argc == 3) {
-        if (bme280_shell_stol(argv[2], 4, 8, &val)) {
+        val = parse_ll_bounds(argv[2], 4, 8, &rc);
+        if (rc) {
             return bme280_shell_err_invalid_arg(argv[2]);
         }
         rc = bme280_get_oversample(&g_sensor_itf, val, &oversample);
@@ -198,13 +183,15 @@ bme280_shell_cmd_oversample(int argc, char **argv)
 
     /* Update the oversampling  */
     if (argc == 4) {
-        if (bme280_shell_stol(argv[2], 4, 8, &val)) {
+        val = parse_ll_bounds(argv[2], 4, 8, &rc);
+        if (rc) {
             return bme280_shell_err_invalid_arg(argv[2]);
         }
 
         type = val;
 
-        if (bme280_shell_stol(argv[3], 0, 5, &val)) {
+        val = parse_ll_bounds(argv[3], 0, 5, &rc);
+        if (rc) {
             return bme280_shell_err_invalid_arg(argv[2]);
         }
 
@@ -225,7 +212,7 @@ static int
 bme280_shell_cmd_mode(int argc, char **argv)
 {
     uint8_t mode;
-    long val;
+    uint8_t val;
     int rc;
 
     if (argc > 3) {
@@ -242,7 +229,8 @@ bme280_shell_cmd_mode(int argc, char **argv)
 
     /* Change mode */
     if (argc == 3) {
-        if (bme280_shell_stol(argv[2], 0, 3, &val)) {
+        val = parse_ll_bounds(argv[2], 0, 3, &rc);
+        if (rc) {
             return bme280_shell_err_invalid_arg(argv[2]);
         }
         rc = bme280_set_mode(&g_sensor_itf, val);
@@ -260,7 +248,7 @@ static int
 bme280_shell_cmd_iir(int argc, char **argv)
 {
     uint8_t iir;
-    long val;
+    uint8_t val;
     int rc;
 
     if (argc > 3) {
@@ -278,7 +266,8 @@ bme280_shell_cmd_iir(int argc, char **argv)
 
     /* Enable/disable iir*/
     if (argc == 3) {
-        if (bme280_shell_stol(argv[2], 0, 1, &val)) {
+        val = parse_ll_bounds(argv[2], 0, 1, &rc);
+        if (rc) {
             return bme280_shell_err_invalid_arg(argv[2]);
         }
         rc = bme280_set_iir(&g_sensor_itf, val);

--- a/hw/drivers/sensors/bme280/src/bme280_shell.c
+++ b/hw/drivers/sensors/bme280/src/bme280_shell.c
@@ -192,7 +192,7 @@ bme280_shell_cmd_oversample(int argc, char **argv)
 
         val = parse_ll_bounds(argv[3], 0, 5, &rc);
         if (rc) {
-            return bme280_shell_err_invalid_arg(argv[2]);
+            return bme280_shell_err_invalid_arg(argv[3]);
         }
 
         oversample = val;

--- a/hw/drivers/sensors/bno055/pkg.yml
+++ b/hw/drivers/sensors/bno055/pkg.yml
@@ -30,3 +30,6 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
+
+pkg.deps.BNO055_CLI:
+    - "@apache-mynewt-core/util/parse"

--- a/hw/drivers/sensors/bno055/src/bno055_shell.c
+++ b/hw/drivers/sensors/bno055/src/bno055_shell.c
@@ -241,7 +241,7 @@ bno055_shell_cmd_read(int argc, char **argv)
 
         val = parse_ll_bounds(argv[3], 0, UINT16_MAX, &rc);
         if (rc) {
-            return bno055_shell_err_invalid_arg(argv[2]);
+            return bno055_shell_err_invalid_arg(argv[3]);
         }
         type = (int)(1 << val);
     }

--- a/hw/drivers/sensors/bno055/src/bno055_shell.c
+++ b/hw/drivers/sensors/bno055/src/bno055_shell.c
@@ -31,6 +31,7 @@
 #include "sensor/quat.h"
 #include "sensor/euler.h"
 #include "hal/hal_i2c.h"
+#include "parse/parse.h"
 
 #if MYNEWT_VAL(BNO055_CLI)
 
@@ -96,7 +97,7 @@ bno055_shell_cmd_sensor_offsets(int argc, char **argv)
     int i;
     int rc;
     struct bno055_sensor_offsets bso;
-    long val;
+    uint16_t val;
     uint16_t offsetdata[11] = {0};
     char *tok;
 
@@ -128,7 +129,8 @@ bno055_shell_cmd_sensor_offsets(int argc, char **argv)
         tok = strtok(argv[2], ":");
         i = 0;
         do {
-            if (sensor_shell_stol(tok, 0, UINT16_MAX, &val)) {
+            val = parse_ll_bounds(tok, 0, UINT16_MAX, &rc);
+            if (rc) {
                 return bno055_shell_err_invalid_arg(argv[2]);
             }
             offsetdata[i] = val;
@@ -209,7 +211,7 @@ static int
 bno055_shell_cmd_read(int argc, char **argv)
 {
     uint16_t samples = 1;
-    long val;
+    uint16_t val;
     int rc;
     void *databuf;
     struct sensor_quat_data *sqd;
@@ -231,12 +233,14 @@ bno055_shell_cmd_read(int argc, char **argv)
 
     /* Check if more than one sample requested */
     if (argc == 4) {
-        if (sensor_shell_stol(argv[2], 1, UINT16_MAX, &val)) {
+        val = parse_ll_bounds(argv[2], 0, UINT16_MAX, &rc);
+        if (rc) {
             return bno055_shell_err_invalid_arg(argv[2]);
         }
         samples = (uint16_t)val;
 
-        if (sensor_shell_stol(argv[3], 0, UINT16_MAX, &val)) {
+        val = parse_ll_bounds(argv[3], 0, UINT16_MAX, &rc);
+        if (rc) {
             return bno055_shell_err_invalid_arg(argv[2]);
         }
         type = (int)(1 << val);
@@ -302,7 +306,7 @@ err:
 static int
 bno055_shell_cmd_opr_mode(int argc, char **argv)
 {
-    long val;
+    uint8_t val;
     int rc;
 
     if (argc > 3) {
@@ -320,7 +324,8 @@ bno055_shell_cmd_opr_mode(int argc, char **argv)
 
     /* Update the mode */
     if (argc == 3) {
-        if (sensor_shell_stol(argv[2], 0, BNO055_OPR_MODE_NDOF, &val)) {
+        val = parse_ll_bounds(argv[2], 0, BNO055_OPR_MODE_NDOF, &rc);
+        if (rc) {
             return bno055_shell_err_invalid_arg(argv[2]);
         }
         /* Make sure mode is valid */
@@ -342,7 +347,7 @@ err:
 static int
 bno055_shell_cmd_pwr_mode(int argc, char **argv)
 {
-    long val;
+    uint8_t val;
     int rc;
 
     if (argc > 3) {
@@ -360,11 +365,8 @@ bno055_shell_cmd_pwr_mode(int argc, char **argv)
 
     /* Update the mode */
     if (argc == 3) {
-        if (sensor_shell_stol(argv[2], 0, BNO055_PWR_MODE_SUSPEND, &val)) {
-            return bno055_shell_err_invalid_arg(argv[2]);
-        }
-        /* Make sure mode is valid */
-        if (val > BNO055_PWR_MODE_SUSPEND) {
+        val = parse_ll_bounds(argv[2], 0, BNO055_PWR_MODE_SUSPEND, &rc);
+        if (rc) {
             return bno055_shell_err_invalid_arg(argv[2]);
         }
 
@@ -382,7 +384,7 @@ err:
 static int
 bno055_shell_units_cmd(int argc, char **argv)
 {
-    long val;
+    uint8_t val;
     int rc;
 
     if (argc > 3) {
@@ -408,7 +410,8 @@ bno055_shell_units_cmd(int argc, char **argv)
 
     /* Update the units */
     if (argc == 3) {
-        if (sensor_shell_stol(argv[2], 0, UINT8_MAX, &val)) {
+        val = parse_ll_bounds(argv[2], 0, UINT8_MAX, &rc);
+        if (rc) {
             return bno055_shell_err_invalid_arg(argv[2]);
         }
 
@@ -426,18 +429,20 @@ err:
 static int
 bno055_shell_cmd_dumpreg(int argc, char **argv)
 {
-    long addr;
+    uint8_t addr;
     uint8_t val;
     int rc;
 
-    if (sensor_shell_stol(argv[2], 0, UINT8_MAX, &addr)) {
+    addr = parse_ll_bounds(argv[2], 0, UINT8_MAX, &rc);
+    if (rc) {
         return bno055_shell_err_invalid_arg(argv[2]);
     }
-    rc = bno055_read8(&g_sensor_itf, (uint8_t)addr, &val);
+
+    rc = bno055_read8(&g_sensor_itf, addr, &val);
     if (rc) {
         goto err;
     }
-    console_printf("0x%02X (ADDR): 0x%02X", (uint8_t)addr, val);
+    console_printf("0x%02X (ADDR): 0x%02X", addr, val);
 
     return 0;
 err:

--- a/hw/drivers/sensors/tcs34725/pkg.yml
+++ b/hw/drivers/sensors/tcs34725/pkg.yml
@@ -30,3 +30,6 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
+
+pkg.deps.TCS34725_CLI:
+    - "@apache-mynewt-core/util/parse"

--- a/hw/drivers/sensors/tsl2561/pkg.yml
+++ b/hw/drivers/sensors/tsl2561/pkg.yml
@@ -33,3 +33,6 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
+
+pkg.deps.TSL2561_CLI:
+    - "@apache-mynewt-core/util/parse"

--- a/hw/drivers/sensors/tsl2561/src/tsl2561_shell.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561_shell.c
@@ -42,6 +42,7 @@
 #include "hal/hal_gpio.h"
 #include "tsl2561/tsl2561.h"
 #include "tsl2561_priv.h"
+#include "parse/parse.h"
 
 #if MYNEWT_VAL(TSL2561_CLI)
 static int tsl2561_shell_cmd(int argc, char **argv);
@@ -55,24 +56,6 @@ static struct sensor_itf g_sensor_itf = {
     .si_type = MYNEWT_VAL(TSL2561_SHELL_ITF_TYPE),
     .si_num = MYNEWT_VAL(TSL2561_SHELL_ITF_NUM),
 };
-
-static int
-tsl2561_shell_stol(char *param_val, long min, long max, long *output)
-{
-    char *endptr;
-    long lval;
-
-    /* Base 10 */
-    lval = strtol(param_val, &endptr, 10);
-    if (param_val != '\0' && *endptr == '\0' &&
-        lval >= min && lval <= max) {
-            *output = lval;
-    } else {
-        return EINVAL;
-    }
-
-    return 0;
-}
 
 static int
 tsl2561_shell_err_too_many_args(char *cmd_name)
@@ -121,7 +104,7 @@ tsl2561_shell_cmd_read(int argc, char **argv)
     uint16_t full;
     uint16_t ir;
     uint16_t samples = 1;
-    long val;
+    uint16_t val;
     int rc;
 
     if (argc > 3) {
@@ -130,10 +113,11 @@ tsl2561_shell_cmd_read(int argc, char **argv)
 
     /* Check if more than one sample requested */
     if (argc == 3) {
-        if (tsl2561_shell_stol(argv[2], 1, UINT16_MAX, &val)) {
+        val = parse_ll_bounds(argv[2], 1, UINT16_MAX, &rc);
+        if (rc) {
             return tsl2561_shell_err_invalid_arg(argv[2]);
         }
-        samples = (uint16_t)val;
+        samples = val;
     }
 
     while(samples--) {
@@ -153,7 +137,7 @@ tsl2561_shell_cmd_read(int argc, char **argv)
 static int
 tsl2561_shell_cmd_gain(int argc, char **argv)
 {
-    long val;
+    uint8_t val;
     uint8_t gain;
     int rc;
 
@@ -173,11 +157,9 @@ tsl2561_shell_cmd_gain(int argc, char **argv)
 
     /* Update the gain */
     if (argc == 3) {
-        if (tsl2561_shell_stol(argv[2], 1, 16, &val)) {
-            return tsl2561_shell_err_invalid_arg(argv[2]);
-        }
+        val = parse_ll_bounds(argv[2], 1, 16, &rc);
         /* Make sure gain is 1 ot 16 */
-        if ((val != 1) && (val != 16)) {
+        if (rc || ((val != 1) && (val != 16))) {
             return tsl2561_shell_err_invalid_arg(argv[2]);
         }
         rc = tsl2561_set_gain(&g_sensor_itf, val ?
@@ -225,11 +207,9 @@ tsl2561_shell_cmd_time(int argc, char **argv)
 
     /* Set the integration time */
     if (argc == 3) {
-        if (tsl2561_shell_stol(argv[2], 13, 402, &val)) {
-            return tsl2561_shell_err_invalid_arg(argv[2]);
-        }
+        val = parse_ll_bounds(argv[2], 13, 402, &rc);
         /* Make sure val is 13, 102 or 402 */
-        if ((val != 13) && (val != 101) && (val != 402)) {
+        if (rc || ((val != 13) && (val != 101) && (val != 402))) {
             return tsl2561_shell_err_invalid_arg(argv[2]);
         }
         switch(val) {
@@ -258,7 +238,7 @@ tsl2561_shell_cmd_int(int argc, char **argv)
 {
     int rc;
     int pin;
-    long val;
+    uint16_t val;
     uint8_t rate;
     uint16_t lower;
     uint16_t upper;
@@ -290,20 +270,23 @@ tsl2561_shell_cmd_int(int argc, char **argv)
     /* Configure the interrupt on 'set' */
     if (argc == 6 && strcmp(argv[2], "set") == 0) {
         /* Get rate */
-        if (tsl2561_shell_stol(argv[3], 0, 15, &val)) {
+        val = parse_ll_bounds(argv[3], 0, 15, &rc);
+        if (rc) {
             return tsl2561_shell_err_invalid_arg(argv[3]);
         }
-        rate = (uint8_t)val;
+        rate = val;
         /* Get lower threshold */
-        if (tsl2561_shell_stol(argv[4], 0, UINT16_MAX, &val)) {
+        val = parse_ll_bounds(argv[4], 0, UINT16_MAX, &rc);
+        if (rc) {
             return tsl2561_shell_err_invalid_arg(argv[4]);
         }
-        lower = (uint16_t)val;
+        lower = val;
         /* Get upper threshold */
-        if (tsl2561_shell_stol(argv[5], 0, UINT16_MAX, &val)) {
+        val = parse_ll_bounds(argv[5], 0, UINT16_MAX, &rc);
+        if (rc) {
             return tsl2561_shell_err_invalid_arg(argv[5]);
         }
-        upper = (uint16_t)val;
+        upper = val;
         /* Set the values */
         rc = tsl2561_setup_interrupt(&g_sensor_itf, rate, lower, upper);
         if (rc) {
@@ -322,10 +305,11 @@ tsl2561_shell_cmd_int(int argc, char **argv)
     /* Setup INT pin on 'pin' */
     if (argc == 4 && strcmp(argv[2], "pin") == 0) {
         /* Get the pin number */
-        if (tsl2561_shell_stol(argv[3], 0, 0xFF, &val)) {
+        val = parse_ll_bounds(argv[3], 0, 0xFF, &rc);
+        if (rc) {
             return tsl2561_shell_err_invalid_arg(argv[3]);
         }
-        pin = (int)val;
+        pin = val;
         /* INT is open drain, pullup is required */
         rc = hal_gpio_init_in(pin, HAL_GPIO_PULL_UP);
         assert(rc == 0);

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -480,8 +480,6 @@ int sensor_mgr_match_bytype(struct sensor *sensor, void *arg);
 #if MYNEWT_VAL(SENSOR_CLI)
 char*
 sensor_ftostr(float num, char *fltstr, int len);
-int
-sensor_shell_stol(char *param_val, long min, long max, long *output);
 #endif
 
 #if MYNEWT_VAL(SENSOR_OIC)

--- a/hw/sensor/pkg.yml
+++ b/hw/sensor/pkg.yml
@@ -32,6 +32,7 @@ pkg.deps.SENSOR_OIC:
 pkg.deps.SENSOR_CLI:
     - sys/shell
     - sys/console/full
+    - util/parse
 
 pkg.init:
     sensor_pkg_init: 501


### PR DESCRIPTION
- Use util/parse package for parsing instead of using
  sensor_shell_stol() or parsing functions in individual drivers.
- Removing the sensor_shell_stol() API.