### PR TITLE
boot/bootutil; security fix - if BOOTUTIL_VALIDATE_SLOT0 was set,

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -572,17 +572,17 @@ boot_validate_slot(int slot)
         return BOOT_EFLASH;
     }
 
-    if ((boot_data.imgs[slot].hdr.ih_magic != IMAGE_MAGIC ||
-	 boot_image_check(&boot_data.imgs[slot].hdr, fap) != 0) &&
-	slot == 1) {
+    if (boot_data.imgs[slot].hdr.ih_magic != IMAGE_MAGIC ||
+        boot_image_check(&boot_data.imgs[slot].hdr, fap) != 0) {
 
-        /* Image in slot 1 is invalid.  Erase the image and continue booting
-         * from slot 0.
-         */
-        flash_area_erase(fap, 0, fap->fa_size);
+        if (slot != 0) {
+            /* Image in slot 1 is invalid.  Erase the image and continue booting
+             * from slot 0.
+             */
+            flash_area_erase(fap, 0, fap->fa_size);
+        }
         return -1;
     }
-
     flash_area_close(fap);
 
     /* Image in slot 1 is valid. */


### PR DESCRIPTION
bootloader would still boot image in slot0 with invalid signature.