### PR TITLE
nimble/bt5_scanner

### DIFF
--- a/hw/drivers/nimble/native/src/ble_phy.c
+++ b/hw/drivers/nimble/native/src/ble_phy.c
@@ -528,12 +528,8 @@ ble_phy_setchan(uint8_t chan, uint32_t access_addr, uint32_t crcinit)
         return BLE_PHY_ERR_INV_PARAM;
     }
 
-    /* Set current access address */
-    if (chan < BLE_PHY_NUM_DATA_CHANS) {
-        g_ble_phy_data.phy_access_address = access_addr;
-    } else {
-        g_ble_phy_data.phy_access_address = BLE_ACCESS_ADDR_ADV;
-    }
+    g_ble_phy_data.phy_access_address = access_addr;
+
     g_ble_phy_data.phy_chan = chan;
 
     return 0;

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -1493,10 +1493,10 @@ ble_phy_setchan(uint8_t chan, uint32_t access_addr, uint32_t crcinit)
         }
 
         /* Set current access address */
-        ble_phy_set_access_addr(BLE_ACCESS_ADDR_ADV);
+        ble_phy_set_access_addr(access_addr);
 
         /* Configure crcinit */
-        NRF_RADIO->CRCINIT = BLE_LL_CRCINIT_ADV;
+        NRF_RADIO->CRCINIT = crcinit;
     }
 
     /* Set the frequency and the data whitening initial value */

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -776,6 +776,9 @@ ble_phy_rx_start_isr(void)
     ble_hdr->rxinfo.channel = g_ble_phy_data.phy_chan;
     ble_hdr->rxinfo.handle = 0;
     ble_hdr->rxinfo.phy = ble_phy_get_cur_phy();
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+    ble_hdr->rxinfo.aux_data = NULL;
+#endif
 
 #if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
     /*
@@ -872,6 +875,8 @@ ble_phy_isr(void)
         if (g_ble_phy_data.phy_state == BLE_PHY_STATE_RX) {
             NRF_RADIO->EVENTS_DISABLED = 0;
             ble_ll_wfr_timer_exp(NULL);
+        } else if (g_ble_phy_data.phy_state == BLE_PHY_STATE_IDLE) {
+            assert(0);
         } else {
             ble_phy_tx_end_isr();
         }

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -228,6 +228,23 @@ ble_phy_mode_set(int cur_phy_mode, int txtorx_phy_mode)
     g_ble_phy_data.phy_cur_phy_mode = (uint8_t)cur_phy_mode;
     g_ble_phy_data.phy_txtorx_phy_mode = (uint8_t)txtorx_phy_mode;
 }
+
+int
+ble_phy_get_cur_phy(void)
+{
+    switch (g_ble_phy_data.phy_cur_phy_mode) {
+        case BLE_PHY_MODE_1M:
+            return BLE_PHY_1M;
+        case BLE_PHY_MODE_2M:
+            return BLE_PHY_2M;
+        case BLE_PHY_MODE_CODED_125KBPS:
+        case BLE_PHY_MODE_CODED_500KBPS:
+            return BLE_PHY_CODED;
+        default:
+            assert(0);
+            return -1;
+    }
+}
 #endif
 
 /**

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -63,9 +63,6 @@ extern uint32_t g_nrf_irk_list[];
 #define NRF_TX_PWR_MAX_DBM      (4)
 #define NRF_TX_PWR_MIN_DBM      (-40)
 
-/* The number of different modulations */
-#define BLE_PHY_NUM_MODULATIONS (4)
-
 /* BLE PHY data structure */
 struct ble_phy_obj
 {
@@ -80,7 +77,7 @@ struct ble_phy_obj
     uint8_t phy_tx_pyld_len;
     uint8_t phy_txtorx_phy_mode;
     uint8_t phy_cur_phy_mode;
-    uint16_t phy_mode_pkt_start_off[BLE_PHY_NUM_MODULATIONS];
+    uint16_t phy_mode_pkt_start_off[BLE_PHY_NUM_MODE];
     uint32_t phy_aar_scratch;
     uint32_t phy_access_address;
     uint32_t phy_pcnf0;

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -193,54 +193,6 @@ struct nrf_ccm_data g_nrf_ccm_data;
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
 
-static inline int ble_phy_pdu_coded_dur(int pyld_len, int s)
-{
-    /*
-     * Specification provides duration for each PDU field directly in us so we
-     * can use them directly here (Vol 6, Part B, 2.2).
-     */
-    return 80 + 256 + 16 + 24 + /* Preamble + Access Address + CI + TERM1 */
-            s * ((BLE_LL_PDU_HDR_LEN + pyld_len) * 8 + 24 + 3); /* PDU + CRC + TERM2 */
-}
-
-/**
- * Calculate the length of BLE PDU
- *
- * Returns the number of usecs it will take to transmit a PDU of payload
- * length 'len' bytes. Each byte takes 8 usecs. This routine includes the LL
- * overhead: preamble (1), access addr (4) and crc (3) and the PDU header (2)
- * for a total of 10 bytes.
- *
- * @param pyld_len PDU payload length (does not include include header).
- * @param phy_mode PHY modulation being used.
- *
- * @return uint32_t The number of usecs it will take to transmit a PDU of
- *                  length 'len' bytes.
- */
-uint32_t
-ble_phy_mode_pdu_dur(uint8_t pyld_len, int phy_mode)
-{
-    uint32_t usecs;
-
-    if (phy_mode == BLE_PHY_MODE_1M) {
-        /* 8 usecs per byte */
-        usecs = (pyld_len + BLE_LL_PREAMBLE_LEN + BLE_LL_ACC_ADDR_LEN
-                 + BLE_LL_CRC_LEN + BLE_LL_PDU_HDR_LEN) << 3;
-    } else if (phy_mode == BLE_PHY_MODE_2M) {
-        /* 4 usecs per byte */
-        usecs = (pyld_len + (2 * BLE_LL_PREAMBLE_LEN) + BLE_LL_ACC_ADDR_LEN
-                 + BLE_LL_CRC_LEN + BLE_LL_PDU_HDR_LEN) << 2;
-    } else if (phy_mode == BLE_PHY_MODE_CODED_125KBPS) {
-        usecs = ble_phy_pdu_coded_dur(pyld_len, 8);
-    } else if (phy_mode == BLE_PHY_MODE_CODED_500KBPS) {
-        usecs = ble_phy_pdu_coded_dur(pyld_len, 2);
-    } else {
-        assert(0);
-    }
-    return usecs;
-}
-
-
 /* Packet start offset (in usecs). This is the preamble plus access address.
  * For LE Coded PHY this also includes CI and TERM1. */
 uint32_t

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -652,7 +652,7 @@ ble_phy_tx_end_isr(void)
          */
         wfr_time = BLE_LL_IFS + (2 * BLE_LL_JITTER_USECS) +
             ble_phy_mode_pdu_start_off(phy) - ble_phy_mode_pdu_start_off(phy);
-        wfr_time += ble_phy_mode_pdu_dur(txlen, phy);
+        wfr_time += ble_ll_pdu_tx_time_get(txlen, phy);
         wfr_time = os_cputime_usecs_to_ticks(wfr_time);
         ble_ll_wfr_enable(txstart + wfr_time);
 #endif

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -775,6 +775,7 @@ ble_phy_rx_start_isr(void)
     ble_hdr->rxinfo.flags = ble_ll_state_get();
     ble_hdr->rxinfo.channel = g_ble_phy_data.phy_chan;
     ble_hdr->rxinfo.handle = 0;
+    ble_hdr->rxinfo.phy = ble_phy_get_cur_phy();
 
 #if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
     /*

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -228,10 +228,12 @@ ble_phy_mode_set(int cur_phy_mode, int txtorx_phy_mode)
     g_ble_phy_data.phy_cur_phy_mode = (uint8_t)cur_phy_mode;
     g_ble_phy_data.phy_txtorx_phy_mode = (uint8_t)txtorx_phy_mode;
 }
+#endif
 
 int
 ble_phy_get_cur_phy(void)
 {
+#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
     switch (g_ble_phy_data.phy_cur_phy_mode) {
         case BLE_PHY_MODE_1M:
             return BLE_PHY_1M;
@@ -244,8 +246,10 @@ ble_phy_get_cur_phy(void)
             assert(0);
             return -1;
     }
-}
+#else
+    return BLE_PHY_1M;
 #endif
+}
 
 /**
  * Copies the data from the phy receive buffer into a mbuf chain.

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -776,7 +776,7 @@ ble_phy_rx_start_isr(void)
     ble_hdr->rxinfo.channel = g_ble_phy_data.phy_chan;
     ble_hdr->rxinfo.handle = 0;
     ble_hdr->rxinfo.phy = ble_phy_get_cur_phy();
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
     ble_hdr->rxinfo.aux_data = NULL;
 #endif
 

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -1186,7 +1186,7 @@ ble_phy_tx_set_start_time(uint32_t cputime, uint8_t rem_usecs)
 int
 ble_phy_rx_set_start_time(uint32_t cputime, uint8_t rem_usecs)
 {
-    int rc;
+    int rc = 0;
 
     /* XXX: This should not be necessary, but paranoia is good! */
     /* Clear timer0 compare to TXEN since we are transmitting */

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -423,6 +423,15 @@ int ble_ll_rand_data_get(uint8_t *buf, uint8_t len);
 void ble_ll_rand_prand_get(uint8_t *prand);
 int ble_ll_rand_start(void);
 
+static inline int
+ble_ll_get_addr_type(uint8_t txrxflag)
+{
+    if (txrxflag) {
+        return BLE_HCI_ADV_OWN_ADDR_RANDOM;
+    }
+    return BLE_HCI_ADV_OWN_ADDR_PUBLIC;
+}
+
 /*
  * XXX: temporary LL debug log. Will get removed once we transition to real
  * log

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -152,6 +152,7 @@ STATS_SECT_START(ble_ll_stats)
     STATS_SECT_ENTRY(rx_scan_rsps)
     STATS_SECT_ENTRY(rx_connect_reqs)
     STATS_SECT_ENTRY(rx_scan_ind)
+    STATS_SECT_ENTRY(rx_aux_connect_rsp)
     STATS_SECT_ENTRY(adv_txg)
     STATS_SECT_ENTRY(adv_late_starts)
     STATS_SECT_ENTRY(sched_state_conn_errs)
@@ -165,6 +166,8 @@ STATS_SECT_START(ble_ll_stats)
     STATS_SECT_ENTRY(aux_scheduled)
     STATS_SECT_ENTRY(aux_received)
     STATS_SECT_ENTRY(aux_fired_for_read)
+    STATS_SECT_ENTRY(aux_conn_req_tx)
+    STATS_SECT_ENTRY(aux_conn_rsp_err)
 STATS_SECT_END
 extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -147,6 +147,7 @@ STATS_SECT_START(ble_ll_stats)
     STATS_SECT_ENTRY(rx_adv_ind)
     STATS_SECT_ENTRY(rx_adv_direct_ind)
     STATS_SECT_ENTRY(rx_adv_nonconn_ind)
+    STATS_SECT_ENTRY(rx_adv_ext_ind)
     STATS_SECT_ENTRY(rx_scan_reqs)
     STATS_SECT_ENTRY(rx_scan_rsps)
     STATS_SECT_ENTRY(rx_connect_reqs)
@@ -160,6 +161,10 @@ STATS_SECT_START(ble_ll_stats)
     STATS_SECT_ENTRY(scan_req_txf)
     STATS_SECT_ENTRY(scan_req_txg)
     STATS_SECT_ENTRY(scan_rsp_txg)
+    STATS_SECT_ENTRY(aux_missed_adv)
+    STATS_SECT_ENTRY(aux_scheduled)
+    STATS_SECT_ENTRY(aux_received)
+    STATS_SECT_ENTRY(aux_fired_for_read)
 STATS_SECT_END
 extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 
@@ -249,6 +254,14 @@ struct ble_dev_addr
 #define BLE_ADV_PDU_TYPE_SCAN_RSP           (4)
 #define BLE_ADV_PDU_TYPE_CONNECT_REQ        (5)
 #define BLE_ADV_PDU_TYPE_ADV_SCAN_IND       (6)
+#define BLE_ADV_PDU_TYPE_ADV_EXT_IND        (7)
+#define BLE_ADV_PDU_TYPE_AUX_ADV_IND        BLE_ADV_PDU_TYPE_ADV_EXT_IND
+#define BLE_ADV_PDU_TYPE_AUX_SCAN_RSP       BLE_ADV_PDU_TYPE_ADV_EXT_IND
+#define BLE_ADV_PDU_TYPE_AUX_SYNC_IND       BLE_ADV_PDU_TYPE_ADV_EXT_IND
+#define BLE_ADV_PDU_TYPE_AUX_CHAIN_IND      BLE_ADV_PDU_TYPE_ADV_EXT_IND
+#define BLE_ADV_PDU_TYPE_AUX_CONNECT_REQ    BLE_ADV_PDU_TYPE_CONNECT_REQ
+#define BLE_ADV_PDU_TYPE_AUX_SCAN_REQ       BLE_ADV_PDU_TYPE_SCAN_REQ
+#define BLE_ADV_PDU_TYPE_AUX_CONNECT_RSP    (8)
 
 /* If Channel Selection Algorithm #2 is supported */
 #define BLE_ADV_PDU_HDR_CHSEL               (0x20)
@@ -316,6 +329,10 @@ struct ble_dev_addr
  */
 #define BLE_CONNECT_REQ_LEN         (34)
 #define BLE_CONNECT_REQ_PDU_LEN     (BLE_CONNECT_REQ_LEN + BLE_LL_PDU_HDR_LEN)
+
+#define BLE_SCAN_REQ_LEN            (12)
+#define BLE_SCAN_RSP_MAX_LEN        (37)
+#define BLE_SCAN_RSP_MAX_EXT_LEN    (251)
 
 /*--- External API ---*/
 /* Initialize the Link Layer */

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -337,6 +337,9 @@ uint32_t ble_ll_pdu_tx_time_get(uint16_t payload_len, int phy_mode);
             + BLE_LL_PREAMBLE_LEN + BLE_LL_CRC_LEN) << 3)
 #endif
 
