### PR TITLE
Multiple oic service uuids

### DIFF
--- a/apps/bleprph_oic/pkg.yml
+++ b/apps/bleprph_oic/pkg.yml
@@ -32,7 +32,7 @@ pkg.deps:
     - net/nimble/transport/ram
     - sys/console/full
     - sys/log/full
-    - sys/stats/stub
+    - sys/stats/full
     - mgmt/oicmgr
     - sys/sysinit
     - sys/shell

--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -93,7 +93,7 @@ bleprph_advertise(void)
      *     o Flags (indicates advertisement type and other general info).
      *     o Advertising tx power.
      *     o Device name.
-     *     o 16-bit service UUIDs (alert notifications).
+     *     o service UUID.
      */
 
     memset(&fields, 0, sizeof fields);
@@ -117,29 +117,25 @@ bleprph_advertise(void)
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
 
+#if MYNEWT_VAL(ADVERTISE_128BIT_UUID)
+    /* Advertise the 128-bit CoAP-over-BLE service UUID in the scan response. */
     fields.uuids128 = (ble_uuid128_t []) {
         BLE_UUID128_INIT(OC_GATT_SERVICE_UUID)
     };
     fields.num_uuids128 = 1;
     fields.uuids128_is_complete = 1;
-
-    rc = ble_gap_adv_set_fields(&fields);
-    if (rc != 0) {
-        BLEPRPH_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
-        return;
-    }
-
+#endif
+#if MYNEWT_VAL(ADVERTISE_16BIT_UUID)
     /* Advertise the 16-bit CoAP-over-BLE service UUID in the scan response. */
-    memset(&fields, 0, sizeof fields);
     fields.uuids16 = (ble_uuid16_t[]) {
         BLE_UUID16_INIT(RUNTIME_COAP_SERVICE_UUID)
     };
     fields.num_uuids16 = 1;
     fields.uuids16_is_complete = 1;
-
-    rc = ble_gap_adv_rsp_set_fields(&fields);
+#endif
+    rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        BLEPRPH_LOG(ERROR, "error setting scan response data; rc=%d\n", rc);
+        BLEPRPH_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
         return;
     }
 

--- a/apps/bleprph_oic/syscfg.yml
+++ b/apps/bleprph_oic/syscfg.yml
@@ -16,6 +16,14 @@
 # under the License.
 #
 
+syscfg.defs:
+    ADVERTISE_16BIT_UUID:
+        description: 'Advertise Runtime 16 bit service UUID'
+        value: 1
+    ADVERTISE_128BIT_UUID:
+        description: 'Advertise Iotivity 128 bit service UUID'
+        value: 0
+
 syscfg.vals:
     # Use INFO log level to reduce code size.  DEBUG is too large for nRF51.
     LOG_LEVEL: 0

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -66,6 +66,7 @@ struct oc_endpoint_ip {
  */
 struct oc_endpoint_ble {
     enum oc_transport_flags flags;
+    uint8_t srv_idx;
     uint16_t conn_handle;
 };
 


### PR DESCRIPTION
This allows registering multiple services for OIC. Server will respond using notification characteristic which matches write characteristic for incoming request.

Also add syscfg knob to bleprph_oic, which allows choosing whether to advertise the 16-bit UUID for OIC, or 128-bit UUID. At the moment only one of them will be allowed.