### PR TITLE
MYNEWT-785: Remove support for 1MHz clock in nimble

### DIFF
--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -71,9 +71,19 @@ syscfg.defs:
         description: 'NRF51 I2C (TWI) interface 0'
         value:  '0'
 
+syscfg.defs.BLE_LP_CLOCK:
+    TIMER_0:
+        value: 0
+    TIMER_3:
+        value: 1
+
 syscfg.vals:
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+
+syscfg.vals.BLE_LP_CLOCK:
+    OS_CPUTIME_FREQ: 32768
+    OS_CPUTIME_TIMER_NUM: 3

--- a/hw/bsp/nrf52840pdk/syscfg.yml
+++ b/hw/bsp/nrf52840pdk/syscfg.yml
@@ -90,9 +90,19 @@ syscfg.defs:
         description: 'NRF52840 I2C (TWI) interface 0'
         value:  '0'
 
+syscfg.defs.BLE_LP_CLOCK:
+    TIMER_0:
+        value: 0
+    TIMER_5:
+        value: 1
+
 syscfg.vals:
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+
+syscfg.vals.BLE_LP_CLOCK:
+    OS_CPUTIME_FREQ: 32768
+    OS_CPUTIME_TIMER_NUM: 5

--- a/hw/bsp/nrf52dk/syscfg.yml
+++ b/hw/bsp/nrf52dk/syscfg.yml
@@ -90,9 +90,19 @@ syscfg.defs:
         description: 'NRF52 I2C (TWI) interface 0'
         value:  '0'
 
+syscfg.defs.BLE_LP_CLOCK:
+    TIMER_0:
+        value: 0
+    TIMER_5:
+        value: 1
+
 syscfg.vals:
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+
+syscfg.vals.BLE_LP_CLOCK:
+    OS_CPUTIME_FREQ: 32768
+    OS_CPUTIME_TIMER_NUM: 5

--- a/hw/drivers/nimble/native/src/ble_phy.c
+++ b/hw/drivers/nimble/native/src/ble_phy.c
@@ -383,11 +383,12 @@ ble_phy_set_txend_cb(ble_phy_tx_end_func txend_cb, void *arg)
  * already be set.
  *
  * @param cputime
+ * @param rem_usecs
  *
  * @return int
  */
 int
-ble_phy_tx_set_start_time(uint32_t cputime)
+ble_phy_tx_set_start_time(uint32_t cputime, uint8_t rem_usecs)
 {
     return 0;
 }
@@ -402,11 +403,12 @@ ble_phy_tx_set_start_time(uint32_t cputime)
  * already be set.
  *
  * @param cputime
+ * @param rem_usecs
  *
  * @return int
  */
 int
-ble_phy_rx_set_start_time(uint32_t cputime)
+ble_phy_rx_set_start_time(uint32_t cputime, uint8_t rem_usecs)
 {
     return 0;
 }
@@ -614,3 +616,8 @@ ble_phy_xcvr_state_get(void)
 }
 
 #endif
+
+void
+ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
+{
+}

--- a/hw/drivers/nimble/nrf51/include/ble/xcvr.h
+++ b/hw/drivers/nimble/nrf51/include/ble/xcvr.h
@@ -25,15 +25,8 @@ extern "C" {
 #endif
 
 /* Transceiver specific defintions */
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
-/*
- * NOTE: we have to account for the RTC output compare issue, which is why
- * this number is much larger when using the 32.768 crystal.
- */
+/* NOTE: we have to account for the RTC output compare issue */
 #define XCVR_PROC_DELAY_USECS         (230)
-#else
-#define XCVR_PROC_DELAY_USECS         (100)
-#endif
 
 #define XCVR_RX_START_DELAY_USECS     (140)
 #define XCVR_TX_START_DELAY_USECS     (140)

--- a/hw/drivers/nimble/nrf51/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf51/src/ble_phy.c
@@ -84,9 +84,7 @@ struct ble_phy_obj
     struct ble_mbuf_hdr rxhdr;
     void *txend_arg;
     ble_phy_tx_end_func txend_cb;
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     uint32_t phy_start_cputime;
-#endif
 };
 struct ble_phy_obj g_ble_phy_data;
 