+/* Calculate maximum octets of PDU payload which can be transmitted during
+ * 'usecs' on a PHY 'phy_mode'. */
+uint16_t ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode);
 
 /* Is this address a resolvable private address? */
 int ble_ll_is_rpa(uint8_t *addr, uint8_t addr_type);

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -327,8 +327,16 @@ int ble_ll_reset(void);
 /* 'Boolean' function returning true if address is a valid random address */
 int ble_ll_is_valid_random_addr(uint8_t *addr);
 
-/* Calculate the amount of time a pdu of 'len' bytes will take to transmit */
-uint16_t ble_ll_pdu_tx_time_get(uint16_t len);
+/* Calculate the amount of time in microseconds a PDU with payload length of
+ * 'payload_len' will take to transmit on a PHY 'phy_mode'. */
+#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
+uint32_t ble_ll_pdu_tx_time_get(uint16_t payload_len, int phy_mode);
+#else
+#define ble_ll_pdu_tx_time_get(payload_len, phy_mode) \
+    (((payload_len) + BLE_LL_PDU_HDR_LEN + BLE_LL_ACC_ADDR_LEN \
+            + BLE_LL_PREAMBLE_LEN + BLE_LL_CRC_LEN) << 3)
+#endif
+
 
 /* Is this address a resolvable private address? */
 int ble_ll_is_rpa(uint8_t *addr, uint8_t addr_type);

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -120,7 +120,9 @@ union ble_ll_conn_sm_flags {
         uint32_t phy_update_sched: 1;
         uint32_t ctrlr_phy_update: 1;
         uint32_t phy_update_event: 1;
-        uint32_t peer_phy_update: 1;    /* XXX:combine with ctrlr udpate bit? */
+        uint32_t peer_phy_update: 1; /* XXX:combine with ctrlr udpate bit? */
+        uint32_t aux_conn_req: 1;
+        uint32_t aux_conn_rsp: 1;
     } cfbit;
     uint32_t conn_flags;
 } __attribute__((packed));
@@ -311,6 +313,10 @@ struct ble_ll_conn_sm
 
     /* XXX: for now, just store them all */
     struct ble_ll_conn_params conn_cp;
+
+    struct ble_ll_scan_sm *scansm;
+    struct hci_ext_create_conn initial_params;
+
 };
 
 /* Flags */
@@ -329,6 +335,8 @@ struct ble_ll_conn_sm
 #define CONN_F_CTRLR_PHY_UPDATE(csm) ((csm)->csmflags.cfbit.ctrlr_phy_update)
 #define CONN_F_PHY_UPDATE_EVENT(csm) ((csm)->csmflags.cfbit.phy_update_event)
 #define CONN_F_PEER_PHY_UPDATE(csm)  ((csm)->csmflags.cfbit.peer_phy_update)
+#define CONN_F_AUX_CONN_REQ(csm)  ((csm)->csmflags.cfbit.aux_conn_req)
+#define CONN_F_AUX_CONN_RSP(csm)  ((csm)->csmflags.cfbit.aux_conn_rsp)
 
 /* Role */
 #define CONN_IS_MASTER(csm)         (csm->conn_role == BLE_LL_CONN_ROLE_MASTER)

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -25,6 +25,7 @@
 #include "nimble/hci_common.h"
 #include "controller/ble_ll_sched.h"
 #include "controller/ble_ll_ctrl.h"
+#include "controller/ble_phy.h"
 #include "hal/hal_timer.h"
 
 #ifdef __cplusplus

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -191,6 +191,7 @@ struct ble_ll_conn_sm
     uint16_t rem_max_rx_time;
     uint16_t eff_max_tx_time;
     uint16_t eff_max_rx_time;
+    uint8_t max_tx_octets_phy_mode[BLE_PHY_NUM_MODE];
 
     /* XXX: TODO: could make this conditional */
     struct ble_ll_conn_phy_data phy_data;

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -315,7 +315,9 @@ struct ble_ll_conn_sm
     struct ble_ll_conn_params conn_cp;
 
     struct ble_ll_scan_sm *scansm;
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
     struct hci_ext_create_conn initial_params;
+#endif
 
 };
 

--- a/net/nimble/controller/include/controller/ble_ll_hci.h
+++ b/net/nimble/controller/include/controller/ble_ll_hci.h
@@ -29,7 +29,8 @@ extern "C" {
 extern const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN];
 
 /* The largest event the controller will send. */
-#define BLE_LL_MAX_EVT_LEN  (70)
+/*TODO Make it configurable maybe?*/
+#define BLE_LL_MAX_EVT_LEN  (251)
 
 /*
  * This determines the number of outstanding commands allowed from the

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -75,6 +75,8 @@ struct ble_ll_scan_params
     uint8_t scan_chan;
     uint16_t scan_itvl;
     uint16_t scan_window;
+    uint32_t scan_win_start_time;
+    uint32_t next_event_start;
 };
 
 struct ble_ll_scan_sm

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -68,6 +68,7 @@ extern "C" {
 
 struct ble_ll_scan_params
 {
+    uint8_t phy;
     uint8_t own_addr_type;
     uint8_t scan_filt_policy;
     uint8_t configured;

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -55,7 +55,7 @@ extern "C" {
 #define BLE_SCAN_RSP_DATA_MAX_LEN       (31)
 #define BLE_SCAN_MAX_PKT_LEN            (37)
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 #define BLE_EXT_SCAN_MAX_PKT_LEN        (256)
 
     /* For Bluetooth 5.0 we need state machine for two PHYs*/
@@ -138,7 +138,7 @@ int ble_ll_scan_set_scan_params(uint8_t *cmd);
 /* Turn scanning on/off */
 int ble_ll_scan_set_enable(uint8_t *cmd, uint8_t ext);
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 int ble_ll_set_ext_scan_params(uint8_t *cmd);
 #endif
 
