### PR TITLE
Increase MCU clock speed on STM32F7-Discovery to maximum 168 MHz.

### DIFF
--- a/hw/bsp/stm32f7discovery/include/bsp/stm32f7xx_hal_conf.h
+++ b/hw/bsp/stm32f7discovery/include/bsp/stm32f7xx_hal_conf.h
@@ -104,7 +104,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)

--- a/hw/bsp/stm32f7discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f7discovery/src/hal_bsp.c
@@ -185,6 +185,7 @@ hal_bsp_init(void)
 
     (void)rc;
 
+    SCB_EnableICache();
     SystemClock_Config();
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/stm32f7discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f7discovery/src/hal_bsp.c
@@ -33,12 +33,8 @@
 #include <hal/hal_timer.h>
 
 #include <stm32f746xx.h>
-#include <stm32f7xx_hal_gpio_ex.h>
-#include <stm32f7xx_hal_flash.h>
-#include <stm32f7xx_hal_rcc.h>
-#include <stm32f7xx_hal_pwr.h>
-#include <stm32f7xx_hal_pwr_ex.h>
 #include <mcu/stm32f7_bsp.h>
+#include <stm32f7xx_hal_gpio_ex.h>
 
 #if MYNEWT_VAL(ETH_0)
 #include <stm32_eth/stm32_eth.h>
@@ -130,63 +126,12 @@ hal_bsp_core_dump(int *area_cnt)
     return dump_cfg;
 }
 