@@ -281,7 +279,6 @@ nrf_wait_disabled(void)
     }
 }
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
 /**
  *
  *
@@ -404,7 +401,6 @@ ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
     /* Enable the disabled interrupt so we time out on events compare */
     NRF_RADIO->INTENSET = RADIO_INTENSET_DISABLED_Msk;
 }
-#endif
 
 /**
  * Setup transceiver for receive.
@@ -496,18 +492,6 @@ ble_phy_tx_end_isr(void)
     uint8_t transition;
     uint8_t txlen;
     uint32_t wfr_time;
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) != 32768)
-    uint32_t txstart;
-#endif
-
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) != 32768)
-    /*
-     * Read captured tx start time. This is not the actual transmit start
-     * time but it is the time at which the address event occurred
-     * (after transmission of access address)
-     */
-    txstart = NRF_TIMER0->CC[1];
-#endif
 
     /* If this transmission was encrypted we need to remember it */
     was_encrypted = g_ble_phy_data.phy_encrypted;
@@ -516,13 +500,8 @@ ble_phy_tx_end_isr(void)
     assert(g_ble_phy_data.phy_state == BLE_PHY_STATE_TX);
 
     /* Log the event */
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
     ble_ll_log(BLE_LL_LOG_ID_PHY_TXEND, g_ble_phy_data.phy_tx_pyld_len,
                was_encrypted, NRF_TIMER0->CC[2]);
-#else
-    ble_ll_log(BLE_LL_LOG_ID_PHY_TXEND, g_ble_phy_data.phy_tx_pyld_len,
-               was_encrypted, txstart);
-#endif
 
     /* Clear events and clear interrupt on disabled event */
     NRF_RADIO->EVENTS_DISABLED = 0;
@@ -562,18 +541,8 @@ ble_phy_tx_end_isr(void)
         if (txlen && was_encrypted) {
             txlen += BLE_LL_DATA_MIC_LEN;
         }
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
         ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_TXRX, 0);
-#else
-        wfr_time = (BLE_LL_IFS + ble_phy_mode_pdu_start_off(BLE_PHY_1M) +
-                    (2 * BLE_LL_JITTER_USECS)) -
-                    ble_phy_mode_pdu_start_off(BLE_PHY_1M);
-        wfr_time += ble_ll_pdu_tx_time_get(txlen, BLE_PHY_1M);
-        wfr_time = os_cputime_usecs_to_ticks(wfr_time);
-        ble_ll_wfr_enable(txstart + wfr_time);
-#endif
     } else {
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
         /*
          * XXX: not sure we need to stop the timer here all the time. Or that
          * it should be stopped here.
@@ -582,10 +551,6 @@ ble_phy_tx_end_isr(void)
         NRF_TIMER0->TASKS_SHUTDOWN = 1;
         NRF_PPI->CHENCLR = PPI_CHEN_CH4_Msk | PPI_CHEN_CH5_Msk |
                            PPI_CHEN_CH20_Msk | PPI_CHEN_CH31_Msk;
-#else
-        /* Disable automatic TXEN */
-        NRF_PPI->CHENCLR = PPI_CHEN_CH20_Msk;
-#endif
         assert(transition == BLE_PHY_TRANSITION_NONE);
     }
 }