@@ -199,12 +199,12 @@ int ble_ll_scan_adv_decode_addr(uint8_t pdu_type, uint8_t *rxbuf,
                                 uint8_t **inita, uint8_t *inita_is_rpa,
                                 int *ext_mode);
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 /* Get aux ptr from ext advertising */
 int ble_ll_scan_get_aux_data(struct ble_ll_scan_sm *scansm,
                              struct ble_mbuf_hdr *ble_hdr, uint8_t *rxbuf,
                              struct ble_ll_aux_data **aux_data);
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
 /* Initialize the extended scanner when we start initiating */
 struct hci_ext_create_conn;
 int ble_ll_scan_ext_initiator_start(struct hci_ext_create_conn *hcc,

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -64,6 +64,7 @@ extern "C" {
 
 #define PHY_UNCODED                    (0)
 #define PHY_CODED                      (1)
+#define PHY_NOT_CONFIGURED             (0xFF)
 
 struct ble_ll_scan_params
 {
@@ -100,7 +101,9 @@ struct ble_ll_scan_sm
     uint16_t period;
 
     uint8_t cur_phy;
+    uint8_t next_phy;
     struct ble_ll_scan_params phy_data[BLE_LL_SCAN_PHY_NUMBER];
+    uint8_t ext_scanning;
 };
 
 /* Scan types */
@@ -113,7 +116,11 @@ struct ble_ll_scan_sm
 int ble_ll_scan_set_scan_params(uint8_t *cmd);
 
 /* Turn scanning on/off */
-int ble_ll_scan_set_enable(uint8_t *cmd);
+int ble_ll_scan_set_enable(uint8_t *cmd, uint8_t ext);
+
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+int ble_ll_set_ext_scan_params(uint8_t *cmd);
+#endif
 
 /*--- Controller Internal API ---*/
 /* Initialize the scanner */

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -68,6 +68,10 @@ extern "C" {
 #define PHY_CODED                      (1)
 #define PHY_NOT_CONFIGURED             (0xFF)
 
+#define BLE_LL_EXT_ADV_MODE_NON_CONN    (0x00)
+#define BLE_LL_EXT_ADV_MODE_CONN        (0x01)
+#define BLE_LL_EXT_ADV_MODE_SCAN        (0x02)
+
 struct ble_ll_scan_params
 {
     uint8_t phy;
@@ -196,7 +200,16 @@ int ble_ll_scan_adv_decode_addr(uint8_t pdu_type, uint8_t *rxbuf,
                                 int *ext_mode);
 
 /* Get aux ptr from ext advertising */
+int ble_ll_scan_get_aux_data(struct ble_ll_scan_sm *scansm,
+                             struct ble_mbuf_hdr *ble_hdr, uint8_t *rxbuf,
+                             struct ble_ll_aux_data **aux_data);
+
 #if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+/* Initialize the extended scanner when we start initiating */
+struct hci_ext_create_conn;
+int ble_ll_scan_ext_initiator_start(struct hci_ext_create_conn *hcc,
+                                    struct ble_ll_scan_sm **sm);
+
 /* Called to parse extended advertising*/
 struct ble_ll_ext_adv;
 int ble_ll_scan_parse_ext_adv(uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr,

--- a/net/nimble/controller/include/controller/ble_ll_sched.h
+++ b/net/nimble/controller/include/controller/ble_ll_sched.h
@@ -104,12 +104,6 @@ int ble_ll_sched_init(void);
 /* Remove item(s) from schedule */
 void ble_ll_sched_rmv_elem(struct ble_ll_sched_item *sch);
 
-/* Get a schedule item */
-struct ble_ll_sched_item *ble_ll_sched_get_item(void);
-
-/* Free a schedule item */
-void ble_ll_sched_free_item(struct ble_ll_sched_item *sch);
-
 /* Schedule a new master connection */
 struct ble_ll_conn_sm;
 int ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,

--- a/net/nimble/controller/include/controller/ble_ll_sched.h
+++ b/net/nimble/controller/include/controller/ble_ll_sched.h
@@ -138,7 +138,7 @@ int ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm * connsm);
  */
 int ble_ll_sched_next_time(uint32_t *next_event_time);
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 struct ble_ll_scan_sm;
 struct ble_ll_aux_data;
 int ble_ll_sched_aux_scan(struct ble_mbuf_hdr *ble_hdr,

--- a/net/nimble/controller/include/controller/ble_ll_sched.h
+++ b/net/nimble/controller/include/controller/ble_ll_sched.h
@@ -69,6 +69,7 @@ extern uint8_t g_ble_ll_sched_offset_ticks;
 #define BLE_LL_SCHED_TYPE_ADV       (1)
 #define BLE_LL_SCHED_TYPE_SCAN      (2)
 #define BLE_LL_SCHED_TYPE_CONN      (3)
+#define BLE_LL_SCHED_TYPE_AUX_SCAN  (4)
 
 /* Return values for schedule callback. */
 #define BLE_LL_SCHED_STATE_RUNNING  (0)
@@ -136,6 +137,16 @@ int ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm * connsm);
  * @return int 0: No events are scheduled 1: there is an upcoming event
  */
 int ble_ll_sched_next_time(uint32_t *next_event_time);
+
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+struct ble_ll_scan_sm;
+struct ble_ll_aux_data;
+int ble_ll_sched_aux_scan(struct ble_mbuf_hdr *ble_hdr,
+                          struct ble_ll_scan_sm *scansm,
+                          struct ble_ll_aux_data *aux_scan);
+
+int ble_ll_sched_is_busy_in(uint32_t usec);
+#endif
 
 /* Stop the scheduler */
 void ble_ll_sched_stop(void);

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -210,6 +210,7 @@ void ble_phy_resolv_list_disable(void);
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
 uint32_t ble_phy_mode_pdu_start_off(int phy);
 void ble_phy_mode_set(int cur_phy, int txtorx_phy);
+int ble_phy_get_cur_phy(void);
 #else
 #define ble_phy_mode_pdu_start_off(phy)     (40)
 

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -194,6 +194,9 @@ void ble_phy_resolv_list_disable(void);
 #define BLE_PHY_MODE_CODED_125KBPS  (0)
 #define BLE_PHY_MODE_CODED_500KBPS  (3)
 
+/* The number of different modes */
+#define BLE_PHY_NUM_MODE            (4)
+
 /* PHY numbers (compatible with HCI) */
 #define BLE_PHY_1M                  (BLE_HCI_LE_PHY_1M)
 #define BLE_PHY_2M                  (BLE_HCI_LE_PHY_2M)

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -205,14 +205,9 @@ void ble_phy_resolv_list_disable(void);
 #define BLE_PHY_MASK_CODED          (BLE_HCI_LE_PHY_CODED_PREF_MASK)
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
-uint32_t ble_phy_mode_pdu_dur(uint8_t len, int phy);
 uint32_t ble_phy_mode_pdu_start_off(int phy);
 void ble_phy_mode_set(int cur_phy, int txtorx_phy);
 #else
-#define ble_phy_mode_pdu_dur(len, phy)      \
-    (((len) + BLE_LL_PDU_HDR_LEN + BLE_LL_ACC_ADDR_LEN + BLE_LL_PREAMBLE_LEN \
-      + BLE_LL_CRC_LEN) << 3)
-
 #define ble_phy_mode_pdu_start_off(phy)     (40)
 
 #endif

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -216,6 +216,27 @@ int ble_phy_get_cur_phy(void);
 
 #endif
 
+static inline int ble_ll_phy_to_phy_mode(int phy, int phy_options)
+{
+    int phy_mode;
+
+    /*
+     * Mode values are set in a way that 1M, 2M and Coded(S=2) are equivalent
+     * to 1M, 2M and Coded in HCI. The only conversion is needed for Coded(S=8)
+     * which uses non-HCI value.
+     */
+
+    phy_mode = phy;
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
+    if (phy == BLE_PHY_CODED && phy_options == BLE_HCI_LE_PHY_CODED_S8_PREF) {
+        phy_mode = BLE_PHY_MODE_CODED_125KBPS;
+    }
+#endif
+
+    return phy_mode;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -212,12 +212,12 @@ void ble_phy_resolv_list_disable(void);
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
 uint32_t ble_phy_mode_pdu_start_off(int phy);
 void ble_phy_mode_set(int cur_phy, int txtorx_phy);
-int ble_phy_get_cur_phy(void);
 #else
 #define ble_phy_mode_pdu_start_off(phy)     (40)
 
 #endif
 
+int ble_phy_get_cur_phy(void);
 static inline int ble_ll_phy_to_phy_mode(int phy, int phy_options)
 {
     int phy_mode;

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -124,13 +124,15 @@ int ble_phy_txpwr_get(void);
 /* Disable the PHY */
 void ble_phy_disable(void);
 
+#define BLE_PHY_WFR_ENABLE_RX       (0)
+#define BLE_PHY_WFR_ENABLE_TXRX     (1)
+
 #if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
 void ble_phy_stop_usec_timer(void);
 void ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs);
-#define BLE_PHY_WFR_ENABLE_RX       (0)
-#define BLE_PHY_WFR_ENABLE_TXRX     (1)
 #else
 #define ble_phy_stop_usec_timer()
+#define ble_phy_wfr_enable(txrx, wfr_usecs)
 #endif
 
 /* Starts rf clock */

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -1272,6 +1272,42 @@ ble_ll_pdu_tx_time_get(uint16_t payload_len, int phy_mode)
     return usecs;
 
 }
+
+uint16_t
+ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
+{
+    uint32_t header_tx_time;
+    uint16_t octets;
+
+    assert(phy_mode < BLE_PHY_NUM_MODE);
+
+    header_tx_time = g_ble_ll_pdu_header_tx_time[phy_mode];
+
+    if (usecs < header_tx_time) {
+        // XXX: this is obviously incorrect, what should we do?
+        return 0;
+    }
+
+    usecs -= header_tx_time;
+
+    if (phy_mode == BLE_PHY_MODE_1M) {
+        /* 8 usecs per byte */
+        octets = usecs >> 3;
+    } else if (phy_mode == BLE_PHY_MODE_2M) {
+        /* 4 usecs per byte */
+        octets = usecs >> 2;
+    } else if (phy_mode == BLE_PHY_MODE_CODED_125KBPS) {
+        /* S=8 => 8 * 8 = 64 usecs per byte */
+        octets = usecs >> 6;
+    } else if (phy_mode == BLE_PHY_MODE_CODED_500KBPS) {
+        /* S=2 => 2 * 8 = 16 usecs per byte */
+        octets = usecs >> 4;
+    } else {
+        assert(0);
+    }
+
+    return octets;
+}
 #endif
 
 /**

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -1285,6 +1285,7 @@ ble_ll_pdu_tx_time_get(uint16_t payload_len, int phy_mode)
     return usecs;
 
 }
+#endif
 
 uint16_t
 ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
@@ -1321,7 +1322,6 @@ ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
 
     return octets;
 }
-#endif
 
 /**
  * Initialize the Link Layer. Should be called only once

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -195,7 +195,13 @@ static void ble_ll_event_tx_pkt(struct os_event *ev);
 static void ble_ll_event_dbuf_overflow(struct os_event *ev);
 
 /* The BLE LL task data structure */
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+/* TODO: This is for testing. Check it we really need it */
+#define BLE_LL_STACK_SIZE   (128)
+#else
 #define BLE_LL_STACK_SIZE   (80)
+#endif
+
 struct os_task g_ble_ll_task;
 os_stack_t g_ble_ll_stack[BLE_LL_STACK_SIZE];
 

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -167,6 +167,7 @@ STATS_NAME_START(ble_ll_stats)
     STATS_NAME(ble_ll_stats, rx_adv_ind)
     STATS_NAME(ble_ll_stats, rx_adv_direct_ind)
     STATS_NAME(ble_ll_stats, rx_adv_nonconn_ind)
+    STATS_NAME(ble_ll_stats, rx_adv_ext_ind)
     STATS_NAME(ble_ll_stats, rx_scan_reqs)
     STATS_NAME(ble_ll_stats, rx_scan_rsps)
     STATS_NAME(ble_ll_stats, rx_connect_reqs)
@@ -180,6 +181,10 @@ STATS_NAME_START(ble_ll_stats)
     STATS_NAME(ble_ll_stats, scan_req_txf)
     STATS_NAME(ble_ll_stats, scan_req_txg)
     STATS_NAME(ble_ll_stats, scan_rsp_txg)
+    STATS_NAME(ble_ll_stats, aux_missed_adv)
+    STATS_NAME(ble_ll_stats, aux_scheduled)
+    STATS_NAME(ble_ll_stats, aux_received)
+    STATS_NAME(ble_ll_stats, aux_fired_for_read)
 STATS_NAME_END(ble_ll_stats)
 
 static void ble_ll_event_rx_pkt(struct os_event *ev);
@@ -266,6 +271,9 @@ ble_ll_count_rx_adv_pdus(uint8_t pdu_type)
 {
     /* Count received packet types  */
     switch (pdu_type) {
+    case BLE_ADV_PDU_TYPE_ADV_EXT_IND:
+        STATS_INC(ble_ll_stats, rx_adv_ext_ind);
+        break;
     case BLE_ADV_PDU_TYPE_ADV_IND:
         STATS_INC(ble_ll_stats, rx_adv_ind);
         break;
@@ -906,6 +914,8 @@ ble_ll_rx_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr)
             if ((len < BLE_DEV_ADDR_LEN) || (len > BLE_ADV_SCAN_IND_MAX_LEN)) {
                 badpkt = 1;
             }
+            break;
+        case BLE_ADV_PDU_TYPE_ADV_EXT_IND:
             break;
         case BLE_ADV_PDU_TYPE_CONNECT_REQ:
             if (len != BLE_CONNECT_REQ_LEN) {

--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -434,7 +434,7 @@ ble_ll_adv_tx_start_cb(struct ble_ll_sched_item *sch)
     ble_phy_txpwr_set(advsm->adv_txpwr);
 
     /* Set channel */
-    rc = ble_phy_setchan(advsm->adv_chan, 0, 0);
+    rc = ble_phy_setchan(advsm->adv_chan, BLE_ACCESS_ADDR_ADV, BLE_LL_CRCINIT_ADV);
     assert(rc == 0);
 
     /* Set transmit start time. */

--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -527,7 +527,7 @@ ble_ll_adv_set_sched(struct ble_ll_adv_sm *advsm)
     sch->sched_type = BLE_LL_SCHED_TYPE_ADV;
 
     /* Set end time to maximum time this schedule item may take */
-    max_usecs = ble_phy_mode_pdu_dur(advsm->adv_pdu_len, BLE_PHY_MODE_1M);
+    max_usecs = ble_ll_pdu_tx_time_get(advsm->adv_pdu_len, BLE_PHY_MODE_1M);
     switch (advsm->adv_type) {
     case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD:
     case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD:

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -2390,7 +2390,7 @@ ble_ll_conn_created(struct ble_ll_conn_sm *connsm, struct ble_mbuf_hdr *rxhdr)
 #else
         connsm->last_anchor_point = rxhdr->beg_cputime;
         endtime = rxhdr->beg_cputime +
-            os_cputime_usecs_to_ticks(ble_phy_mode_pdu_dur(BLE_CONNECT_REQ_LEN,
+            os_cputime_usecs_to_ticks(ble_ll_pdu_tx_time_get(BLE_CONNECT_REQ_LEN,
                                                       BLE_PHY_1M));
         connsm->slave_cur_tx_win_usecs =
             connsm->tx_win_size * BLE_LL_CONN_TX_WIN_USECS;

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -216,27 +216,6 @@ STATS_NAME_START(ble_ll_conn_stats)
     STATS_NAME(ble_ll_conn_stats, mic_failures)
 STATS_NAME_END(ble_ll_conn_stats)
 
-static inline int ble_ll_conn_phy_to_phy_mode(int phy, int phy_options)
-{
-    int phy_mode;
-
-    /*
-     * Mode values are set in a way that 1M, 2M and Coded(S=2) are equivalent
-     * to 1M, 2M and Coded in HCI. The only conversion is needed for Coded(S=8)
-     * which uses non-HCI value.
-     */
-
-    phy_mode = phy;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
-    if (phy == BLE_PHY_CODED && phy_options == BLE_HCI_LE_PHY_CODED_S8_PREF) {
-        phy_mode = BLE_PHY_MODE_CODED_125KBPS;
-    }
-#endif
-
-    return phy_mode;
-}
-
 static void ble_ll_conn_event_end(struct os_event *ev);
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
@@ -2151,14 +2130,14 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
         if (connsm->phy_data.new_tx_phy) {
             connsm->phy_data.cur_tx_phy = connsm->phy_data.new_tx_phy;
             connsm->phy_data.tx_phy_mode =
-                                ble_ll_conn_phy_to_phy_mode(connsm->phy_data.cur_tx_phy,
+                                ble_ll_phy_to_phy_mode(connsm->phy_data.cur_tx_phy,
                                                    connsm->phy_data.phy_options);
         }
 
         if (connsm->phy_data.new_rx_phy) {
             connsm->phy_data.cur_rx_phy = connsm->phy_data.new_rx_phy;
             connsm->phy_data.rx_phy_mode =
-                                ble_ll_conn_phy_to_phy_mode(connsm->phy_data.cur_rx_phy,
+                                ble_ll_phy_to_phy_mode(connsm->phy_data.cur_rx_phy,
                                                    connsm->phy_data.phy_options);
         }
 

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -786,6 +786,25 @@ ble_ll_conn_wfr_timer_exp(void)
     STATS_INC(ble_ll_conn_stats, wfr_expirations);
 }
 
+void
+ble_ll_conn_init_wrf_timer_exp(void)
+{
+    struct ble_ll_conn_sm *connsm;
+    struct ble_ll_scan_sm *scansm;
+
+    connsm = g_ble_ll_conn_cur_sm;
+    if (!connsm) {
+        return;
+    }
+
+    scansm = connsm->scansm;
+    if (scansm && scansm->cur_aux_data) {
+        ble_ll_scan_aux_data_free(scansm->cur_aux_data);
+        scansm->cur_aux_data = NULL;
+        STATS_INC(ble_ll_stats, aux_missed_adv);
+        ble_ll_event_send(&scansm->scan_sched_ev);
+    }
+}
 /**
  * Callback for slave when it transmits a data pdu and the connection event
  * ends after the transmission.
@@ -1366,6 +1385,16 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
     g_ble_ll_conn_cur_sm = connsm;
     assert(connsm);
 
+    if (CONN_F_AUX_CONN_REQ(connsm) && !CONN_F_AUX_CONN_RSP(connsm)) {
+        /*We are here when AUX_CONN_REQ has been sent but we did not receive
+         * AUX CONN RSP. Forget about last aux_conn_req and scan again
+         */
+
+        CONN_F_AUX_CONN_REQ(connsm) = 0;
+        ble_ll_scan_chk_resume();
+        return BLE_LL_SCHED_STATE_DONE;
+    }
+
     /* Disable whitelisting as connections do not use it */
     ble_ll_whitelist_disable();
 
@@ -1619,19 +1648,10 @@ ble_ll_conn_auth_pyld_timer_start(struct ble_ll_conn_sm *connsm)
 }
 #endif
 
-/**
- * Called when a create connection command has been received. This initializes
- * a connection state machine in the master role.
- *
- * NOTE: Must be called before the state machine is started
- *
- * @param connsm
- * @param hcc
- */
-void
-ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
-                        struct hci_create_conn *hcc)
+static void
+ble_ll_conn_master_common_init(struct ble_ll_conn_sm *connsm)
 {
+
     /* Set master role */
     connsm->conn_role = BLE_LL_CONN_ROLE_MASTER;
 
@@ -1650,6 +1670,34 @@ ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
 
     /* Hop increment is a random value between 5 and 16. */
     connsm->hop_inc = (rand() % 12) + 5;
+
+    /* Set channel map to map requested by host */
+    connsm->num_used_chans = g_ble_ll_conn_params.num_used_chans;
+    memcpy(connsm->chanmap, g_ble_ll_conn_params.master_chan_map,
+           BLE_LL_CONN_CHMAP_LEN);
+
+    /*  Calculate random access address and crc initialization value */
+    connsm->access_addr = ble_ll_conn_calc_access_addr();
+    connsm->crcinit = rand() & 0xffffff;
+
+    /* Set initial schedule callback */
+    connsm->conn_sch.sched_cb = ble_ll_conn_event_start_cb;
+}
+/**
+ * Called when a create connection command has been received. This initializes
+ * a connection state machine in the master role.
+ *
+ * NOTE: Must be called before the state machine is started
+ *
+ * @param connsm
+ * @param hcc
+ */
+void
+ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
+                        struct hci_create_conn *hcc)
+{
+
+    ble_ll_conn_master_common_init(connsm);
 
     /* Set slave latency and supervision timeout */
     connsm->slave_latency = hcc->conn_latency;
@@ -1677,19 +1725,80 @@ ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
     } else {
         connsm->max_ce_len = hcc->max_ce_len;
     }
-
-    /* Set channel map to map requested by host */
-    connsm->num_used_chans = g_ble_ll_conn_params.num_used_chans;
-    memcpy(connsm->chanmap, g_ble_ll_conn_params.master_chan_map,
-           BLE_LL_CONN_CHMAP_LEN);
-
-    /*  Calculate random access address and crc initialization value */
-    connsm->access_addr = ble_ll_conn_calc_access_addr();
-    connsm->crcinit = rand() & 0xffffff;
-
-    /* Set initial schedule callback */
-    connsm->conn_sch.sched_cb = ble_ll_conn_event_start_cb;
 }
+
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+
+void
+ble_ll_conn_ext_master_init(struct ble_ll_conn_sm *connsm,
+                        struct hci_ext_create_conn *hcc)
+{
+
+    ble_ll_conn_master_common_init(connsm);
+
+    /* Set own address type and peer address if needed */
+    connsm->own_addr_type = hcc->own_addr_type;
+    if (hcc->filter_policy == 0) {
+        memcpy(&connsm->peer_addr, &hcc->peer_addr, BLE_DEV_ADDR_LEN);
+        connsm->peer_addr_type = hcc->peer_addr_type;
+    }
+
+    connsm->initial_params = *hcc;
+}
+
+static void
+ble_ll_conn_set_phy(struct ble_ll_conn_sm *connsm, int tx_phy ,int rx_phy)
+{
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+    struct ble_ll_conn_phy_data *phy_data = &connsm->phy_data;
+
+    phy_data->rx_phy_mode = ble_ll_phy_to_phy_mode(rx_phy,
+                                                   BLE_HCI_LE_PHY_CODED_ANY);
+    phy_data->cur_rx_phy = rx_phy;
+
+    phy_data->tx_phy_mode = ble_ll_phy_to_phy_mode(tx_phy,
+                                                   BLE_HCI_LE_PHY_CODED_ANY);
+    phy_data->cur_tx_phy = tx_phy;
+
+#endif
+}
+
+void
+ble_ll_conn_ext_set_params(struct ble_ll_conn_sm *connsm,
+                           struct hci_ext_conn_params *hcc_params,
+                           int tx_phy, int tx_phy_ops,
+                           int rx_phy, int rx_phy_ops)
+{
+    /* Set slave latency and supervision timeout */
+    connsm->slave_latency = hcc_params->conn_latency;
+    connsm->supervision_tmo = hcc_params->supervision_timeout;
+
+    /* XXX: for now, just make connection interval equal to max */
+    connsm->conn_itvl = hcc_params->conn_itvl_max;
+
+
+    /* Check the min/max CE lengths are less than connection interval */
+    if (hcc_params->min_ce_len > (connsm->conn_itvl * 2)) {
+        connsm->min_ce_len = connsm->conn_itvl * 2;
+    } else {
+        connsm->min_ce_len = hcc_params->min_ce_len;
+    }
+
+    if (hcc_params->max_ce_len > (connsm->conn_itvl * 2)) {
+        connsm->max_ce_len = connsm->conn_itvl * 2;
+    } else {
+        connsm->max_ce_len = hcc_params->max_ce_len;
+    }
+
+#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
+    ble_ll_conn_calc_itvl_ticks(connsm);
+#endif
+
+    ble_ll_conn_set_phy(connsm, tx_phy, rx_phy);
+}
+
+
+#endif
 
 static void
 ble_ll_conn_set_csa(struct ble_ll_conn_sm *connsm, bool chsel)
@@ -2258,7 +2367,8 @@ ble_ll_conn_created(struct ble_ll_conn_sm *connsm, struct ble_mbuf_hdr *rxhdr)
 
         usecs = rxhdr->rem_usecs + 1250 +
             (connsm->tx_win_off * BLE_LL_CONN_TX_WIN_USECS) +
-            ble_ll_pdu_tx_time_get(BLE_CONNECT_REQ_LEN, BLE_PHY_MODE_1M);
+            ble_ll_pdu_tx_time_get(BLE_CONNECT_REQ_LEN,
+                                 connsm->phy_data.tx_phy_mode);
 
         /* Anchor point is cputime. */
         endtime = os_cputime_usecs_to_ticks(usecs);
@@ -2617,6 +2727,11 @@ ble_ll_conn_req_txend(void *arg)
     ble_ll_state_set(BLE_LL_STATE_STANDBY);
 }
 
+static void
+ble_ll_conn_req_txend_init(void *arg)
+{
+    ble_ll_state_set(BLE_LL_STATE_INITIATING);
+}
 /**
  * Send a connection requestion to an advertiser
  *
@@ -2625,18 +2740,22 @@ ble_ll_conn_req_txend(void *arg)
  * @param addr_type Address type of advertiser
  * @param adva Address of advertiser
  */
-static int
+int
 ble_ll_conn_request_send(uint8_t addr_type, uint8_t *adva, uint16_t txoffset,
-                         int rpa_index)
+                         int rpa_index, uint8_t end_trans)
 {
-    int rc;
     struct os_mbuf *m;
+    int rc;
 
     /* XXX: TODO: assume we are already on correct phy */
     m = ble_ll_scan_get_pdu();
     ble_ll_conn_req_pdu_update(m, adva, addr_type, txoffset, rpa_index);
-    ble_phy_set_txend_cb(ble_ll_conn_req_txend, NULL);
-    rc = ble_phy_tx(m, BLE_PHY_TRANSITION_NONE);
+    if (end_trans == BLE_PHY_TRANSITION_NONE) {
+        ble_phy_set_txend_cb(ble_ll_conn_req_txend, NULL);
+    } else {
+        ble_phy_set_txend_cb(ble_ll_conn_req_txend_init, NULL);
+    }
+    rc = ble_phy_tx(m, end_trans);
     return rc;
 }
 
@@ -2668,28 +2787,40 @@ ble_ll_conn_event_halt(void)
  * @param rxbuf
  */
 void
-ble_ll_init_rx_pkt_in(uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr)
+ble_ll_init_rx_pkt_in(uint8_t pdu_type, uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr)
 {
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
     int8_t rpa_index;
 #endif
     uint8_t addr_type;
     uint8_t *addr;
+    uint8_t *adv_addr;
     struct ble_ll_conn_sm *connsm;
+    int ext_adv_mode = -1;
 
     /* Get the connection state machine we are trying to create */
     connsm = g_ble_ll_conn_create_sm;
+    if (!connsm) {
+        return;
+    }
+
+    if (pdu_type == BLE_ADV_PDU_TYPE_ADV_EXT_IND) {
+        /* Do nothing, we need AUX_CONN_RSP*/
+        ble_ll_scan_aux_data_free(ble_hdr->rxinfo.aux_data);
+        return;
+    }
 
     /* If we have sent a connect request, we need to enter CONNECTION state */
     if (connsm && CONN_F_CONN_REQ_TXD(connsm)) {
         /* Set address of advertiser to which we are connecting. */
+
+        if (ble_ll_scan_adv_decode_addr(pdu_type, rxbuf, ble_hdr,
+                                        &adv_addr, &addr_type,
+                                        NULL, NULL, &ext_adv_mode)) {
+            return;
+        }
+
         if (ble_ll_scan_whitelist_enabled()) {
-            /* Get address type of advertiser */
-            if (rxbuf[0] & BLE_ADV_PDU_HDR_TXADD_MASK) {
-                addr_type = BLE_HCI_CONN_PEER_ADDR_RANDOM;
-            } else {
-                addr_type = BLE_HCI_CONN_PEER_ADDR_PUBLIC;
-            }
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
             /*
@@ -2702,10 +2833,10 @@ ble_ll_init_rx_pkt_in(uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr)
                 addr_type = g_ble_ll_resolv_list[rpa_index].rl_addr_type + 2;
                 addr = g_ble_ll_resolv_list[rpa_index].rl_identity_addr;
             } else {
-                addr = rxbuf + BLE_LL_PDU_HDR_LEN;
+                addr = adv_addr;
             }
 #else
-            addr = rxbuf + BLE_LL_PDU_HDR_LEN;
+            addr = adv_addr;
 #endif
 
             connsm->peer_addr_type = addr_type;
@@ -2720,34 +2851,25 @@ ble_ll_init_rx_pkt_in(uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr)
         g_ble_ll_conn_create_sm = NULL;
         ble_ll_scan_sm_stop(0);
 
-        ble_ll_conn_set_csa(connsm, rxbuf[0] & BLE_ADV_PDU_HDR_CHSEL_MASK);
+        /* For AUX Connect CSA2 is mandatory. Otherwise we need to check bit
+         * mask
+         */
+        if (ble_hdr->rxinfo.channel < BLE_PHY_NUM_DATA_CHANS) {
+            ble_ll_conn_set_csa(connsm, 1);
+        } else {
+            ble_ll_conn_set_csa(connsm, rxbuf[0] & BLE_ADV_PDU_HDR_CHSEL_MASK);
+        }
+
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+        /* Lets take last used phy */
+        ble_ll_conn_set_phy(connsm, ble_hdr->rxinfo.phy, ble_hdr->rxinfo.phy);
+#endif
         ble_ll_conn_created(connsm, NULL);
     } else {
         ble_ll_scan_chk_resume();
     }
 }
 
-static int
-ble_ll_conn_adv_decode_addr(struct ble_ll_conn_sm *connsm, uint8_t pdu_type,
-                            uint8_t *rxbuf, uint8_t **addr,
-                            uint8_t *addr_type, uint8_t **inita,
-                            uint8_t *inita_is_rpa, struct ble_mbuf_hdr *ble_hdr)
-{
-    *addr_type = ble_ll_get_addr_type(rxbuf[0] & BLE_ADV_PDU_HDR_TXADD_MASK);
-    *addr = rxbuf + BLE_LL_PDU_HDR_LEN;
-
-    if (pdu_type != BLE_ADV_PDU_TYPE_ADV_DIRECT_IND) {
-        *inita = NULL;
-        *inita_is_rpa = 0;
-        return 0;
-    }
-
-    *inita = rxbuf + BLE_LL_PDU_HDR_LEN + BLE_DEV_ADDR_LEN;
-    if (*addr_type) {
-        *inita_is_rpa = (uint8_t)ble_ll_is_rpa(*inita, *addr_type);
-    }
-    return 0;
-}
 /**
  * Called when a receive PDU has ended and we are in the initiating state.
  *
@@ -2776,15 +2898,20 @@ ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
     uint8_t *init_addr = NULL;
     uint8_t pyld_len;
     uint8_t inita_is_rpa;
+    uint8_t conn_req_end_trans;
     struct os_mbuf *rxpdu;
     struct ble_ll_conn_sm *connsm;
+    struct ble_ll_scan_sm *scansm;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
     struct ble_ll_resolv_entry *rl;
 #endif
+    uint8_t phy;
+    struct ble_ll_aux_data *aux_data = NULL;
+    int ext_adv_mode = -1;
 
     /* Get connection state machine to use if connection to be established */
     connsm = g_ble_ll_conn_create_sm;
-
+    scansm = connsm->scansm;
     /*
      * We have to restart receive if we cant hand up pdu. We return 0 so that
      * the phy does not get disabled.
@@ -2799,31 +2926,80 @@ ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
     pdu_type = rxbuf[0] & BLE_ADV_PDU_HDR_TYPE_MASK;
     inita_is_rpa = 0;
 
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+    if (pdu_type == BLE_ADV_PDU_TYPE_ADV_EXT_IND) {
+        if (!scansm) {
+            goto init_rx_isr_exit;
+        }
+        if (!scansm->ext_scanning) {
+            goto init_rx_isr_exit;
+        }
+        /* Let see if there is AUX ptr. If so schedule for getting it */
+        rc = ble_ll_scan_get_aux_data(scansm, ble_hdr, rxbuf, &aux_data);
+        if (rc < 0) {
+            /* No memory or broken packet */
+            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_AUX_INVALID;
+            goto init_rx_isr_exit;
+        }
+    }
+#endif
+
     /* Lets get addresses from advertising report*/
-    if (ble_ll_conn_adv_decode_addr(connsm, pdu_type, rxbuf, &adv_addr,
-                                    &addr_type,
-                                    &init_addr, &inita_is_rpa, ble_hdr)) {
+    if (ble_ll_scan_adv_decode_addr(pdu_type, rxbuf, ble_hdr,
+                                    &adv_addr, &addr_type,
+                                    &init_addr, &inita_is_rpa,
+                                    &ext_adv_mode)) {
         goto init_rx_isr_exit;
     }
 
     switch (pdu_type) {
     case BLE_ADV_PDU_TYPE_ADV_IND:
         break;
-    case BLE_ADV_PDU_TYPE_ADV_DIRECT_IND:
-        /*
-         * If we expect our address to be private and the INITA is not,
-         * we dont respond!
-         */
-        if (connsm->own_addr_type > BLE_HCI_ADV_OWN_ADDR_RANDOM) {
-            if (!inita_is_rpa) {
-                goto init_rx_isr_exit;
-            }
-        } else {
-            if (!ble_ll_is_our_devaddr(init_addr, addr_type)) {
-                goto init_rx_isr_exit;
-            }
+    case BLE_ADV_PDU_TYPE_ADV_EXT_IND:
+        /* Lets see if we have addr. If not we need to wait for aux ptr*/
+        if (!adv_addr || !(ext_adv_mode & BLE_LL_EXT_ADV_MODE_CONN)) {
+            goto init_rx_isr_exit;
         }
-        break;
+
+        if (aux_data) {
+            /* AUX to be proceed. Set this flag anyway, so LL know to ignore
+             * this packet
+             * */
+            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_AUX_PTR_WAIT;
+            if (ble_ll_sched_aux_scan(ble_hdr, scansm, aux_data)) {
+                ble_ll_scan_aux_data_free(aux_data);
+            }
+            rc = -1;
+            goto init_rx_isr_exit;
+        }
+
+        ble_hdr->rxinfo.aux_data = scansm->cur_aux_data;
+        scansm->cur_aux_data = NULL;
+
+        if (!init_addr) {
+            break;
+        }
+        /* if there is direct address lets fall down and check it.*/
+        // no break
+    case BLE_ADV_PDU_TYPE_ADV_DIRECT_IND:
+            /*
+             * If we expect our address to be private and the INITA is not,
+             * we dont respond!
+             */
+            if (connsm->own_addr_type > BLE_HCI_ADV_OWN_ADDR_RANDOM) {
+                if (!inita_is_rpa) {
+                    goto init_rx_isr_exit;
+                }
+            } else {
+                if (!ble_ll_is_our_devaddr(init_addr, addr_type)) {
+                    goto init_rx_isr_exit;
+                }
+            }
+            break;
+    case BLE_ADV_PDU_TYPE_AUX_CONNECT_RSP:
+        CONN_F_AUX_CONN_RSP(connsm) = 1;
+        rc = -1;
+        goto init_rx_isr_exit;
     default:
         goto init_rx_isr_exit;
     }
@@ -2895,27 +3071,50 @@ ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
         }
     }
 
-    /* Attempt to schedule new connection. Possible that this might fail */
-        if (!ble_ll_sched_master_new(connsm, ble_hdr, pyld_len)) {
-        /* Setup to transmit the connect request */
-        rc = ble_ll_conn_request_send(addr_type, adv_addr,
-                                      connsm->tx_win_off, index);
-        if (!rc) {
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
-            if (ble_hdr->rxinfo.channel) {
-                /* Lets wait for */
-                    ble_ll_sched_rmv_elem(&connsm->conn_sch);
-            }
-#endif
-            CONN_F_CONN_REQ_TXD(connsm) = 1;
-            STATS_INC(ble_ll_conn_stats, conn_req_txd);
-        } else {
-            ble_ll_sched_rmv_elem(&connsm->conn_sch);
-        }
+    /* Check if we should send AUX_CONNECT_REQ and wait for AUX_CONNECT_RSP */
+    if (ble_hdr->rxinfo.channel < BLE_PHY_NUM_DATA_CHANS) {
+        conn_req_end_trans = BLE_PHY_TRANSITION_TX_RX;
     } else {
-        /* Count # of times we could not set schedule */
-        STATS_INC(ble_ll_conn_stats, cant_set_sched);
+        conn_req_end_trans = BLE_PHY_TRANSITION_NONE;
     }
+
+    if (connsm->scansm->ext_scanning) {
+            phy = ble_phy_get_cur_phy();
+
+            /* Update connection state machine with appropriate parameters for
+             * certain PHY
+             */
+            ble_ll_conn_ext_set_params(connsm,
+                                       &connsm->initial_params.params[phy - 1],
+                                       phy, BLE_HCI_LE_PHY_CODED_ANY,
+                                       phy, BLE_HCI_LE_PHY_CODED_ANY);
+
+    }
+
+    /* Create the connection request */
+    ble_ll_conn_req_pdu_make(connsm, ble_hdr->rxinfo.channel);
+
+    if (ble_ll_sched_master_new(connsm, ble_hdr, pyld_len)) {
+        STATS_INC(ble_ll_conn_stats, cant_set_sched);
+        goto init_rx_isr_exit;
+    }
+
+    /* Setup to transmit the connect request */
+    rc = ble_ll_conn_request_send(addr_type, adv_addr,
+                                  connsm->tx_win_off, index,
+                                  conn_req_end_trans);
+    if (rc) {
+        ble_ll_sched_rmv_elem(&connsm->conn_sch);
+        goto init_rx_isr_exit;
+    }
+
+    CONN_F_CONN_REQ_TXD(connsm) = 1;
+    if (ble_hdr->rxinfo.channel < BLE_PHY_NUM_DATA_CHANS) {
+        /* Lets wait for AUX_CONNECT_RSP */
+        CONN_F_AUX_CONN_REQ(connsm) = 1;
+        STATS_INC(ble_ll_stats, aux_conn_req_tx);
+    }
+    STATS_INC(ble_ll_conn_stats, conn_req_txd);
 
 init_rx_isr_exit:
     /*
@@ -2933,6 +3132,7 @@ init_rx_isr_exit:
          */
         if (CONN_F_CONN_REQ_TXD(connsm) == 1) {
             CONN_F_CONN_REQ_TXD(connsm) = 0;
+            CONN_F_AUX_CONN_REQ(connsm) = 0;
             ble_ll_sched_rmv_elem(&connsm->conn_sch);
         }
         ble_phy_restart_rx();

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -1447,18 +1447,19 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
         }
     } else {
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
-            if (CONN_F_ENCRYPTED(connsm)) {
-                ble_phy_encrypt_enable(connsm->enc_data.rx_pkt_cntr,
-                                       connsm->enc_data.iv,
-                                       connsm->enc_data.enc_block.cipher_text,
-                                       1);
-            } else {
-                ble_phy_encrypt_disable();
-            }
+        if (CONN_F_ENCRYPTED(connsm)) {
+            ble_phy_encrypt_enable(connsm->enc_data.rx_pkt_cntr,
+                                   connsm->enc_data.iv,
+                                   connsm->enc_data.enc_block.cipher_text,
+                                   1);
+        } else {
+            ble_phy_encrypt_disable();
+        }
 #endif
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_mode_set(connsm->phy_data.rx_phy_mode,connsm->phy_data.rx_phy_mode);
+        ble_phy_mode_set(connsm->phy_data.rx_phy_mode,
+                             connsm->phy_data.rx_phy_mode);
 #endif
 
 #if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -1257,7 +1257,6 @@ ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf)
     if (phy_options > BLE_HCI_LE_PHY_CODED_S8_PREF) {
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
-    connsm->phy_data.phy_options = phy_options & 0x03;
 
     /* Check valid parameters */
     rc = ble_ll_hci_chk_phy_masks(cmdbuf + 2, &tx_phys, &rx_phys);
@@ -1265,6 +1264,7 @@ ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf)
         goto phy_cmd_param_err;
     }
 
+    connsm->phy_data.phy_options = phy_options & 0x03;
     connsm->phy_data.host_pref_tx_phys_mask = tx_phys,
     connsm->phy_data.host_pref_rx_phys_mask = rx_phys;
 

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -86,7 +86,7 @@ ble_ll_conn_hci_chk_conn_params(uint16_t itvl_min, uint16_t itvl_max,
 
     if ((itvl_min > itvl_max) ||
         (itvl_min < BLE_HCI_CONN_ITVL_MIN) ||
-        (itvl_min > BLE_HCI_CONN_ITVL_MAX) ||
+        (itvl_max > BLE_HCI_CONN_ITVL_MAX) ||
         (latency > BLE_HCI_CONN_LATENCY_MAX) ||
         (spvn_tmo < BLE_HCI_CONN_SPVN_TIMEOUT_MIN) ||
         (spvn_tmo > BLE_HCI_CONN_SPVN_TIMEOUT_MAX)) {

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -518,7 +518,7 @@ ble_ll_conn_create(uint8_t *cmdbuf)
     return rc;
 }
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 
 int
 ble_ll_ext_conn_create(uint8_t *cmdbuf)

--- a/net/nimble/controller/src/ble_ll_conn_priv.h
+++ b/net/nimble/controller/src/ble_ll_conn_priv.h
@@ -96,6 +96,16 @@ void ble_ll_conn_enqueue_pkt(struct ble_ll_conn_sm *connsm, struct os_mbuf *om,
 struct ble_ll_conn_sm *ble_ll_conn_sm_get(void);
 void ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
                              struct hci_create_conn *hcc);
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+void ble_ll_conn_ext_master_init(struct ble_ll_conn_sm *connsm,
+                                 struct hci_ext_create_conn *hcc);
+
+void ble_ll_conn_ext_set_params(struct ble_ll_conn_sm *connsm,
+                                struct hci_ext_conn_params *hcc_params,
+                                int tx_phy, int tx_phy_ops,
+                                int rx_phy, int rx_phy_ops);
+#endif
+
 struct ble_ll_conn_sm *ble_ll_conn_find_active_conn(uint16_t handle);
 void ble_ll_conn_datalen_update(struct ble_ll_conn_sm *connsm,
                                 struct ble_ll_len_req *req);
@@ -112,10 +122,12 @@ void ble_ll_conn_tx_pkt_in(struct os_mbuf *om, uint16_t handle, uint16_t len);
 int ble_ll_conn_rx_isr_start(struct ble_mbuf_hdr *rxhdr, uint32_t aa);
 int ble_ll_conn_rx_isr_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr);
 void ble_ll_conn_rx_data_pdu(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr);
-void ble_ll_init_rx_pkt_in(uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr);
+void ble_ll_init_rx_pkt_in(uint8_t pdu_type, uint8_t *rxbuf,
+                           struct ble_mbuf_hdr *ble_hdr);
 int ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
                            struct ble_mbuf_hdr *ble_hdr);
 void ble_ll_conn_wfr_timer_exp(void);
+void ble_ll_conn_init_wrf_timer_exp(void);
 int ble_ll_conn_is_lru(struct ble_ll_conn_sm *s1, struct ble_ll_conn_sm *s2);
 uint32_t ble_ll_conn_get_ce_end_time(void);
 void ble_ll_conn_event_halt(void);
@@ -162,7 +174,10 @@ int ble_ll_hci_acl_rx(struct os_mbuf *om, void *arg);
 int ble_ll_conn_hci_le_rd_phy(uint8_t *cmdbuf, uint8_t *rsp, uint8_t *rsplen);
 int ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf);
 int ble_ll_conn_chk_phy_upd_start(struct ble_ll_conn_sm *connsm);
