### PR TITLE
Fix onboard sensor config & misc

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -424,7 +424,7 @@ sensor_ble_oic_server_init(void)
     ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;
 
     /* Set the default device name. */
-    rc = ble_svc_gap_device_name_set("sensy");
+    rc = ble_svc_gap_device_name_set("sn");
     assert(rc == 0);
 
     rc = oc_main_init((oc_handler_t *)&sensor_oic_handler);

--- a/apps/sensors_test/syscfg.yml
+++ b/apps/sensors_test/syscfg.yml
@@ -44,7 +44,7 @@ syscfg.vals:
     TSL2561_CLI: 1
     BNO055_CLI: 1
     TCS34725_CLI: 1
-    BME280_CLI: 1
+    BME280_CLI: 0
 
     # Setup Sensor BLE OIC GATT Server
     SENSOR_OIC: 1

--- a/hw/bsp/ruuvi_tag_revb2/pkg.yml
+++ b/hw/bsp/ruuvi_tag_revb2/pkg.yml
@@ -98,3 +98,6 @@ pkg.deps.UART_1:
 
 pkg.deps.BME280_ONB:
     - hw/drivers/sensors/bme280
+
+pkg.init:
+    config_bme280_sensor: 400

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -167,12 +167,12 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 }
 
 /**
- * BME280 Sensor default configuration used by the creator package
+ * BME280 Sensor default configuration
  *
  * @return 0 on success, non-zero on failure
  */
 #if MYNEWT_VAL(BME280_ONB)
-static int
+int
 config_bme280_sensor(void)
 {
     int rc;
@@ -181,11 +181,6 @@ config_bme280_sensor(void)
 
     dev = (struct os_dev *) os_dev_open("bme280_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
-
-    if (!(dev->od_flags & OS_DEV_F_STATUS_READY)) {
-        rc = SYS_EINVAL;
-        goto err;
-    }
 
     memset(&bmecfg, 0, sizeof(bmecfg));
 
@@ -204,7 +199,6 @@ config_bme280_sensor(void)
 
     rc = bme280_config((struct bme280 *)dev, &bmecfg);
 
-err:
     os_dev_close(dev);
     return rc;
 }
@@ -217,11 +211,8 @@ sensor_dev_create(void)
     (void)rc;
 
 #if MYNEWT_VAL(BME280_ONB)
-    rc = os_dev_create((struct os_dev *) &bme280, "bme280",
+    rc = os_dev_create((struct os_dev *) &bme280, "bme280_0",
       OS_DEV_INIT_PRIMARY, 0, bme280_init, (void *)&spi_0_itf_bme);
-    assert(rc == 0);
-
-    rc = config_bme280_sensor();
     assert(rc == 0);
 #endif
 

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -138,11 +138,6 @@ config_bme280_sensor(void)
     dev = (struct os_dev *) os_dev_open("bme280_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
 
-    if (!(dev->od_flags & OS_DEV_F_STATUS_READY)) {
-        rc = SYS_EINVAL;
-        goto err;
-    }
-
     memset(&bmecfg, 0, sizeof(bmecfg));
 
     bmecfg.bc_mode = BME280_MODE_NORMAL;
@@ -160,7 +155,6 @@ config_bme280_sensor(void)
 
     rc = bme280_config((struct bme280 *)dev, &bmecfg);
 
-err:
     os_dev_close(dev);
     return rc;
 }
@@ -182,11 +176,6 @@ config_tcs34725_sensor(void)
     dev = (struct os_dev *) os_dev_open("tcs34725_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
 
-    if (!(dev->od_flags & OS_DEV_F_STATUS_READY)) {
-        rc = SYS_EINVAL;
-        goto err;
-    }
-
     /* Gain set to 16X and Inetgration time set to 24ms */
     tcscfg.gain = TCS34725_GAIN_16X;
     tcscfg.integration_time = TCS34725_INTEGRATIONTIME_24MS;
@@ -195,7 +184,6 @@ config_tcs34725_sensor(void)
 
     rc = tcs34725_config((struct tcs34725 *)dev, &tcscfg);
 
-err:
     os_dev_close(dev);
     return rc;
 }
@@ -217,11 +205,6 @@ config_tsl2561_sensor(void)
     dev = (struct os_dev *) os_dev_open("tsl2561_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
 
-    if (!(dev->od_flags & OS_DEV_F_STATUS_READY)) {
-        rc = SYS_EINVAL;
-        goto err;
-    }
-
     /* Gain set to 1X and Inetgration time set to 13ms */
     tslcfg.gain = TSL2561_LIGHT_GAIN_1X;
     tslcfg.integration_time = TSL2561_LIGHT_ITIME_13MS;
@@ -229,7 +212,6 @@ config_tsl2561_sensor(void)
 
     rc = tsl2561_config((struct tsl2561 *)dev, &tslcfg);
 
-err:
     os_dev_close(dev);
     return rc;
 }
@@ -251,11 +233,6 @@ config_lsm303dlhc_sensor(void)
     dev = (struct os_dev *) os_dev_open("lsm303dlhc_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
 
-    if (!(dev->od_flags & OS_DEV_F_STATUS_READY)) {
-        rc = SYS_EINVAL;
-        goto err;
-    }
-
     /* read once per sec.  API should take this value in ms. */
     lsmcfg.accel_rate = LSM303DLHC_ACCEL_RATE_1;
     lsmcfg.accel_range = LSM303DLHC_ACCEL_RANGE_2;
@@ -269,7 +246,6 @@ config_lsm303dlhc_sensor(void)
 
     rc = lsm303dlhc_config((struct lsm303dlhc *) dev, &lsmcfg);
 
-err:
     os_dev_close(dev);
     return rc;
 }
@@ -291,11 +267,6 @@ config_bno055_sensor(void)
     dev = (struct os_dev *) os_dev_open("bno055_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
 
-    if (!(dev->od_flags & OS_DEV_F_STATUS_READY)) {
-        rc = SYS_EINVAL;
-        goto err;
-    }
-
     bcfg.bc_units = BNO055_ACC_UNIT_MS2   | BNO055_ANGRATE_UNIT_DPS |
                     BNO055_EULER_UNIT_DEG | BNO055_TEMP_UNIT_DEGC   |
                     BNO055_DO_FORMAT_ANDROID;
@@ -315,7 +286,6 @@ config_bno055_sensor(void)
 
     rc = bno055_config((struct bno055 *) dev, &bcfg);
 
-err:
     os_dev_close(dev);
     return rc;
 }


### PR DESCRIPTION
- Fix onbaord sensor config by adding it to sysinit
- removing DEVICE_READY check from config functions as it is not
  needed as the check already happens in os_dev_open()
- Fixing comments