@@ -673,22 +638,16 @@ ble_phy_rx_start_isr(void)
 {
     int rc;
     uint32_t state;
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     uint32_t usecs;
     uint32_t ticks;
-#endif
     struct ble_mbuf_hdr *ble_hdr;
 
     /* Clear events and clear interrupt */
     NRF_RADIO->EVENTS_ADDRESS = 0;
 
     /* Clear wfr timer channels and DISABLED interrupt */
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     NRF_RADIO->INTENCLR = RADIO_INTENCLR_DISABLED_Msk | RADIO_INTENCLR_ADDRESS_Msk;
     NRF_PPI->CHENCLR = PPI_CHEN_CH4_Msk | PPI_CHEN_CH5_Msk;
-#else
-    NRF_RADIO->INTENCLR = RADIO_INTENCLR_ADDRESS_Msk;
-#endif
 
     /* Initialize flags, channel and state in ble header at rx start */
     ble_hdr = &g_ble_phy_data.rxhdr;
@@ -696,7 +655,6 @@ ble_phy_rx_start_isr(void)
     ble_hdr->rxinfo.channel = g_ble_phy_data.phy_chan;
     ble_hdr->rxinfo.handle = 0;
 
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
     /*
      * Calculate receive start time.
      *
@@ -710,10 +668,6 @@ ble_phy_rx_start_isr(void)
         ++ticks;
     }
     ble_hdr->beg_cputime = g_ble_phy_data.phy_start_cputime + ticks;
-#else
-    ble_hdr->beg_cputime = NRF_TIMER0->CC[1] -
-        os_cputime_usecs_to_ticks(ble_phy_mode_pdu_start_off(BLE_PHY_MODE_1M));
-#endif
 
     /* Wait to get 1st byte of frame */
     while (1) {
@@ -775,24 +729,18 @@ ble_phy_isr(void)
 
     /* We get this if we have started to receive a frame */
     if ((irq_en & RADIO_INTENCLR_ADDRESS_Msk) && NRF_RADIO->EVENTS_ADDRESS) {
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
         irq_en &= ~RADIO_INTENCLR_DISABLED_Msk;
-#endif
         ble_phy_rx_start_isr();
     }
 
     /* Check for disabled event. This only happens for transmits now */
     if ((irq_en & RADIO_INTENCLR_DISABLED_Msk) && NRF_RADIO->EVENTS_DISABLED) {
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
         if (g_ble_phy_data.phy_state == BLE_PHY_STATE_RX) {
             NRF_RADIO->EVENTS_DISABLED = 0;
             ble_ll_wfr_timer_exp(NULL);
         } else {
             ble_phy_tx_end_isr();
         }
-#else
-        ble_phy_tx_end_isr();
-#endif
     }
 
     /* Receive packet end (we dont enable this for transmit) */
@@ -869,13 +817,8 @@ ble_phy_init(void)
     /* Configure IFS */
     NRF_RADIO->TIFS = BLE_LL_IFS;
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     /* Captures tx/rx start in timer0 cc 1 and tx/rx end in timer0 cc 2 */
     NRF_PPI->CHENSET = PPI_CHEN_CH26_Msk | PPI_CHEN_CH27_Msk;
-#else
-    /* Captures tx/rx start in timer0 capture 1 */
-    NRF_PPI->CHENSET = PPI_CHEN_CH26_Msk;
-#endif
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION) == 1)
     NRF_CCM->INTENCLR = 0xffffffff;
@@ -895,7 +838,6 @@ ble_phy_init(void)
 #endif
 
     /* TIMER0 setup for PHY when using RTC */
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
     NRF_TIMER0->TASKS_STOP = 1;
     NRF_TIMER0->TASKS_SHUTDOWN = 1;
     NRF_TIMER0->BITMODE = 3;    /* 32-bit timer */
@@ -913,7 +855,6 @@ ble_phy_init(void)
     NRF_PPI->CH[4].TEP = (uint32_t)&(NRF_TIMER0->TASKS_CAPTURE[3]);
     NRF_PPI->CH[5].EEP = (uint32_t)&(NRF_TIMER0->EVENTS_COMPARE[3]);
     NRF_PPI->CH[5].TEP = (uint32_t)&(NRF_RADIO->TASKS_DISABLE);
-#endif
 
     /* Set isr in vector table and enable interrupt */
     NVIC_SetPriority(RADIO_IRQn, 0);