-
+void ble_ll_conn_req_pdu_make(struct ble_ll_conn_sm *connsm, uint8_t chan);
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+int ble_ll_ext_conn_create(uint8_t *cmdbuf);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/net/nimble/controller/src/ble_ll_conn_priv.h
+++ b/net/nimble/controller/src/ble_ll_conn_priv.h
@@ -96,7 +96,7 @@ void ble_ll_conn_enqueue_pkt(struct ble_ll_conn_sm *connsm, struct os_mbuf *om,
 struct ble_ll_conn_sm *ble_ll_conn_sm_get(void);
 void ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
                              struct hci_create_conn *hcc);
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 void ble_ll_conn_ext_master_init(struct ble_ll_conn_sm *connsm,
                                  struct hci_ext_create_conn *hcc);
 
@@ -175,7 +175,7 @@ int ble_ll_conn_hci_le_rd_phy(uint8_t *cmdbuf, uint8_t *rsp, uint8_t *rsplen);
 int ble_ll_conn_hci_le_set_phy(uint8_t *cmdbuf);
 int ble_ll_conn_chk_phy_upd_start(struct ble_ll_conn_sm *connsm);
 void ble_ll_conn_req_pdu_make(struct ble_ll_conn_sm *connsm, uint8_t chan);
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 int ble_ll_ext_conn_create(uint8_t *cmdbuf);
 #endif
 #ifdef __cplusplus