-/** System Clock Configuration.
- *
- * Configures CPU to run at 168 MHz.
- *
- * ((16 MHz / 10) * 210) / 2 = 168 MHz
- */
-void SystemClock_Config(void)
-{
-
-    RCC_OscInitTypeDef RCC_OscInitStruct;
-    RCC_ClkInitTypeDef RCC_ClkInitStruct;
-
-    /**Configure the main internal regulator output voltage
-    */
-    __HAL_RCC_PWR_CLK_ENABLE();
-
-    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
-
-    /* Initializes the CPU, AHB and APB busses clocks */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = 16;
-    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
-    RCC_OscInitStruct.PLL.PLLM = 10;
-    RCC_OscInitStruct.PLL.PLLN = 210;
-    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
-    RCC_OscInitStruct.PLL.PLLQ = 2;
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-    {
-        /* TODO: Throw error */
-    }
-
-    /* Initializes the CPU, AHB and APB busses clocks */
-    RCC_ClkInitStruct.ClockType = \
-        RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | \
-        RCC_CLOCKTYPE_PCLK2;
-    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
-    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
-
-    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5) != HAL_OK)
-    {
-        /* TODO: Throw error */
-    }
-}
-
 void
 hal_bsp_init(void)
 {
     int rc;
 
     (void)rc;
-
-    SCB_EnableICache();
-    SystemClock_Config();
 
 #if MYNEWT_VAL(UART_0)
     rc = os_dev_create((struct os_dev *) &hal_uart0, "uart0",

--- a/hw/bsp/stm32f7discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f7discovery/src/hal_bsp.c
@@ -34,6 +34,10 @@
 
 #include <stm32f746xx.h>
 #include <stm32f7xx_hal_gpio_ex.h>
+#include <stm32f7xx_hal_flash.h>
+#include <stm32f7xx_hal_rcc.h>
+#include <stm32f7xx_hal_pwr.h>
+#include <stm32f7xx_hal_pwr_ex.h>
 #include <mcu/stm32f7_bsp.h>
 
 #if MYNEWT_VAL(ETH_0)
@@ -126,12 +130,62 @@ hal_bsp_core_dump(int *area_cnt)
     return dump_cfg;
 }
 
+/** System Clock Configuration.
+ *
+ * Configures CPU to run at 168 MHz.
+ *
+ * ((16 MHz / 10) * 210) / 2 = 168 MHz
+ */
+void SystemClock_Config(void)
+{
+
+    RCC_OscInitTypeDef RCC_OscInitStruct;
+    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+
+    /**Configure the main internal regulator output voltage
+    */
+    __HAL_RCC_PWR_CLK_ENABLE();
+
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
+
+    /* Initializes the CPU, AHB and APB busses clocks */
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+    RCC_OscInitStruct.HSICalibrationValue = 16;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLM = 10;
+    RCC_OscInitStruct.PLL.PLLN = 210;
+    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+    RCC_OscInitStruct.PLL.PLLQ = 2;
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+    {
+        /* TODO: Throw error */
+    }
+
+    /* Initializes the CPU, AHB and APB busses clocks */
+    RCC_ClkInitStruct.ClockType = \
+        RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | \
+        RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5) != HAL_OK)
+    {
+        /* TODO: Throw error */
+    }
+}
+
 void
 hal_bsp_init(void)
 {
     int rc;
 
     (void)rc;
+
+    SystemClock_Config();
 
 #if MYNEWT_VAL(UART_0)
     rc = os_dev_create((struct os_dev *) &hal_uart0, "uart0",

--- a/hw/bsp/stm32f7discovery/src/system_stm32f7xx.c
+++ b/hw/bsp/stm32f7discovery/src/system_stm32f7xx.c
@@ -64,6 +64,11 @@
   */
 
 #include "stm32f7xx.h"
+#include "stm32f7xx_hal_gpio_ex.h"
+#include "stm32f7xx_hal_flash.h"
+#include "stm32f7xx_hal_rcc.h"
+#include "stm32f7xx_hal_pwr.h"
+#include "stm32f7xx_hal_pwr_ex.h"
 #include "bsp/cmsis_nvic.h"
 
 #if !defined  (HSE_VALUE)
@@ -135,6 +140,8 @@
   * @{
   */
 
+static void SystemClock_Config(void);
+
 /**
   * @}
   */
@@ -174,6 +181,9 @@ void SystemInit(void)
 
   /* Disable all interrupts */
   RCC->CIR = 0x00000000;
+
+  /* Configure System Clock */
+  SystemClock_Config();
 
   /* Relocate the vector table */
   NVIC_Relocate();
@@ -261,6 +271,56 @@ void SystemCoreClockUpdate(void)
   tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4)];
   /* HCLK frequency */
   SystemCoreClock >>= tmp;
+}
+
+/** System Clock Configuration.
+ *
+ * Configures CPU to run at 168 MHz.
+ *
+ * ((16 MHz / 10) * 210) / 2 = 168 MHz
+ */
+void SystemClock_Config(void)
+{
+
+    RCC_OscInitTypeDef RCC_OscInitStruct;
+    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+
+    SCB_EnableICache();
+
+    /**Configure the main internal regulator output voltage
+    */
+    __HAL_RCC_PWR_CLK_ENABLE();
+
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
+
+    /* Initializes the CPU, AHB and APB busses clocks */
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+    RCC_OscInitStruct.HSICalibrationValue = 16;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLM = 10;
+    RCC_OscInitStruct.PLL.PLLN = 210;
+    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+    RCC_OscInitStruct.PLL.PLLQ = 2;
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+    {
+        /* TODO: Throw error */
+    }
+
+    /* Initializes the CPU, AHB and APB busses clocks */
+    RCC_ClkInitStruct.ClockType = \
+        RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | \
+        RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5) != HAL_OK)
+    {
+        /* TODO: Throw error */
+    }
 }
 
 /**

--- a/hw/mcu/stm/stm32f7xx/src/hal_system_start.c
+++ b/hw/mcu/stm/stm32f7xx/src/hal_system_start.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -46,6 +46,7 @@ hal_system_start(void *img_start)
 
     /* Remap memory such that flash gets mapped to the code region. */
     SYSCFG->MEMRMP = 0;
+    SCB_InvalidateICache();
     __DSB();
 
     /* Jump to image. */


### PR DESCRIPTION
Function generated using Cube MX, with the STM32F7-DISCOVERY board
definition. Uses internal oscillator at 16 MHz.