@@ -1033,7 +974,6 @@ ble_phy_set_txend_cb(ble_phy_tx_end_func txend_cb, void *arg)
     g_ble_phy_data.txend_arg = arg;
 }
 
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
 /**
  * Called to set the start time of a transmission.
  *
@@ -1115,65 +1055,6 @@ ble_phy_rx_set_start_time(uint32_t cputime, uint8_t rem_usecs)
     }
     return rc;
 }
-#else
-/**
- * Called to set the start time of a transmission.
- *
- * This function is called to set the start time when we are not going from
- * rx to tx automatically.
- *
- * NOTE: care must be taken when calling this function. The channel should
- * already be set.
- *
- * @param cputime   This is the tick at which the 1st bit of the preamble
- *                  should be transmitted
- * @return int
- */
-int
-ble_phy_tx_set_start_time(uint32_t cputime)
-{
-    int rc;
-
-    cputime -= os_cputime_usecs_to_ticks(XCVR_TX_START_DELAY_USECS);
-    NRF_PPI->CHENCLR = PPI_CHEN_CH21_Msk;
-    NRF_TIMER0->CC[0] = cputime;
-    NRF_TIMER0->EVENTS_COMPARE[0] = 0;
-    NRF_PPI->CHENSET = PPI_CHEN_CH20_Msk;
-    if ((int32_t)(os_cputime_get32() - cputime) >= 0) {
-        STATS_INC(ble_phy_stats, tx_late);
-        ble_phy_disable();
-        rc = BLE_PHY_ERR_TX_LATE;
-    } else {
-        rc = 0;
-    }
-
-    return rc;
-}
-
-#if 0
-int
-ble_phy_rx_set_start_time(void)
-{
-    /*
-     * XXX: For now, we dont use this function if we are not using the
-     * RTC. Keeping the code around just in case we want to use it later.
-     */
-    NRF_PPI->CHENCLR = PPI_CHEN_CH20_Msk;
-    NRF_TIMER0->CC[0] = cputime;
-    NRF_TIMER0->EVENTS_COMPARE[0] = 0;
-    NRF_PPI->CHENSET = PPI_CHEN_CH21_Msk;
-    if ((int32_t)(os_cputime_get32() - cputime) >= 0) {
-        STATS_INC(ble_phy_stats, rx_late);
-        NRF_PPI->CHENCLR = PPI_CHEN_CH21_Msk;
-        NRF_RADIO->TASKS_RXEN = 1;
-        rc =  BLE_PHY_ERR_RX_LATE;
-    } else {
-        rc = 0;
-    }
-    return rc;
-}
-#endif
-#endif
 
 int
 ble_phy_tx(struct os_mbuf *txpdu, uint8_t end_trans)
@@ -1421,7 +1302,6 @@ ble_phy_setchan(uint8_t chan, uint32_t access_addr, uint32_t crcinit)
     return 0;
 }
 
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
 /**
  * Stop the timer used to count microseconds when using RTC for cputime
  */
@@ -1432,7 +1312,6 @@ ble_phy_stop_usec_timer(void)
     NRF_TIMER0->TASKS_SHUTDOWN = 1;
     NRF_RTC0->EVTENCLR = RTC_EVTENSET_COMPARE0_Msk;
 }
-#endif
 
 /**
  * ble phy disable irq and ppi

--- a/hw/drivers/nimble/nrf52/include/ble/xcvr.h
+++ b/hw/drivers/nimble/nrf52/include/ble/xcvr.h
@@ -24,16 +24,11 @@
 extern "C" {
 #endif
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
 /*
- * NOTE: we have to account for the RTC output compare issue, which is why
- * this number is much larger when using the 32.768 crystal for cputime. We
- * want it to be 5 ticks.
+ * NOTE: we have to account for the RTC output compare issue. We want it to be
+ * 5 ticks.
  */
 #define XCVR_PROC_DELAY_USECS         (153)
-#else
-#define XCVR_PROC_DELAY_USECS         (50)
-#endif
 #define XCVR_RX_START_DELAY_USECS     (140)
 #define XCVR_TX_START_DELAY_USECS     (140)
 #define XCVR_TX_SCHED_DELAY_USECS     \