--- a/net/nimble/controller/src/ble_ll_hci.c
+++ b/net/nimble/controller/src/ble_ll_hci.c
@@ -567,6 +567,7 @@ ble_ll_hci_le_cmd_send_cmd_status(uint16_t ocf)
     switch (ocf) {
     case BLE_HCI_OCF_LE_RD_REM_FEAT:
     case BLE_HCI_OCF_LE_CREATE_CONN:
+    case BLE_HCI_OCF_LE_EXT_CREATE_CONN:
     case BLE_HCI_OCF_LE_CONN_UPDATE:
     case BLE_HCI_OCF_LE_START_ENCRYPT:
     case BLE_HCI_OCF_LE_RD_P256_PUBKEY:
@@ -843,7 +844,10 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen)
         break;
     case BLE_HCI_OCF_LE_SET_EXT_SCAN_ENABLE:
         rc = ble_ll_scan_set_enable(cmdbuf, 1);
-    break;
+        break;
+    case BLE_HCI_OCF_LE_EXT_CREATE_CONN:
+        rc = ble_ll_ext_conn_create(cmdbuf);
+        break;
 #endif
     case BLE_HCI_OCF_LE_RD_MAX_DATA_LEN:
         rc = ble_ll_hci_le_rd_max_data_len(rspbuf, rsplen);

