### PR TITLE
Misc fixes

### DIFF
--- a/hw/mcu/native/src/hal_uart.c
+++ b/hw/mcu/native/src/hal_uart.c
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <syscfg/syscfg.h>
+
 #include "defs/error.h"
 #include "os/os.h"
 #include "hal/hal_uart.h"
@@ -42,7 +44,11 @@
 
 #define UART_CNT                2
 
+#if MYNEWT_VAL(CONSOLE_UART_TX_BUF_SIZE)
+#define UART_MAX_BYTES_PER_POLL	MYNEWT_VAL(CONSOLE_UART_TX_BUF_SIZE) - 2
+#else
 #define UART_MAX_BYTES_PER_POLL	64
+#endif
 #define UART_POLLER_STACK_SZ	OS_STACK_ALIGN(1024)
 #define UART_POLLER_PRIO	0
 

--- a/net/oic/include/oic/oc_rep.h
+++ b/net/oic/include/oic/oc_rep.h
@@ -70,10 +70,10 @@ int oc_rep_finalize(void);
     g_err |= cbor_encode_text_string(&object##_map, value, strlen(value));     \
   } while (0)
 
-#define oc_rep_set_byte_string(object, key, value)                             \
+#define oc_rep_set_byte_string(object, key, value, length)                     \
   do {                                                                         \
     g_err |= cbor_encode_text_string(&object##_map, #key, strlen(#key));       \
-    g_err |= cbor_encode_byte_string(&object##_map, value, strlen(value));     \
+    g_err |= cbor_encode_byte_string(&object##_map, value, length);            \
   } while (0)
 
 #define oc_rep_start_array(parent, key)                                        \

--- a/net/oic/src/port/mynewt/ip4_adaptor.c
+++ b/net/oic/src/port/mynewt/ip4_adaptor.c
@@ -347,7 +347,7 @@ oc_connectivity_init_ip4(void)
     return 0;
 
 oc_connectivity_init_err:
-    oc_connectivity_shutdown_ipv4();
+    oc_connectivity_shutdown_ip4();
     return rc;
 }
 

--- a/net/oic/src/port/mynewt/ip4_adaptor.c
+++ b/net/oic/src/port/mynewt/ip4_adaptor.c
@@ -347,7 +347,7 @@ oc_connectivity_init_ip4(void)
     return 0;
 
 oc_connectivity_init_err:
-    oc_connectivity_shutdown();
+    oc_connectivity_shutdown_ipv4();
     return rc;
 }
 

--- a/net/oic/src/port/mynewt/ip_adaptor.c
+++ b/net/oic/src/port/mynewt/ip_adaptor.c
@@ -348,7 +348,7 @@ oc_connectivity_init_ip6(void)
     return 0;
 
 oc_connectivity_init_err:
-    oc_connectivity_shutdown();
+    oc_connectivity_shutdown_ip6();
     return rc;
 }
 

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -260,6 +260,9 @@ conf_get_value(char *name, char *buf, int buf_len)
         return NULL;
     }
 
+    if (!ch->ch_get) {
+        return NULL;
+    }
     return ch->ch_get(name_argc - 1, &name_argv[1], buf, buf_len);
 }
 

--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -28,6 +28,8 @@ extern "C" {
  * Maximum configurable serial number.
  */
 #define ID_SERIAL_MAX_LEN       64
+extern char id_serial[];
+extern char id_mfghash[];
 
 /*
  * Initialize manufacturing info storage/reporting.

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -46,10 +46,10 @@ static const char *bsp_str = "";
 static const char *app_str = "";
 #endif
 
-static char serial[ID_SERIAL_MAX_LEN];
+char id_serial[ID_SERIAL_MAX_LEN];
 
 /** Base64-encoded null-terminated manufacturing hash. */
-static char id_mfghash[BASE64_ENCODE_SIZE(MFG_HASH_SZ) + 1];
+char id_mfghash[BASE64_ENCODE_SIZE(MFG_HASH_SZ) + 1];
 
 struct conf_handler id_conf = {
     .ch_name = "id",
@@ -75,7 +75,7 @@ id_conf_get(int argc, char **argv, char *val, int val_len_max)
         } else if (!strcmp(argv[0], "app")) {
             return (char *)app_str;
         } else if (!strcmp(argv[0], "serial")) {
-            return serial;
+            return id_serial;
         } else if (!strcmp(argv[0], "mfghash")) {
             return id_mfghash;
         }
@@ -88,7 +88,7 @@ id_conf_set(int argc, char **argv, char *val)
 {
     if (argc == 1) {
         if (!strcmp(argv[0], "serial")) {
-            return CONF_VALUE_SET(val, CONF_STRING, serial);
+            return CONF_VALUE_SET(val, CONF_STRING, id_serial);
         }
     }
     return OS_ENOENT;
@@ -112,7 +112,7 @@ id_conf_export(void (*export_func)(char *name, char *val),
         export_func("id/app", (char *)app_str);
         export_func("id/mfghash", (char *)id_mfghash);
     }
-    export_func("id/serial", serial);
+    export_func("id/serial", id_serial);
 
     return 0;
 }


### PR DESCRIPTION
- encoding byte arrays in oic responses was wrong
- export serial number, manufacturing id as global symbols from sys/is
- allow config handlers to not specify get routine
- cut'n'past to native console deadlocks the system
- failing to create ipv4 sockets was closing ipv6 socket for oic