--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -31,6 +31,10 @@
 extern "C" {
 #endif
 
+#if MYNEWT_VAL(OS_CPUTIME_FREQ) != 32768
+#error 32.768kHz clock required
+#endif
+
 /*
  * XXX:
  * I guess this should not depend on the 32768 crystal to be honest. This

--- a/net/nimble/controller/include/controller/ble_ll_conn.h
+++ b/net/nimble/controller/include/controller/ble_ll_conn.h
@@ -250,11 +250,9 @@ struct ble_ll_conn_sm
     uint16_t max_ce_len;
     uint16_t tx_win_off;
     uint32_t anchor_point;
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     uint8_t anchor_point_usecs;     /* XXX: can this be uint8_t ?*/
     uint8_t conn_itvl_usecs;
     uint32_t conn_itvl_ticks;
-#endif
     uint32_t last_anchor_point;     /* Slave only */
     uint32_t slave_cur_tx_win_usecs;
     uint32_t slave_cur_window_widening;

--- a/net/nimble/controller/include/controller/ble_ll_sched.h
+++ b/net/nimble/controller/include/controller/ble_ll_sched.h
@@ -51,9 +51,7 @@ extern "C" {
  * This is the offset from the start of the scheduled item until the actual
  * tx/rx should occur, in ticks.
  */
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
 extern uint8_t g_ble_ll_sched_offset_ticks;
-#endif
 
 /*
  * This is the number of slots needed to transmit and receive a maximum

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -26,6 +26,14 @@
 extern "C" {
 #endif
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) && !MYNEWT_VAL(BSP_NRF52840)
+#error LE 2M PHY can only be enabled on nRF52840
+#endif
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY) && !MYNEWT_VAL(BSP_NRF52840)
+#error LE Coded PHY can only be enabled on nRF52840
+#endif
+
 /* Forward declarations */
 struct os_mbuf;
 

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -97,16 +97,11 @@ int ble_phy_reset(void);
 /* Set the PHY channel */
 int ble_phy_setchan(uint8_t chan, uint32_t access_addr, uint32_t crcinit);
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
 /* Set transmit start time */
 int ble_phy_tx_set_start_time(uint32_t cputime, uint8_t rem_usecs);
 
 /* Set receive start time */
 int ble_phy_rx_set_start_time(uint32_t cputime, uint8_t rem_usecs);
-#else
-/* Set transmit start time */
-int ble_phy_tx_set_start_time(uint32_t cputime);
-#endif
 
 /* Set the transmit end callback and argument */
 void ble_phy_set_txend_cb(ble_phy_tx_end_func txend_cb, void *arg);
@@ -135,13 +130,8 @@ void ble_phy_disable(void);
 #define BLE_PHY_WFR_ENABLE_RX       (0)
 #define BLE_PHY_WFR_ENABLE_TXRX     (1)
 
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
 void ble_phy_stop_usec_timer(void);
 void ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs);
-#else
-#define ble_phy_stop_usec_timer()
-#define ble_phy_wfr_enable(txrx, wfr_usecs)
-#endif
 
 /* Starts rf clock */
 void ble_phy_rfclk_enable(void);

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -577,9 +577,6 @@ ble_ll_wfr_timer_exp(void *arg)
 void
 ble_ll_wfr_enable(uint32_t cputime)
 {
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) != 32768
-    os_cputime_timer_start(&g_ble_ll_data.ll_wfr_timer, cputime);
-#endif
 }
 
 /**
@@ -588,9 +585,6 @@ ble_ll_wfr_enable(uint32_t cputime)
 void
 ble_ll_wfr_disable(void)
 {
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) != 32768
-    os_cputime_timer_stop(&g_ble_ll_data.ll_wfr_timer);
-#endif
 }
 
 /**
@@ -834,12 +828,8 @@ ble_ll_rx_start(uint8_t *rxbuf, uint8_t chan, struct ble_mbuf_hdr *rxhdr)
     uint8_t pdu_type;
     struct ble_ll_conn_sm *connsm;
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     ble_ll_log(BLE_LL_LOG_ID_RX_START, chan, rxhdr->rem_usecs,
                rxhdr->beg_cputime);
-#else
-    ble_ll_log(BLE_LL_LOG_ID_RX_START, chan, 0, rxhdr->beg_cputime);
-#endif
 
     /* Advertising channel PDU */
     pdu_type = rxbuf[0] & BLE_ADV_PDU_HDR_TYPE_MASK;
@@ -1393,12 +1383,6 @@ ble_ll_init(void)
                     &g_ble_ll_data.ll_evq,
                     ble_ll_hw_err_timer_cb,
                     NULL);