--- a/net/nimble/controller/src/ble_ll_hci.c
+++ b/net/nimble/controller/src/ble_ll_hci.c
@@ -735,7 +735,7 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen)
         rc = ble_ll_adv_set_enable(cmdbuf, 0);
         break;
     case BLE_HCI_OCF_LE_SET_SCAN_ENABLE:
-        rc = ble_ll_scan_set_enable(cmdbuf);
+        rc = ble_ll_scan_set_enable(cmdbuf, 0);
         break;
     case BLE_HCI_OCF_LE_SET_SCAN_PARAMS:
         rc = ble_ll_scan_set_scan_params(cmdbuf);
@@ -836,6 +836,14 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen)
     case BLE_HCI_OCF_LE_SET_PRIVACY_MODE:
         rc = ble_ll_resolve_set_priv_mode(cmdbuf);
         break;
+#endif
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+    case BLE_HCI_OCF_LE_SET_EXT_SCAN_PARAM:
+        rc = ble_ll_set_ext_scan_params(cmdbuf);
+        break;
+    case BLE_HCI_OCF_LE_SET_EXT_SCAN_ENABLE:
+        rc = ble_ll_scan_set_enable(cmdbuf, 1);
+    break;
 #endif
     case BLE_HCI_OCF_LE_RD_MAX_DATA_LEN:
         rc = ble_ll_hci_le_rd_max_data_len(rspbuf, rsplen);

