### PR TITLE
MYNEWT-780 Sensor driver shells: expose ADDR syscf

### DIFF
--- a/hw/drivers/sensors/bno055/src/bno055_shell.c
+++ b/hw/drivers/sensors/bno055/src/bno055_shell.c
@@ -44,6 +44,7 @@ static struct shell_cmd bno055_shell_cmd_struct = {
 static struct sensor_itf g_sensor_itf = {
     .si_type = MYNEWT_VAL(BNO055_SHELL_ITF_TYPE),
     .si_num = MYNEWT_VAL(BNO055_SHELL_ITF_NUM),
+    .si_addr = MYNEWT_VAL(BNO055_SHELL_ITF_ADDR),
 };
 
 static int

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -33,3 +33,6 @@ syscfg.defs:
     BNO055_SHELL_ITF_NUM:
         description: 'BNO055 interface number'
         value: 0
+    BNO055_SHELL_ITF_ADDR:
+        description: 'BNO055 I2C Address'
+        value: 0x28

--- a/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
@@ -37,6 +37,7 @@ static struct shell_cmd tcs34725_shell_cmd_struct = {
 static struct sensor_itf g_sensor_itf = {
     .si_type = MYNEWT_VAL(TCS34725_SHELL_ITF_TYPE),
     .si_num = MYNEWT_VAL(TCS34725_SHELL_ITF_NUM),
+    .si_addr = MYNEWT_VAL(TCS34725_SHELL_ITF_ADDR)
 };
 
 static int

--- a/hw/drivers/sensors/tcs34725/syscfg.yml
+++ b/hw/drivers/sensors/tcs34725/syscfg.yml
@@ -33,4 +33,7 @@ syscfg.defs:
     TCS34725_SHELL_ITF_NUM:
         description: 'TCS34725 interface number'
         value: 0
+    TCS34725_SHELL_ITF_ADDR:
+        description: 'TCS34725 I2C address'
+        value : 0x29
 

--- a/hw/drivers/sensors/tsl2561/src/tsl2561_shell.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561_shell.c
@@ -54,6 +54,7 @@ static struct shell_cmd tsl2561_shell_cmd_struct = {
 static struct sensor_itf g_sensor_itf = {
     .si_type = MYNEWT_VAL(TSL2561_SHELL_ITF_TYPE),
     .si_num = MYNEWT_VAL(TSL2561_SHELL_ITF_NUM),
+    .si_addr = MYNEWT_VAL(TSL2561_SHELL_ITF_ADDR),
 };
 
 static int

--- a/hw/drivers/sensors/tsl2561/syscfg.yml
+++ b/hw/drivers/sensors/tsl2561/syscfg.yml
@@ -36,3 +36,6 @@ syscfg.defs:
     TSL2561_SHELL_ITF_NUM:
         description: 'Select interface number'
         value: 0
+    TSL2561_SHELL_ITF_ADDR:
+        description: 'TSL2561 I2C Addresss'
+        value: 0x39


### PR DESCRIPTION
Sensor driver shells should expose ADDR syscfg since the shell should use a specific address to talk to a sensor device.