-
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) != 32768
-    /* Initialize wait for response timer */
-    os_cputime_timer_init(&g_ble_ll_data.ll_wfr_timer, ble_ll_wfr_timer_exp,
-                          NULL);
-#endif
 
     /* Initialize LL HCI */
     ble_ll_hci_init();

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -852,14 +852,10 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm)
     ble_phy_mode_set(phy_mode, phy_mode);
 #endif
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     /* XXX: probably need to make sure hfxo is running too */
     /* XXX: can make this better; want to just start asap. */
     rc = ble_phy_rx_set_start_time(os_cputime_get32() +
                                    g_ble_ll_sched_offset_ticks, 0);
-#else
-    rc = ble_phy_rx();
-#endif
     if (!rc) {
         /* Enable/disable whitelisting */
         if (scansm->scan_filt_policy & 1) {

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -39,9 +39,7 @@ struct hal_timer g_ble_ll_sched_timer;
 uint8_t g_ble_ll_sched_xtal_ticks;
 #endif
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
 uint8_t g_ble_ll_sched_offset_ticks;
-#endif
 
 #define BLE_LL_SCHED_ADV_WORST_CASE_USECS       \
     (BLE_LL_SCHED_MAX_ADV_PDU_USECS + BLE_LL_IFS + BLE_LL_SCHED_ADV_MAX_USECS \
@@ -166,7 +164,6 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
     /* Get schedule element from connection */
     sch = &connsm->conn_sch;
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     /* Set schedule start and end times */
     sch->start_time = connsm->anchor_point - g_ble_ll_sched_offset_ticks;
     if (connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) {
@@ -176,16 +173,6 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
     } else {
         sch->remainder = connsm->anchor_point_usecs;
     }
-#else
-    /* Set schedule start and end times */
-    if (connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) {
-        usecs = XCVR_RX_SCHED_DELAY_USECS;
-        usecs += connsm->slave_cur_window_widening;
-    } else {
-        usecs = XCVR_TX_SCHED_DELAY_USECS;
-    }
-    sch->start_time = connsm->anchor_point - os_cputime_usecs_to_ticks(usecs);
-#endif
     sch->end_time = connsm->ce_end_time;
 
     /* Better be past current time or we just leave */
@@ -333,7 +320,6 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     sch = &connsm->conn_sch;
     req_slots = MYNEWT_VAL(BLE_LL_CONN_INIT_SLOTS);
 
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     /* XXX:
      * The calculations for the 32kHz crystal bear alot of explanation. The
      * earliest possible time that the master can start the connection with a
@@ -417,25 +403,6 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     }
     earliest_end = earliest_start + dur;
     itvl_t = connsm->conn_itvl_ticks;
-#else
-    adv_rxend = ble_hdr->beg_cputime +
-        os_cputime_usecs_to_ticks(ble_ll_pdu_tx_time_get(pyld_len, BLE_PHY_MODE_1M));
-    /*
-     * The earliest start time is 1.25 msecs from the end of the connect
-     * request transmission. Note that adv_rxend is the end of the received
-     * advertisement, so we need to add an IFS plus the time it takes to send
-     * the connection request. The 1.25 msecs starts from the end of the conn
-     * request. Also include minimum WindowOffset value if configured.
-     */
-    dur = os_cputime_usecs_to_ticks(req_slots * BLE_LL_SCHED_USECS_PER_SLOT);
-    earliest_start = adv_rxend +
-        os_cputime_usecs_to_ticks(BLE_LL_IFS +
-                                  ble_ll_pdu_tx_time_get(BLE_CONNECT_REQ_LEN, BLE_PHY_MODE_1M) +
-                                  BLE_LL_CONN_INITIAL_OFFSET +
-                                  MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) * BLE_LL_CONN_TX_OFF_USECS);
-    earliest_end = earliest_start + dur;
-    itvl_t = os_cputime_usecs_to_ticks(connsm->conn_itvl * BLE_LL_CONN_ITVL_USECS);
-#endif
 
     /* We have to find a place for this schedule */
     OS_ENTER_CRITICAL(sr);
@@ -483,7 +450,6 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
         if (!rc) {
             /* calculate number of window offsets. Each offset is 1.25 ms */
             sch->enqueued = 1;
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
             /*
              * NOTE: we dont add sched offset ticks as we want to under-estimate
              * the transmit window slightly since the window size is currently
@@ -491,28 +457,18 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
              */
             dur = os_cputime_ticks_to_usecs(earliest_start - initial_start);
             connsm->tx_win_off = dur / BLE_LL_CONN_TX_OFF_USECS;
-#else
-            dur = os_cputime_ticks_to_usecs(earliest_start - initial_start);
-            dur += XCVR_TX_SCHED_DELAY_USECS;
-            connsm->tx_win_off = dur / BLE_LL_CONN_TX_OFF_USECS;
-#endif
         }
     }
 
     if (!rc) {
         sch->start_time = earliest_start;
         sch->end_time = earliest_end;
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
         /*
          * Since we have the transmit window to transmit in, we dont need
          * to set the anchor point usecs; just transmit to the nearest tick.
          */
         connsm->anchor_point = earliest_start + g_ble_ll_sched_offset_ticks;
         connsm->anchor_point_usecs = 0;
-#else
-        connsm->anchor_point = earliest_start +
-            os_cputime_usecs_to_ticks(XCVR_TX_SCHED_DELAY_USECS);
-#endif
         connsm->ce_end_time = earliest_end;
     }
 
@@ -554,7 +510,6 @@ ble_ll_sched_slave_new(struct ble_ll_conn_sm *connsm)
     sch = &connsm->conn_sch;
 
     /* Set schedule start and end times */
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     /*
      * XXX: for now, we dont care about anchor point usecs for the slave. It
      * does not matter if we turn on the receiver up to one tick before w
@@ -563,11 +518,6 @@ ble_ll_sched_slave_new(struct ble_ll_conn_sm *connsm)
      */
     sch->start_time = connsm->anchor_point - g_ble_ll_sched_offset_ticks -
         os_cputime_usecs_to_ticks(connsm->slave_cur_window_widening) - 1;
-#else
-    sch->start_time = connsm->anchor_point -
-        os_cputime_usecs_to_ticks(XCVR_RX_SCHED_DELAY_USECS +
-                                  connsm->slave_cur_window_widening);
-#endif
     sch->end_time = connsm->ce_end_time;
     sch->remainder = 0;
 
@@ -1224,10 +1174,8 @@ ble_ll_sched_init(void)
      * This is the offset from the start of the scheduled item until the actual
      * tx/rx should occur, in ticks. We also "round up" to the nearest tick.
      */
-#if MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768
     g_ble_ll_sched_offset_ticks =
         os_cputime_usecs_to_ticks(XCVR_TX_SCHED_DELAY_USECS + 30);
-#endif
 
     /* Initialize cputimer for the scheduler */
     os_cputime_timer_init(&g_ble_ll_sched_timer, ble_ll_sched_run, NULL);

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -1175,7 +1175,7 @@ ble_ll_sched_init(void)
      * tx/rx should occur, in ticks. We also "round up" to the nearest tick.
      */
     g_ble_ll_sched_offset_ticks =
-        os_cputime_usecs_to_ticks(XCVR_TX_SCHED_DELAY_USECS + 30);
+        (uint8_t) os_cputime_usecs_to_ticks(XCVR_TX_SCHED_DELAY_USECS + 30);
 
     /* Initialize cputimer for the scheduler */
     os_cputime_timer_init(&g_ble_ll_sched_timer, ble_ll_sched_run, NULL);

--- a/net/nimble/controller/syscfg.yml
+++ b/net/nimble/controller/syscfg.yml
@@ -25,6 +25,11 @@ syscfg.defs:
             drivers.
         value: 1
 
+    BLE_LP_CLOCK:
+        description: >
+            Used by BSP packages to configure LP clock for controller.
+        value: 1
+
     BLE_LL_PRIO:
         description: 'The priority of the LL task'
         type: 'task_priority'

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -103,9 +103,7 @@ struct ble_mbuf_hdr
         struct ble_mbuf_hdr_txinfo txinfo;
     };
     uint32_t beg_cputime;
-#if (MYNEWT_VAL(OS_CPUTIME_FREQ) == 32768)
     uint32_t rem_usecs;
-#endif
 };
 
 #define BLE_MBUF_HDR_AUX_INVALID(hdr) \


### PR DESCRIPTION
This removes controller code which uses 1MHz clock so we always use code for 32.768kHz clock.