### PR TITLE
Enable i2c_scan only when there is I2C peripheral

### DIFF
--- a/apps/slinky/pkg.yml
+++ b/apps/slinky/pkg.yml
@@ -26,7 +26,6 @@ pkg.keywords:
 
 pkg.deps:
     - test/flash_test
-    - test/i2c_scan
     - mgmt/imgmgr
     - mgmt/newtmgr
     - mgmt/newtmgr/transport/nmgr_shell
@@ -39,6 +38,10 @@ pkg.deps:
     - sys/log/full
     - sys/stats/full
     - boot/split
+
+pkg.deps.I2C_0: test/i2c_scan
+pkg.deps.I2C_1: test/i2c_scan
+pkg.deps.I2C_2: test/i2c_scan
 
 pkg.deps.CONFIG_NFFS:
     - fs/nffs


### PR DESCRIPTION
The slinky app includes i2c_scan, but this causes a build error
on HAL ports which don't include an i2c driver. This change only
includes i2c_scan when some I2C_x switch is enabled.