### PR TITLE
BLE Host - decrease default mtu; make configurable at build time.

### DIFF
--- a/net/nimble/host/include/host/ble_att.h
+++ b/net/nimble/host/include/host/ble_att.h
@@ -101,7 +101,6 @@ struct os_mbuf;
  * 512-byte attribute value.
  */
 #define BLE_ATT_MTU_MAX                     527
-#define BLE_ATT_MTU_PREFERRED_DFLT          527
 
 int ble_att_svr_read_local(uint16_t attr_handle, struct os_mbuf **out_om);
 int ble_att_svr_write_local(uint16_t attr_handle, struct os_mbuf *om);

--- a/net/nimble/host/src/ble_att.c
+++ b/net/nimble/host/src/ble_att.c
@@ -587,7 +587,7 @@ ble_att_init(void)
 {
     int rc;
 
-    ble_att_preferred_mtu_val = BLE_ATT_MTU_PREFERRED_DFLT;
+    ble_att_preferred_mtu_val = MYNEWT_VAL(BLE_ATT_PREFERRED_MTU);
 
     rc = stats_init_and_reg(
         STATS_HDR(ble_att_stats), STATS_SIZE_INIT_PARMS(ble_att_stats,

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -288,6 +288,10 @@ syscfg.defs:
         value: 1
 
     # ATT options.
+    BLE_ATT_PREFERRED_MTU:
+        description: The preferred MTU to indicate in MTU exchange commands.
+        value: 256
+
     BLE_ATT_SVR_MAX_PREP_ENTRIES:
         description: >
             A GATT server uses these when a peer performs a "write long

--- a/net/nimble/host/test/src/ble_hs_conn_test.c
+++ b/net/nimble/host/test/src/ble_hs_conn_test.c
@@ -79,7 +79,7 @@ TEST_CASE(ble_hs_conn_test_direct_connect_success)
 
     chan = ble_hs_conn_chan_find_by_scid(conn, BLE_L2CAP_CID_ATT);
     TEST_ASSERT_FATAL(chan != NULL);
-    TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
+    TEST_ASSERT(chan->my_mtu == MYNEWT_VAL(BLE_ATT_PREFERRED_MTU));
     TEST_ASSERT(chan->peer_mtu == 0);
 
     ble_hs_unlock();
@@ -133,7 +133,7 @@ TEST_CASE(ble_hs_conn_test_direct_connectable_success)
 
     chan = ble_hs_conn_chan_find_by_scid(conn, BLE_L2CAP_CID_ATT);
     TEST_ASSERT_FATAL(chan != NULL);
-    TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
+    TEST_ASSERT(chan->my_mtu == MYNEWT_VAL(BLE_ATT_PREFERRED_MTU));
     TEST_ASSERT(chan->peer_mtu == 0);
 
     ble_hs_unlock();
@@ -194,7 +194,7 @@ TEST_CASE(ble_hs_conn_test_undirect_connectable_success)
 
     chan = ble_hs_conn_chan_find_by_scid(conn, BLE_L2CAP_CID_ATT);
     TEST_ASSERT_FATAL(chan != NULL);
-    TEST_ASSERT(chan->my_mtu == BLE_ATT_MTU_PREFERRED_DFLT);
+    TEST_ASSERT(chan->my_mtu == MYNEWT_VAL(BLE_ATT_PREFERRED_MTU));
     TEST_ASSERT(chan->peer_mtu == 0);
 
     ble_hs_unlock();


### PR DESCRIPTION
This commit introduces two changes:

1. Reduce the default preferred ATT MTU from 527 to 256.  This is
desirable because supporting such a large MTU requires more mbuf space
than the example apps allocate.  Furthermore, such a large MTU requires
more stack space from higher layer protocols.

2. Make default preferred MTU configurable via the following syscfg
setting:

    BLE_ATT_PREFERRED_MTU:
        description: The preferred MTU to indicate in MTU exchange commands.
        value: 256