--- a/net/nimble/controller/src/ble_ll_hci.c
+++ b/net/nimble/controller/src/ble_ll_hci.c
@@ -838,7 +838,7 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen)
         rc = ble_ll_resolve_set_priv_mode(cmdbuf);
         break;
 #endif
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
     case BLE_HCI_OCF_LE_SET_EXT_SCAN_PARAM:
         rc = ble_ll_set_ext_scan_params(cmdbuf);
         break;

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -1199,12 +1199,12 @@ ble_ll_scan_chk_resume(void)
 }
 
 /**
- * Connection supervision timer callback; means that the connection supervision
- * timeout has been reached and we should perform the appropriate actions.
+ * Scan timer callback; means that the scan window timeout has been reached
+ * and we should perform the appropriate actions.
  *
  * Context: Interrupt (cputimer)
  *
- * @param arg Pointer to connection state machine.
+ * @param arg Pointer to scan state machine.
  */
 void
 ble_ll_scan_timer_cb(void *arg)

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -582,7 +582,7 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm)
 #endif
 
     /* Set channel */
-    rc = ble_phy_setchan(scanphy->scan_chan, 0, 0);
+    rc = ble_phy_setchan(scanphy->scan_chan, BLE_ACCESS_ADDR_ADV, BLE_LL_CRCINIT_ADV);
     assert(rc == 0);
 
     /*

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -577,6 +577,9 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm)
 {
     int rc;
     struct ble_ll_scan_params *scanphy = &scansm->phy_data[scansm->cur_phy];
+#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
+    uint8_t phy_mode;
+#endif
 
     /* Set channel */
     rc = ble_phy_setchan(scanphy->scan_chan, 0, 0);
@@ -601,7 +604,8 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm)
 #endif
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_mode_set(BLE_PHY_MODE_1M, BLE_PHY_MODE_1M);
+    phy_mode = ble_ll_phy_to_phy_mode(scanphy->phy, BLE_HCI_LE_PHY_CODED_ANY);
+    ble_phy_mode_set(phy_mode, phy_mode);
 #endif
 
 #if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
@@ -833,7 +837,7 @@ ble_ll_scan_switch_phy(struct ble_ll_scan_sm *scansm)
     scansm->next_phy = scansm->cur_phy;
     scansm->cur_phy = tmp;
 
-    /*TODO Modify PHY*/
+    /* PHY is changing in ble_ll_scan_start() */
 }
 
 /**
@@ -1883,6 +1887,10 @@ ble_ll_scan_init(void)
         scanp->scan_itvl = BLE_HCI_SCAN_ITVL_DEF;
         scanp->scan_window = BLE_HCI_SCAN_WINDOW_DEF;
     }
+
+    scansm->phy_data[PHY_UNCODED].phy = BLE_PHY_1M;
+    scansm->phy_data[PHY_CODED].phy = BLE_PHY_CODED;
+
     /* Initialize scanning timer */
     os_cputime_timer_init(&scansm->scan_timer, ble_ll_scan_timer_cb, scansm);
 

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -1330,7 +1330,7 @@ scan_continue:
      * we have failed the scan request (as we would have reset the scan rsp
      * pending flag if we received a valid response
      */
-    if (scansm->scan_rsp_pending && scan_rsp_chk) {
+    if (scansm && scansm->scan_rsp_pending && scan_rsp_chk) {
         ble_ll_scan_req_backoff(scansm, 0);
     }
 

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -818,7 +818,9 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm)
     int rc;
     struct ble_ll_scan_params *scanphy = &scansm->phy_data[scansm->cur_phy];
     uint8_t scan_chan;
+#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
     uint8_t phy_mode;
+#endif
     int phy;
 
     ble_ll_get_chan_to_scan(scansm, &scan_chan, &phy);

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -1502,6 +1502,16 @@ ble_ll_set_ext_scan_params(uint8_t *cmd)
         coded->configured = 1;
     }
 
+    /* For now we don't accept request for continuous scan if 2 PHYs are
+     * requested.
+     */
+    if ((cmd[2] ==
+            (BLE_HCI_LE_PHY_1M_PREF_MASK | BLE_HCI_LE_PHY_CODED_PREF_MASK)) &&
+                ((uncoded->scan_itvl == uncoded->scan_window) ||
+                (coded->scan_itvl == coded-> scan_window))) {
+            return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
     memcpy(g_ble_ll_scan_params, new_params, sizeof(new_params));
 
     return 0;

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -419,7 +419,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     itvl_t = connsm->conn_itvl_ticks;
 #else
     adv_rxend = ble_hdr->beg_cputime +
-        os_cputime_usecs_to_ticks(ble_phy_mode_pdu_dur(pyld_len, BLE_PHY_MODE_1M));
+        os_cputime_usecs_to_ticks(ble_ll_pdu_tx_time_get(pyld_len, BLE_PHY_MODE_1M));
     /*
      * The earliest start time is 1.25 msecs from the end of the connect
      * request transmission. Note that adv_rxend is the end of the received
@@ -430,7 +430,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     dur = os_cputime_usecs_to_ticks(req_slots * BLE_LL_SCHED_USECS_PER_SLOT);
     earliest_start = adv_rxend +
         os_cputime_usecs_to_ticks(BLE_LL_IFS +
-                                  ble_phy_mode_pdu_dur(BLE_CONNECT_REQ_LEN, BLE_PHY_MODE_1M) +
+                                  ble_ll_pdu_tx_time_get(BLE_CONNECT_REQ_LEN, BLE_PHY_MODE_1M) +
                                   BLE_LL_CONN_INITIAL_OFFSET +
                                   MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) * BLE_LL_CONN_TX_OFF_USECS);
     earliest_end = earliest_start + dur;

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -256,10 +256,12 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
                 ble_ll_adv_event_rmvd_from_sched((struct ble_ll_adv_sm *)
                                                   entry->cb_arg);
                 break;
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
             case BLE_LL_SCHED_TYPE_AUX_SCAN:
                 ble_ll_scan_aux_data_free((struct ble_ll_aux_data *)
                                           entry->cb_arg);
                 break;
+#endif
             default:
                 assert(0);
                 break;
@@ -1075,7 +1077,7 @@ ble_ll_sched_rfclk_chk_restart(void)
  * @return int
  */
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 int
 ble_ll_sched_is_busy_in(uint32_t usec)
 {

--- a/net/nimble/controller/syscfg.yml
+++ b/net/nimble/controller/syscfg.yml
@@ -230,6 +230,13 @@ syscfg.defs:
             This option is used to enable/disable support for the coded PHY.
         value: '0'
 
+    BLE_LL_CFG_FEAT_LL_EXT_ADV:
+        description: >
+            This option is used to enable/disable support for Extended
+            Advertising Feature. That means extended scanner, advertiser
+            and connect.
+        value: 0
+
     BLE_PUBLIC_DEV_ADDR:
         description: >
             Allows the target or app to override the public device address

--- a/net/nimble/host/src/ble_gap.c
+++ b/net/nimble/host/src/ble_gap.c
@@ -447,7 +447,7 @@ ble_gap_read_le_phy(uint16_t conn_handle, uint8_t *tx_phy, uint8_t *rx_phy)
         return BLE_HS_ENOTCONN;
     }
 
-    rc = ble_hs_hci_build_le_read_phy(conn_handle, buf, sizeof(buf));
+    rc = ble_hs_hci_cmd_build_le_read_phy(conn_handle, buf, sizeof(buf));
     if (rc != 0) {
         return rc;
     }
@@ -475,7 +475,7 @@ ble_gap_set_prefered_default_le_phy(uint8_t tx_phys_mask, uint8_t rx_phys_mask)
     uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_DEFAULT_PHY_LEN];
     int rc;
 
-    rc = ble_hs_hci_build_le_set_default_phy(tx_phys_mask, rx_phys_mask, buf,
+    rc = ble_hs_hci_cmd_build_le_set_default_phy(tx_phys_mask, rx_phys_mask, buf,
                                              sizeof(buf));
     if (rc != 0) {
         return rc;
@@ -500,7 +500,7 @@ ble_gap_set_prefered_le_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
         return BLE_HS_ENOTCONN;
     }
 
-    rc = ble_hs_hci_build_le_set_phy(conn_handle, tx_phys_mask, rx_phys_mask,
+    rc = ble_hs_hci_cmd_build_le_set_phy(conn_handle, tx_phys_mask, rx_phys_mask,
                                      phy_opts, buf, sizeof(buf));
     if (rc != 0) {
         return rc;

--- a/net/nimble/host/src/ble_hs_hci_cmd.c
+++ b/net/nimble/host/src/ble_hs_hci_cmd.c
@@ -1226,7 +1226,7 @@ ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(
  * OGF=0x08 OCF=0x0030
  */
 int
-ble_hs_hci_build_le_read_phy(uint16_t conn_handle, uint8_t *dst, int dst_len)
+ble_hs_hci_cmd_build_le_read_phy(uint16_t conn_handle, uint8_t *dst, int dst_len)
 {
     BLE_HS_DBG_ASSERT(
         dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_RD_PHY_LEN);
@@ -1293,8 +1293,8 @@ ble_hs_hci_cmd_body_le_set_default_phy(uint8_t tx_phys_mask,
  * OGF=0x08 OCF=0x0031
  */
 int
-ble_hs_hci_build_le_set_default_phy(uint8_t tx_phys_mask, uint8_t rx_phys_mask,
-                                    uint8_t *dst, int dst_len)
+ble_hs_hci_cmd_build_le_set_default_phy(uint8_t tx_phys_mask, uint8_t rx_phys_mask,
+                                        uint8_t *dst, int dst_len)
 {
 
     BLE_HS_DBG_ASSERT(
@@ -1345,9 +1345,9 @@ ble_hs_hci_cmd_body_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
  * OGF=0x08 OCF=0x0032
  */
 int
-ble_hs_hci_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
-                            uint8_t rx_phys_mask, uint16_t phy_opts,
-                            uint8_t *dst, int dst_len)
+ble_hs_hci_cmd_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
+                                uint8_t rx_phys_mask, uint16_t phy_opts,
+                                uint8_t *dst, int dst_len)
 {
 
     BLE_HS_DBG_ASSERT(
@@ -1386,9 +1386,9 @@ ble_hs_hci_cmd_body_le_set_priv_mode(const uint8_t *addr, uint8_t addr_type,
  *  OGF=0x08 OCF=0x004e
  */
 int
-ble_hs_hci_build_le_set_priv_mode(const uint8_t *addr, uint8_t addr_type,
-                                  uint8_t priv_mode, uint8_t *dst,
-                                  uint16_t dst_len)
+ble_hs_hci_cmd_build_le_set_priv_mode(const uint8_t *addr, uint8_t addr_type,
+                                      uint8_t priv_mode, uint8_t *dst,
+                                      uint16_t dst_len)
 {
     BLE_HS_DBG_ASSERT(
         dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_PRIVACY_MODE_LEN);

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -159,16 +159,16 @@ int ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(
 int ble_hs_hci_cmd_build_set_random_addr(const uint8_t *addr,
                                          uint8_t *dst, int dst_len);
 
-int ble_hs_hci_build_le_set_priv_mode(const uint8_t *addr, uint8_t addr_type,
+int ble_hs_hci_cmd_build_le_set_priv_mode(const uint8_t *addr, uint8_t addr_type,
                                       uint8_t priv_mode, uint8_t *dst,
                                       uint16_t dst_len);
 
-int ble_hs_hci_build_le_read_phy(uint16_t conn_handle, uint8_t *dst,
+int ble_hs_hci_cmd_build_le_read_phy(uint16_t conn_handle, uint8_t *dst,
                                  int dst_len);
-int ble_hs_hci_build_le_set_default_phy(uint8_t tx_phys_mask,
+int ble_hs_hci_cmd_build_le_set_default_phy(uint8_t tx_phys_mask,
                                         uint8_t rx_phys_mask,
                                         uint8_t *dst, int dst_len);
-int ble_hs_hci_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
+int ble_hs_hci_cmd_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
                                 uint8_t rx_phys_mask, uint16_t phy_opts,
                                 uint8_t *dst, int dst_len);
 #ifdef __cplusplus

--- a/net/nimble/host/src/ble_hs_pvcy.c
+++ b/net/nimble/host/src/ble_hs_pvcy.c
@@ -213,7 +213,7 @@ ble_hs_pvcy_set_mode(const ble_addr_t *addr, uint8_t priv_mode)
     uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_PRIVACY_MODE_LEN];
     int rc;
 
-    rc = ble_hs_hci_build_le_set_priv_mode(addr->val, addr->type, priv_mode,
+    rc = ble_hs_hci_cmd_build_le_set_priv_mode(addr->val, addr->type, priv_mode,
                                            buf, sizeof(buf));
     if (rc != 0) {
         return rc;

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -62,7 +62,7 @@ struct ble_encryption_block
  */
 struct ble_mbuf_hdr_rxinfo
 {
-    uint8_t flags;
+    uint16_t flags;
     uint8_t channel;
     uint8_t handle;
     int8_t  rssi;
@@ -70,16 +70,22 @@ struct ble_mbuf_hdr_rxinfo
 #if MYNEWT_VAL(BLE_MULTI_ADV_SUPPORT)
     void *advsm;   /* advertising state machine */
 #endif
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+    void *aux_data;
+#endif
 };
 
 /* Flag definitions for rxinfo  */
-#define BLE_MBUF_HDR_F_CRC_OK           (0x80)
-#define BLE_MBUF_HDR_F_DEVMATCH         (0x40)
-#define BLE_MBUF_HDR_F_MIC_FAILURE      (0x20)
-#define BLE_MBUF_HDR_F_SCAN_RSP_TXD     (0x10)
-#define BLE_MBUF_HDR_F_SCAN_RSP_CHK     (0x08)
-#define BLE_MBUF_HDR_F_RESOLVED         (0x04)
-#define BLE_MBUF_HDR_F_RXSTATE_MASK     (0x03)
+#define BLE_MBUF_HDR_F_EXT_ADV          (0x0400)
+#define BLE_MBUF_HDR_F_AUX_PTR_WAIT     (0x0200)
+#define BLE_MBUF_HDR_F_AUX_INVALID      (0x0100)
+#define BLE_MBUF_HDR_F_CRC_OK           (0x0080)
+#define BLE_MBUF_HDR_F_DEVMATCH         (0x0040)
+#define BLE_MBUF_HDR_F_MIC_FAILURE      (0x0020)
+#define BLE_MBUF_HDR_F_SCAN_RSP_TXD     (0x0010)
+#define BLE_MBUF_HDR_F_SCAN_RSP_CHK     (0x0008)
+#define BLE_MBUF_HDR_F_RESOLVED         (0x0004)
+#define BLE_MBUF_HDR_F_RXSTATE_MASK     (0x0003)
 
 /* Transmit info. NOTE: no flags defined */
 struct ble_mbuf_hdr_txinfo
@@ -101,6 +107,12 @@ struct ble_mbuf_hdr
     uint32_t rem_usecs;
 #endif
 };
+
+#define BLE_MBUF_HDR_AUX_INVALID(hdr) \
+    ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_INVALID)
+
+#define BLE_MBUF_HDR_WAIT_AUX(hdr)      \
+	((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_PTR_WAIT)
 
 #define BLE_MBUF_HDR_CRC_OK(hdr)        \
     ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_CRC_OK)

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -70,7 +70,7 @@ struct ble_mbuf_hdr_rxinfo
 #if MYNEWT_VAL(BLE_MULTI_ADV_SUPPORT)
     void *advsm;   /* advertising state machine */
 #endif
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
     void *aux_data;
 #endif
 };

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -76,6 +76,7 @@ struct ble_mbuf_hdr_rxinfo
 };
 
 /* Flag definitions for rxinfo  */
+#define BLE_MBUF_HDR_F_RESOLVED         (0x0800)
 #define BLE_MBUF_HDR_F_EXT_ADV          (0x0400)
 #define BLE_MBUF_HDR_F_AUX_PTR_WAIT     (0x0200)
 #define BLE_MBUF_HDR_F_AUX_INVALID      (0x0100)
@@ -84,8 +85,7 @@ struct ble_mbuf_hdr_rxinfo
 #define BLE_MBUF_HDR_F_MIC_FAILURE      (0x0020)
 #define BLE_MBUF_HDR_F_SCAN_RSP_TXD     (0x0010)
 #define BLE_MBUF_HDR_F_SCAN_RSP_CHK     (0x0008)
-#define BLE_MBUF_HDR_F_RESOLVED         (0x0004)
-#define BLE_MBUF_HDR_F_RXSTATE_MASK     (0x0003)
+#define BLE_MBUF_HDR_F_RXSTATE_MASK     (0x0007)
 
 /* Transmit info. NOTE: no flags defined */
 struct ble_mbuf_hdr_txinfo

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -66,6 +66,7 @@ struct ble_mbuf_hdr_rxinfo
     uint8_t channel;
     uint8_t handle;
     int8_t  rssi;
+    int8_t  phy;
 #if MYNEWT_VAL(BLE_MULTI_ADV_SUPPORT)
     void *advsm;   /* advertising state machine */
 #endif

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -109,22 +109,22 @@ struct ble_mbuf_hdr
 };
 
 #define BLE_MBUF_HDR_AUX_INVALID(hdr) \
-    ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_INVALID)
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_INVALID))
 
 #define BLE_MBUF_HDR_WAIT_AUX(hdr)      \
-	((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_PTR_WAIT)
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_PTR_WAIT))
 
 #define BLE_MBUF_HDR_CRC_OK(hdr)        \
-    ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_CRC_OK)
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_CRC_OK))
 
 #define BLE_MBUF_HDR_MIC_FAILURE(hdr)   \
-    ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_MIC_FAILURE)
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_MIC_FAILURE))
 
 #define BLE_MBUF_HDR_RESOLVED(hdr)      \
-    ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_RESOLVED)
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_RESOLVED))
 
 #define BLE_MBUF_HDR_RX_STATE(hdr)      \
-    ((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_RXSTATE_MASK)
+    ((uint8_t)((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_RXSTATE_MASK))
 
 #define BLE_MBUF_HDR_PTR(om)            \
     (struct ble_mbuf_hdr *)((uint8_t *)om + sizeof(struct os_mbuf) + \

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -771,7 +771,7 @@ struct hci_create_conn
     uint16_t max_ce_len;
 };
 
-#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV) || MYNEWT_VAL(BLE_EXT_ADV)
 /* LE create connection command (ocf=0x0043). */
 struct hci_ext_conn_params
 {

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -771,6 +771,31 @@ struct hci_create_conn
     uint16_t max_ce_len;
 };
 
+#if MYNEWT_VAL(BLE_EXT_SCAN_SUPPORT)
+/* LE create connection command (ocf=0x0043). */
+struct hci_ext_conn_params
+{
+    uint16_t scan_itvl;
+    uint16_t scan_window;
+    uint16_t conn_itvl_min;
+    uint16_t conn_itvl_max;
+    uint16_t conn_latency;
+    uint16_t supervision_timeout;
+    uint16_t min_ce_len;
+    uint16_t max_ce_len;
+};
+
+struct hci_ext_create_conn
+{
+    uint8_t filter_policy;
+    uint8_t own_addr_type;
+    uint8_t peer_addr_type;
+    uint8_t peer_addr[BLE_DEV_ADDR_LEN];
+    uint8_t init_phy_mask;
+    struct hci_ext_conn_params params[3];
+};
+#endif
+
 /* LE connection update command (ocf=0x0013). */
 struct hci_conn_update
 {

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -209,6 +209,12 @@ extern "C" {
 #define BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD  (4)
 #define BLE_HCI_ADV_TYPE_MAX                (4)
 
+#define BLE_HCI_ADV_CONN_MASK               (0x0001)
+#define BLE_HCI_ADV_SCAN_MASK               (0x0002)
+#define BLE_HCI_ADV_DIRECT_MASK             (0x0004)
+#define BLE_HCI_ADV_SCAN_RSP_MASK           (0x0008)
+#define BLE_HCI_ADV_LEGACY_MASK             (0x0010)
+
 /* Own address types */
 #define BLE_HCI_ADV_OWN_ADDR_PUBLIC         (0)
 #define BLE_HCI_ADV_OWN_ADDR_RANDOM         (1)
@@ -644,6 +650,14 @@ extern "C" {
 #define BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND     (2)
 #define BLE_HCI_ADV_RPT_EVTYPE_NONCONN_IND  (3)
 #define BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP     (4)
+
+/* Bluetooth 5, Vol 2, Part E, 7.7.65.13 */
+#define BLE_HCI_LEGACY_ADV_EVTYPE_ADV_IND                 (0x13)
+#define BLE_HCI_LEGACY_ADV_EVTYPE_ADV_DIRECT_IND          (0x15)
+#define BLE_HCI_LEGACY_ADV_EVTYPE_ADV_SCAN_IND            (0x12)
+#define BLE_HCI_LEGACY_ADV_EVTYPE_ADV_NONCON_IND          (0x10)
+#define BLE_HCI_LEGACY_ADV_EVTYPE_SCAN_RSP_ADV_IND        (0x1b)
+#define BLE_HCI_LEGACY_ADV_EVTYPE_SCAN_RSP_ADV_SCAN_IND   (0x1a)
 
 /* LE sub-event specific definitions */
 #define BLE_HCI_LE_MIN_LEN                  (1) /* Not including event hdr. */

--- a/net/nimble/syscfg.yml
+++ b/net/nimble/syscfg.yml
@@ -51,6 +51,3 @@ syscfg.defs:
             advertising instances is this number plus 1 (assuming the device
             supports advertising).
         value: 0
-    BLE_EXT_SCAN_SUPPORT:
-        description: "Enable extended scan support from Bluetooth 5.0"
-        value: 0

--- a/net/nimble/syscfg.yml
+++ b/net/nimble/syscfg.yml
@@ -51,3 +51,6 @@ syscfg.defs:
             advertising instances is this number plus 1 (assuming the device
             supports advertising).
         value: 0
+    BLE_EXT_SCAN_SUPPORT:
+        description: "Enable extended scan support from Bluetooth 5.0"
+        value: 0


### PR DESCRIPTION
In this pull request you can find  first part of extended advertising feature for controller part and . It contains:
* required PHY changes
* handling non-connectable/connectable/scanable extended advertising packets.
* handling extended connect request

Configuration to run:
* Set Low Power RTC
* Set BLE_LL_CFG_FEAT_LL_EXT_ADV to 1